### PR TITLE
chmap64/item-10: dynamic audio-maps fixture + AEM->fabric map binding contract (behave 9/9)

### DIFF
--- a/docs/CHMAP64_AEM_BINDING.md
+++ b/docs/CHMAP64_AEM_BINDING.md
@@ -1,0 +1,154 @@
+<!--
+SPDX-FileCopyrightText: 2026 Kebag Logic
+SPDX-License-Identifier: CERN-OHL-W-2.0
+-->
+
+# chmap64 — AEM dynamic-audio-map → fabric map-word binding contract
+
+The `chmap64` feature adds a **render crossbar** (listener side: incoming AAF
+stream channels → physical render/DAC channels) and a **capture mux** (talker
+side: physical capture/ADC channels → outgoing stream channels), both
+programmed by a small **map RAM**. Each RAM entry is a *map word*:
+
+```
+map word  = { en, stream[2:0], ch[2:0] }      // 7 bits
+              en      1 = this physical channel is driven
+              stream  source stream index      (0..7, the 8x8 lanes)
+              ch      source channel in stream  (0..7)
+```
+
+The **canonical programmer** of that RAM is the IEEE 1722.1 / Milan dynamic
+audio-map command set, not a bespoke register poke. This document is the
+normative binding between the two; the executable form lives in
+`tests/features/item10_audio_maps.feature` +
+`tests/steps/tsn_gen_steps.py::MilanAudioMapModel` (item-10 row
+`item-10-audio-maps`, matrix `M-AECP-4`).
+
+## Commands (codes verified against `hdl/ieee17221/aecp/aecp_pkg.sv`)
+
+| Command | `aecp_pkg.sv` | code | Spec | Milan |
+|---|---|---|---|---|
+| `GET_AUDIO_MAP` | `CMD_GET_AUDIO_MAP = 15'd43` | **0x2B** | §7.4.44 | 5.4.2.26 |
+| `ADD_AUDIO_MAPPINGS` | `CMD_ADD_AUDIO_MAPPINGS = 15'd44` | **0x2C** | §7.4.45 | 5.4.2.27 |
+| `REMOVE_AUDIO_MAPPINGS` | `CMD_REMOVE_AUDIO_MAPPINGS = 15'd45` | **0x2D** | §7.4.46 | 5.4.2.28 |
+
+> The values are the AEM `command_type` (Table 7.128) — decimal 43/44/45.
+> They are **not** 0x1A/0x1B/0x1C; always read `aecp_pkg.sv`, never a comment.
+
+A mapping record (8 bytes on the wire) is
+`(stream_index, stream_channel, cluster_offset, cluster_channel)`. Clusters
+model the physical channels; per Milan 5.4.2.26 the deployed clusters are
+**mono** (one channel each), so `cluster_channel == 0` and the store key is the
+`cluster_offset` alone — *at most one dynamic mapping per Audio-Cluster
+channel*.
+
+## The projection rule (AEM → map word)
+
+The dynamic map lives on `STREAM_PORT_INPUT[0]` (the render side). The RTL
+responder is `KL_aecp_response_builder` under ``` `AEM_DYNMAP ```; the store is
+`dmap_v_r[key]` / `dmap_ch_r[key]` with `key = cluster_offset`, sized
+`AEM_DMAP_KEYS_C` (generated from the end-station JSON by
+`avdecc/gen_aem_store.py`; builder self-test defaults `KEYS=8`, `NMAPS=2`,
+`PAGE=4`).
+
+For every mapping record `(si, sc, co, cc)`:
+
+```
+address  = co                         // cluster-offset = physical render channel
+                                      //   (cc == 0, mono clusters)
+
+ADD    (accepted)  →  RAM[address] = { en=1, stream=si, ch=sc }
+REMOVE (matched)   →  RAM[address] = { en=0, stream=0,  ch=0  }
+```
+
+Packed: `word = (en<<6) | (stream<<3) | ch`. Example: adding `si=0, sc=3, co=0`
+yields `RAM[0] = 0x43` (`en=1, stream=0, ch=3`).
+
+### Validity (ADD, 5.4.2.27 — all-or-nothing)
+
+A record is valid iff **all** hold; any invalid record fails the *whole*
+command with `BAD_ARGUMENTS` and **nothing** is written:
+
+| Check | Rule | RTL term |
+|---|---|---|
+| single audio input | `stream_index == 0` | `w_dm_shape_ok` |
+| mono cluster | `cluster_channel == 0` | `w_dm_shape_ok` |
+| key in range | `cluster_offset < AEM_DMAP_KEYS_C` | `w_dm_key_ok` |
+| channel in format | `stream_channel < channels(STREAM_INPUT[0])` | `w_dm_ch_ok` |
+| no intra-command dup | same `cluster_offset` used twice in one command → reject | `dmap_claim_r[key]` |
+
+A valid ADD to an already-mapped key **replaces** it (the 5.4.2.27 accept-and-
+replace option). `stream_index` is fixed at 0 in the current single-input build;
+the chmap64 8×8 build widens `KEYS` and the `stream` field — the projection rule
+above is unchanged.
+
+### REMOVE (5.4.2.28 — lenient)
+
+REMOVE clears an **exact** `(cluster_offset, stream_channel)` match and *ignores*
+everything else (unmatched, duplicate); it always returns `SUCCESS` on the input
+port. GET then shows the key gone / the word disabled.
+
+### GET_AUDIO_MAP (getter)
+
+`STREAM_PORT_INPUT[0]` pages the live store: `number_of_maps` is the fixed
+partition count `AEM_DMAP_NMAPS_C`; each page emits `PAGE` keys, listing the
+mapped ones as `(stream_index=0, stream_channel, cluster_offset, cluster_channel=0)`.
+`map_index >= NMAPS` → `BAD_ARGUMENTS` (§7.4.44.1). `STREAM_PORT_OUTPUT[0]` is
+the static capture map (well-formed, `number_of_maps=1`). Any other
+descriptor/index → `NO_SUCH_DESCRIPTOR`.
+
+### Status codes returned (as the RTL actually returns them)
+
+| Situation | Status | value |
+|---|---|---|
+| accepted ADD/REMOVE/GET | `SUCCESS` | 0 |
+| unknown descriptor/index | `NO_SUCH_DESCRIPTOR` | 2 |
+| invalid record / dup key / bad map_index | `BAD_ARGUMENTS` | 7 |
+| ADD/REMOVE on the static output map | `NOT_SUPPORTED` | 11 |
+| locked/acquired by another controller | `ENTITY_LOCKED` / `ENTITY_ACQUIRED` | 3 / 4 |
+
+## Cluster ↔ physical-channel table (I2S 2ch + TDM8 8ch)
+
+The `AUDIO_CLUSTER` descriptors of the end-station
+(`avdecc/milan-v12-entity.json`) enumerate the physical channels; the render
+crossbar addresses them by flattened `cluster_offset` (mono clusters):
+
+| cluster_offset | physical render channel | interface |
+|---|---|---|
+| 0 | render L | I2S stereo, ch 0 |
+| 1 | render R | I2S stereo, ch 1 |
+| 2 | render 2 | TDM8 slot 0 |
+| 3 | render 3 | TDM8 slot 1 |
+| 4 | render 4 | TDM8 slot 2 |
+| 5 | render 5 | TDM8 slot 3 |
+| 6 | render 6 | TDM8 slot 4 |
+| 7 | render 7 | TDM8 slot 5 |
+| … | … | TDM8 slots 6-7 when `KEYS ≥ 10` |
+
+`AEM_DMAP_KEYS_C` is generated to cover the deployed physical channel count
+(I2S 2 + TDM8 8 = 10 for the full render; the builder unit-test fixture uses 8).
+The capture mux mirrors this on `STREAM_PORT_OUTPUT` (static in the current
+RTL: I2S/TDM8 capture channels → outgoing stream channels).
+
+## Arbitration — who owns the map write port
+
+- **The AEM engine owns the map RAM write port.** `ADD`/`REMOVE_AUDIO_MAPPINGS`
+  is the authoritative, spec-visible programmer; every accepted edit projects to
+  a map word as above, and `GET_AUDIO_MAP` is the read-back of record.
+- **The CSR window is a debug-override**, not the normal control path. It exists
+  for bring-up / bench pokes and is subordinate to the AEM engine: a controller
+  issuing dynamic maps is the source of truth, and any CSR scribble is expected
+  to be re-asserted by the next AEM edit / `GET_AUDIO_MAP` reconciliation. Do not
+  drive both concurrently in production; the CSR path carries no lock semantics.
+
+## Traceability — `PDU_GETTER_SETTER_VERIFICATION.md` audio-maps row
+
+The item-10 plan doc `docs/testing/PDU_GETTER_SETTER_VERIFICATION.md` is owned
+by the sibling open PR `item-10-pdu-getter-setter-verify` and is **not present on
+`main`** (this PR's base), so its table cannot be appended here without an
+add/add collision. When that PR lands, its AECP/AEM table row
+
+> `GET_AUDIO_MAP + ADD/REMOVE_AUDIO_MAPPINGS | getter + action (es-4.16) | matrix M-AECP-4 | item-10-audio-maps`
+
+is satisfied by this fixture; update its "Existing coverage" cell to
+`item10_audio_maps (getter + action + fabric)` and mark the row done.

--- a/tests/features/item10_audio_maps.feature
+++ b/tests/features/item10_audio_maps.feature
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:AUDIO_MAPS @matrix:M-AECP-4
+Feature: Item-10 dynamic audio maps + chmap64 AEM->fabric binding contract
+  IEEE 1722.1-2021 GET_AUDIO_MAP (cmd 43 / 0x2B), ADD_AUDIO_MAPPINGS (44 /
+  0x2C) and REMOVE_AUDIO_MAPPINGS (45 / 0x2D) on the dynamic STREAM_PORT_INPUT[0]
+  (Milan es-4.16 / 5.4.2.26-28). Command codes are the RTL/spec values verified
+  against hdl/ieee17221/aecp/aecp_pkg.sv. Frames are tsn_gen-generated and
+  decode-cross-checked; the Milan audio-map model mirrors the `AEM_DYNMAP path
+  of KL_aecp_response_builder (KEYS=8, NMAPS=2, PAGE=4 - the RTL itself is
+  verified by tb/verilator/aecp).
+
+  Each accepted mapping projects to a chmap64 render map word
+  {en, stream[2:0], ch[2:0]} at the cluster-offset (physical-channel) address,
+  each removal disables it - the executable chmap64 binding contract
+  (docs/CHMAP64_AEM_BINDING.md).
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan audio-map model
+
+  # (a) getter, well-formed on the default (empty) dynamic map
+  @class:getter
+  Scenario: GET_AUDIO_MAP on the default input map is well-formed and empty
+    Given tsn_gen generated a GET_AUDIO_MAP frame with seed 3
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 43
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "map_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the last GET lists 0 mappings
+    And the fabric render crossbar has 0 enabled words
+
+  # (b) action + getter round-trip: ADD then GET reflects the added mapping
+  @class:action @paired
+  Scenario: ADD_AUDIO_MAPPINGS then GET_AUDIO_MAP reflects the added mapping
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 5
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 44
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 0
+    And I patch field "mapping_stream_channel" to 3
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 is en 1 stream 0 ch 3
+    And the fabric map word at cluster_offset 0 equals 0x43
+    And the fabric render crossbar has 1 enabled words
+    Given tsn_gen generated a GET_AUDIO_MAP frame with seed 6
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 43
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "map_index" to 0
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the last GET lists 1 mappings
+    And the last GET contains stream_channel 3 at cluster_offset 0
+
+  # (c) action + getter round-trip: REMOVE then GET reflects the removal
+  @class:action @paired
+  Scenario: REMOVE_AUDIO_MAPPINGS then GET_AUDIO_MAP reflects the removal
+    When I ADD mapping stream_channel 3 at cluster_offset 0
+    Then the audio-map model responds status 0
+    And the fabric render crossbar has 1 enabled words
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 7
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 45
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 0
+    And I patch field "mapping_stream_channel" to 3
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 is en 0 stream 0 ch 0
+    And the fabric render crossbar has 0 enabled words
+    When the audio-map model GETs input page 0
+    Then the audio-map model responds status 0
+    And the last GET lists 0 mappings
+
+  # (d) negatives - the codes the RTL actually returns (BAD_ARGUMENTS = 7)
+  @class:action @negative
+  Scenario: ADD with an out-of-range stream_index is refused, nothing projected
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 9
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 44
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 5
+    And I patch field "mapping_stream_channel" to 1
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    Then tsn_gen decodes every patched field back
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 7
+    And the fabric render crossbar has 0 enabled words
+
+  @class:action @negative
+  Scenario: ADD with a duplicate cluster key in one command is refused (all-or-nothing)
+    When I ADD a same-key mapping pair at cluster_offset 2 with stream_channels 1 and 2
+    Then the audio-map model responds status 7
+    And the fabric render crossbar has 0 enabled words
+
+  @class:action @negative
+  Scenario: ADD on the static STREAM_PORT_OUTPUT map is NOT_SUPPORTED
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 11
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 44
+    And I patch field "descriptor_type" to 0x0F
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 0
+    And I patch field "mapping_stream_channel" to 0
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 11
+
+  @class:getter @negative
+  Scenario: GET_AUDIO_MAP on an unknown descriptor is refused
+    Given tsn_gen generated a GET_AUDIO_MAP frame with seed 13
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 43
+    And I patch field "descriptor_type" to 0x05
+    And I patch field "descriptor_index" to 0
+    And I patch field "map_index" to 0
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 2
+
+  @class:getter @negative
+  Scenario: GET_AUDIO_MAP with an out-of-range map_index is BAD_ARGUMENTS
+    When the audio-map model GETs input page 2
+    Then the audio-map model responds status 7
+
+  # (e) the chmap64 binding contract: the crossbar tracks accepted mappings
+  @class:action @fabric
+  Scenario: the render crossbar projects, replaces and clears map words
+    When I ADD mapping stream_channel 1 at cluster_offset 0
+    And I ADD mapping stream_channel 2 at cluster_offset 1
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 equals 0x41
+    And the fabric map word at cluster_offset 1 equals 0x42
+    And the fabric render crossbar has 2 enabled words
+    When I ADD mapping stream_channel 4 at cluster_offset 1
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 1 is en 1 stream 0 ch 4
+    And the fabric render crossbar has 2 enabled words
+    When I REMOVE mapping stream_channel 1 at cluster_offset 0
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 is en 0 stream 0 ch 0
+    And the fabric map word at cluster_offset 1 equals 0x44
+    And the fabric render crossbar has 1 enabled words

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -45,6 +45,30 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('descriptor_type', 16),
                    ('descriptor_index', 16), ('control_values', 64)],
     },
