### PR TITLE
item-11: AAF per-stage latency taps (CSR)

### DIFF
--- a/docs/reference/REGISTER_MAP.md
+++ b/docs/reference/REGISTER_MAP.md
@@ -39,6 +39,8 @@ MAC/*` in [`REQUIREMENTS.md`](../../REQUIREMENTS.md).
 | `0x700` | RX destination-MAC TCAM filter |
 | `0x7A0` | ACMP bind-restore (saved-state fast-connect, Milan 5.5.3.5.2) |
 | `0x800` | Indexed per-stream window (NxN streams, SEL/SNAP + 0x810-0x868) |
+| `0x870` | AAF per-stage latency taps (item-11, `KL_aaf_latency_taps`) |
+| `0x8F8` | MMCM-DRP media-clock servo (Milan v1.2 7.3.4) |
 
 The ring-DMA engines of the fully-FPGA build have their **own** CSR space
 (LiteX-generated, e.g. the `0xf000_2800`/`0xf000_3000` regions) - see the
@@ -464,6 +466,60 @@ TSpec words exist.
 (dir 1): every window word reads 0, writes are ignored (no alias, no engine
 strobes, no provisioning), SNAP latches zeros and completes. `A_STRM_SEL` /
 `A_STRM_SNAP` themselves always decode.
+
+### 0x870  -  AAF per-stage latency taps  `(roadmap item-11, KL_aaf_latency_taps)`
+
+Per-stage TX/RX AAF pipeline latency, measured in **axis_clk cycles** (divide
+by the datapath clock - 50 MHz Arty / 100 MHz AX7101 - for seconds). Two
+independent chains each latch a free-running cycle count at the documented
+pipeline points and expose the inter-stage deltas (last / min / max,
+saturating 16-bit) plus the gPTP epoch of the measured reference frame:
+
+  * **TX**: `CAP` (ring/I2S pair in) `->` `PKT_SOF` (packetizer first beat)
+    `->` `PKT_EOF` (packetizer last beat) `->` `MAC_TX` (frame egresses the
+    MAC boundary). Deltas d0 = CAP→SOF, d1 = SOF→EOF, d2 = EOF→MAC.
+  * **RX**: `MAC_RX` (frame ingress) `->` `ACCEPT` (AVTP monitor
+    parse-complete / accept pulse) `->` `DEPKT` (payload last beat) `->`
+    `PCM_RING` (payload accepted at the ring writer). Deltas d0 = MAC_RX→ACCEPT,
+    d1 = ACCEPT→DEPKT, d2 = DEPKT→RING.
+
+**Measurement model.** Each chain follows ONE tagged reference frame at a
+time: it arms on a stage-0 edge (latching the epoch cycle + gPTP time), takes
+the next edge at each later stage as that frame's progress, and on the final
+stage records the deltas + publishes the epoch + increments `samples`. A
+per-stage timeout (`TIMEOUT_C` ≈ 0.5 ms) aborts and re-arms a stuck token
+(`timeouts++`), so a dropped frame never wedges the chain. The token is
+followed by ORDER, not a threaded frame id, so under mixed traffic a shared
+boundary (`MAC_TX`/`MAC_RX`) may catch a nearer non-AAF edge - min/last/max
+therefore characterise the latency ENVELOPE rather than one exact frame. The
+I2S-out playout stage is FIFO-fill dominated (the CDC pair FIFO decouples PDUs
+from DAC frames) and stays observed via `I2SPB_STAT` fill/converged; a **DDR3
+per-sample history ring is the documented follow-up**.
+
+Both the `LTAP_CTRL` status word and the 16 RO readback words live at
+`>= 0x800`, so - exactly like the servo - they need the `rd_in_window`
+carve-out or they read 0. Per-delta packing: word `2d` = `{max16, last16}`,
+word `2d+1` = `{16'd0, min16}`.
+
+| Offset | Name | Acc | Reset | Description |
+|--------|------|-----|-------|-------------|
+| `0x870` | `LTAP_CTRL` | RW | `0x2` | W: `[1]` enable (measure; reset 1), `[0]` W1S clear all stats. R: `[1]` enable, `[8]` tx_active, `[11:9]` tx stage awaited, `[12]` rx_active, `[15:13]` rx stage awaited |
+| `0x874` | `LTAP_TX_EPOCH` | RO | `0` | gPTP ns (`ptp_now[31:0]`) latched at the last completed TX frame's CAP stage |
+| `0x878` | `LTAP_TX_INFO` | RO | `0` | `[15:0]` samples (completed TX frames, saturating), `[31:16]` timeouts (aborted tokens) |
+| `0x87C` | `LTAP_TX_D0` | RO | `0` | CAP→SOF: `[15:0]` last, `[31:16]` max (cycles) |
+| `0x880` | `LTAP_TX_D0_MIN` | RO | `0xFFFF` | CAP→SOF: `[15:0]` min (cycles) |
+| `0x884` | `LTAP_TX_D1` | RO | `0` | SOF→EOF: `[15:0]` last, `[31:16]` max |
+| `0x888` | `LTAP_TX_D1_MIN` | RO | `0xFFFF` | SOF→EOF: `[15:0]` min |
+| `0x88C` | `LTAP_TX_D2` | RO | `0` | EOF→MAC_TX: `[15:0]` last, `[31:16]` max |
+| `0x890` | `LTAP_TX_D2_MIN` | RO | `0xFFFF` | EOF→MAC_TX: `[15:0]` min |
+| `0x894` | `LTAP_RX_EPOCH` | RO | `0` | gPTP ns latched at the last completed RX frame's MAC_RX stage |
+| `0x898` | `LTAP_RX_INFO` | RO | `0` | `[15:0]` samples, `[31:16]` timeouts |
+| `0x89C` | `LTAP_RX_D0` | RO | `0` | MAC_RX→ACCEPT: `[15:0]` last, `[31:16]` max |
+| `0x8A0` | `LTAP_RX_D0_MIN` | RO | `0xFFFF` | MAC_RX→ACCEPT: `[15:0]` min |
+| `0x8A4` | `LTAP_RX_D1` | RO | `0` | ACCEPT→DEPKT: `[15:0]` last, `[31:16]` max |
+| `0x8A8` | `LTAP_RX_D1_MIN` | RO | `0xFFFF` | ACCEPT→DEPKT: `[15:0]` min |
+| `0x8AC` | `LTAP_RX_D2` | RO | `0` | DEPKT→PCM_RING: `[15:0]` last, `[31:16]` max |
+| `0x8B0` | `LTAP_RX_D2_MIN` | RO | `0xFFFF` | DEPKT→PCM_RING: `[15:0]` min |
 
 ### 0x8F8  -  MMCM-DRP media-clock servo  `(Milan v1.2 7.3.4, KL_mmcm_drp_servo)`
 

--- a/hdl/common/csr/milan_csr.sv
+++ b/hdl/common/csr/milan_csr.sv
@@ -226,6 +226,11 @@ module milan_csr #(
   input  wire [31:0]             i_mcsrv_stat,        //! RO 0x8F8: MMCM-DRP media-clock servo status
   output wire                    o_mcsrv_ps_invert,   //! MCSRV_CTRL 0x8FC[0]: PS direction flip
   output wire                    o_mcsrv_auto_repair, //! MCSRV_CTRL 0x8FC[1]: 1 = allow DRP divider repair (bench-gated, default 0)
+  //! item-11 AAF per-stage latency taps (LTAP group, base 0x870)
+  input  wire [16*32-1:0]        i_ltap_regs,         //! RO 0x874-0x8B0: 16 packed readback words (KL_aaf_latency_taps)
+  input  wire [31:0]             i_ltap_status,       //! RO 0x870 status field (active/stage; enable OR-ed in here)
+  output wire                    o_ltap_en,           //! LTAP_CTRL[1]: measurement enable (default 1)
+  output wire                    o_ltap_clr,          //! LTAP_CTRL[0] W1S: 1-cycle stats clear
   output wire                    o_crft_en,           //! CRF talker enable (0x750)
   output wire [63:0]             o_crft_sid,          //! CRF talker stream_id (0x754/0x758)
   output wire [47:0]             o_crft_dest_mac,     //! CRF talker DMAC (0x75C/0x760)
@@ -450,6 +455,13 @@ module milan_csr #(
   //! to it for a future servo knob.
   localparam [ADDR_WIDTH-1:0] A_MCSRV_STAT = 'h8F8;  //! RO live: {trim16, flags, state3}
   localparam [ADDR_WIDTH-1:0] A_MCSRV_CTRL = 'h8FC;  //! RW: [0] ps_invert (bench sign knob, 2026-07-23); [1] auto_repair enable (bench-gated DRP divider repair, default 0)
+  //! item-11 AAF per-stage latency taps (KL_aaf_latency_taps). Parked just
+  //! ABOVE the 0x800 stream window (which ends at A_STRMW_END = 0x870): CTRL
+  //! at 0x870 then 16 packed RO words at 0x874-0x8B0. Like the servo, the RO
+  //! words need the >=0x800 rd_in_window carve-out below or they read 0.
+  localparam [ADDR_WIDTH-1:0] A_LTAP_CTRL = 'h870;   //! RW: [1] enable (def 1); W1S [0] clear stats. RO: {stage/active status}
+  localparam [ADDR_WIDTH-1:0] A_LTAP_BASE = 'h874;   //! first RO readback word (16 words, packed)
+  localparam [ADDR_WIDTH-1:0] A_LTAP_END  = 'h8B4;   //! one past the last RO word (0x8B0)
   // ---- 0x800 indexed per-stream window (P11, NXN_ARCHITECTURE.md §1.5).
   //  SEL picks {dir, idx}; the 0x810-0x85C word block then views ONE stream.
   //  Legacy flat registers stay the authority for index 0 (N=1 bit-compat
@@ -611,6 +623,8 @@ module milan_csr #(
   logic [31:0] as2_lo, as2_hi;           //! parent bridge clockIdentity                //! MAAP_CTRL: [0]=en, [1]=seed_valid, [15:8]=count, [31:16]=seed_offset
   logic [31:0] tone_ctrl;                //! TONE_CTRL: [0]=en (pilot tone)
   logic [31:0] mcsrv_ctrl;               //! MCSRV_CTRL 0x8FC: [0]=ps_invert, [1]=auto_repair enable
+  logic        ltap_en_r;                //! LTAP_CTRL[1]: latency-tap measurement enable (reset 1)
+  logic        ltap_clr_p;               //! LTAP_CTRL[0] W1S: 1-cycle stats-clear strobe
   logic [31:0] gptp_pdelay;              //! GPTP_PDELAY: neighbor pdelay (ns)
   logic [31:0] lwsrp_vid;                //! LWSRP_VID: [11:0] SR VID
   logic [31:0] lwsrp_dmlo, lwsrp_dmhi;   //! lwSRP stream DMAC {dmhi[15:0], dmlo}
@@ -795,6 +809,8 @@ module milan_csr #(
       as2_lo <= 32'h0; as2_hi <= 32'h0;
       tone_ctrl  <= 32'h0;
       mcsrv_ctrl <= 32'h0;
+      ltap_en_r  <= 1'b1;   //! latency taps measure by default
+      ltap_clr_p <= 1'b0;
       gptp_pdelay <= 32'h0;
       lwsrp_vid  <= 32'h0000_0002;
       lwsrp_dmlo <= 32'hF000_FE01;
@@ -824,6 +840,7 @@ module milan_csr #(
       ptp_load_p <= 1'b0; ptp_adj_p <= 1'b0; ptp_snap_p <= 1'b0;
       adp_adv_p <= 1'b0; adp_dep_p <= 1'b0;
       tcam_wr_p <= 1'b0;
+      ltap_clr_p <= 1'b0;
       //! P12: engine CFG-word write requests hold until the engine's
       //! same-cycle accept (the engines arbitrate their single RAM write
       //! port; a one-cycle pulse could be lost to an engine-write slot)
@@ -897,6 +914,10 @@ module milan_csr #(
           A_AS2_HI:     as2_hi   <= s_axi_wdata;
           A_TONE_CTRL:  tone_ctrl  <= s_axi_wdata;
           A_MCSRV_CTRL: mcsrv_ctrl <= s_axi_wdata;
+          A_LTAP_CTRL: begin              //! [1] enable RW; [0] W1S stats clear
+            ltap_en_r <= s_axi_wdata[1];
+            if (s_axi_wdata[0]) ltap_clr_p <= 1'b1;
+          end
           //! I2SPB rail counters W1C (gaps 5b): each half clears on a write
           //! with any bit of that half set - the saturated-and-stuck-forever
           //! rail becomes re-armable without touching the other rail
@@ -1220,9 +1241,11 @@ module milan_csr #(
 
   always_comb begin : read_mux
     logic [ADDR_WIDTH-1:0] soff;         //! STAT window offset
+    logic [ADDR_WIDTH-1:0] loff;         //! LTAP RO-word offset
     live_mux = 32'h0;
     live_hit = 1'b1;
     soff = rd_addr_q - A_STATS_BASE;
+    loff = rd_addr_q - A_LTAP_BASE;
     unique case (rd_addr_q)
       A_IRQ_STATUS: live_mux = irq_status;
       A_IRQ_RAW:    live_mux = irq_status;
@@ -1269,6 +1292,8 @@ module milan_csr #(
       A_LINKG_STAT: live_mux = i_linkg_stat;
       A_MCSRV_STAT: live_mux = i_mcsrv_stat;
       A_MCSRV_CTRL: live_mux = mcsrv_ctrl;
+      //! LTAP_CTRL: module status ({stage,active}) with enable OR-ed into [1]
+      A_LTAP_CTRL:  live_mux = i_ltap_status | {30'd0, ltap_en_r, 1'b0};
       A_I2SPB_DBG:  live_mux = i_i2spb_dbg;
       //! E1 commit readback: {busy, done, 20'0, status, 4'0, idx}
       A_REST_CMD:   live_mux = {rest_pend_r, rest_done_r, 20'd0,
@@ -1276,6 +1301,8 @@ module milan_csr #(
       default: begin
         if (rd_addr_q >= A_STATS_BASE && rd_addr_q < A_STATS_END)
           live_mux = stat_snap[soff[2 +: 4]];
+        else if (rd_addr_q >= A_LTAP_BASE && rd_addr_q < A_LTAP_END)
+          live_mux = i_ltap_regs[32*32'(loff[5:2]) +: 32];  //! 16 packed RO words
         else
           live_hit = 1'b0;                //! -> shadow (or 0 above the window)
       end
@@ -1362,7 +1389,10 @@ module milan_csr #(
   //! EVERY build while the servo ran fine - caught by the [SERVO] dp-TB leg)
   wire rd_in_window = ~|rd_addr_q[ADDR_WIDTH-1:11] ||
                       (rd_addr_q == A_MCSRV_STAT) ||
-                      (rd_addr_q == A_MCSRV_CTRL);
+                      (rd_addr_q == A_MCSRV_CTRL) ||
+                      //! item-11 LTAP group (CTRL 0x870 + 16 RO words) lives
+                      //! >=0x800, so it needs the same carve-out as the servo
+                      ((rd_addr_q >= A_LTAP_CTRL) && (rd_addr_q < A_LTAP_END));
   always_ff @(posedge aclk) begin : read_data_reg
     if (!aresetn) r_data <= 32'h0;
     else if (rd_pend)
@@ -1424,6 +1454,8 @@ module milan_csr #(
   assign o_tone_enable      = tone_ctrl[0];
   assign o_mcsrv_ps_invert  = mcsrv_ctrl[0];
   assign o_mcsrv_auto_repair = mcsrv_ctrl[1];
+  assign o_ltap_en          = ltap_en_r;
+  assign o_ltap_clr         = ltap_clr_p;
   assign o_i2spb_clr_under  = i2spb_clru_p;
   assign o_i2spb_clr_over   = i2spb_clro_p;
   assign o_tone_att         = tone_ctrl[3:1];

--- a/hdl/ieee1722/aaf/KL_aaf_latency_taps.sv
+++ b/hdl/ieee1722/aaf/KL_aaf_latency_taps.sv
@@ -1,0 +1,266 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ *
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+//---------------------------------------------------------------------------//
+/*
+------------------------------------------------------------------------------
+  File        : KL_aaf_latency_taps.sv
+  Description : Per-stage AAF pipeline latency taps (roadmap item 11).
+
+                Two independent measurement chains - the AAF talker (TX) and
+                the AAF listener (RX) - each latch a free-running cycle count
+                at a set of documented pipeline points and expose the
+                inter-stage deltas (last / min / max, saturating) plus the
+                gPTP epoch of the measured reference frame over CSR.
+
+                  TX  : CAP (ring/I2S pair in) -> PKT_SOF (packetizer first
+                        beat) -> PKT_EOF (packetizer last beat) -> MAC_TX
+                        (frame egresses the MAC boundary)
+                  RX  : MAC_RX (frame ingress) -> ACCEPT (AVTP monitor
+                        parse-complete/accept pulse) -> DEPKT (payload last
+                        beat) -> PCM_RING (payload accepted at the ring
+                        writer)
+
+                MEASUREMENT MODEL - single in-flight tagged reference frame.
+                Each chain follows ONE frame at a time: it ARMS on a stage-0
+                valid-edge (latching the epoch cycle + gPTP time), then takes
+                the NEXT valid-edge at each subsequent stage as that frame's
+                progress, recording delta[k] = t(stage k) - t(stage k-1).
+                When the final stage fires the sample completes (min/last/max
+                updated, epoch published, samples++) and the chain re-arms;
+                frames that enter while a measurement is in flight are ignored
+                until it finishes. A per-stage timeout (TIMEOUT_C cycles)
+                aborts and re-arms a stuck token (timeouts++), so a dropped
+                frame can never wedge the chain.
+
+                COHERENCE - the token is followed by ORDER, not by a threaded
+                frame id (no invasive per-module tag). Under steady single-
+                stream AAF flow the next-edge at each stage is that frame's;
+                under mixed traffic a shared boundary (MAC_TX / MAC_RX) may
+                catch a nearer non-AAF frame edge, so min/last/max characterise
+                the latency ENVELOPE rather than one exact frame. The stage-0
+                CAP edge is any captured pair, so the CAP->PKT delta spans up
+                to one 6-sample accumulation window. Deltas are in axis_clk
+                cycles (divide by the datapath clock for seconds). The I2S-out
+                playout stage is FIFO-fill dominated (the CDC pair FIFO
+                decouples PDUs from DAC frames) and stays observed via the
+                existing I2SPB_STAT fill/converged rails; a DDR3 per-sample
+                history ring is the documented follow-up.
+
+  House style : mirrors hdl/common/KL_link_guard.sv.
+  Company     : Kebag Logic
+  Project     : Milan AVB endstation
+------------------------------------------------------------------------------
+*/
+//---------------------------------------------------------------------------//
+
+`default_nettype none
+
+// ==========================================================================
+//  Single-chain latency measurement engine (instantiated once per direction)
+// ==========================================================================
+module KL_aaf_latency_chain #(
+  parameter int unsigned N_STAGES_P = 4,      //! tap points on this chain (>=2)
+  parameter int unsigned CW_P       = 32,     //! free-running cycle-count width
+  parameter int unsigned DW_P       = 16,     //! saturating per-stage delta width
+  parameter int unsigned TIMEOUT_C  = 20000   //! per-stage re-arm guard (cycles)
+) (
+  input  wire                        clk_i,
+  input  wire                        rst_n,       //! active-low sync reset
+  input  wire                        en_i,        //! measure enable (LTAP_CTRL[1])
+  input  wire                        clr_i,       //! 1-cycle stats clear (LTAP_CTRL[0])
+  input  wire [CW_P-1:0]             cyc_i,        //! shared free-running cycle count
+  input  wire [31:0]                 now_i,        //! gPTP ns epoch source (ptp_now[31:0])
+  input  wire [N_STAGES_P-1:0]       stage_p_i,    //! per-stage valid-edge pulses
+
+  output wire [31:0]                 epoch_o,      //! gPTP ns at last completed frame's stage 0
+  output wire [15:0]                 samples_o,    //! completed reference frames (saturating)
+  output wire [15:0]                 timeouts_o,   //! aborted (timed-out) tokens (saturating)
+  output wire [(N_STAGES_P-1)*DW_P-1:0] last_o,    //! last inter-stage delta per stage
+  output wire [(N_STAGES_P-1)*DW_P-1:0] min_o,     //! min  inter-stage delta per stage
+  output wire [(N_STAGES_P-1)*DW_P-1:0] max_o,     //! max  inter-stage delta per stage
+  output wire                        active_o,     //! a measurement is in flight
+  output wire [2:0]                  stage_o       //! stage index currently awaited
+);
+
+  localparam int unsigned NDLT_C  = N_STAGES_P - 1;                       //! # deltas
+  localparam int unsigned SIDXW_C = (N_STAGES_P <= 2) ? 1 : $clog2(N_STAGES_P);
+  localparam int unsigned TOW_C   = $clog2(TIMEOUT_C + 1);
+
+  logic                active_r;
+  logic [SIDXW_C-1:0]  stg_r;          //! stage awaited (1..N-1)
+  logic [CW_P-1:0]     prevc_r;        //! cycle stamp of the previous stage
+  logic [31:0]         epoch_pend_r;   //! epoch latched at arm
+  logic [31:0]         epoch_r;        //! published epoch
+  logic [TOW_C-1:0]    to_r;           //! per-stage timeout down-counter
+  logic [15:0]         samples_r, timeouts_r;
+  logic [DW_P-1:0]     last_r [NDLT_C];
+  logic [DW_P-1:0]     min_r  [NDLT_C];
+  logic [DW_P-1:0]     max_r  [NDLT_C];
+
+  //! current inter-stage delta (saturating into DW_P bits)
+  wire [CW_P-1:0] diff_w = cyc_i - prevc_r;
+  wire [DW_P-1:0] dsat_w = (|diff_w[CW_P-1:DW_P]) ? {DW_P{1'b1}}
+                                                  : diff_w[DW_P-1:0];
+  //! delta-array index for the awaited stage (stg_r-1 -> 0..NDLT_C-1)
+  wire [SIDXW_C-1:0] didx_w = stg_r - 1'b1;
+
+  function automatic [15:0] inc16(input [15:0] v);
+    inc16 = (&v) ? v : v + 16'd1;
+  endfunction
+
+  always_ff @(posedge clk_i) begin : chain_fsm
+    if (!rst_n) begin
+      active_r     <= 1'b0;
+      stg_r        <= SIDXW_C'(1);
+      prevc_r      <= '0;
+      epoch_pend_r <= '0;
+      epoch_r      <= '0;
+      to_r         <= '0;
+      samples_r    <= '0;
+      timeouts_r   <= '0;
+      for (int i = 0; i < NDLT_C; i++) begin
+        last_r[i] <= '0;
+        min_r[i]  <= '1;
+        max_r[i]  <= '0;
+      end
+    end
+    else if (clr_i) begin
+      //! stats clear wins over measurement; the in-flight token is dropped
+      active_r   <= 1'b0;
+      stg_r      <= SIDXW_C'(1);
+      epoch_r    <= '0;
+      samples_r  <= '0;
+      timeouts_r <= '0;
+      for (int i = 0; i < NDLT_C; i++) begin
+        last_r[i] <= '0;
+        min_r[i]  <= '1;
+        max_r[i]  <= '0;
+      end
+    end
+    else if (!en_i) begin
+      active_r <= 1'b0;                       //! disabled: idle, stats frozen
+    end
+    else begin
+      if (!active_r) begin
+        //! ARM on a stage-0 edge: latch the epoch cycle + gPTP time
+        if (stage_p_i[0]) begin
+          active_r     <= 1'b1;
+          stg_r        <= SIDXW_C'(1);
+          prevc_r      <= cyc_i;
+          epoch_pend_r <= now_i;
+          to_r         <= TOW_C'(TIMEOUT_C);
+        end
+      end
+      else if (to_r == '0) begin
+        //! token timed out mid-chain: abort and re-arm
+        active_r   <= 1'b0;
+        timeouts_r <= inc16(timeouts_r);
+      end
+      else begin
+        to_r <= to_r - 1'b1;
+        if (stage_p_i[stg_r]) begin
+          last_r[didx_w] <= dsat_w;
+          if (dsat_w < min_r[didx_w]) min_r[didx_w] <= dsat_w;
+          if (dsat_w > max_r[didx_w]) max_r[didx_w] <= dsat_w;
+          prevc_r <= cyc_i;
+          to_r    <= TOW_C'(TIMEOUT_C);       //! re-arm per-stage guard
+          if (32'(stg_r) == NDLT_C) begin
+            active_r  <= 1'b0;                 //! final stage: sample complete
+            samples_r <= inc16(samples_r);
+            epoch_r   <= epoch_pend_r;
+          end
+          else begin
+            stg_r <= stg_r + 1'b1;
+          end
+        end
+      end
+    end
+  end : chain_fsm
+
+  genvar g;
+  generate
+    for (g = 0; g < NDLT_C; g++) begin : g_flat
+      assign last_o[g*DW_P +: DW_P] = last_r[g];
+      assign min_o [g*DW_P +: DW_P] = min_r[g];
+      assign max_o [g*DW_P +: DW_P] = max_r[g];
+    end
+  endgenerate
+
+  assign epoch_o    = epoch_r;
+  assign samples_o  = samples_r;
+  assign timeouts_o = timeouts_r;
+  assign active_o   = active_r;
+  assign stage_o    = active_r ? 3'(stg_r) : 3'd0;
+
+endmodule
+
+// ==========================================================================
+//  Two-chain top: shared cycle counter + TX/RX chains + status packing
+// ==========================================================================
+module KL_aaf_latency_taps #(
+  parameter int unsigned N_STAGES_P = 4,      //! tap points per chain
+  parameter int unsigned CW_P       = 32,     //! free-running cycle-count width
+  parameter int unsigned DW_P       = 16,     //! saturating per-stage delta width
+  parameter int unsigned TIMEOUT_C  = 20000   //! per-stage re-arm guard (cycles)
+) (
+  input  wire                        clk_i,       //! datapath (axis) clock
+  input  wire                        rst_n,       //! active-low sync reset
+  input  wire                        en_i,        //! LTAP_CTRL[1] measure enable
+  input  wire                        clr_i,       //! LTAP_CTRL[0] W1S stats clear
+  input  wire [31:0]                 now_i,       //! gPTP ns (ptp_now[31:0]) epoch source
+
+  input  wire [N_STAGES_P-1:0]       tx_stage_p_i, //! TX chain stage edges
+  input  wire [N_STAGES_P-1:0]       rx_stage_p_i, //! RX chain stage edges
+
+  output wire [31:0]                 tx_epoch_o,
+  output wire [31:0]                 rx_epoch_o,
+  output wire [15:0]                 tx_samples_o,
+  output wire [15:0]                 rx_samples_o,
+  output wire [15:0]                 tx_timeouts_o,
+  output wire [15:0]                 rx_timeouts_o,
+  output wire [(N_STAGES_P-1)*DW_P-1:0] tx_last_o, tx_min_o, tx_max_o,
+  output wire [(N_STAGES_P-1)*DW_P-1:0] rx_last_o, rx_min_o, rx_max_o,
+  output wire [31:0]                 status_o     //! {rx_stage,rx_active,tx_stage,tx_active} for LTAP_CTRL RO
+);
+
+  //! shared free-running cycle counter (the delta time base for both chains)
+  logic [CW_P-1:0] cyc_r;
+  always_ff @(posedge clk_i) begin : cyc_ctr
+    if (!rst_n) cyc_r <= '0;
+    else        cyc_r <= cyc_r + 1'b1;
+  end : cyc_ctr
+
+  wire        tx_active_w, rx_active_w;
+  wire [2:0]  tx_stage_w,  rx_stage_w;
+
+  KL_aaf_latency_chain #(
+    .N_STAGES_P(N_STAGES_P), .CW_P(CW_P), .DW_P(DW_P), .TIMEOUT_C(TIMEOUT_C)
+  ) tx_chain (
+    .clk_i (clk_i), .rst_n (rst_n), .en_i (en_i), .clr_i (clr_i),
+    .cyc_i (cyc_r), .now_i (now_i), .stage_p_i (tx_stage_p_i),
+    .epoch_o (tx_epoch_o), .samples_o (tx_samples_o), .timeouts_o (tx_timeouts_o),
+    .last_o (tx_last_o), .min_o (tx_min_o), .max_o (tx_max_o),
+    .active_o (tx_active_w), .stage_o (tx_stage_w)
+  );
+
+  KL_aaf_latency_chain #(
+    .N_STAGES_P(N_STAGES_P), .CW_P(CW_P), .DW_P(DW_P), .TIMEOUT_C(TIMEOUT_C)
+  ) rx_chain (
+    .clk_i (clk_i), .rst_n (rst_n), .en_i (en_i), .clr_i (clr_i),
+    .cyc_i (cyc_r), .now_i (now_i), .stage_p_i (rx_stage_p_i),
+    .epoch_o (rx_epoch_o), .samples_o (rx_samples_o), .timeouts_o (rx_timeouts_o),
+    .last_o (rx_last_o), .min_o (rx_min_o), .max_o (rx_max_o),
+    .active_o (rx_active_w), .stage_o (rx_stage_w)
+  );
+
+  //! LTAP_CTRL readback status: enable bit is OR-ed in by milan_csr at bit[1]
+  assign status_o = {16'd0, rx_stage_w, rx_active_w,
+                     tx_stage_w, tx_active_w, 8'd0};
+
+endmodule
+
+`default_nettype wire

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -673,6 +673,12 @@ parameter int PB_PREFILL_C = 0     //! playback prefill release (0 = midpoint;
   wire        acmp_rest_ack_w;
   wire [1:0]  acmp_rest_status_w;
 
