### PR TITLE
tb: AAF talker->listener digital audio loop (bit-exact + THD+N)

### DIFF
--- a/tb/verilator/aaf_audio_loop/Makefile
+++ b/tb/verilator/aaf_audio_loop/Makefile
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# Digital audio loop: KL_aaf_packetizer (talker) -> parser -> KL_avtp_rx_monitor
+# -> KL_aaf_rx_depacketizer (listener). Proves the recovered payload is
+# bit-exact to the injected 1 kHz tone and measures its THD+N. Offline.
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+C          = $(RTL_DIR)/common
+A          = $(RTL_DIR)/ieee1722/avtp
+F          = $(RTL_DIR)/ieee1722/aaf
+TOP        = aaf_audio_loop_wrap
+
+VFLAGS = --cc --exe --build -j 0 --top-module $(TOP) \
+         +incdir+$(C) +incdir+$(A) +incdir+$(F) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
+         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-IMPORTSTAR -Wno-CASEINCOMPLETE \
+         -Wno-EOFNEWLINE -Wno-PINCONNECTEMPTY -CFLAGS "-std=c++17 -O2"
+
+SRCS = $(C)/ethernet_packet_pkg.sv $(A)/avtp_subtype_pkg.sv \
+       $(F)/KL_aaf_packetizer.sv \
+       $(A)/avtp_stream_parser.sv $(A)/KL_avtp_rx_monitor.sv \
+       $(F)/KL_aaf_rx_depacketizer.sv \
+       ../../../third_party/verilog-axis/rtl/axis_fifo.v \
+       aaf_audio_loop_wrap.sv
+
+.PHONY: all run clean
+all: run
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) sim_main.cpp -o Vaaf_audio_loop_sim
+	./obj_dir/Vaaf_audio_loop_sim
+
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/aaf_audio_loop/aaf_audio_loop_wrap.sv
+++ b/tb/verilator/aaf_audio_loop/aaf_audio_loop_wrap.sv
@@ -1,0 +1,149 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+//! Verilator harness: the FULL digital audio loop - talker media half
+//! (KL_aaf_packetizer, N=1, direct L/R pair injection) wired straight into
+//! the listener media half (avtp_stream_parser -> KL_avtp_rx_monitor ->
+//! KL_aaf_rx_depacketizer), the exact milan_datapath TX/RX pairing.
+//!
+//! Injected PCM pairs are packetized into IEEE-1722 AAF-PCM class-A frames,
+//! the frames are format/stream-matched and accepted by the RX monitor, and
+//! the depacketizer re-emits ONLY the sample payload (S32BE). The sim_main
+//! drives a coherent 1 kHz tone in and proves the recovered payload is
+//! bit-exact to the source (the path adds nothing) and measures its THD+N.
+//! No board, no bench - this closes the "is the talker->listener AUDIO path
+//! transparent?" gap that the per-block unit TBs never covered.
+
+`default_nettype none
+
+module aaf_audio_loop_wrap #(
+  parameter int unsigned CLK_FREQ_HZ_P = 50_000_000   //! monitor silence timer
+)(
+  input  wire        clk,
+  input  wire        rst_n,
+
+  //! --- talker (t0) config: direct CSR-alias inputs -----------------------
+  input  wire [47:0] dest_mac_i,        //! t0 stream DMAC
+  input  wire [47:0] station_mac_i,     //! src MAC (stream_id high 48)
+  input  wire [11:0] vlan_vid_i,        //! SR class VID
+  input  wire [31:0] transit_ns_i,      //! presentation offset
+  input  wire [63:0] ptp_ns_i,          //! live PHC ns
+  input  wire        stream_en_i,       //! enable t0
+
+  //! --- talker stimulus: one L/R pair per pulse ---------------------------
+  input  wire        pair_valid_i,
+  input  wire [23:0] pair_l_i,
+  input  wire [23:0] pair_r_i,
+
+  //! --- listener binding (AECP/ACMP state the SM would install) -----------
+  input  wire [63:0] cfg_sid_i,         //! bound stream_id (= {station_mac,uid})
+  input  wire        bound_i,           //! listener sink 0 bound
+  input  wire [63:0] fmt_i,             //! current STREAM_INPUT[0] format u64
+  input  wire [31:0] ptp_now_i,         //! PHC ns for LATE/EARLY (non-gating)
+  input  wire [31:0] pres_ofs_i,        //! presentation offset ns
+  input  wire        servo_conv_i,      //! playback clock converged
+
+  //! --- recovered PCM payload out (toward the DRAM ring) ------------------
+  output wire [63:0] pcm_tdata_o,
+  output wire        pcm_tvalid_o,
+  output wire        pcm_tlast_o,
+  input  wire        pcm_tready_i,
+  output wire [15:0] pcm_pdus_o,
+  output wire [15:0] pcm_drops_o,
+  output wire [31:0] frames_rx_o,       //! FRAMES_RX (accepted PDUs)
+  output wire [31:0] unsupported_fmt_o, //! UNSUPPORTED_FORMAT (should stay 0)
+
+  //! --- TX frame tap (visibility) -----------------------------------------
+  output wire [63:0] tx_tdata_o,
+  output wire [7:0]  tx_tkeep_o,
+  output wire        tx_tvalid_o,
+  output wire        tx_tlast_o,
+  output wire [31:0] frames_sent_o
+);
+
+  // ---- talker media half: shared packetizer, N=1 --------------------------
+  wire [63:0] ax_tdata;
+  wire [7:0]  ax_tkeep;
+  wire        ax_tvalid, ax_tlast;
+
+  KL_aaf_packetizer #(.N_TALKERS_P(1)) u_tx (
+    .clk_i (clk), .rst_n (rst_n),
+    .pair_valid_i (pair_valid_i), .pair_slot_i (4'd0),
+    .pair_l_i (pair_l_i), .pair_r_i (pair_r_i),
+    .stream_en_i (stream_en_i),
+    .dest_mac_i (dest_mac_i), .station_mac_i (station_mac_i),
+    .vlan_vid_i (vlan_vid_i), .transit_ns_i (transit_ns_i),
+    .ptp_ns_i (ptp_ns_i),
+    .tctx_wr_en_i (1'b0), .tctx_wr_addr_i (7'd0), .tctx_wr_data_i (32'd0),
+    .tctx_wr_rdy_o (),
+    .tctx_rd_en_i (1'b0), .tctx_rd_addr_i (7'd0),
+    .tctx_rd_data_o (), .tctx_rd_valid_o (),
+    .m_axis_tdata (ax_tdata), .m_axis_tkeep (ax_tkeep),
+    .m_axis_tvalid (ax_tvalid), .m_axis_tlast (ax_tlast),
+    .m_axis_tready (1'b1),          //! RX taps never backpressure the datapath
+    .frames_sent_o (frames_sent_o)
+  );
+
+  assign tx_tdata_o  = ax_tdata;
+  assign tx_tkeep_o  = ax_tkeep;
+  assign tx_tvalid_o = ax_tvalid;
+  assign tx_tlast_o  = ax_tlast;
+
+  // ---- listener media half: parser -> monitor -> depacketizer -------------
+  wire        match_w, tu_w;
+  wire [7:0]  subtype_w, seq_w;
+  wire [31:0] ts_w;
+  wire [63:0] fsh_w;
+  wire        accept_w;
+
+  avtp_stream_parser #(
+    .TDATA_WIDTH (64), .BIG_ENDIAN (0), .N_STREAMS (1)
+  ) u_par (
+    .clk (clk), .resetn (rst_n),
+    .cfg_stream_id_i (cfg_sid_i),
+    .cfg_stream_en_i (bound_i),
+    .s_tdata_i (ax_tdata), .s_tkeep_i (ax_tkeep),
+    .s_tvalid_i (ax_tvalid), .s_tready_i (1'b1), .s_tlast_i (ax_tlast),
+    .match_valid_o (match_w),
+    .match_index_o (), .stream_id_o (), .avtp_ts_o (ts_w),
+    .subtype_o (subtype_w), .ts_valid_o (),
+    .seq_num_o (seq_w), .ts_uncertain_o (tu_w), .fsh_o (fsh_w),
+    .avtp_frames_o (), .matched_frames_o ()
+  );
+
+  KL_avtp_rx_monitor #(.CLK_FREQ_HZ_P(CLK_FREQ_HZ_P)) u_mon (
+    .clk_i (clk), .rst_n (rst_n),
+    .match_valid_i (match_w), .subtype_i (subtype_w), .seq_num_i (seq_w),
+    .ts_uncertain_i (tu_w), .avtp_ts_i (ts_w), .fsh_i (fsh_w),
+    .bound_i (bound_i), .fmt_i (fmt_i),
+    .ptp_now_i (ptp_now_i), .pres_ofs_i (pres_ofs_i),
+    .media_reset_p_i (1'b0),
+    .clk_src_i (16'd0), .servo_conv_i (servo_conv_i),
+    .cnt_media_locked_o (), .cnt_media_unlocked_o (),
+    .cnt_stream_interrupted_o (), .cnt_seq_mismatch_o (),
+    .cnt_ts_uncertain_o (), .cnt_unsupported_fmt_o (unsupported_fmt_o),
+    .cnt_frames_rx_o (frames_rx_o), .cnt_media_reset_o (),
+    .cnt_late_ts_o (), .cnt_early_ts_o (),
+    .media_locked_o (), .dirty_p_o (), .pdu_accept_p_o (accept_w),
+    .last_ts_o (), .last_tsd_o ()
+  );
+
+  KL_aaf_rx_depacketizer u_depkt (
+    .clk_i (clk), .rst_n (rst_n),
+    .s_tdata_i (ax_tdata), .s_tkeep_i (ax_tkeep),
+    .s_tvalid_i (ax_tvalid), .s_tready_i (1'b1), .s_tlast_i (ax_tlast),
+    .pdu_accept_p_i (accept_w),
+    .pdu_accept_idx_i (4'd0),           //! N=1 shape
+    .m_axis_tdata (pcm_tdata_o), .m_axis_tkeep (),
+    .m_axis_tvalid (pcm_tvalid_o), .m_axis_tlast (pcm_tlast_o),
+    .m_axis_tuser (),
+    .m_axis_tready (pcm_tready_i),
+    .pdus_o (pcm_pdus_o), .drops_o (pcm_drops_o),
+    .pdu_out_p_o (), .pdu_out_idx_o (), .drop_p_o (), .drop_idx_o ()
+  );
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/aaf_audio_loop/sim_main.cpp
+++ b/tb/verilator/aaf_audio_loop/sim_main.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Digital audio loop: KL_aaf_packetizer (talker, N=1, direct pair injection)
+// -> avtp_stream_parser -> KL_avtp_rx_monitor -> KL_aaf_rx_depacketizer
+// (listener). Drives a coherent 1 kHz tone (48 kHz, 24-bit, -12 dBFS - the
+// bench tone_1k_m12 amplitude) into the talker and proves:
+//   (1) every AAF PDU is stream+format matched and ACCEPTED (FRAMES_RX),
+//   (2) the recovered S32BE payload is BIT-EXACT to the injected samples
+//       (the packetize/depacketize path adds nothing - the pad byte is 0),
+//   (3) the THD+N of the recovered tone sits at the 24-bit quantization
+//       floor (a bit-exact path contributes 0 dB of its own).
+// This closes the talker->listener AUDIO gap the per-block unit TBs never
+// covered - offline, no board.
+#include "Vaaf_audio_loop_wrap.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+#include <cmath>
+
+static const double PI = 3.14159265358979323846;
+
+static Vaaf_audio_loop_wrap* dut;
+static long checks = 0, fails = 0;
+static void ck(const char* t, long got, long exp){
+    checks++;
+    if(got != exp){ fails++; printf("  [FAIL] %-46s got=%ld exp=%ld\n", t, got, exp); }
+    else           printf("  [ ok ] %-46s = %ld\n", t, got);
+}
+
+// ---- coherent 1 kHz tone: 48000 * 32 / 1536 = 1000 Hz exactly -------------
+static const int    M     = 1536;      // analysis window = 32 whole cycles
+static const int    KCYC  = 32;        // fundamental bin
+static const int    NF    = 300;       // frames to inject (1800 pairs > M + margin)
+static const int    AMP   = (1 << 21); // -12.04 dBFS (matches bench tone_1k_m12)
+
+static int32_t tone24(int n){          // signed 24-bit sample of the tone
+    double v = AMP * sin(2.0 * PI * KCYC * n / M);
+    long q = lround(v);
+    if(q >  (1 << 23) - 1) q =  (1 << 23) - 1;
+    if(q < -(1 << 23))     q = -(1 << 23);
+    return (int32_t)q;
+}
+
+// ---- recovered payload capture (S32BE, always full 8-byte beats) ----------
+static std::vector<uint8_t> rxcur;
+static std::vector<int32_t> rsamp;     // sign-extended 24-bit, interleaved L,R
+static long padbad = 0, framebad = 0;
+
+static void capture(){
+    if(dut->pcm_tvalid_o && dut->pcm_tready_i){
+        uint64_t d = dut->pcm_tdata_o;                 // full word (no partial beats)
+        for(int i = 0; i < 8; i++) rxcur.push_back((d >> (8*i)) & 0xFF);
+        if(dut->pcm_tlast_o){
+            if(rxcur.size() % 4 != 0) framebad++;
+            for(size_t o = 0; o + 3 < rxcur.size(); o += 4){
+                int32_t s = (rxcur[o] << 16) | (rxcur[o+1] << 8) | rxcur[o+2];
+                if(rxcur[o+3] != 0) padbad++;          // 24-in-32, low byte must be 0
+                if(s & 0x800000) s -= 0x1000000;       // sign-extend 24-bit
+                rsamp.push_back(s);
+            }
+            rxcur.clear();
+        }
+    }
+}
+
+static void step(){ dut->clk = 0; dut->eval(); dut->clk = 1; dut->eval(); capture(); }
+static void cyc(int n){ for(int i = 0; i < n; i++) step(); }
+
+static void inject_pair(int32_t l, int32_t r){
+    dut->pair_l_i = (uint32_t)(l & 0xFFFFFF);
+    dut->pair_r_i = (uint32_t)(r & 0xFFFFFF);
+    dut->pair_valid_i = 1; step();
+    dut->pair_valid_i = 0; cyc(23);        // drain cadence (proven in NxN P4)
+}
+
+int main(int argc, char** argv){
+    Verilated::commandArgs(argc, argv);
+    dut = new Vaaf_audio_loop_wrap;
+
+    // talker config (t0 via direct CSR-alias inputs)
+    dut->rst_n = 0; dut->stream_en_i = 0; dut->pair_valid_i = 0;
+    dut->dest_mac_i    = 0x91E0F000FE01ULL;
+    dut->station_mac_i = 0x020000000002ULL;
+    dut->vlan_vid_i    = 2;
+    dut->transit_ns_i  = 2000000;
+    dut->ptp_ns_i      = 0x11223344;
+    dut->pcm_tready_i  = 1;
+    // listener binding the ACMP/AECP SM would install
+    dut->cfg_sid_i     = 0x0200000000020000ULL;   // {station_mac, uid=0}
+    dut->bound_i       = 1;
+    dut->fmt_i         = 0x0205022002006000ULL;    // AAF/48k/INT32/32/8ch-max
+    dut->ptp_now_i     = 0x11223344;
+    dut->pres_ofs_i    = 2000000;
+    dut->servo_conv_i  = 1;
+
+    cyc(8); dut->rst_n = 1; dut->stream_en_i = 1; cyc(8);
+
+    printf("== AAF talker -> listener digital audio loop ==\n");
+    printf("   1 kHz tone, 48 kHz, 24-bit, -12 dBFS, %d frames\n", NF);
+
+    const int total = NF * 6;
+    for(int n = 0; n < total; n++) inject_pair(tone24(n), tone24(n));
+    cyc(600);                                       // final drain
+
+    // ---- accounting ------------------------------------------------------
+    printf("\n[accounting]\n");
+    ck("talker emitted >= NF frames", (long)dut->frames_sent_o >= NF, 1);
+    ck("listener FRAMES_RX == talker frames", (long)dut->frames_rx_o,
+                                              (long)dut->frames_sent_o);
+    ck("UNSUPPORTED_FORMAT rejects = 0",   (long)dut->unsupported_fmt_o, 0);
+    ck("depacketizer whole-frame drops = 0", (long)dut->pcm_drops_o, 0);
+    ck("recovered >= 2*M samples (L+R)", (long)rsamp.size() >= (long)(2*M), 1);
+    ck("every payload frame length %%4==0", framebad, 0);
+    ck("S32BE pad byte always 0 (24-in-32)", padbad, 0);
+
+    // ---- bit-exact transparency -----------------------------------------
+    printf("\n[bit-exact transparency]\n");
+    long npairs = (long)rsamp.size() / 2;
+    long off = -1;
+    for(int cand = 0; cand < 12 && off < 0; cand++){
+        bool okc = true;
+        for(int k = 0; k < 8; k++)
+            if(rsamp[2*k] != tone24(k + cand)){ okc = false; break; }
+        if(okc) off = cand;
+    }
+    ck("recovered stream aligns to source", off >= 0, 1);
+    if(off < 0) off = 0;
+    long mism = 0, ncmp = 0;
+    for(long k = 0; k + off < total && k < npairs; k++){
+        int32_t exp = tone24((int)(k + off));
+        if(rsamp[2*k]     != exp) mism++;
+        if(rsamp[2*k + 1] != exp) mism++;
+        ncmp++;
+    }
+    printf("  [info] compared %ld pairs (L+R), alignment offset %ld\n", ncmp, off);
+    ck("BYTE-EXACT: recovered L/R == injected tone", mism, 0);
+
+    // ---- THD+N of the recovered tone ------------------------------------
+    printf("\n[audio-domain THD+N of the recovered stream]\n");
+    if((long)rsamp.size() >= 2*M){
+        std::vector<double> x(M);
+        for(int i = 0; i < M; i++) x[i] = (double)rsamp[2*i];   // L channel
+        double mean = 0; for(double v : x) mean += v; mean /= M;
+        for(double& v : x) v -= mean;
+        double re = 0, im = 0;
+        for(int n = 0; n < M; n++){
+            double a = 2.0 * PI * KCYC * n / M;
+            re += x[n] * cos(a); im -= x[n] * sin(a);
+        }
+        double Efund = 2.0 * (re*re + im*im) / M;
+        double Etot  = 0; for(double v : x) Etot += v*v;
+        double thdn  = 10.0 * log10((Etot - Efund) / Efund);
+        printf("  [info] recovered 1 kHz THD+N = %.1f dB "
+               "(24-bit source quant floor; path adds 0)\n", thdn);
+        ck("recovered-tone THD+N <= -120 dB", thdn <= -120.0, 1);
+    } else {
+        ck("recovered-tone THD+N (skipped: too few samples)", 0, 1);
+    }
+
+    printf("\n======================================================================\n");
+    printf("AAF audio loop: %ld checks, %ld failures\nRESULT: %s\n",
+           checks, fails, fails ? "FAIL" : "PASS");
+    delete dut;
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Status

🟢 Green — 10/10 checks, `tb-aaf-audio-loop` → `main`.

## Description

Closes the audio-path gap the per-block unit TBs never covered: **no TB proved the talker→listener AUDIO path end-to-end**. This wires the real talker media half (`KL_aaf_packetizer`, N=1, direct L/R pair injection) straight into the real listener media half (`avtp_stream_parser` → `KL_avtp_rx_monitor` → `KL_aaf_rx_depacketizer`) — the exact `milan_datapath` TX/RX pairing — and drives a coherent 1 kHz / 24-bit / −12 dBFS tone through it.

| Check | Result |
|---|---|
| 300 talker frames → listener FRAMES_RX | 300 = 300, 0 UNSUPPORTED_FORMAT, 0 drops |
| Recovered payload vs injected tone | **BYTE-EXACT** (1800 L/R pairs, 0 mismatches, S32BE pad byte always 0) |
| THD+N of the recovered stream | **−135.6 dB** = the 24-bit source quantization floor (the RTL path adds nothing) |

## How to get into the same state

See `docs/testing/PDU_GETTER_SETTER_VERIFICATION.md` §Prerequisites for the common clone/setup, then:

```bash
git checkout tb-aaf-audio-loop
git submodule update --init third_party/verilog-axis
```

## How to validate

```bash
cd tb/verilator/aaf_audio_loop && make run
```

Expected: `AAF audio loop: 10 checks, 0 failures — RESULT: PASS` with the THD+N info line ≤ −120 dB.

## Definition of Done

- [x] Real RTL both sides (no models): packetizer → parser → monitor → depacketizer
- [x] Accounting: every emitted PDU accepted (FRAMES_RX == frames_sent), no drops
- [x] Bit-exact transparency proven on a coherent tone
- [x] In-sim THD+N at the 24-bit quantization floor (≤ −120 dB gate)
- [ ] Reviewer runs `make run` green