+    'GET_AUDIO_MAP': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_get_audio_map::AECP_GET_AUDIO_MAP::'
+                      'AECP_GET_AUDIO_MAP_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('map_index', 16),
+                   ('reserved', 16)],
+    },
+    'AUDIO_MAPPINGS': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_audio_mappings::AECP_AUDIO_MAPPINGS::'
+                      'AECP_AUDIO_MAPPINGS_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('number_of_mappings', 16),
+                   ('reserved', 16), ('mapping_stream_index', 16),
+                   ('mapping_stream_channel', 16), ('mapping_cluster_offset', 16),
+                   ('mapping_cluster_channel', 16)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -150,6 +174,143 @@ class MilanAecpModel:
                 return STATUS_BAD_ARGUMENTS
             self.identify = value
             return STATUS_SUCCESS
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Milan v1.2 dynamic audio-map model + chmap64 fabric projection
+# (mirrors KL_aecp_response_builder under `AEM_DYNMAP, and encodes the
+# AEM->fabric binding contract documented in docs/CHMAP64_AEM_BINDING.md).
+#
+# Command codes are the RTL/spec values from hdl/ieee17221/aecp/aecp_pkg.sv:
+#   GET_AUDIO_MAP        = 43 (0x2B)   §7.4.44
+#   ADD_AUDIO_MAPPINGS   = 44 (0x2C)   §7.4.45 / Milan 5.4.2.27
+#   REMOVE_AUDIO_MAPPINGS= 45 (0x2D)   §7.4.46 / Milan 5.4.2.28
+# ---------------------------------------------------------------------------
+
+CMD_GET_AUDIO_MAP = 43
+CMD_ADD_AUDIO_MAPPINGS = 44
+CMD_REMOVE_AUDIO_MAPPINGS = 45
+DESC_STREAM_PORT_INPUT = 0x0E
+DESC_STREAM_PORT_OUTPUT = 0x0F
+STATUS_NOT_SUPPORTED = 11
+
+
+class MilanAudioMapModel:
+    """Dynamic audio-map responder for STREAM_PORT_INPUT[0], mirroring the
+    `AEM_DYNMAP path of KL_aecp_response_builder (defaults KEYS=8, NMAPS=2,
+    PAGE=4 from avdecc/gen_aem_store.py; the RTL is verified by tb/aecp).
+
+    Milan 5.4.2.26 mono clusters: the store key IS the mapping_cluster_offset
+    (at most one dynamic mapping per Audio-Cluster channel). A mapping record
+    is (stream_index, stream_channel, cluster_offset, cluster_channel).
+
+      * ADD is all-or-nothing (5.4.2.27): any invalid record -> BAD_ARGUMENTS
+        and NOTHING is written; a repeated key within one command is the
+        mandated same-cluster-channel conflict -> BAD_ARGUMENTS.
+      * REMOVE is lenient (5.4.2.28): clears exact matches, ignores the rest,
+        always SUCCESS on the input port.
+
+    Each accepted record projects to a chmap64 render map word
+    {en, stream[2:0], ch[2:0]} at the cluster-offset (physical-channel)
+    address; each cleared record disables that word. That projection IS the
+    executable chmap64 binding contract (docs/CHMAP64_AEM_BINDING.md)."""
+
+    def __init__(self, keys=8, nmaps=2, page=4, stream_channels=8):
+        self.keys = keys              # AEM_DMAP_KEYS_C: render output channels
+        self.nmaps = nmaps            # AEM_DMAP_NMAPS_C: GET_AUDIO_MAP pages
+        self.page = page              # AEM_DMAP_PAGE_C: mappings per page
+        self.stream_channels = stream_channels  # channels in STREAM_INPUT[0]
+        self.store = {}               # cluster_offset -> stream_channel
+        self.fabric_map = {}          # cluster_offset -> {en,stream,ch} word
+        self.last_get = None          # rows returned by the last GET page
+
+    # -- validity (5.4.2.27) ------------------------------------------------
+    def _shape_ok(self, si, sc, co, cc):
+        # single audio-carrying input (stream_index 0), mono cluster
+        # (cluster_channel 0), cluster key in range
+        return si == 0 and cc == 0 and co < self.keys
+
+    def _ch_ok(self, sc):
+        # stream_channel inside the current STREAM_INPUT[0] format
+        return sc < self.stream_channels
+
+    # -- fabric projection --------------------------------------------------
+    def _project_add(self, si, sc, co):
+        self.fabric_map[co] = {'en': 1, 'stream': si, 'ch': sc}
+
+    def _project_remove(self, co):
+        self.fabric_map[co] = {'en': 0, 'stream': 0, 'ch': 0}
+
+    def word(self, co):
+        """The 7-bit chmap64 map word {en[6], stream[5:3], ch[2:0]}."""
+        m = self.fabric_map.get(co, {'en': 0, 'stream': 0, 'ch': 0})
+        return ((m['en'] & 1) << 6) | ((m['stream'] & 0x7) << 3) | (m['ch'] & 0x7)
+
+    def enabled_words(self):
+        return sum(1 for m in self.fabric_map.values() if m['en'])
+
+    # -- command processing -------------------------------------------------
+    def process_mappings(self, cmd, dt, di, mappings):
+        if dt == DESC_STREAM_PORT_OUTPUT and di == 0:
+            return STATUS_NOT_SUPPORTED          # static output maps
+        if dt != DESC_STREAM_PORT_INPUT or di != 0:
+            return STATUS_NO_SUCH_DESCRIPTOR
+        if len(mappings) > 60:                   # one-AECPDU engine bound
+            return STATUS_BAD_ARGUMENTS
+        if not mappings:
+            return STATUS_SUCCESS                # empty edit, no change
+
+        if cmd == CMD_ADD_AUDIO_MAPPINGS:
+            claim = set()                        # intra-command same-key guard
+            for si, sc, co, cc in mappings:      # validate pass
+                if (not self._shape_ok(si, sc, co, cc)
+                        or not self._ch_ok(sc) or co in claim):
+                    return STATUS_BAD_ARGUMENTS  # all-or-nothing
+                claim.add(co)
+            for si, sc, co, cc in mappings:      # commit pass (replace allowed)
+                self.store[co] = sc
+                self._project_add(si, sc, co)
+            return STATUS_SUCCESS
+
+        # REMOVE — lenient single commit pass
+        for si, sc, co, cc in mappings:
+            if (self._shape_ok(si, sc, co, cc) and sc < 16
+                    and self.store.get(co) == sc):
+                del self.store[co]
+                self._project_remove(co)
+        return STATUS_SUCCESS
+
+    def process_get(self, dt, di, map_index):
+        if dt == DESC_STREAM_PORT_OUTPUT and di == 0:
+            self.last_get = None                 # static output map, well-formed
+            return STATUS_SUCCESS
+        if dt != DESC_STREAM_PORT_INPUT or di != 0:
+            self.last_get = None
+            return STATUS_NO_SUCH_DESCRIPTOR
+        if map_index >= self.nmaps:              # 7.4.44.1 paging
+            self.last_get = None
+            return STATUS_BAD_ARGUMENTS
+        lo = map_index * self.page
+        self.last_get = [(0, self.store[k], k, 0)
+                         for k in range(lo, lo + self.page) if k in self.store]
+        return STATUS_SUCCESS
+
+    def process(self, fields):
+        """Drive the model from a decoded tsn_gen frame (one mapping/frame,
+        matching the aecp_aem_audio_mappings.yaml single-mapping layout)."""
+        cmd = fields['command_type']
+        dt = fields.get('descriptor_type', 0)
+        di = fields.get('descriptor_index', 0)
+        if cmd == CMD_GET_AUDIO_MAP:
+            return self.process_get(dt, di, fields.get('map_index', 0))
+        if cmd in (CMD_ADD_AUDIO_MAPPINGS, CMD_REMOVE_AUDIO_MAPPINGS):
+            n = fields.get('number_of_mappings', 1)
+            rec = (fields.get('mapping_stream_index', 0),
+                   fields.get('mapping_stream_channel', 0),
+                   fields.get('mapping_cluster_offset', 0),
+                   fields.get('mapping_cluster_channel', 0))
+            return self.process_mappings(cmd, dt, di, [rec] if n else [])
         return None
 
 
