### PR TITLE
chmap64: KL_chan_map_render - 64 stream-channel -> physical render crossbar (TB N/N)

### DIFF
--- a/hdl/ieee1722/aaf/KL_chan_map_render.sv
+++ b/hdl/ieee1722/aaf/KL_chan_map_render.sv
@@ -1,0 +1,221 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+/*
+------------------------------------------------------------------------------
+  File        : KL_chan_map_render.sv
+  Author      : Kebag Logic
+
+  Date        : 2026-07-23
+  Description : 64 stream-channel -> physical render crossbar (NxN render
+                stage). Consumes a clone of the shared AAF RX depacketizer
+                payload stream (KL_aaf_rx_depacketizer m_axis: 64-bit beats
+                = 2 consecutive S32BE samples of the wire-interleaved
+                payload, tuser = stream index, one AXIS frame per PDU, full
+                8-byte beats) and maintains a latest-sample wire-truth
+                latch cur_r[s][c] of the top 24 bits of every
+                (stream, wire channel) sample - free-running, no media
+                queueing (the physical outputs run on their own 48 kHz
+                tick; slips follow the house free-run rule).
+
+                CLONE QUALIFIER: the tap never backpressures (no tready
+                here), so s_tvalid_i must be the ACCEPTED-beat strobe of
+                the tapped link (tvalid && tready), the same discipline as
+                the depacketizer's own tap side and the KL_pcm_route
+                render-tap consumers.
+
+                De-interleave: payload sample k belongs to wire channel
+                k % chans[s] (channel-interleaved wire order, 6 samples/ch
+                per Milan 48k PDU); chans[s] comes from the RX monitors'
+                wire_chans_o (flat 4-bit fields, 0 treated as 2 - same
+                pre-first-accept rule as KL_i2s_playback). The position
+                counter advances incrementally (wrap compare, no modulo
+                hardware) and restarts at every frame's tlast, so
+                back-to-back PDUs of different streams / channel counts
+                stay aligned. Wire channels beyond N_CH_P are virtual:
+                counted for the interleave, never latched.
+
+                Render: a map RAM (one write port, entry format
+                {en[7], rsvd[6], stream[5:3], ch[2:0]}) routes any of the
+                N_STREAMS_P*N_CH_P latched stream-channels to any of the
+                N_PHYS_P physical output channels (default 10: I2S-out
+                L/R = phys 0/1, TDM8-out lane0 slots 0..7 = phys 2..9).
+                On every tick_i (one pulse per 48 kHz output media frame)
+                the whole phys vector is registered in one shot and
+                phys_valid_o pulses - map writes between ticks are never
+                visible on the outputs (glitch-free at frame rate).
+                Unmapped (en = 0) phys channels render 24'd0.
+
+                Ownership of the write port (AEM audio-map engine or CSR)
+                is upstream and out of scope - the port is only exposed.
+                Single clock domain; tick_i arrives already synchronized.
+
+  Company     : Kebag Logic
+  Project     : Milan AVTP
+
+  Notes       :
+    - Map stream/ch fields are 3 bits: the format caps N_STREAMS_P and
+      N_CH_P at 8 (the 8x8 = 64 stream-channel shape). Smaller builds are
+      guarded (out-of-range entries render 0); larger need a wider entry.
+------------------------------------------------------------------------------
+*/
+
+//! 64 stream-channel -> physical render crossbar: latches the top 24 bits
+//! of every (stream, wire channel) sample from the depacketizer payload
+//! clone (latest-sample wire-truth, free-running), then on each 48 kHz
+//! tick renders N_PHYS_P outputs through a map RAM
+//! ({en[7], rsvd[6], stream[5:3], ch[2:0]}; unmapped = 0) - registered in
+//! one shot, so map writes are only ever visible at tick boundaries.
+
+`default_nettype none
+
+module KL_chan_map_render #(
+  parameter int unsigned N_STREAMS_P = 8,   //! RX streams (map field: <= 8)
+  parameter int unsigned N_CH_P      = 8,   //! wire channels kept per stream
+                                            //! (map field: <= 8)
+  parameter int unsigned N_PHYS_P    = 10   //! physical output channels
+                                            //! (default: I2S L/R = 0/1,
+                                            //! TDM8 lane0 slots = 2..9)
+)(
+  input  wire                        clk_i,         //! Global clock
+  input  wire                        rst_n,         //! Active-low synchronous
+                                                    //! reset
+
+  //! --- depacketizer payload AXIS clone (never backpressured; drive
+  //! --- s_tvalid_i with the tapped link's ACCEPTED beats) -----------------
+  input  wire [63:0]                 s_tdata_i,     //! 2 consecutive S32BE
+                                                    //! samples, wire order
+  input  wire                        s_tvalid_i,
+  input  wire                        s_tlast_i,     //! one AXIS frame per PDU
+  input  wire [3:0]                  s_tuser_i,     //! stream index s
+
+  //! --- per-stream wire channel count (RX monitors' wire_chans_o) ---------
+  input  wire [N_STREAMS_P*4-1:0]    wire_chans_i,  //! 4-bit fields; 0 -> 2
+
+  //! --- output media frame tick (one pulse per 48 kHz frame) --------------
+  input  wire                        tick_i,
+
+  //! --- map RAM write port (AEM audio-map engine / CSR upstream) ----------
+  input  wire                        map_wr_en_i,   //! one-cycle write strobe
+  input  wire [$clog2(N_PHYS_P)-1:0] map_wr_addr_i, //! phys channel p
+  input  wire [7:0]                  map_wr_data_i, //! {en[7], rsvd[6],
+                                                    //!  stream[5:3], ch[2:0]}
+
+  //! --- map readback (combinational) --------------------------------------
+  input  wire [$clog2(N_PHYS_P)-1:0] map_rd_addr_i,
+  output logic [7:0]                 map_rd_data_o,
+
+  //! --- rendered physical channels (registered at tick_i) -----------------
+  output logic [N_PHYS_P*24-1:0]     phys_smp_o,    //! phys p = [p*24 +: 24]
+  output logic                       phys_valid_o,  //! one-cycle pulse
+  output logic [N_PHYS_P-1:0]        mapped_mask_o  //! live en bits (comb)
+);
+
+  //! map entry field positions ({en, rsvd, stream[2:0], ch[2:0]})
+  localparam int unsigned MAP_EN_B_C = 7;
+
+  // ------------------------------------------------------------------ //
+  // Map RAM: N_PHYS_P x 8, one write port + combinational readback      //
+  // ------------------------------------------------------------------ //
+  logic [7:0] map_r [N_PHYS_P];
+
+  always_ff @(posedge clk_i) begin : map_write
+    if (!rst_n) begin
+      for (int p = 0; p < N_PHYS_P; p++) map_r[p] <= 8'h00;
+    end
+    else if (map_wr_en_i && (32'(map_wr_addr_i) < N_PHYS_P)) begin
+      map_r[map_wr_addr_i] <= map_wr_data_i;
+    end
+  end : map_write
+
+  always_comb begin : map_read
+    map_rd_data_o = 8'h00;
+    for (int p = 0; p < N_PHYS_P; p++) begin
+      if (32'(map_rd_addr_i) == p) map_rd_data_o = map_r[p];
+      mapped_mask_o[p] = map_r[p][MAP_EN_B_C];
+    end
+  end : map_read
+
+  // ------------------------------------------------------------------ //
+  // De-interleave walker: wire channel of each payload sample.          //
+  // 2 samples per beat; the counter wraps at the stream's channel count //
+  // and restarts at tlast (frames are atomic - tuser is frame-stable).  //
+  // ------------------------------------------------------------------ //
+  logic [3:0] chpos_r;     //! wire channel of the current beat's FIRST sample
+
+  //! channel count of the in-flight stream (constant-base mux, guarded
+  //! against tuser >= N_STREAMS_P; 0 treated as 2 - pre-first-accept rule)
+  logic [3:0] chans_raw_w;
+  always_comb begin : chans_lookup
+    chans_raw_w = 4'd0;
+    for (int s = 0; s < N_STREAMS_P; s++) begin
+      if (32'(s_tuser_i) == s) chans_raw_w = wire_chans_i[s*4 +: 4];
+    end
+  end : chans_lookup
+  wire [3:0] eff_chans_w = (chans_raw_w == 4'd0) ? 4'd2 : chans_raw_w;
+
+  //! increment-with-wrap (ch is always < chans, so +1 never overflows past
+  //! the compare)
+  function automatic [3:0] chwrap(input [3:0] ch, input [3:0] chans);
+    chwrap = ((4'(ch + 4'd1)) == chans) ? 4'd0 : 4'(ch + 4'd1);
+  endfunction
+
+  //! the two S32BE samples of the beat: wire byte first = MSB, byte lane j
+  //! = wire byte j (depacketizer out_assemble); top 24 bits keep the
+  //! 24-in-32 left-justified audio, the pad byte (lanes 3/7) is dropped
+  wire [23:0] smp0_w = {s_tdata_i[7:0],   s_tdata_i[15:8],  s_tdata_i[23:16]};
+  wire [23:0] smp1_w = {s_tdata_i[39:32], s_tdata_i[47:40], s_tdata_i[55:48]};
+  wire [3:0]  ch0_w  = chpos_r;
+  wire [3:0]  ch1_w  = chwrap(ch0_w, eff_chans_w);
+
+  // ------------------------------------------------------------------ //
+  // Latest-sample wire-truth latch: cur_r[s][c] free-runs on the clone  //
+  // ------------------------------------------------------------------ //
+  logic [23:0] cur_r [N_STREAMS_P][N_CH_P];
+
+  always_ff @(posedge clk_i) begin : sample_latch
+    if (!rst_n) begin
+      chpos_r <= '0;
+      for (int s = 0; s < N_STREAMS_P; s++) begin
+        for (int c = 0; c < N_CH_P; c++) cur_r[s][c] <= 24'd0;
+      end
+    end
+    else if (s_tvalid_i) begin
+      if (32'(s_tuser_i) < N_STREAMS_P) begin
+        //! wire channels beyond N_CH_P are virtual: walked, never latched
+        if (32'(ch0_w) < N_CH_P) cur_r[s_tuser_i[2:0]][ch0_w[2:0]] <= smp0_w;
+        if (32'(ch1_w) < N_CH_P) cur_r[s_tuser_i[2:0]][ch1_w[2:0]] <= smp1_w;
+      end
+      chpos_r <= s_tlast_i ? 4'd0 : chwrap(ch1_w, eff_chans_w);
+    end
+  end : sample_latch
+
+  // ------------------------------------------------------------------ //
+  // Render: the whole phys vector registers in one shot on tick_i, so   //
+  // map writes between ticks are never visible (glitch-free at 48 kHz)  //
+  // ------------------------------------------------------------------ //
+  always_ff @(posedge clk_i) begin : render_tick
+    if (!rst_n) begin
+      phys_smp_o   <= '0;
+      phys_valid_o <= 1'b0;
+    end
+    else begin
+      phys_valid_o <= tick_i;
+      if (tick_i) begin
+        for (int p = 0; p < N_PHYS_P; p++) begin
+          logic [7:0] m;
+          m = map_r[p];
+          phys_smp_o[p*24 +: 24] <=
+            (m[MAP_EN_B_C] && (32'(m[5:3]) < N_STREAMS_P)
+                           && (32'(m[2:0]) < N_CH_P))
+              ? cur_r[m[5:3]][m[2:0]] : 24'd0;
+        end
+      end
+    end
+  end : render_tick
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/chmap_render/Makefile
+++ b/tb/verilator/chmap_render/Makefile
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# KL_chan_map_render verification: 64 stream-channel -> physical render
+# crossbar. Drives a depacketizer-clone AXIS with recognizable per-sample
+# ramps (stream/ch/seq encoded in the 24-bit payload), programs identity /
+# permuted / cross-stream / unmapped maps, and asserts byte-exact routing on
+# the phys outputs at each 48 kHz tick (map + cur_r frozen between ticks).
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+TOP        = KL_chan_map_render
+VFLAGS = --cc --exe --build -j 0 --top-module $(TOP) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
+         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-IMPORTSTAR -Wno-CASEINCOMPLETE \
+         -Wno-EOFNEWLINE -CFLAGS "-std=c++17 -O2"
+SRCS = $(RTL_DIR)/ieee1722/aaf/KL_chan_map_render.sv
+.PHONY: all run clean
+all: run
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) sim_main.cpp -o VKL_chan_map_render_sim
+	./obj_dir/VKL_chan_map_render_sim
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/chmap_render/sim_main.cpp
+++ b/tb/verilator/chmap_render/sim_main.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// KL_chan_map_render harness: drive a depacketizer-clone AXIS (64-bit beats =
+// 2 consecutive S32BE samples, wire-interleaved payload, tuser = stream, tlast
+// per PDU) with recognizable per-sample ramps whose 24-bit value encodes
+// {s[3:0], c[3:0], seq[15:0]}. Program identity / permuted / cross-stream /
+// unmapped maps and assert BYTE-EXACT routing on the phys outputs at each
+// 48 kHz tick. Also proves the glitch-free contract: both the map RAM AND the
+// free-running cur_r latch are only ever sampled onto the outputs at a tick
+// (old value until tick, new after), plus tlast beat-realignment across
+// back-to-back PDUs of different (even/odd) channel counts, and pad-byte drop.
+#include "VKL_chan_map_render.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+
+static VKL_chan_map_render* dut;
+static long checks = 0, fails = 0;
+
+static void ck(const char* w, uint32_t got, uint32_t exp) {
+  checks++;
+  if (got != exp) {
+    fails++;
+    printf("  [FAIL] %-34s got=0x%06x exp=0x%06x\n", w, got, exp);
+  }
+}
+
+static void step() {
+  dut->clk_i = 0; dut->eval();
+  dut->clk_i = 1; dut->eval();
+}
+
+// 24-bit sample payload = {s[3:0], c[3:0], seq[15:0]}
+static uint32_t value(int s, int c, int seq) {
+  return (((uint32_t)(s & 0xF)) << 20) | (((uint32_t)(c & 0xF)) << 16) |
+         ((uint32_t)(seq & 0xFFFF));
+}
+
+// pack two 24-bit samples (+ their pad bytes) into a wire-order S32BE beat:
+// lane j = wire byte j; sample byte 0 = MSB; lane 3/7 = pad (must be dropped).
+static uint64_t beat(uint32_t v0, uint8_t p0, uint32_t v1, uint8_t p1) {
+  uint64_t b = 0;
+  b |= (uint64_t)((v0 >> 16) & 0xFF) << 0;
+  b |= (uint64_t)((v0 >> 8) & 0xFF) << 8;
+  b |= (uint64_t)(v0 & 0xFF) << 16;
+  b |= (uint64_t)p0 << 24;
+  b |= (uint64_t)((v1 >> 16) & 0xFF) << 32;
+  b |= (uint64_t)((v1 >> 8) & 0xFF) << 40;
+  b |= (uint64_t)(v1 & 0xFF) << 48;
+  b |= (uint64_t)p1 << 56;
+  return b;
+}
+
+static void set_chans(const int c[8]) {
+  uint32_t v = 0;
+  for (int s = 0; s < 8; s++) v |= ((uint32_t)(c[s] & 0xF)) << (s * 4);
+  dut->wire_chans_i = v;
+}
+
+// drive one AAF PDU: C channels, 6 samples/channel (Milan 48k), 2 samples/beat.
+// sample k -> channel k%C, within-channel seq k/C (0..5); tag offsets seq so
+// each frame's latched values (seq 5 -> tag+5) are distinguishable.
+static void drive_frame(int s, int C, int tag, bool deassert = true) {
+  int nbeats = (6 * C) / 2;  // = 3*C, always whole (6*C even)
+  for (int b = 0; b < nbeats; b++) {
+    int k0 = 2 * b, k1 = 2 * b + 1;
+    uint32_t v0 = value(s, k0 % C, tag + k0 / C);
+    uint32_t v1 = value(s, k1 % C, tag + k1 / C);
+    dut->s_tdata_i  = beat(v0, 0xAA, v1, 0x55);  // nonzero pad -> must drop
+    dut->s_tvalid_i = 1;
+    dut->s_tuser_i  = s;
+    dut->s_tlast_i  = (b == nbeats - 1) ? 1 : 0;
+    step();
+  }
+  if (deassert) { dut->s_tvalid_i = 0; dut->s_tlast_i = 0; }
+}
+
+static void wr_map(int p, int en, int s, int c) {
+  dut->map_wr_en_i   = 1;
+  dut->map_wr_addr_i = p;
+  dut->map_wr_data_i = ((en & 1) << 7) | ((s & 7) << 3) | (c & 7);
+  step();
+  dut->map_wr_en_i = 0;
+}
+
+static void do_tick() {
+  dut->s_tvalid_i = 0;   // cur_r frozen while we sample it onto the outputs
+  dut->tick_i = 1; step();
+  dut->tick_i = 0;       // phys_smp_o / phys_valid_o now hold this frame
+}
+
+static uint32_t phys(int p) {
+  int lo = p * 24, wi = lo >> 5, off = lo & 31;
+  uint64_t w = (uint64_t)dut->phys_smp_o[wi] |
+               ((uint64_t)dut->phys_smp_o[wi + 1] << 32);
+  return (uint32_t)((w >> off) & 0xFFFFFF);
+}
+
+static uint8_t rd_map(int p) {
+  dut->map_rd_addr_i = p; dut->eval();
+  return dut->map_rd_data_o;
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new VKL_chan_map_render;
+
+  // ---- reset ----
+  dut->rst_n = 0; dut->s_tvalid_i = 0; dut->s_tlast_i = 0; dut->s_tuser_i = 0;
+  dut->tick_i = 0; dut->map_wr_en_i = 0; dut->map_wr_addr_i = 0;
+  dut->map_wr_data_i = 0; dut->map_rd_addr_i = 0; dut->s_tdata_i = 0;
+  int chans[8] = {2, 8, 2, 3, 2, 2, 2, 2};
+  set_chans(chans);
+  for (int i = 0; i < 6; i++) step();
+  dut->rst_n = 1;
+
+  printf("== KL_chan_map_render ==\n");
+
+  // ================================================================
+  // Phase 1: latch 4 streams, program the default identity map
+  //   (I2S L/R = phys0/1 <- stream0; TDM8 slots = phys2..9 <- stream1)
+  // ================================================================
+  drive_frame(0, 2, 0x100);   // cur[0][c] = value(0,c,0x105)
+  drive_frame(1, 8, 0x200);   // cur[1][c] = value(1,c,0x205)
+  drive_frame(2, 2, 0x300);   // cur[2][c] = value(2,c,0x305)
+  drive_frame(3, 3, 0x400);   // cur[3][c] = value(3,c,0x405)  (odd straddle)
+
+  wr_map(0, 1, 0, 0); wr_map(1, 1, 0, 1);
+  for (int p = 2; p < 10; p++) wr_map(p, 1, 1, p - 2);   // stream1 ch0..7
+  do_tick();
+  ck("id.phys_valid", dut->phys_valid_o, 1);
+  ck("id.mask", dut->mapped_mask_o, 0x3FF);
+  ck("id.phys0 s0c0", phys(0), value(0, 0, 0x105));
+  ck("id.phys1 s0c1", phys(1), value(0, 1, 0x105));
+  for (int c = 0; c < 8; c++)
+    ck("id.phys s1", phys(2 + c), value(1, c, 0x205));
+  ck("id.rdmap0", rd_map(0), (1 << 7) | (0 << 3) | 0);
+  ck("id.rdmap9", rd_map(9), (1 << 7) | (1 << 3) | 7);
+  // phys_valid is a one-cycle pulse
+  dut->tick_i = 0; step();
+  ck("id.valid_pulse_clears", dut->phys_valid_o, 0);
+
+  // ================================================================
+  // Phase 2: permuted (reverse stream1) + cross to stream2
+  // ================================================================
+  wr_map(0, 1, 2, 0); wr_map(1, 1, 2, 1);
+  for (int p = 2; p < 10; p++) wr_map(p, 1, 1, 9 - p);   // ch7..0 reversed
+  do_tick();
+  ck("perm.phys0 s2c0", phys(0), value(2, 0, 0x305));
+  ck("perm.phys1 s2c1", phys(1), value(2, 1, 0x305));
+  for (int p = 2; p < 10; p++)
+    ck("perm.phys s1rev", phys(p), value(1, 9 - p, 0x205));
+
+  // ================================================================
+  // Phase 3: full cross-stream incl. odd stream3, and a duplicated source
+  //          (phys0 and phys9 both point at stream3 ch0)
+  // ================================================================
+  int ms[10] = {3, 3, 3, 0, 0, 1, 2, 2, 1, 3};
+  int mc[10] = {0, 1, 2, 0, 1, 3, 0, 1, 0, 0};
+  int mtag[10] = {0x405, 0x405, 0x405, 0x105, 0x105,
+                  0x205, 0x305, 0x305, 0x205, 0x405};
+  for (int p = 0; p < 10; p++) wr_map(p, 1, ms[p], mc[p]);
+  do_tick();
+  for (int p = 0; p < 10; p++)
+    ck("cross.phys", phys(p), value(ms[p], mc[p], mtag[p]));
+
+  // ================================================================
+  // Phase 4: unmapped (en=0) channels render 0; mask tracks live en bits
+  // ================================================================
+  for (int p = 3; p < 10; p++) wr_map(p, 0, 0, 0);
+  do_tick();
+  ck("unmap.mask", dut->mapped_mask_o, 0x007);
+  ck("unmap.phys0", phys(0), value(3, 0, 0x405));
+  ck("unmap.phys1", phys(1), value(3, 1, 0x405));
+  ck("unmap.phys2", phys(2), value(3, 2, 0x405));
+  for (int p = 3; p < 10; p++) ck("unmap.zero", phys(p), 0);
+
+  // ================================================================
+  // Phase 5a: cur_r free-runs, but a mapped output only changes at a tick
+  // ================================================================
+  wr_map(0, 1, 0, 0); do_tick();
+  ck("free.baseline", phys(0), value(0, 0, 0x105));
+  drive_frame(0, 2, 0x700);          // cur[0][0] now value(0,0,0x705), NO tick
+  ck("free.frozen_no_tick", phys(0), value(0, 0, 0x105));  // still old
+  do_tick();
+  ck("free.after_tick", phys(0), value(0, 0, 0x705));      // now new
+
+  // ================================================================
+  // Phase 5b: a map rewrite is likewise frozen until the next tick
+  // ================================================================
+  wr_map(1, 1, 1, 0); do_tick();
+  ck("remap.baseline", phys(1), value(1, 0, 0x205));
+  wr_map(1, 1, 2, 1);                 // repoint phys1, NO tick
+  ck("remap.frozen_no_tick", phys(1), value(1, 0, 0x205));  // still old route
+  do_tick();
+  ck("remap.after_tick", phys(1), value(2, 1, 0x305));      // new route
+
+  // ================================================================
+  // Phase 6: tlast beat-realignment across back-to-back PDUs of different
+  //          channel counts (8 -> 3 odd -> 2) with tvalid never dropping.
+  //          If the tlast reset failed, the odd 3ch frame would drag chpos
+  //          into the following frames and corrupt the embedded ch field.
+  // ================================================================
+  drive_frame(1, 8, 0xA00, /*deassert=*/false);
+  drive_frame(3, 3, 0xB00, /*deassert=*/false);
+  drive_frame(0, 2, 0xC00, /*deassert=*/true);
+  wr_map(0, 1, 1, 7); wr_map(1, 1, 3, 0); wr_map(2, 1, 3, 1);
+  wr_map(3, 1, 3, 2); wr_map(4, 1, 0, 0); wr_map(5, 1, 0, 1);
+  for (int p = 6; p < 10; p++) wr_map(p, 0, 0, 0);
+  do_tick();
+  ck("b2b.s1c7", phys(0), value(1, 7, 0xA05));
+  ck("b2b.s3c0", phys(1), value(3, 0, 0xB05));
+  ck("b2b.s3c1", phys(2), value(3, 1, 0xB05));
+  ck("b2b.s3c2", phys(3), value(3, 2, 0xB05));
+  ck("b2b.s0c0", phys(4), value(0, 0, 0xC05));
+  ck("b2b.s0c1", phys(5), value(0, 1, 0xC05));
+
+  printf("%ld checks, %ld failures, RESULT: %s\n", checks, fails,
+         fails ? "FAIL" : "PASS");
+  delete dut;
+  return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Status

Ready for review. New module + Verilator TB, both self-contained (single file each). TB green: **58 checks, 0 failures, RESULT: PASS**. No changes to any existing RTL, wrapper, or build file — the map write port is exposed only; its owner (AEM audio-map engine / CSR) is upstream and out of scope for this PR.

## Description

`hdl/ieee1722/aaf/KL_chan_map_render.sv` — the render stage of the 8×8 AAF listener: an N_STREAMS_P·N_CH_P (default 64) stream-channel → N_PHYS_P (default 10) physical-channel crossbar.

- Consumes a **clone** of the shared `KL_aaf_rx_depacketizer` payload AXIS (64-bit beats = 2 consecutive S32BE samples of the wire-interleaved payload, `tuser` = stream index, one AXIS frame per PDU, full 8-byte beats). Never backpressures — no `tready`; drive `s_tvalid_i` with the tapped link's accepted beats.
- **De-interleave:** a single beat-position walker computes each sample's wire channel = `sample_pos % chans[s]` (2 samples/beat), restarting at every `tlast`. `chans[s]` comes from the RX monitors' `wire_chans_o` (flat 4-bit fields, `0` treated as `2`). Odd channel counts straddle correctly across beats; wire channels ≥ N_CH_P are walked for the interleave but never latched.
- **Latch:** free-running latest-sample wire-truth `cur_r[s][c]` of the top 24 bits of every sample (the S32BE pad byte, lanes 3/7, is dropped).
- **Render:** a map RAM (one write port, entry `{en[7], rsvd[6], stream[5:3], ch[2:0]}`) routes any latched stream-channel to any phys. On each `tick_i` (one pulse per 48 kHz output frame) the **whole phys vector registers in one shot** and `phys_valid_o` pulses — so both map writes AND cur_r updates between ticks are invisible until the next tick (glitch-free at frame rate). Unmapped (`en=0`) phys render `24'd0`.
- Combinational map readback (`map_rd_addr_i` / `map_rd_data_o`) and live `mapped_mask_o[N_PHYS_P-1:0]`.
- Default N_PHYS_P=10 = I2S-out L/R (phys 0/1) + TDM8-out lane0 slots 0..7 (phys 2..9). Single clock domain, no CDC (ticks arrive synchronized). House style (SPDX/banner, `default_nettype none`/`wire`, `//!` port docs, `_r/_w`, named blocks, sync active-low `rst_n`, 2-space).

