### PR TITLE
item-10: GET/SET_CONTROL (IDENTIFY) paired fixture

### DIFF
--- a/tests/features/item10_control.feature
+++ b/tests/features/item10_control.feature
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:CONTROL @matrix:CMD-13
+Feature: Item-10 GET/SET_CONTROL (IDENTIFY) - getter/setter round-trip (paired)
+  Paired fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 3) for the
+  IDENTIFY CONTROL (LINEAR_UINT8, only 0/255 legal). GET_CONTROL (0x0019=25) shares
+  the SET_CONTROL (0x0018=24) wire layout, so the GET frame is the SET frame with
+  command_type patched. Frames are tsn_gen-generated; the Milan AECP model mirrors
+  KL_aecp_response_builder (the RTL is verified by tb/verilator/aecp).
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: GET_CONTROL returns the current IDENTIFY level, well-formed
+    Given tsn_gen generated a SET_CONTROL frame with seed 20
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 25
+    And I patch field "descriptor_type" to 0x1A
+    And I patch field "descriptor_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model identify level is 0
+
+  @class:paired
+  Scenario: the getter reflects the setter (SET IDENTIFY=255 then GET)
+    Given tsn_gen generated a SET_CONTROL frame with seed 21
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 24
+    And I patch field "descriptor_type" to 0x1A
+    And I patch field "descriptor_index" to 0
+    And I patch field "control_values" to 0xFF00000000000000
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model identify level is 255
+    Given tsn_gen generated a SET_CONTROL frame with seed 22
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 25
+    And I patch field "descriptor_type" to 0x1A
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model identify level is 255
+
+  @class:setter @negative
+  Scenario: SET_CONTROL with an out-of-range IDENTIFY value is refused
+    Given tsn_gen generated a SET_CONTROL frame with seed 23
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 24
+    And I patch field "descriptor_type" to 0x1A
+    And I patch field "descriptor_index" to 0
+    And I patch field "control_values" to 0x0100000000000000
+    When the Milan AECP model processes the frame
+    Then the model responds status 7

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -122,6 +122,7 @@ def pg_decode(context, key, hexstr):
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_GET_CONTROL = 25   # 0x0019
 
 
 class MilanAecpModel:
@@ -142,6 +143,10 @@ class MilanAecpModel:
                 return STATUS_BAD_ARGUMENTS
             self.clock_source_index = fields['clock_source_index']
             return STATUS_SUCCESS
+        if cmd == CMD_GET_CONTROL:
+            if dt != DESC_CONTROL or di != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            return STATUS_SUCCESS        # getter: response carries self.identify
         if cmd == CMD_SET_CONTROL:
             if dt != DESC_CONTROL or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR


### PR DESCRIPTION
## Status
🟢 **Green** — 3 scenarios / 41 steps · `item-10-control` → `main`

## Description
Second per-command verification off the plan (#13). A **paired** fixture for the IDENTIFY `GET/SET_CONTROL` (LINEAR_UINT8, only 0/255 legal).
- `GET_CONTROL` (`0x0019`) shares the `SET_CONTROL` (`0x0018`) wire layout → GET is the SET frame with `command_type` patched.
- Extends `MilanAecpModel` with `GET_CONTROL`.
- Scenarios: getter well-formed · SET IDENTIFY=255 → GET reflects it · setter-negative (out-of-range → BAD_ARGUMENTS).

## How to get into the same state
Common setup: see [**Prerequisites & running**](../blob/item-10-pdu-getter-setter-verify/docs/testing/PDU_GETTER_SETTER_VERIFICATION.md). Then:
```bash
git checkout item-10-control
```

## How to validate
```bash
$BEHAVE tests -i item10_control
```
Expected: `1 feature passed · 3 scenarios passed · 41 steps passed`.

## Definition of Done
- [x] Paired: getter + SET→GET round-trip + setter-negative
- [x] Command codes spec-accurate (IEEE 1722.1 Table 7.126: SET `0x0018`, GET `0x0019`)
- [x] Green offline (tsn_gen + model)
- [x] Tagged `@class:paired`/`@class:setter` · `@cmd:CONTROL` · `@matrix:CMD-13`
