### PR TITLE
item-10: GET/SET_SAMPLING_RATE paired fixture

### DIFF
--- a/tests/features/item10_sampling_rate.feature
+++ b/tests/features/item10_sampling_rate.feature
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:SAMPLING_RATE @matrix:CMD-20
+Feature: Item-10 GET/SET_SAMPLING_RATE - getter/setter round-trip (paired)
+  Paired fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 3) for the AUDIO_UNIT
+  media sampling rate. GET_SAMPLING_RATE (0x0015) shares the SET_SAMPLING_RATE (0x0014) wire
+  layout, so the GET frame is the SET frame with command_type patched. Frames are tsn_gen-
+  generated; the Milan AECP model mirrors KL_aecp_response_builder.
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: GET_SAMPLING_RATE returns the current rate (default 48 kHz), well-formed
+    Given tsn_gen generated a SET_SAMPLING_RATE frame with seed 40
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 21
+    And I patch field "descriptor_type" to 0x02
+    And I patch field "descriptor_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model sampling_rate is 48000
+
+  @class:paired
+  Scenario: the getter reflects the setter (SET 96 kHz then GET)
+    Given tsn_gen generated a SET_SAMPLING_RATE frame with seed 41
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 20
+    And I patch field "descriptor_type" to 0x02
+    And I patch field "descriptor_index" to 0
+    And I patch field "sampling_rate" to 96000
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model sampling_rate is 96000
+    Given tsn_gen generated a SET_SAMPLING_RATE frame with seed 42
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 21
+    And I patch field "descriptor_type" to 0x02
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model sampling_rate is 96000
+
+  @class:setter @negative
+  Scenario: SET_SAMPLING_RATE to an unsupported rate is refused, rate unchanged
+    Given tsn_gen generated a SET_SAMPLING_RATE frame with seed 43
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 20
+    And I patch field "descriptor_type" to 0x02
+    And I patch field "descriptor_index" to 0
+    And I patch field "sampling_rate" to 12345
+    When the Milan AECP model processes the frame
+    Then the model responds status 7
+    And the model sampling_rate is 48000
+
+  @class:getter @negative
+  Scenario: GET_SAMPLING_RATE on a non-AUDIO_UNIT descriptor is refused
+    Given tsn_gen generated a SET_SAMPLING_RATE frame with seed 44
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 21
+    And I patch field "descriptor_type" to 0x00
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 2

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -45,6 +45,16 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('descriptor_type', 16),
                    ('descriptor_index', 16), ('control_values', 64)],
     },
+    'SET_SAMPLING_RATE': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_set_sampling_rate::AECP_SET_SAMPLING_RATE::'
+                      'AECP_SET_SAMPLING_RATE_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('sampling_rate', 32)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -122,6 +132,9 @@ def pg_decode(context, key, hexstr):
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_SET_SAMPLING_RATE, CMD_GET_SAMPLING_RATE = 20, 21
+DESC_AUDIO_UNIT = 0x0002
+VALID_RATES = {44100, 48000, 96000}
 
 
 class MilanAecpModel:
@@ -131,10 +144,22 @@ class MilanAecpModel:
     def __init__(self):
         self.clock_source_index = 0
         self.identify = 0
+        self.sampling_rate = 48000
 
     def process(self, fields):
         cmd = fields['command_type']
         dt, di = fields['descriptor_type'], fields['descriptor_index']
+        if cmd == CMD_SET_SAMPLING_RATE:
+            if dt != DESC_AUDIO_UNIT or di != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            if fields['sampling_rate'] not in VALID_RATES:
+                return STATUS_BAD_ARGUMENTS
+            self.sampling_rate = fields['sampling_rate']
+            return STATUS_SUCCESS
+        if cmd == CMD_GET_SAMPLING_RATE:
+            if dt != DESC_AUDIO_UNIT or di != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            return STATUS_SUCCESS        # getter: response carries sampling_rate
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR
@@ -538,3 +563,8 @@ def step_acmp_fuzz_invariant(context):
             assert addressed, f'unaddressed frame answered: {f}'
             assert resp['message_type'] == f['message_type'] + 1
     assert context.listener.state in LSM
+
+
+@then('the model sampling_rate is {v:d}')
+def _model_sr(context, v):
+    assert context.aecp_model.sampling_rate == v, f"sr={context.aecp_model.sampling_rate}"


### PR DESCRIPTION
## Status
🟢 **Green** — 4 scenarios · `item-10-sampling-rate` → `main`

## Description
Item-10 per-command verification off the plan (#13). **Paired** fixture for the AUDIO_UNIT media `GET/SET_SAMPLING_RATE`.
- `GET_SAMPLING_RATE` (`0x0015`) shares the `SET_SAMPLING_RATE` (`0x0014`) wire layout → GET is the SET frame with `command_type` patched.
- Adds the `SET_SAMPLING_RATE` tsn_gen `LAYOUTS` entry + `SET/GET_SAMPLING_RATE` handling in `MilanAecpModel` (valid set {44.1, 48, 96 kHz} on AUDIO_UNIT[0]).
- Scenarios: getter default 48 kHz · SET 96 kHz → GET reflects it · setter unsupported-rate → BAD_ARGUMENTS (unchanged) · getter non-AUDIO_UNIT → NO_SUCH_DESCRIPTOR.

## How to get into the same state
Common setup: see [Prerequisites & running](docs/testing/PDU_GETTER_SETTER_VERIFICATION.md). Then:
```bash
git checkout item-10-sampling-rate
```

## How to validate
```bash
$BEHAVE tests -i item10_sampling_rate
```
Expected: `1 feature passed · 4 scenarios passed`.

## Definition of Done
- [x] Paired: getter + SET→GET round-trip + setter-negative + getter-negative
- [x] Command codes spec-accurate (IEEE 1722.1 Table 7.126: SET `0x0014`, GET `0x0015`)
- [x] Green offline (tsn_gen + model)
- [x] Tagged `@class:paired`/`@class:getter`/`@class:setter` · `@cmd:SAMPLING_RATE` · `@matrix:CMD-20`
