### PR TITLE
item-10: GET/SET_STREAM_FORMAT paired fixture

### DIFF
--- a/tests/features/item10_stream_format.feature
+++ b/tests/features/item10_stream_format.feature
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:STREAM_FORMAT @matrix:CMD-8
+Feature: Item-10 GET/SET_STREAM_FORMAT - getter/setter round-trip (paired)
+  Paired fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 3) for the STREAM_INPUT/
+  STREAM_OUTPUT AAF stream format. GET_STREAM_FORMAT (0x0009) shares the SET_STREAM_FORMAT
+  (0x0008) wire layout, so the GET frame is the SET frame with command_type patched. Frames are
+  tsn_gen-generated; the Milan AECP model mirrors KL_aecp_response_builder. The formats are the
+  real AAF_PCM 48 kHz strings from avdecc/milan-v12-entity.json: 2ch default 0x0205022000806000
+  (= 145524899430031360) and up-to-8ch 0x0215022002006000 (= 150028499082567680).
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: GET_STREAM_FORMAT returns the current format (default AAF_PCM 48k 2ch), well-formed
+    Given tsn_gen generated a SET_STREAM_FORMAT frame with seed 80
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 9
+    And I patch field "descriptor_type" to 0x05
+    And I patch field "descriptor_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model stream_format is 145524899430031360
+
+  @class:paired
+  Scenario: the getter reflects the setter (SET up-to-8ch then GET)
+    Given tsn_gen generated a SET_STREAM_FORMAT frame with seed 81
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 8
+    And I patch field "descriptor_type" to 0x05
+    And I patch field "descriptor_index" to 0
+    And I patch field "stream_format" to 0x0215022002006000
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model stream_format is 150028499082567680
+    Given tsn_gen generated a SET_STREAM_FORMAT frame with seed 82
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 9
+    And I patch field "descriptor_type" to 0x05
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model stream_format is 150028499082567680
+
+  @class:setter @negative
+  Scenario: SET_STREAM_FORMAT to an unsupported format is refused, format unchanged
+    Given tsn_gen generated a SET_STREAM_FORMAT frame with seed 83
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 8
+    And I patch field "descriptor_type" to 0x06
+    And I patch field "descriptor_index" to 0
+    And I patch field "stream_format" to 0xDEADBEEFDEADBEEF
+    When the Milan AECP model processes the frame
+    Then the model responds status 7
+    And the model stream_format is 145524899430031360
+
+  @class:getter @negative
+  Scenario: GET_STREAM_FORMAT on a non-STREAM descriptor is refused
+    Given tsn_gen generated a SET_STREAM_FORMAT frame with seed 84
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 9
+    And I patch field "descriptor_type" to 0x00
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 2

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -45,6 +45,16 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('descriptor_type', 16),
                    ('descriptor_index', 16), ('control_values', 64)],
     },
+    'SET_STREAM_FORMAT': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_set_stream_format::AECP_SET_STREAM_FORMAT::'
+                      'AECP_SET_STREAM_FORMAT_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('stream_format', 64)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -122,6 +132,12 @@ def pg_decode(context, key, hexstr):
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_SET_STREAM_FORMAT, CMD_GET_STREAM_FORMAT = 8, 9   # IEEE 1722.1 Table 7.126
+DESC_STREAM_INPUT, DESC_STREAM_OUTPUT = 0x0005, 0x0006
+# Milan AAF_PCM 48 kHz stream formats (avdecc/milan-v12-entity.json STREAM_INPUT/OUTPUT[0]):
+STREAM_FMT_AAF_48K_2CH = 0x0205022000806000          # AAF_PCM 48k 2ch 32b (default)
+STREAM_FMT_AAF_48K_8CH = 0x0215022002006000          # AAF_PCM 48k up-to-8ch 32b
+VALID_STREAM_FORMATS = {STREAM_FMT_AAF_48K_2CH, STREAM_FMT_AAF_48K_8CH}
 
 
 class MilanAecpModel:
@@ -131,10 +147,22 @@ class MilanAecpModel:
     def __init__(self):
         self.clock_source_index = 0
         self.identify = 0
+        self.stream_format = STREAM_FMT_AAF_48K_2CH
 
     def process(self, fields):
         cmd = fields['command_type']
         dt, di = fields['descriptor_type'], fields['descriptor_index']
+        if cmd == CMD_SET_STREAM_FORMAT:
+            if dt not in (DESC_STREAM_INPUT, DESC_STREAM_OUTPUT) or di != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            if fields['stream_format'] not in VALID_STREAM_FORMATS:
+                return STATUS_BAD_ARGUMENTS
+            self.stream_format = fields['stream_format']
+            return STATUS_SUCCESS
+        if cmd == CMD_GET_STREAM_FORMAT:
+            if dt not in (DESC_STREAM_INPUT, DESC_STREAM_OUTPUT) or di != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            return STATUS_SUCCESS        # getter: response carries stream_format
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR
@@ -538,3 +566,9 @@ def step_acmp_fuzz_invariant(context):
             assert addressed, f'unaddressed frame answered: {f}'
             assert resp['message_type'] == f['message_type'] + 1
     assert context.listener.state in LSM
+
+
+@then('the model stream_format is {v:d}')
+def _model_sf(context, v):
+    assert context.aecp_model.stream_format == v, \
+        f"sf={context.aecp_model.stream_format}"


### PR DESCRIPTION
## Status
🟢 **Green** — 4 scenarios · `item-10-stream-format` → `main`

## Description
Item-10 per-command verification off the plan (#13). **Paired** fixture for the STREAM_INPUT/STREAM_OUTPUT AAF `GET/SET_STREAM_FORMAT`.
- `GET_STREAM_FORMAT` (`0x0009`) shares the `SET_STREAM_FORMAT` (`0x0008`) wire layout → GET is the SET frame with `command_type` patched.
- Adds the `SET_STREAM_FORMAT` tsn_gen `LAYOUTS` entry (11 fields, 35-byte PDU per `aecp_aem_set_stream_format.yaml`) + `SET/GET_STREAM_FORMAT` handling in `MilanAecpModel`, gated on descriptor STREAM_INPUT (`0x0005`)/STREAM_OUTPUT (`0x0006`) index 0 and a valid-format set.
- The valid formats are the real AAF_PCM 48 kHz strings from `avdecc/milan-v12-entity.json`: 2ch default `0x0205022000806000` and up-to-8ch `0x0215022002006000`.
- Scenarios: getter default AAF_PCM 48k 2ch · SET up-to-8ch → GET reflects it · setter unsupported-format → BAD_ARGUMENTS (unchanged) · getter non-STREAM descriptor → NO_SUCH_DESCRIPTOR.

## How to get into the same state
Common setup: see [Prerequisites & running](docs/testing/PDU_GETTER_SETTER_VERIFICATION.md). Then:
```bash
git checkout item-10-stream-format
```

## How to validate
```bash
$BEHAVE tests -i item10_stream_format
```
Expected: `1 feature passed · 4 scenarios passed · 51 steps passed`.

## Definition of Done
- [x] Paired: getter + SET→GET round-trip + setter-negative + getter-negative
- [x] Command codes spec-accurate (IEEE 1722.1 Table 7.126: SET `0x0008`, GET `0x0009`)
- [x] Green offline (tsn_gen + model)
- [x] Tagged `@class:paired`/`@class:getter`/`@class:setter` · `@cmd:STREAM_FORMAT` · `@matrix:CMD-8`
