### PR TITLE
item-10: GET/SET_CLOCK_SOURCE paired fixture (getter reflects setter)

### DIFF
--- a/tests/features/item10_clock_source.feature
+++ b/tests/features/item10_clock_source.feature
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:CLOCK_SOURCE @matrix:CMD-11
+Feature: Item-10 GET/SET_CLOCK_SOURCE - getter/setter round-trip (paired fixture)
+  The paired fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 3):
+  the getter must REFLECT the setter. GET_CLOCK_SOURCE and SET_CLOCK_SOURCE share
+  the wire layout (both carry clock_source_index), so the GET frame is the SET
+  frame with command_type patched to 18 (GET) vs 22 (SET). Frames are tsn_gen-
+  generated + decode-cross-checked; the Milan AECP model mirrors
+  KL_aecp_response_builder (the RTL itself is verified by tb/verilator/aecp).
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: GET_CLOCK_SOURCE returns the current source, well-formed
+    Given tsn_gen generated a SET_CLOCK_SOURCE frame with seed 10
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 23
+    And I patch field "descriptor_type" to 0x24
+    And I patch field "descriptor_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model clock_source_index is 0
+
+  @class:paired
+  Scenario: the getter reflects the setter (SET then GET round-trip)
+    Given tsn_gen generated a SET_CLOCK_SOURCE frame with seed 2
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 22
+    And I patch field "descriptor_type" to 0x24
+    And I patch field "descriptor_index" to 0
+    And I patch field "clock_source_index" to 1
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model clock_source_index is 1
+    Given tsn_gen generated a SET_CLOCK_SOURCE frame with seed 11
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 23
+    And I patch field "descriptor_type" to 0x24
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model clock_source_index is 1
+
+  @class:getter @negative
+  Scenario: GET_CLOCK_SOURCE on a non-CLOCK_DOMAIN descriptor is refused
+    Given tsn_gen generated a SET_CLOCK_SOURCE frame with seed 12
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 23
+    And I patch field "descriptor_type" to 0x00
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 2

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -122,6 +122,7 @@ def pg_decode(context, key, hexstr):
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_GET_CLOCK_SOURCE = 23   # 0x0017
 
 
 class MilanAecpModel:
@@ -135,6 +136,10 @@ class MilanAecpModel:
     def process(self, fields):
         cmd = fields['command_type']
         dt, di = fields['descriptor_type'], fields['descriptor_index']
+        if cmd == CMD_GET_CLOCK_SOURCE:
+            if dt != DESC_CLOCK_DOMAIN or di != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            return STATUS_SUCCESS        # getter: no state change; response carries clock_source_index
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR


### PR DESCRIPTION
## Status
🟢 **Green** — 3 scenarios / 40 steps · `item-10-clock-source` → `main`

## Description
First per-command verification off the plan (#13). A **paired** fixture for `GET/SET_CLOCK_SOURCE` — proves *the getter reflects the setter*, the coupling neither a getter- nor setter-only test exercises.
- `GET_CLOCK_SOURCE` (`0x0017`) and `SET_CLOCK_SOURCE` (`0x0016`) share the wire layout → the GET frame is the SET frame with `command_type` patched.
- Extends `MilanAecpModel` with `GET_CLOCK_SOURCE` (read-only).
- Scenarios: getter well-formed · SET→GET round-trip · getter-negative (non-CLOCK_DOMAIN → NO_SUCH_DESCRIPTOR).

## How to get into the same state
Common setup: see [**Prerequisites & running**](../blob/item-10-pdu-getter-setter-verify/docs/testing/PDU_GETTER_SETTER_VERIFICATION.md). Then:
```bash
git checkout item-10-clock-source
```

## How to validate
```bash
$BEHAVE tests -i item10_clock_source
```
Expected: `1 feature passed · 3 scenarios passed · 40 steps passed`.

## Definition of Done
- [x] Paired: getter + SET→GET round-trip + getter-negative
- [x] Command codes spec-accurate (IEEE 1722.1 Table 7.126: SET `0x0016`, GET `0x0017`)
- [x] Green offline (tsn_gen + model), no DUT/bench
- [x] Tagged `@class:paired`/`@class:getter` · `@cmd:CLOCK_SOURCE` · `@matrix:CMD-11`
