### PR TITLE
item-5: N×N 8×8 elaboration + sim + area-lever analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bd/.Xil/
 tb/verilator/*/obj_dir/
 tb/verilator/*/obj_ctx/
 tb/verilator/*/obj_nxn/
+tb/verilator/*/obj_nxn8/
 obj_dir/
 obj_dir_*/
 

--- a/docs/NXN_ARCHITECTURE.md
+++ b/docs/NXN_ARCHITECTURE.md
@@ -3,7 +3,8 @@
 Normative architecture for roadmap item 5 (`docs/MILAN_COMPLIANCE_GAPS.md`,
 "Suggested order of attack" item 5). Test shapes: **AX7101 = 8x8**,
 **Arty = 4x4** (`configs/endstation_ax7101_8x8.yaml`,
-`configs/endstation_arty_4x4.yaml`). Status: DESIGN — no RTL in this round.
+`configs/endstation_arty_4x4.yaml`). Status: IMPLEMENTED — shared-engine RTL
+is live; the 8x8 shape elaborates and sim-scales green (§6 item-5 note).
 
 **The replication verdict (why this doc exists).** The calibrated resource
 estimator (`sw/builder/endstation_builder.py`, per-module costs measured from
@@ -487,3 +488,38 @@ deltas of the merged engines, LUT4:LUT6 charged 1:1 = safe-side). Recomputed
 verdicts: **4x4 = 84.9% LUT, 8x8 = 89.2% LUT** — both FIT the part with
 headroom, both in the OVER band as this table predicted (87.3/87.7 modeled);
 `test_builder` gate 13 pins the envelope (< 88% / < 92%).
+
+### 6.1 item-5 ELABORATION + SIM PROOF (2026-07-23)
+
+The 8x8 shape is no longer design-only — it elaborates and sim-scales:
+
+- **Elaborates.** `milan_soc.py --full --milan-clk-freq 50e6 --num-streams 8
+  --output-dir /tmp/elab_nxn8` emits `gateware/alinx_ax7101.v` clean
+  (43 359 lines; `.N_STREAMS(4'd8)` on the `milan_datapath` instance). No N=8
+  elaboration errors. The `--num-streams 4` netlist is identical except the
+  deltas below.
+- **Sim-scales green.** `tb/verilator/milan_dp` builds an N=8 config
+  (`obj_nxn8`, `-GN_STREAMS=8 -DNSTREAMS_TB=8`) of the same self-checking
+  `sim_nxn` harness: **82 checks / 0 fail**, adding a full-index routing sweep
+  that provisions streams 3..7 *simultaneously* and proves each lands on the
+  PCM ring with its own `tuser` + byte-exact payload, isolated per-stream
+  Table 7-157 counters, and unknown-sid drop at width N — the 8-stream
+  independent-routing proof. N=4 (`obj_nxn`) stays green 70/0; legacy 172/0.
+- **Measured 4→8 resource delta.** The LiteX netlist grows ~84 lines: the
+  per-stream PCM-ring offset CSRs `milandma_pcm_offsets{0..N-1}` gain +4
+  32-bit regs, the ring-select muxes widen to a 3-bit index, and the `>= N`
+  user/sel clamps move 4→8. The real per-stream growth lives inside
+  `milan_datapath` (parameter-passed, not flattened into this netlist): the
+  LCTX monitor context RAM `lctx_r` (32×32b = 1 Kib/stream) doubles 128→256
+  words (4→8 Kib — still ¼ of one RAMB36 as this section predicted); the
+  stream-table SID flops add 64 b/stream (256→512 b); ACMP/lwSRP/packetizer
+  contexts index-widen by log2 N only. Confirms the thesis: cost is
+  per-ENGINE, N only widens indexes and deepens BRAM.
+- **Ship levers to fit 8x8 on xc7a100t** (bench Vivado build is gated, not
+  this round): the shipping config is **1-hart NaxRiscv** (`--cpu-count 1`,
+  the arg default) **+ `--l2-bytes 32768`** (lever 1 above: −8 BRAM +
+  placement relief; perf delta per the standing USER authorization). With
+  both, the modeled 8x8 envelope holds at 89.2% LUT / 70% BRAM (gate 13
+  ceiling < 92%). If it still refuses to close, levers 2–5 apply, ending in
+  the config-selectable-N fallback (ship the 4x4 gateware on AX, keep 8x8 as
+  the sweep target — the architecture is unchanged).

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -83,9 +83,11 @@ all: run
 run:
 	$(VERILATOR) $(VFLAGS) $(SRCS) $(CPP) -o Vmilan_dp_sim
 	$(VERILATOR) $(VFLAGS) --Mdir obj_nxn -GN_STREAMS=4 $(SRCS) sim_nxn.cpp -o Vmilan_dp_nxn
