### PR TITLE
item-10: GET/SET_CONFIGURATION paired fixture

### DIFF
--- a/tests/features/item10_configuration.feature
+++ b/tests/features/item10_configuration.feature
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:CONFIGURATION @matrix:CMD-6
+Feature: Item-10 GET/SET_CONFIGURATION - getter/setter round-trip (paired)
+  Paired fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 3) for the entity-
+  level current configuration. GET_CONFIGURATION (0x0007) shares the SET_CONFIGURATION
+  (0x0006) wire layout, so the GET frame is the SET frame with command_type patched. Frames
+  are tsn_gen-generated; the Milan AECP model mirrors KL_aecp_response_builder.
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: GET_CONFIGURATION returns the current configuration_index, well-formed
+    Given tsn_gen generated a SET_CONFIGURATION frame with seed 30
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 7
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model configuration_index is 0
+
+  @class:paired
+  Scenario: the getter reflects the setter (SET configuration 2 then GET)
+    Given tsn_gen generated a SET_CONFIGURATION frame with seed 31
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 6
+    And I patch field "configuration_index" to 2
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model configuration_index is 2
+    Given tsn_gen generated a SET_CONFIGURATION frame with seed 32
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 7
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model configuration_index is 2
+
+  @class:setter @negative
+  Scenario: SET_CONFIGURATION out-of-range is refused, configuration unchanged
+    Given tsn_gen generated a SET_CONFIGURATION frame with seed 33
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 6
+    And I patch field "configuration_index" to 9
+    When the Milan AECP model processes the frame
+    Then the model responds status 7
+    And the model configuration_index is 0

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -45,6 +45,16 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('descriptor_type', 16),
                    ('descriptor_index', 16), ('control_values', 64)],
     },
+    'SET_CONFIGURATION': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_set_configuration::AECP_SET_CONFIGURATION::'
+                      'AECP_SET_CONFIGURATION_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('reserved', 16),
+                   ('configuration_index', 16)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -122,6 +132,8 @@ def pg_decode(context, key, hexstr):
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_SET_CONFIGURATION, CMD_GET_CONFIGURATION = 6, 7
+NUM_CONFIGS = 3
 
 
 class MilanAecpModel:
@@ -131,10 +143,18 @@ class MilanAecpModel:
     def __init__(self):
         self.clock_source_index = 0
         self.identify = 0
+        self.configuration_index = 0
 
     def process(self, fields):
         cmd = fields['command_type']
-        dt, di = fields['descriptor_type'], fields['descriptor_index']
+        dt, di = fields.get('descriptor_type'), fields.get('descriptor_index')  # entity-level cmds (CONFIGURATION) have none
+        if cmd == CMD_SET_CONFIGURATION:
+            if fields['configuration_index'] >= NUM_CONFIGS:
+                return STATUS_BAD_ARGUMENTS
+            self.configuration_index = fields['configuration_index']
+            return STATUS_SUCCESS
+        if cmd == CMD_GET_CONFIGURATION:
+            return STATUS_SUCCESS        # getter: response carries configuration_index
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR
@@ -538,3 +558,8 @@ def step_acmp_fuzz_invariant(context):
             assert addressed, f'unaddressed frame answered: {f}'
             assert resp['message_type'] == f['message_type'] + 1
     assert context.listener.state in LSM
+
+
+@then('the model configuration_index is {v:d}')
+def _model_cfg(context, v):
+    assert context.aecp_model.configuration_index == v, f"cfg={context.aecp_model.configuration_index}"


### PR DESCRIPTION
## Status
🟢 **Green** — 3 scenarios / 34 steps · `item-10-configuration` → `main`

## Description
Item-10 per-command verification off the plan (#13). **Paired** fixture for the entity-level current configuration `GET/SET_CONFIGURATION`.
- `GET_CONFIGURATION` (`0x0007`) shares the `SET_CONFIGURATION` (`0x0006`) wire layout → GET is the SET frame with `command_type` patched.
- Adds the `SET_CONFIGURATION` tsn_gen `LAYOUTS` entry + `SET/GET_CONFIGURATION` handling in `MilanAecpModel`. Also makes `descriptor_type/index` optional in the model (`.get()`) since CONFIGURATION is entity-level — a general fix that unblocks the other descriptor-less commands.
- Scenarios: getter well-formed · SET config 2 → GET reflects it · setter out-of-range (≥ NUM_CONFIGS → BAD_ARGUMENTS, unchanged).

## How to get into the same state
Common setup: see [Prerequisites & running](docs/testing/PDU_GETTER_SETTER_VERIFICATION.md). Then:
```bash
git checkout item-10-configuration
```

## How to validate
```bash
$BEHAVE tests -i item10_configuration
```
Expected: `1 feature passed · 3 scenarios passed · 34 steps passed`.

## Definition of Done
- [x] Paired: getter + SET→GET round-trip + setter-negative (unchanged on reject)
- [x] Command codes spec-accurate (IEEE 1722.1 Table 7.126: SET `0x0006`, GET `0x0007`)
- [x] `descriptor_type/index` made optional in the model (entity-level cmds)
- [x] Green offline (tsn_gen + model)
- [x] Tagged `@class:paired`/`@class:setter` · `@cmd:CONFIGURATION` · `@matrix:CMD-6`