+  //! item-11 AAF per-stage latency taps (LTAP CSR group, base 0x870):
+  //! 16 packed RO words + status feed milan_csr; en/clr come back from it.
+  wire [16*32-1:0] ltap_regs_w;
+  wire [31:0]      ltap_status_w;
+  wire             ltap_en_w, ltap_clr_w;
+
   milan_csr #(
     .NUM_QUEUES(NUM_QUEUES),
     .ADDR_WIDTH(16),
@@ -843,6 +849,11 @@ parameter int PB_PREFILL_C = 0     //! playback prefill release (0 = midpoint;
     .i_mcsrv_stat       (mcsrv_stat_w),
     .o_mcsrv_ps_invert  (mcsrv_ps_invert_w),
     .o_mcsrv_auto_repair (mcsrv_auto_repair_w),
+    // item-11 AAF per-stage latency taps (LTAP group 0x870)
+    .i_ltap_regs        (ltap_regs_w),
+    .i_ltap_status      (ltap_status_w),
+    .o_ltap_en          (ltap_en_w),
+    .o_ltap_clr         (ltap_clr_w),
     .o_crft_en          (cfg_crft_en),
     .o_crft_sid         (cfg_crft_sid),
     .o_crft_dest_mac    (cfg_crft_dmac),
@@ -2041,6 +2052,85 @@ parameter int PB_PREFILL_C = 0     //! playback prefill release (0 = midpoint;
     .counts_o(stats_counts),
     .rollover_o(stats_rollover)
   );