+	$(VERILATOR) $(VFLAGS) --Mdir obj_nxn8 -GN_STREAMS=8 -CFLAGS -DNSTREAMS_TB=8 $(SRCS) sim_nxn.cpp -o Vmilan_dp_nxn8
 	@echo "======================================================================"
 	./obj_dir/Vmilan_dp_sim
 	./obj_nxn/Vmilan_dp_nxn
+	./obj_nxn8/Vmilan_dp_nxn8
 
 clean:
-	rm -rf obj_dir obj_nxn
+	rm -rf obj_dir obj_nxn obj_nxn8

--- a/tb/verilator/milan_dp/sim_nxn.cpp
+++ b/tb/verilator/milan_dp/sim_nxn.cpp
@@ -47,6 +47,15 @@
 #include <cstdint>
 #include <cstring>
 #include <vector>
+#include <cstdio>
+
+// Stream count the C++ side walks. Paired with the RTL -GN_STREAMS by the
+// Makefile: the default obj_nxn build is N=4; the obj_nxn8 build passes
+// -GN_STREAMS=8 AND -DNSTREAMS_TB=8 so the sweep below walks idx 3..7 (the
+// AX 8x8 target - the top half of the index space only exists at N=8).
+#ifndef NSTREAMS_TB
+#define NSTREAMS_TB 4
+#endif
 
 static Vmilan_datapath* dut;
 static long checks = 0, fails = 0;
