### PR TITLE
item-10: GET/SET_NAME paired fixture

### DIFF
--- a/tests/features/item10_name.feature
+++ b/tests/features/item10_name.feature
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:NAME @matrix:CMD-16
+Feature: Item-10 GET/SET_NAME - getter/setter round-trip (paired)
+  Paired fixture (docs/testing/PDU_GETTER_SETTER_VERIFICATION.md, class 3) for the AVDECC
+  object name. GET_NAME (0x0011) shares the SET_NAME (0x0010) wire layout, so the GET frame
+  is the SET frame with command_type patched. object_name is a 64-octet (512-bit) avdecc_string;
+  the round-trip patches it to a distinctive sentinel and asserts the getter reflects the setter
+  on the model's stored value. Frames are tsn_gen-generated; the Milan AECP model mirrors
+  KL_aecp_response_builder.
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  @class:getter
+  Scenario: GET_NAME on the ENTITY descriptor is well-formed and read-only
+    Given tsn_gen generated a SET_NAME frame with seed 50
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 17
+    And I patch field "descriptor_type" to 0x0000
+    And I patch field "descriptor_index" to 0
+    And I patch field "name_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model object_name is 0
+
+  @class:paired
+  Scenario: the getter reflects the setter (SET object_name then GET)
+    Given tsn_gen generated a SET_NAME frame with seed 51
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 16
+    And I patch field "descriptor_type" to 0x0000
+    And I patch field "descriptor_index" to 0
+    And I patch field "name_index" to 0
+    And I patch field "name" to 12648430
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model object_name is 12648430
+    Given tsn_gen generated a SET_NAME frame with seed 52
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 17
+    And I patch field "descriptor_type" to 0x0000
+    And I patch field "descriptor_index" to 0
+    And I patch field "name_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model object_name is 12648430
+
+  @class:getter @negative
+  Scenario: GET_NAME on an unknown descriptor_type is refused
+    Given tsn_gen generated a SET_NAME frame with seed 53
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 17
+    And I patch field "descriptor_type" to 0x00FF
+    And I patch field "descriptor_index" to 0
+    And I patch field "name_index" to 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 2

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -45,6 +45,17 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('descriptor_type', 16),
                    ('descriptor_index', 16), ('control_values', 64)],
     },
+    'SET_NAME': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_set_name::AECP_SET_NAME::'
+                      'AECP_SET_NAME_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('name_index', 16),
+                   ('configuration_index', 16), ('name', 512)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -121,7 +132,9 @@ def pg_decode(context, key, hexstr):
 
 STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
+DESC_ENTITY, DESC_CONFIGURATION = 0x0000, 0x0001
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
+CMD_SET_NAME, CMD_GET_NAME = 16, 17     # 0x0010 / 0x0011 (IEEE 1722.1 Table 7.126)
 
 
 class MilanAecpModel:
@@ -131,10 +144,21 @@ class MilanAecpModel:
     def __init__(self):
         self.clock_source_index = 0
         self.identify = 0
+        self.object_name = 0          # 64-octet avdecc_string (ENTITY/CONFIGURATION name)
 
     def process(self, fields):
         cmd = fields['command_type']
         dt, di = fields['descriptor_type'], fields['descriptor_index']
+        if cmd in (CMD_SET_NAME, CMD_GET_NAME):
+            # NAME lives on ENTITY[0] / CONFIGURATION[0], name_index 0; GET
+            # shares the wire layout and is read-only (the response carries
+            # object_name), SET writes it.
+            if dt not in (DESC_ENTITY, DESC_CONFIGURATION) \
+                    or fields['name_index'] != 0:
+                return STATUS_NO_SUCH_DESCRIPTOR
+            if cmd == CMD_SET_NAME:
+                self.object_name = fields['name']
+            return STATUS_SUCCESS
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR
@@ -377,6 +401,12 @@ def step_model_csi(context, v):
 @then('the model identify level is {v:d}')
 def step_model_identify(context, v):
     assert context.aecp_model.identify == v
+
+
+@then('the model object_name is {v:d}')
+def step_model_object_name(context, v):
+    assert context.aecp_model.object_name == v, \
+        f"object_name={context.aecp_model.object_name}, expected {v}"
 
 
 @when('the model processes {n:d} SET_CLOCK_SOURCE frames from seeds {a:d} to {b:d}')


### PR DESCRIPTION
## Status
🟢 **Green** — 3 scenarios · `item-10-name` → `main`

## Description
Item-10 per-command verification off the plan (#13). **Paired** fixture for the AVDECC object `GET/SET_NAME`.
- `GET_NAME` (`0x0011`) shares the `SET_NAME` (`0x0010`) wire layout → GET is the SET frame with `command_type` patched.
- Adds the `SET_NAME` tsn_gen `LAYOUTS` entry (per `aecp_aem_set_name.yaml`, incl. the 64-octet / 512-bit `name` avdecc_string) + `SET/GET_NAME` handling in `MilanAecpModel` (NAME lives on ENTITY[0] / CONFIGURATION[0], `name_index` 0; SET writes `object_name`, GET is read-only).
- Scenarios: getter well-formed + read-only (`object_name` unchanged at default) · SET `object_name`=12648430 → GET reflects it (round-trip on the 512-bit field) · getter unknown `descriptor_type` → NO_SUCH_DESCRIPTOR.
- The getter scenario cross-checks the full frame both ways: `tsn_gen --decode` of every patched field + our MSB-first extractor agreeing with tsn_gen on all 13 fields (including the 512-bit `name`).

## How to get into the same state
Common setup: see [Prerequisites & running](docs/testing/PDU_GETTER_SETTER_VERIFICATION.md) (#13). Then:
```bash
git checkout item-10-name
```

## How to validate
```bash
export TSAGEN_DIR=/home/alex/tsn-gen
export PACKET_GEN=$TSAGEN_DIR/build/traffic-gen/packet_gen
$BEHAVE tests -i item10_name
```
Expected: `1 feature passed · 3 scenarios passed · 44 steps passed`.

## Definition of Done
- [x] Paired: getter well-formed + SET→GET round-trip (reflects the setter) + getter-negative
- [x] Command codes spec-accurate (IEEE 1722.1 Table 7.126: SET `0x0010`=16, GET `0x0011`=17; matches `aecp_aem_set_name.yaml`)
- [x] 512-bit `name` field layout verified — extractor agrees with tsn_gen decode
- [x] Green offline (tsn_gen + model); `@tsn_gen` scenarios skip cleanly without `packet_gen`
- [x] Tagged `@class:paired`/`@class:getter` · `@cmd:NAME` · `@matrix:CMD-16`