`tb/verilator/chmap_render/` — direct-verilate TB (Makefile mirrors `tb/verilator/avtp_rxmon/` VFLAGS). Drives streams with recognizable ramps whose 24-bit payload encodes `{s[3:0], c[3:0], seq[15:0]}` and byte-exactly asserts routing.

## How to get into the same state

```
git fetch origin && git checkout chmap-render
# Verilator >= 5.0 on PATH (built with 5.050). No third-party / package deps:
# the module and TB each verilate stand-alone.
```

## How to validate

```
make -C tb/verilator/chmap_render
```

Expected final line:

```
58 checks, 0 failures, RESULT: PASS
```

Exit code 0 on pass, nonzero on any failure. What the 58 checks cover:
- **Identity map** (I2S L/R ← stream0, TDM8 ← stream1 ch0..7): 10 phys byte-exact + `phys_valid_o` pulse (asserts one cycle, then clears) + `mapped_mask_o=0x3FF` + map readback.
- **Permuted** (reversed stream1) and **full cross-stream** maps incl. a duplicated source (two phys ← same stream-channel).
- **Odd channel count** (stream3 = 3ch) de-interleave / beat-straddle.
- **Unmapped** (`en=0`) phys render 0; `mapped_mask_o` tracks live en bits.
- **Glitch-free contract:** cur_r free-runs but a mapped output only changes at a tick; a map rewrite is likewise frozen until the next tick (old value until tick, new after).
- **`tlast` beat-realignment** across back-to-back PDUs of different channel counts (8→3 odd→2) with `tvalid` never dropping.
- **Pad-byte drop:** every beat carries nonzero S32BE pad bytes (0xAA/0x55) that must not leak into the latched 24-bit value.

## Definition of Done

- [x] `KL_chan_map_render.sv` implements the spec (params N_STREAMS_P=8 / N_CH_P=8 / N_PHYS_P=10; depacketizer-clone AXIS input; per-stream `wire_chans_i`; `tick_i`; map write port + readback; `phys_smp_o` / `phys_valid_o` / `mapped_mask_o`).
- [x] House style enforced; `verilator --lint-only` clean (only the intended pad-byte UNUSEDSIGNAL, suppressed by the TB Makefile flags as in `avtp_rxmon`).
- [x] Verilator TB with ≥ 25 meaningful checks (58 present), byte-exact, exits nonzero on fail.
- [x] `make -C tb/verilator/chmap_render` → PASS.
- [x] No existing files touched; build artifacts gitignored.
- [ ] Peer review (not self-approved).