@@ -403,6 +564,85 @@ def step_fuzz_invariant(context):
                 f'model rejected a legal write with {status}: {f}'
     csi = context.aecp_model.clock_source_index
     assert csi < 3, f'state corrupted: clock_source_index={csi}'
+
+
+# ---------------------------------------------------------------------------
+# Steps — Milan dynamic audio maps + chmap64 fabric projection
+# ---------------------------------------------------------------------------
+
+@given('a fresh Milan audio-map model')
+def step_fresh_audiomap(context):
+    context.amap = MilanAudioMapModel()
+
+
+@when('the audio-map model processes the frame')
+def step_audiomap_process(context):
+    context.amap_status = context.amap.process(context.frame_fields)
+
+
+@when('I ADD mapping stream_channel {sc:d} at cluster_offset {co:d}')
+def step_amap_add(context, sc, co):
+    context.amap_status = context.amap.process_mappings(
+        CMD_ADD_AUDIO_MAPPINGS, DESC_STREAM_PORT_INPUT, 0, [(0, sc, co, 0)])
+
+
+@when('I REMOVE mapping stream_channel {sc:d} at cluster_offset {co:d}')
+def step_amap_remove(context, sc, co):
+    context.amap_status = context.amap.process_mappings(
+        CMD_REMOVE_AUDIO_MAPPINGS, DESC_STREAM_PORT_INPUT, 0, [(0, sc, co, 0)])
+
+
+@when('I ADD a same-key mapping pair at cluster_offset {co:d} with stream_channels {a:d} and {b:d}')
+def step_amap_add_dup(context, co, a, b):
+    context.amap_status = context.amap.process_mappings(
+        CMD_ADD_AUDIO_MAPPINGS, DESC_STREAM_PORT_INPUT, 0,
+        [(0, a, co, 0), (0, b, co, 0)])
+
+
+@when('the audio-map model GETs input page {mi:d}')
+def step_amap_get(context, mi):
+    context.amap_status = context.amap.process_get(
+        DESC_STREAM_PORT_INPUT, 0, mi)
+
+
+@then('the audio-map model responds status {code:d}')
+def step_amap_status(context, code):
+    assert context.amap_status == code, \
+        f'audio-map status {context.amap_status}, expected {code}'
+
+
+@then('the fabric map word at cluster_offset {co:d} is en {en:d} stream {s:d} ch {ch:d}')
+def step_fabric_word_fields(context, co, en, s, ch):
+    m = context.amap.fabric_map.get(co, {'en': 0, 'stream': 0, 'ch': 0})
+    assert (m['en'], m['stream'], m['ch']) == (en, s, ch), \
+        f'cluster_offset {co}: fabric word {m}, expected en={en} stream={s} ch={ch}'
+
+
+@then('the fabric map word at cluster_offset {co:d} equals {val}')
+def step_fabric_word_value(context, co, val):
+    v = int(val, 0)
+    assert context.amap.word(co) == v, \
+        f'cluster_offset {co}: word {context.amap.word(co):#04x}, expected {v:#04x}'
+
+
+@then('the fabric render crossbar has {n:d} enabled words')
+def step_fabric_enabled(context, n):
+    assert context.amap.enabled_words() == n, \
+        f'{context.amap.enabled_words()} enabled words, expected {n}'
+
+
+@then('the last GET lists {n:d} mappings')
+def step_get_count(context, n):
+    assert context.amap.last_get is not None, 'no GET page captured'
+    assert len(context.amap.last_get) == n, \
+        f'GET page has {len(context.amap.last_get)} mappings, expected {n}'
+
+
+@then('the last GET contains stream_channel {sc:d} at cluster_offset {co:d}')
+def step_get_contains(context, sc, co):
+    assert context.amap.last_get is not None, 'no GET page captured'
+    assert (0, sc, co, 0) in context.amap.last_get, \
+        f'(sc={sc}, co={co}) not in GET page {context.amap.last_get}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Status

