### PR TITLE
item-10: READ_DESCRIPTOR getter fixture (read-only, idempotent, reject-unknown)

### DIFF
--- a/tests/features/item10_read_descriptor.feature
+++ b/tests/features/item10_read_descriptor.feature
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:READ_DESCRIPTOR @matrix:CMD-4 @class:getter
+Feature: Item-10 READ_DESCRIPTOR - descriptor getter (read-only, idempotent, reject-unknown)
+  Getter fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 1) for the AEM
+  READ_DESCRIPTOR (0x0004) command. READ_DESCRIPTOR is getter-only - there is no SET pair:
+  reading a KNOWN Milan-entity descriptor returns SUCCESS with a well-formed response; an
+  unknown descriptor_type or an out-of-range descriptor_index returns NO_SUCH_DESCRIPTOR; and
+  the read is idempotent (it never mutates entity state). The known-descriptor set mirrors the
+  Milan entity AEM: ENTITY[0], CONFIGURATION[0..2], AUDIO_UNIT[0], STREAM_INPUT[0],
+  STREAM_OUTPUT[0], CLOCK_DOMAIN[0]. Frames are tsn_gen-generated; the Milan AECP model mirrors
+  KL_aecp_response_builder.
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: READ_DESCRIPTOR of ENTITY[0] returns SUCCESS, well-formed
+    Given tsn_gen generated a READ_DESCRIPTOR frame with seed 50
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 4
+    And I patch field "descriptor_type" to 0x0000
+    And I patch field "descriptor_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+
+  @class:getter
+  Scenario: READ_DESCRIPTOR of CONFIGURATION[2] (last valid index) returns SUCCESS
+    Given tsn_gen generated a READ_DESCRIPTOR frame with seed 51
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 4
+    And I patch field "descriptor_type" to 0x0001
+    And I patch field "descriptor_index" to 2
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+
+  @class:getter @negative
+  Scenario: READ_DESCRIPTOR of an unknown descriptor_type is refused
+    Given tsn_gen generated a READ_DESCRIPTOR frame with seed 52
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 4
+    And I patch field "descriptor_type" to 0x00FF
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 2
+
+  @class:getter @negative
+  Scenario: READ_DESCRIPTOR of CONFIGURATION with an out-of-range index is refused
+    Given tsn_gen generated a READ_DESCRIPTOR frame with seed 53
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 4
+    And I patch field "descriptor_type" to 0x0001
+    And I patch field "descriptor_index" to 9
+    When the Milan AECP model processes the frame
+    Then the model responds status 2
+
+  @class:getter
+  Scenario: READ_DESCRIPTOR is idempotent - two reads of ENTITY[0] both SUCCESS
+    Given tsn_gen generated a READ_DESCRIPTOR frame with seed 54
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 4
+    And I patch field "descriptor_type" to 0x0000
+    And I patch field "descriptor_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -45,6 +45,17 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('descriptor_type', 16),
                    ('descriptor_index', 16), ('control_values', 64)],
     },
+    'READ_DESCRIPTOR': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_read_descriptor::AECP_READ_DESCRIPTOR::'
+                      'AECP_READ_DESCRIPTOR_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('configuration_index', 16),
+                   ('reserved', 16), ('descriptor_type', 16),
+                   ('descriptor_index', 16)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -122,6 +133,19 @@ def pg_decode(context, key, hexstr):
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_READ_DESCRIPTOR = 4                 # 0x0004, verified vs aecp_aem_read_descriptor.yaml
+DESC_ENTITY, DESC_CONFIGURATION, DESC_AUDIO_UNIT = 0x0000, 0x0001, 0x0002
+DESC_STREAM_INPUT, DESC_STREAM_OUTPUT = 0x0005, 0x0006
+# Known descriptors of the Milan entity: descriptor_type -> count of valid indices.
+# A read outside this map (unknown type, or index >= count) is NO_SUCH_DESCRIPTOR.
+KNOWN_DESCRIPTORS = {
+    DESC_ENTITY: 1,          # ENTITY[0]
+    DESC_CONFIGURATION: 3,   # CONFIGURATION[0..2]
+    DESC_AUDIO_UNIT: 1,      # AUDIO_UNIT[0]
+    DESC_STREAM_INPUT: 1,    # STREAM_INPUT[0]
+    DESC_STREAM_OUTPUT: 1,   # STREAM_OUTPUT[0]
+    DESC_CLOCK_DOMAIN: 1,    # CLOCK_DOMAIN[0]
+}
 
 
 class MilanAecpModel:
@@ -135,6 +159,11 @@ class MilanAecpModel:
     def process(self, fields):
         cmd = fields['command_type']
         dt, di = fields['descriptor_type'], fields['descriptor_index']
+        if cmd == CMD_READ_DESCRIPTOR:
+            n = KNOWN_DESCRIPTORS.get(dt)
+            if n is None or di >= n:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            return STATUS_SUCCESS        # getter: read-only, response echoes the descriptor
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR


### PR DESCRIPTION
## Status
🟢 **Green** — 5 scenarios · `item-10-read-descriptor` → `main`

## Description
Item-10 per-command verification off the plan (#13). **Getter** fixture (class 1 — the reference implementation for the getter class: read-only, idempotent, reject-unknown) for the AEM `READ_DESCRIPTOR` (`0x0004`) command.
- `READ_DESCRIPTOR` is **getter-only** — there is no `SET` pair. Reading a KNOWN descriptor → `SUCCESS` (well-formed); an unknown `descriptor_type` or an out-of-range `descriptor_index` → `NO_SUCH_DESCRIPTOR`; the read is idempotent (it never mutates entity state).
- Adds the `READ_DESCRIPTOR` tsn_gen `LAYOUTS` entry (mirrors `aecp_aem_read_descriptor.yaml`: `configuration_index` / `reserved` / `descriptor_type` / `descriptor_index`) + `READ_DESCRIPTOR` handling in `MilanAecpModel` against a known-descriptor set matching the Milan entity AEM: `ENTITY[0]`, `CONFIGURATION[0..2]`, `AUDIO_UNIT[0]`, `STREAM_INPUT[0]`, `STREAM_OUTPUT[0]`, `CLOCK_DOMAIN[0]`.
- Scenarios: read `ENTITY[0]` → SUCCESS (well-formed, tsn_gen decode + extractor cross-check) · read `CONFIGURATION[2]` (last valid index) → SUCCESS · unknown `descriptor_type` `0x00FF` → NO_SUCH_DESCRIPTOR · `CONFIGURATION` out-of-range index `9` → NO_SUCH_DESCRIPTOR · idempotence: two reads of `ENTITY[0]` both SUCCESS.

## How to get into the same state
Common setup: see [Prerequisites & running](docs/testing/PDU_GETTER_SETTER_VERIFICATION.md). Then:
```bash
git checkout item-10-read-descriptor
```

## How to validate
```bash
$BEHAVE tests -i item10_read_descriptor
```
Expected: `1 feature passed · 5 scenarios passed`.

## Definition of Done
- [x] Getter: known-read → SUCCESS + well-formed · unknown type / out-of-range index → NO_SUCH_DESCRIPTOR · idempotent (two reads identical)
- [x] Command code spec-accurate (IEEE 1722.1-2021 §9.2.9: `READ_DESCRIPTOR` `command_type` = `0x0004`, verified vs `aecp_aem_read_descriptor.yaml`)
- [x] Green offline (tsn_gen + model), no regression in the full `behave tests` suite (9 features / 62 scenarios)
- [x] Tagged `@class:getter` · `@cmd:READ_DESCRIPTOR` · `@matrix:CMD-4`