@@ -197,7 +206,8 @@ int main(int argc, char** argv) {
     Verilated::commandArgs(argc, argv);
     dut = new Vmilan_datapath;
 
-    printf("=== milan_datapath NxN integration (N_STREAMS=4, P12) ===\n");
+    printf("=== milan_datapath NxN integration (N_STREAMS=%d, P12) ===\n",
+           NSTREAMS_TB);
     dut->axis_resetn = 0; dut->gtx_resetn = 0;
     dut->s_axi_awvalid = dut->s_axi_wvalid = dut->s_axi_arvalid = 0;
     dut->s_axi_bready = dut->s_axi_rready = 0;
@@ -464,6 +474,76 @@ int main(int argc, char** argv) {
     (void)axi_read(A_SW_SID_LO);
     ck("ctx0 SID reads 0 (bind left ctx0 alone)", axi_read(A_SW_SID_LO) |
                                                   axi_read(A_SW_SID_HI), 0);
+
+    // ======================================================================
+    // item-5 (N x N, the AX 8x8 target): full-index routing sweep. The checks
+    // above prove idx 1/2/3 at N=4; this proves EVERY fresh index 3..N-1 is
+    // provisioned, live, and routed independently AT THE SAME TIME. Default
+    // build (N=4) walks idx 3; the obj_nxn8 build (-GN_STREAMS=8) walks idx
+    // 3..7 - the top half of the stream-index space that exists only at N=8,
+    // so a PASS here IS the 8-stream routing proof the AX shape needs.
+    printf("-- N-wide routing: fresh streams 3..%d live at once, by index --\n",
+           NSTREAMS_TB - 1);
+    // provision every fresh stream simultaneously, DMA route so each lands on
+    // the PCM ring tagged with its own tuser. sid(s) = {0x30+s,0,0,0,0,
+    // 0x30+s,0,s}: distinct from sidB/C/X and from each other.
+    for (int s = 3; s < NSTREAMS_TB; s++) {
+        uint32_t sid_hi = ((uint32_t)(0x30 + s) << 24);
+        uint32_t sid_lo = ((uint32_t)(0x30 + s) << 16) | (uint32_t)s;
+        axi_write(A_STRM_SEL, s & 0xF);                  // dir=0 idx=s
+        axi_write(A_SW_SID_LO, sid_lo);
+        axi_write(A_SW_SID_HI, sid_hi);
+        axi_write(A_SW_FMT_LO, FMT_LO);
+        axi_write(A_SW_FMT_HI, FMT_HI);
+        axi_write(A_SW_CTRL, (RT_DMA << 1) | 1u);        // en, DMA flag
+    }
+    // CFG readback per stream through the ENGINE-ARBITRATED LCTX port B
+    for (int s = 3; s < NSTREAMS_TB; s++) {
+        axi_write(A_STRM_SEL, s & 0xF);
+        char nm[56]; snprintf(nm, sizeof nm, "ctx%d CTRL readback (port B)", s);
+        ck(nm, axi_read(A_SW_CTRL), 0x3);
+    }
+    // inject one uniquely-payloaded frame per stream, interleaved, ALL table
+    // entries live: the classifier must tag each frame with the right index.
+    size_t ring0 = pcm_frames.size();
+    for (int s = 3; s < NSTREAMS_TB; s++) {
+        uint8_t sid[8] = {(uint8_t)(0x30 + s), 0, 0, 0, 0,
+                          (uint8_t)(0x30 + s), 0, (uint8_t)s};
+        inject(mkaaf(sid, (uint8_t)(0x40 + s), 2, (uint8_t)(0xA0 + s)), 120);
+    }
+    ck("sweep: one ring frame per fresh stream",
+       (unsigned)(pcm_frames.size() - ring0), (unsigned)(NSTREAMS_TB - 3));
+    // each ring frame carries its own stream's tuser + byte-exact payload
+    bool sweep_user_ok = true, sweep_pay_ok = true;
+    for (int s = 3; s < NSTREAMS_TB; s++) {
+        size_t k = ring0 + (size_t)(s - 3);
+        if (k >= pcm_frames.size()) { sweep_user_ok = false; break; }
+        if (pcm_frames[k].user != s) sweep_user_ok = false;
+        if (pcm_frames[k].bytes.size() != 48) sweep_pay_ok = false;
+        else for (int i = 0; i < 48; i++)
+            if (pcm_frames[k].bytes[i] != (uint8_t)(0xA0 + s + i)) sweep_pay_ok = false;
+    }
+    ck("sweep: ring tuser == stream index for all", sweep_user_ok, 1);
+    ck("sweep: 48-byte payload byte-exact for all", sweep_pay_ok, 1);
+    // isolation: each fresh stream counted EXACTLY its own single frame (no
+    // cross-count across the N simultaneously-live contexts) - Table 7-157.
+    for (int s = 3; s < NSTREAMS_TB; s++) {
+        axi_write(A_STRM_SEL, s & 0xF);
+        snap_and_wait();
+        char nm[64];
+        snprintf(nm, sizeof nm, "ctx%d FRAMES_RX == 1 (isolated)", s);
+        ck(nm, axi_read(A_SW_CNT0 + 9*4), 1);
+        snprintf(nm, sizeof nm, "ctx%d PDUS == 1", s);
+        ck(nm, axi_read(A_SW_PDUS), 1);
+    }
+    // an unknown sid (no table entry at any index) is still ignored at width N
+    {
+        const uint8_t sidU[8] = {0x5A, 0, 0, 0, 0, 0x5A, 0, 0x0F};
+        size_t before = pcm_frames.size();
+        inject(mkaaf(sidU, 50, 2, 0x11), 120);
+        ck("sweep: unknown sid ignored (no ring frame)",
+           (unsigned)pcm_frames.size(), (unsigned)before);
+    }
 
     printf("--------------------------------------------------------------\n");
     printf("checks: %ld   failures: %ld\n", checks, fails);


### PR DESCRIPTION
## Status
🟢 **Green** — N=8 sim **82/0** (+ N=4 70/0, legacy 172/0) · 8×8 elaborates clean · `item-05-nxn-8x8` → `main`

## Description
Roadmap **item 5** — proves the N×N AAF datapath scales to the AX **8×8** target in elaboration + sim and pins the ship area levers. (Silicon Vivado build is bench-gated, out of scope.)
- **8×8 elaborates clean:** `milan_soc.py --num-streams 8` emits the netlist with `.N_STREAMS(4'd8)` — no N=8 errors.
- **N=8 sim (82/0):** provisions listener streams 3..7 simultaneously; self-checks per-stream ring routing (`tuser` == stream index), byte-exact payloads, isolated counters, unknown-sid drop — idx 4-7 only exist at N=8.
- **Resource delta 4→8:** per-stream PCM-ring offset CSRs +4 regs; ring-select muxes → 3-bit; LCTX context RAM 128→256 words (¼ RAMB36); ACMP/lwSRP/packetizer contexts index-widen by log2 N.
- Docs: `NXN_ARCHITECTURE.md` §6.1 (proof + area levers); ship fit = 1-hart + `--l2-bytes 32768`.

## How to get into the same state
```bash
git clone git@github.com:kebag-logic/milan-fpga.git && cd milan-fpga
git checkout item-05-nxn-8x8
```

## How to validate
```bash
# N=8 (+N=4, legacy) datapath sim:
make -C tb/verilator/milan_dp        # -> obj_nxn8 82/0, obj_nxn 70/0, obj_dir 172/0
# 8x8 elaboration (no Vivado):
cd sw/litex && PYTHONPATH=$(for d in /home/alex/litex-milan/*/;do echo -n "$d:";done)/home/alex/litex-milan \
  python3 milan_soc.py --full --milan-clk-freq 50e6 --num-streams 8 --output-dir /tmp/elab_nxn8
# -> emits gateware/alinx_ax7101.v with .N_STREAMS(4'd8)
```

## Definition of Done
- [x] 8×8 SoC elaborates clean (netlist emitted)
- [x] N=8 sim green — 8 independent streams route correctly
- [x] Resource delta 4→8 documented + ship area levers pinned
- [ ] Silicon Vivado 3-seed build (bench-gated — separate PR)