+
+  // ==========================================================================
+  //  AAF per-stage latency taps (roadmap item 11) — latch a free-running
+  //  cycle count at each documented AAF pipeline point, expose per-stage
+  //  last/min/max deltas + the gPTP epoch over the LTAP CSR group (0x870).
+  //  TX chain: CAP (pair in) -> PKT_SOF -> PKT_EOF -> MAC_TX.
+  //  RX chain: MAC_RX -> ACCEPT (AVTP parse) -> DEPKT -> PCM_RING.
+  //  (I2S-out playout is FIFO-fill dominated — observed via I2SPB_STAT; a
+  //   DDR3 per-sample history ring is the documented follow-up.)
+  // ==========================================================================
+  wire aaf_tx_acc_w = aaf_tx_tvalid       & aaf_tx_tready;
+  wire mac_tx_acc_w = m_axis_mac_tx_tvalid & m_axis_mac_tx_tready;
+  wire mac_rx_acc_w = s_axis_mac_rx_tvalid & s_axis_mac_rx_tready;
+  wire dpkt_acc_w   = dpkt_pcm_tvalid_w    & dpkt_pcm_tready_w;
+  wire ring_acc_w   = m_axis_pcm_tvalid    & m_axis_pcm_tready;
+
+  //! start-of-frame trackers for the two shared AXIS boundaries
+  logic aaf_tx_inframe_r, mac_rx_inframe_r;
+  always_ff @(posedge axis_clk) begin : ltap_inframe
+    if (!axis_resetn) begin
+      aaf_tx_inframe_r <= 1'b0;
+      mac_rx_inframe_r <= 1'b0;
+    end
+    else begin
+      if (aaf_tx_acc_w) aaf_tx_inframe_r <= ~aaf_tx_tlast;
+      if (mac_rx_acc_w) mac_rx_inframe_r <= ~s_axis_mac_rx_tlast;
+    end
+  end : ltap_inframe
+
+  //! single-cycle stage edges (stage 0 = the chain's arm/epoch trigger)
+  wire ltap_txcap_w  = aafcap_pv_w;                             //! ring/I2S pair in
+  wire ltap_txsof_w  = aaf_tx_acc_w & ~aaf_tx_inframe_r;        //! packetizer first beat
+  wire ltap_txeof_w  = aaf_tx_acc_w &  aaf_tx_tlast;            //! packetizer last beat
+  wire ltap_txmac_w  = mac_tx_acc_w &  m_axis_mac_tx_tlast;     //! frame egress at MAC
+  wire ltap_rxsof_w  = mac_rx_acc_w & ~mac_rx_inframe_r;        //! frame ingress from MAC
+  wire ltap_rxacc_w  = avtprx_accept_p;                        //! AVTP monitor accept/parse
+  wire ltap_rxdpk_w  = dpkt_acc_w & dpkt_pcm_tlast_w;          //! depacketizer payload last
+  wire ltap_rxring_w = ring_acc_w & m_axis_pcm_tlast;          //! payload into the PCM ring
+
+  wire [31:0]     ltap_tx_epoch_w, ltap_rx_epoch_w;
+  wire [15:0]     ltap_tx_smp_w, ltap_rx_smp_w, ltap_tx_to_w, ltap_rx_to_w;
+  wire [3*16-1:0] ltap_tx_last_w, ltap_tx_min_w, ltap_tx_max_w;
+  wire [3*16-1:0] ltap_rx_last_w, ltap_rx_min_w, ltap_rx_max_w;
+
+  KL_aaf_latency_taps #(
+    .N_STAGES_P (4), .CW_P (32), .DW_P (16),
+    .TIMEOUT_C  (MILAN_CLK_FREQ_HZ / 2000)   //! ~0.5 ms per-stage re-arm guard
+  ) aaf_latency_taps (
+    .clk_i (axis_clk), .rst_n (axis_resetn),
+    .en_i  (ltap_en_w), .clr_i (ltap_clr_w),
+    .now_i (ptp_now_w[31:0]),
+    .tx_stage_p_i ({ltap_txmac_w, ltap_txeof_w, ltap_txsof_w, ltap_txcap_w}),
+    .rx_stage_p_i ({ltap_rxring_w, ltap_rxdpk_w, ltap_rxacc_w, ltap_rxsof_w}),
+    .tx_epoch_o (ltap_tx_epoch_w), .rx_epoch_o (ltap_rx_epoch_w),
+    .tx_samples_o (ltap_tx_smp_w), .rx_samples_o (ltap_rx_smp_w),
+    .tx_timeouts_o (ltap_tx_to_w), .rx_timeouts_o (ltap_rx_to_w),
+    .tx_last_o (ltap_tx_last_w), .tx_min_o (ltap_tx_min_w), .tx_max_o (ltap_tx_max_w),
+    .rx_last_o (ltap_rx_last_w), .rx_min_o (ltap_rx_min_w), .rx_max_o (ltap_rx_max_w),
+    .status_o (ltap_status_w)
+  );
+
+  //! pack the 16 RO words in the exact LTAP CSR order (0x874..0x8B0). Per
+  //! delta d: word{2d} = {max16, last16}, word{2d+1} = {16'd0, min16}.
+  assign ltap_regs_w[32*0  +: 32] = ltap_tx_epoch_w;
+  assign ltap_regs_w[32*1  +: 32] = {ltap_tx_to_w, ltap_tx_smp_w};
+  assign ltap_regs_w[32*2  +: 32] = {ltap_tx_max_w[16*0 +: 16], ltap_tx_last_w[16*0 +: 16]};
+  assign ltap_regs_w[32*3  +: 32] = {16'd0,                     ltap_tx_min_w [16*0 +: 16]};
+  assign ltap_regs_w[32*4  +: 32] = {ltap_tx_max_w[16*1 +: 16], ltap_tx_last_w[16*1 +: 16]};
+  assign ltap_regs_w[32*5  +: 32] = {16'd0,                     ltap_tx_min_w [16*1 +: 16]};
+  assign ltap_regs_w[32*6  +: 32] = {ltap_tx_max_w[16*2 +: 16], ltap_tx_last_w[16*2 +: 16]};
+  assign ltap_regs_w[32*7  +: 32] = {16'd0,                     ltap_tx_min_w [16*2 +: 16]};
+  assign ltap_regs_w[32*8  +: 32] = ltap_rx_epoch_w;
+  assign ltap_regs_w[32*9  +: 32] = {ltap_rx_to_w, ltap_rx_smp_w};
+  assign ltap_regs_w[32*10 +: 32] = {ltap_rx_max_w[16*0 +: 16], ltap_rx_last_w[16*0 +: 16]};
+  assign ltap_regs_w[32*11 +: 32] = {16'd0,                     ltap_rx_min_w [16*0 +: 16]};
+  assign ltap_regs_w[32*12 +: 32] = {ltap_rx_max_w[16*1 +: 16], ltap_rx_last_w[16*1 +: 16]};
+  assign ltap_regs_w[32*13 +: 32] = {16'd0,                     ltap_rx_min_w [16*1 +: 16]};
+  assign ltap_regs_w[32*14 +: 32] = {ltap_rx_max_w[16*2 +: 16], ltap_rx_last_w[16*2 +: 16]};
+  assign ltap_regs_w[32*15 +: 32] = {16'd0,                     ltap_rx_min_w [16*2 +: 16]};
 
 endmodule
 

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -351,6 +351,7 @@ _MILAN_DATAPATH_SOURCES = [
     "hdl/ieee1722/aaf/aaf_talker_i2s.sv", "hdl/ieee1722/aaf/KL_aaf_rx_depacketizer.sv",
     "hdl/ieee1722/aaf/KL_pcm_ring_bram.sv",   # --pcm-ring bram: shed-proof on-chip PCM ring
     "hdl/ieee1722/aaf/KL_i2s_playback.sv", "hdl/ieee1722/aaf/KL_tone_gen.sv",
+    "hdl/ieee1722/aaf/KL_aaf_latency_taps.sv",   # item-11: per-stage AAF latency taps (LTAP CSR group 0x870)
     "hdl/ieee1722/aaf/KL_media_adv.sv", "hdl/common/cdc_pair_fifo.sv",
     "hdl/ieee1722/avtp/avtp_subtype_pkg.sv", "hdl/ieee1722/avtp/avtp_stream_parser.sv",
     "hdl/ieee1722/avtp/KL_stream_table.sv",

--- a/tb/verilator/aaf_latency_taps/Makefile
+++ b/tb/verilator/aaf_latency_taps/Makefile
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# KL_aaf_latency_taps (per-stage AAF pipeline latency taps, item-11) harness.
+#   make        - build and run the self-checking harness
+#   make clean  - remove build artifacts
+
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+TOP        = KL_aaf_latency_taps
+
+# TIMEOUT_C shrunk to 64 cycles so the token-abort leg runs in microseconds.
+VFLAGS = --cc --exe --build -j 0 \
+         --top-module $(TOP) \
+         -Wall -Wno-fatal -Werror-UNDRIVEN -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL \
+         -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-EOFNEWLINE \
+         -CFLAGS "-std=c++17 -O2" \
+         -GTIMEOUT_C=64
+
+SRCS = $(RTL_DIR)/ieee1722/aaf/KL_aaf_latency_taps.sv
+CPP  = sim_main.cpp
+
+.PHONY: all run clean
+all: run
+
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) $(CPP) -o Vaaf_latency_taps_sim
+	./obj_dir/Vaaf_latency_taps_sim
+
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/aaf_latency_taps/sim_main.cpp
+++ b/tb/verilator/aaf_latency_taps/sim_main.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// KL_aaf_latency_taps self-checking harness (roadmap item-11). Built with a
+// shrunken per-stage timeout (-GTIMEOUT_C=64) so the token-abort leg runs in
+// microseconds of sim time.
+//
+// The module measures inter-stage deltas in free-running cycles: driving a
+// stage-k pulse D cycles after stage-(k-1) makes the recorded delta EXACTLY D
+// (cyc_r increments once per posedge, both pulses sample cyc on their edge).
+// The module's last/min/max/samples/timeouts/epoch/status outputs are the
+// values milan_datapath packs 1:1 into the LTAP CSR words (0x870..0x8B0).
+//
+// Covers: known-delta capture (TX + RX), min/max accumulation over samples,
+// gPTP epoch latch at arm, TX/RX chain independence, in-flight status
+// (active + awaited stage), stage-0-while-active ignored (single in-flight),
+// per-stage timeout abort + re-arm, enable gating, and W1S stats clear.
+
+#include "VKL_aaf_latency_taps.h"
+#include "verilated.h"
+#include <cstdio>
+
+static VKL_aaf_latency_taps *dut;
+static int pass = 0, fail = 0;
+
+static void tick() {
+  dut->clk_i = 0; dut->eval();
+  dut->clk_i = 1; dut->eval();
+}
+
+static void ck(const char *name, uint64_t got, uint64_t want) {
+  if (got == want) { pass++; printf("[PASS] %s\n", name); }
+  else { fail++; printf("[FAIL] %s: got 0x%llx want 0x%llx\n", name,
+                        (unsigned long long)got, (unsigned long long)want); }
+}
+
+// one idle cycle with no stage edges
+static void idle(int n) {
+  dut->tx_stage_p_i = 0; dut->rx_stage_p_i = 0;
+  for (int i = 0; i < n; i++) tick();
+}
+// pulse one TX / RX stage bit for exactly one cycle
+static void tx_pulse(int s) { dut->tx_stage_p_i = 1u << s; tick(); dut->tx_stage_p_i = 0; }
+static void rx_pulse(int s) { dut->rx_stage_p_i = 1u << s; tick(); dut->rx_stage_p_i = 0; }
+
+// a full 4-stage TX frame with the three inter-stage deltas d0,d1,d2
+static void frame_tx(int d0, int d1, int d2, uint32_t nowv) {
+  dut->now_i = nowv;
+  tx_pulse(0);
+  idle(d0 - 1); tx_pulse(1);
+  idle(d1 - 1); tx_pulse(2);
+  idle(d2 - 1); tx_pulse(3);
+}
+static void frame_rx(int d0, int d1, int d2, uint32_t nowv) {
+  dut->now_i = nowv;
+  rx_pulse(0);
+  idle(d0 - 1); rx_pulse(1);
+  idle(d1 - 1); rx_pulse(2);
+  idle(d2 - 1); rx_pulse(3);
+}
+
+// 16-bit slice out of a packed delta bus
+static uint64_t seg(uint64_t bus, int idx) { return (bus >> (16 * idx)) & 0xFFFF; }
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new VKL_aaf_latency_taps;
+
+  dut->rst_n = 0; dut->en_i = 1; dut->clr_i = 0;
+  dut->now_i = 0; dut->tx_stage_p_i = 0; dut->rx_stage_p_i = 0;
+  for (int i = 0; i < 4; i++) tick();
+  dut->rst_n = 1; idle(4);
+
+  // -- fresh state: no samples, min rails read all-ones --------------------
+  ck("init tx_samples",  dut->tx_samples_o, 0);
+  ck("init tx_timeouts", dut->tx_timeouts_o, 0);
+  ck("init tx_min d0",   seg(dut->tx_min_o, 0), 0xFFFF);
+  ck("init tx_active",   (dut->status_o >> 8) & 1, 0);
+
+  // -- TX frame A: known deltas (5,7,9), epoch 0x1111 ----------------------
+  frame_tx(5, 7, 9, 0x1111);
+  ck("A tx_last d0", seg(dut->tx_last_o, 0), 5);
+  ck("A tx_last d1", seg(dut->tx_last_o, 1), 7);
+  ck("A tx_last d2", seg(dut->tx_last_o, 2), 9);
+  ck("A tx_min d0",  seg(dut->tx_min_o, 0), 5);
+  ck("A tx_max d2",  seg(dut->tx_max_o, 2), 9);
+  ck("A tx_samples", dut->tx_samples_o, 1);
+  ck("A tx_epoch",   dut->tx_epoch_o, 0x1111);
+  ck("A tx idle",    (dut->status_o >> 8) & 1, 0);
+
+  // -- TX frame B: (3,11,4) -> last=B, min=elementwise-min, max=max --------
+  idle(3);
+  frame_tx(3, 11, 4, 0x2222);
+  ck("B tx_last d0", seg(dut->tx_last_o, 0), 3);
+  ck("B tx_last d1", seg(dut->tx_last_o, 1), 11);
+  ck("B tx_last d2", seg(dut->tx_last_o, 2), 4);
+  ck("B tx_min d0",  seg(dut->tx_min_o, 0), 3);   // min(5,3)
+  ck("B tx_min d1",  seg(dut->tx_min_o, 1), 7);   // min(7,11)
+  ck("B tx_min d2",  seg(dut->tx_min_o, 2), 4);   // min(9,4)
+  ck("B tx_max d0",  seg(dut->tx_max_o, 0), 5);   // max(5,3)
+  ck("B tx_max d1",  seg(dut->tx_max_o, 1), 11);  // max(7,11)
+  ck("B tx_max d2",  seg(dut->tx_max_o, 2), 9);   // max(9,4)
+  ck("B tx_samples", dut->tx_samples_o, 2);
+  ck("B tx_epoch",   dut->tx_epoch_o, 0x2222);
+
+  // -- RX chain is fully independent of TX ---------------------------------
+  idle(3);
+  frame_rx(2, 4, 6, 0x3333);
+  ck("RX rx_last d0", seg(dut->rx_last_o, 0), 2);
+  ck("RX rx_last d1", seg(dut->rx_last_o, 1), 4);
+  ck("RX rx_last d2", seg(dut->rx_last_o, 2), 6);
+  ck("RX rx_samples", dut->rx_samples_o, 1);
+  ck("RX rx_epoch",   dut->rx_epoch_o, 0x3333);
+  ck("RX tx untouched", dut->tx_samples_o, 2);   // TX counters unchanged
+
+  // -- in-flight status: active + awaited stage index ----------------------
+  idle(3);
+  dut->now_i = 0x4444;
+  tx_pulse(0);
+  ck("flight active",  (dut->status_o >> 8) & 1, 1);
+  ck("flight stage=1", (dut->status_o >> 9) & 7, 1);
+  idle(3); tx_pulse(1);
+  ck("flight stage=2", (dut->status_o >> 9) & 7, 2);
+  idle(3); tx_pulse(2);
+  ck("flight stage=3", (dut->status_o >> 9) & 7, 3);
+  idle(3); tx_pulse(3);
+  ck("flight complete active", (dut->status_o >> 8) & 1, 0);
+  ck("flight samples", dut->tx_samples_o, 3);
+  ck("flight last d0", seg(dut->tx_last_o, 0), 4);   // 1 + idle(3)
+
+  // -- single in-flight: a stage-0 edge mid-measurement is ignored ---------
+  idle(3);
+  dut->now_i = 0x5555;
+  tx_pulse(0);                       // arm (epoch latches 0x5555 here)
+  dut->now_i = 0xDEAD;               // if a re-arm wrongly took, epoch->0xDEAD
+  idle(1); tx_pulse(0);              // spurious re-arm edge: must be ignored
+  idle(1); tx_pulse(1);              // d0 = (2+1)+... measured from FIRST arm
+  idle(5); tx_pulse(2);
+  idle(5); tx_pulse(3);
+  ck("ignore-rearm samples", dut->tx_samples_o, 4);
+  ck("ignore-rearm epoch",   dut->tx_epoch_o, 0x5555);   // first arm's now, not re-arm
+  ck("ignore-rearm last d0", seg(dut->tx_last_o, 0), 4); // 1+1+1+1 cycles to stage1
+
+  // -- per-stage timeout: token aborts, re-arms, no false sample -----------
+  idle(3);
+  uint32_t smp_before = dut->tx_samples_o;
+  tx_pulse(0);
+  idle(80);                          // > TIMEOUT_C(64): guard fires
+  ck("timeout counted",  dut->tx_timeouts_o, 1);
+  ck("timeout not sampled", dut->tx_samples_o, smp_before);
+  ck("timeout re-armed inactive", (dut->status_o >> 8) & 1, 0);
+  // a clean frame after the abort still measures
+  frame_tx(6, 6, 6, 0x6666);
+  ck("post-timeout samples", dut->tx_samples_o, smp_before + 1);
+  ck("post-timeout last d1", seg(dut->tx_last_o, 1), 6);
+
+  // -- enable gating: en=0 freezes measurement (stats preserved) -----------
+  idle(3);
+  uint32_t smp_en = dut->tx_samples_o;
+  dut->en_i = 0;
+  frame_tx(4, 4, 4, 0x7777);         // fully ignored while disabled
+  ck("disabled no sample", dut->tx_samples_o, smp_en);
+  ck("disabled inactive",  (dut->status_o >> 8) & 1, 0);
+  dut->en_i = 1;
+  frame_tx(8, 8, 8, 0x8888);
+  ck("re-enabled samples", dut->tx_samples_o, smp_en + 1);
+  ck("re-enabled last d0", seg(dut->tx_last_o, 0), 8);
+
+  // -- W1C stats clear: everything zeroed, min rails back to all-ones ------
+  dut->clr_i = 1; idle(1); dut->clr_i = 0; idle(1);
+  ck("clr tx_samples",  dut->tx_samples_o, 0);
+  ck("clr tx_timeouts", dut->tx_timeouts_o, 0);
+  ck("clr rx_samples",  dut->rx_samples_o, 0);
+  ck("clr tx_last d1",  seg(dut->tx_last_o, 1), 0);
+  ck("clr tx_max d1",   seg(dut->tx_max_o, 1), 0);
+  ck("clr tx_min d1",   seg(dut->tx_min_o, 1), 0xFFFF);
+  ck("clr tx_epoch",    dut->tx_epoch_o, 0);
+  // measurement resumes cleanly after a clear
+  frame_tx(10, 12, 14, 0x9999);
+  ck("post-clr last d0", seg(dut->tx_last_o, 0), 10);
+  ck("post-clr min d2",  seg(dut->tx_min_o, 2), 14);
+  ck("post-clr samples", dut->tx_samples_o, 1);
+
+  printf("\n%d checks: %d PASS, %d FAIL\n", pass + fail, pass, fail);
+  delete dut;
+  return fail ? 1 : 0;
+}

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -70,6 +70,7 @@ SRCS = $(C)/ethernet_packet_pkg.sv $(C)/axi_stream_if.sv $(RTL_DIR)/ieee17221/ad
        $(RTL_DIR)/ieee1722/maap/KL_maap.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_i2s_playback.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_tone_gen.sv \
+       $(RTL_DIR)/ieee1722/aaf/KL_aaf_latency_taps.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_media_adv.sv \
        $(RTL_DIR)/common/cdc_pair_fifo.sv \
        $(RTL_DIR)/common/eth_event_counter/ethernet_events.sv \


### PR DESCRIPTION
## Status
🟢 **Green** — new TB 58/58 · datapath regression 172/0 + N=4 63/0 (servo carve-out intact) · SoC elaborates · `item-11-aaf-latency-taps` → `main`

## Description
Roadmap **item 11** — per-stage TX/RX AAF latency taps, so the AAF latency budget is measurable on silicon.
- **New gateware** `hdl/ieee1722/aaf/KL_aaf_latency_taps.sv` (house style): two single-in-flight chains on one free-running cycle counter — arm on the stage-0 edge (latch cycle + `ptp_now` epoch), follow each later stage, record saturating 16-bit inter-stage deltas (last/min/max); per-stage timeout aborts + re-arms a stuck token.
- **Tap points** in `milan_datapath.sv` (single-cycle axis_clk edges, no sub-module edits): TX `CAP → PKT_SOF → PKT_EOF → MAC_TX`; RX `MAC_RX → ACCEPT → DEPKT → PCM_RING`.
- **CSR group** `LTAP` base `0x870` in `milan_csr.sv` + `REGISTER_MAP.md` — `LTAP_CTRL` (RW enable + W1S clear) + 16 packed RO words. Added to the `>=0x800 rd_in_window` carve-out (the documented trap, else reads 0).
- Follow-up (documented): the I2S-out playout stage is FIFO-fill dominated → observed via `I2SPB_STAT`; a DDR3 per-sample history ring is next.

## How to get into the same state
```bash
git clone git@github.com:kebag-logic/milan-fpga.git && cd milan-fpga
git checkout item-11-aaf-latency-taps
git submodule update --init third_party/verilog-axis   # needed for the milan_dp TB
```

## How to validate
```bash
make -C tb/verilator/aaf_latency_taps     # -> 58 checks, 0 fail
make -C tb/verilator/milan_dp             # regression -> 172/0 + N=4 63/0 (servo 0x8F8 read still green)
cd sw/litex && PYTHONPATH=$(for d in /home/alex/litex-milan/*/;do echo -n "$d:";done)/home/alex/litex-milan \
  python3 milan_soc.py --full --milan-clk-freq 50e6 --output-dir /tmp/elab_item11
```

## Definition of Done
- [x] New TB green (58/58): known-delta capture, min/max, gPTP epoch, chain independence, single-in-flight, timeout, W1S clear
- [x] CSR group `0x870` documented + in the `rd_in_window` carve-out (reads non-zero)
- [x] No datapath regression (172/0 + 63/0); servo carve-out intact
- [x] SoC elaborates clean
- [ ] DDR3 per-sample history ring (documented follow-up)