Ready for review. Host-sim only (no board, no bench). `behave -i item10_audio_maps` = **9 scenarios / 133 steps, 0 failed**; whole-suite `--dry-run` parses clean (9 features / 66 scenarios / 591 steps, 0 undefined). Self-test output posted as a comment below (results only, not an approval).

## Description

Delivers the item-10 backlog row `item-10-audio-maps` (matrix `M-AECP-4`, es-4.16) **and** the `chmap64` AEM→fabric binding contract:

- `tests/features/item10_audio_maps.feature` — GET_AUDIO_MAP getter on the default map; ADD→GET round-trip; REMOVE→GET round-trip; negatives (out-of-range `stream_index`, intra-command duplicate key, ADD on the static output map, unknown descriptor, out-of-range `map_index`); and the fabric-projection scenario that drives the render crossbar (project / replace / clear).
- `tests/steps/tsn_gen_steps.py` — two new `LAYOUTS` (`GET_AUDIO_MAP`, `AUDIO_MAPPINGS`), the `MilanAudioMapModel` (mirrors `KL_aecp_response_builder` under `` `AEM_DYNMAP ``, `KEYS=8/NMAPS=2/PAGE=4`) with the `fabric_map` projection, and the `@then` steps asserting the projected map words.
- `docs/CHMAP64_AEM_BINDING.md` — the mapping→map-word projection rule, the cluster↔physical-channel table (I2S 2ch + TDM8 8ch), the status-code table, and the arbitration note (AEM engine owns the map write port; the CSR window is a debug-override).

Command codes are the RTL/spec values verified against `hdl/ieee17221/aecp/aecp_pkg.sv`: `GET_AUDIO_MAP=43 (0x2B)`, `ADD_AUDIO_MAPPINGS=44 (0x2C)`, `REMOVE_AUDIO_MAPPINGS=45 (0x2D)`.

tsn_gen YAML: **both layouts already exist** in tsn-gen (`aecp_aem_get_audio_map.yaml`, `aecp_aem_audio_mappings.yaml`); no new YAML was needed. The single-mapping (`number_of_mappings=1`) frame is patched field-by-field; multi-mapping cases (duplicate-key, multi-key crossbar) are driven through the model directly since the YAML models one mapping per PDU.

Note on the plan doc: `docs/testing/PDU_GETTER_SETTER_VERIFICATION.md` is owned by the sibling open PR `item-10-pdu-getter-setter-verify` and is not on `main` (this PR's base), so its audio-maps row could not be appended without an add/add collision. The row-update text is carried in `docs/CHMAP64_AEM_BINDING.md` (Traceability section) to drop in when that PR lands.

## How to get into the same state

Prerequisites and one-time setup are the centralized item-10 bench convention — see `docs/testing/PDU_GETTER_SETTER_VERIFICATION.md` §Prerequisites (`TSAGEN_DIR`, `PACKET_GEN`, the `behave` venv). Then:

```bash
git checkout chmap-aemfix
export TSAGEN_DIR=/home/alex/tsn-gen
export PACKET_GEN=$TSAGEN_DIR/build/traffic-gen/packet_gen
~/litex-milan/venv/bin/behave tests -i item10_audio_maps
```

`@tsn_gen` scenarios skip cleanly when `packet_gen` is absent (CI-green without the tool).

## How to validate

- `~/litex-milan/venv/bin/behave tests -i item10_audio_maps` → 9/9 scenarios, 133/133 steps green.
- `~/litex-milan/venv/bin/behave tests --dry-run` → parses clean, no undefined steps.
- Cross-check the codes: `grep -E "CMD_(GET|ADD|REMOVE)_AUDIO" hdl/ieee17221/aecp/aecp_pkg.sv` → 43/44/45.
- Cross-check the projection: `fabric_map[cluster_offset] = {en, stream=stream_index, ch=stream_channel}`, packed `word = (en<<6)|(stream<<3)|ch` (e.g. ADD `si0 sc3 co0` → `0x43`).

## Definition of Done

- [x] getter, ADD→GET, REMOVE→GET, and negative scenarios all green
- [x] fabric projection asserted as executable map words (the chmap64 binding contract)
- [x] command codes verified against `aecp_pkg.sv` (not trusted from the request)
- [x] negatives return the codes the RTL actually returns (7 BAD_ARGUMENTS, 2 NO_SUCH_DESCRIPTOR, 11 NOT_SUPPORTED)
- [x] whole-suite dry-run clean, no undefined steps
- [x] binding contract documented (`docs/CHMAP64_AEM_BINDING.md`)
