### PR TITLE
chmap64: KL_chan_map_capture - per-pair-slot TX source mux + pair_slot widen to 32 slots (TB N/N, aaf regression green)

### DIFF
--- a/hdl/ieee1722/aaf/KL_aaf_packetizer.sv
+++ b/hdl/ieee1722/aaf/KL_aaf_packetizer.sv
@@ -92,8 +92,12 @@ module KL_aaf_packetizer #(
 
   //! --- pair stream from the capture front-end (one crossing, all slots) -
   input  wire         pair_valid_i,      //! one-cycle pulse per L/R pair
-  input  wire [3:0]   pair_slot_i,       //! pair slot (talker t owns chans/2
-                                         //! consecutive slots - see header)
+  input  wire [4:0]   pair_slot_i,       //! pair slot 0..31 (talker t owns
+                                         //! chans/2 consecutive slots; 32-slot
+                                         //! space = 8 talkers x 4 pairs max -
+                                         //! see header. Physical capture drives
+                                         //! only 0..15; the chan-map mux uses
+                                         //! the full width)
   input  wire [23:0]  pair_l_i,
   input  wire [23:0]  pair_r_i,
 

--- a/hdl/ieee1722/aaf/KL_chan_map_capture.sv
+++ b/hdl/ieee1722/aaf/KL_chan_map_capture.sv
@@ -1,0 +1,291 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+/*
+------------------------------------------------------------------------------
+  File        : KL_chan_map_capture.sv
+  Author      : Kebag Logic
+
+  Date        : 2026-07-23
+  Description : Per-pair-slot TX source multiplexer (docs/NXN_ARCHITECTURE.md
+                §2.1 capture family; the SW-defined end-station channel map).
+                Sits between the several pair-stream sources and the shared
+                KL_aaf_packetizer's pair-injection interface: for every one of
+                the N_SLOTS_P TX pair slots (the prefix-sum slot space; talker
+                t owns chans/2 consecutive slots - see the packetizer header)
+                a small map RAM selects which audio source feeds that slot.
+
+                8 talker streams x up to 8 channels = up to 32 stereo PAIR
+                slots, so the map is 32 entries deep and the emitted
+                pair_slot_o is the full 5-bit (0..31) space the packetizer now
+                accepts (the pair_slot widening).
+
+                MAP ENTRY (8 bits, one per slot): {en[7], src[6:4], idx[3:0]}
+                  en  - 1 = this slot is live and injected every media tick;
+                        0 = the slot emits nothing (skipped in the walk).
+                  src - the source bucket:
+                          0 ZERO    : digital silence (L=R=0)
+                          1 I2S_IN  : the stereo I2S capture pair (idx unused)
+                          2 TDM_IN  : TDM pair idx (0..N_TDM_P/2-1; slot pair
+                                      idx carries TDM slots {2*idx, 2*idx+1})
+                          3 RING    : ALSA playback ring pair idx (the
+                                      KL_pcm_tx pair-channel index)
+                          4 TONE    : the pilot tone on BOTH channels
+                        (5..7 reserved -> silence)
+                  idx - the within-source pair index (see src).
+
+                SOURCE BUCKETS (wire-truth, free-running): the latest pair per
+                source is latched into a hold register the instant its
+                pair_valid pulse arrives, so the tick-time walk always injects
+                the freshest sample. The tone bucket is the live tone_smp_i
+                (both L/R). No CDC lives here - every source has already
+                crossed into clk_i.
+
+                EMIT (media sample tick): on tick_i the engine walks the slot
+                map low-to-high; each ENABLED slot injects one pair
+                (pair_valid_o one-cycle pulse + pair_slot_o + pair_l_o/
+                pair_r_o) then idles GAP_CYC_P cycles before the next slot -
+                the proven inject cadence the packetizer admits (one pair per
+                cycle with a settle gap, mirroring the golden NxN TB's
+                pair()). Disabled slots are skipped with no pulse. Six media
+                ticks (6 samples/ch) fill one AVTPDU per talker on the shared
+                6-sample cadence; a tick arriving mid-walk is queued one deep
+                (never dropped).
+
+  Company     : Kebag Logic
+  Project     : Milan AVTP
+------------------------------------------------------------------------------
+*/
+
+//! Per-pair-slot TX source mux (NXN §2.1 capture family): a 32-slot map RAM
+//! ({en, src, idx}) routes each packetizer pair slot to a source bucket (I2S
+//! capture / TDM / ALSA ring / tone / silence); free-running source holds,
+//! per-tick low-to-high slot walk emitting the packetizer inject cadence
+//! (one pulse + GAP_CYC_P settle), disabled slots silent. Single clock, no CDC.
+
+`default_nettype none
+
+module KL_chan_map_capture #(
+  parameter int unsigned N_SLOTS_P = 32,   //! TX pair slots (prefix-sum space)
+  parameter int unsigned N_TDM_P   = 8,    //! TDM slots (pairs = N_TDM_P/2)
+  parameter int unsigned N_RING_P  = 16,   //! ALSA ring pair sources (idx 0..15)
+  parameter int unsigned GAP_CYC_P = 24    //! settle cycles between slot injects
+)(
+  input  wire         clk_i,             //! datapath clock
+  input  wire         rst_n,             //! active-low synchronous reset
+
+  //! --- map RAM write port (CSR window / TB) ------------------------------
+  input  wire         map_wr_en_i,       //! one-cycle write strobe
+  input  wire [$clog2(N_SLOTS_P)-1:0] map_wr_addr_i, //! slot index
+  input  wire [7:0]   map_wr_data_i,     //! {en[7], src[6:4], idx[3:0]}
+
+  //! --- map RAM readback port (registered, 1-cycle latency) ---------------
+  input  wire         map_rd_en_i,       //! one-cycle read request
+  input  wire [$clog2(N_SLOTS_P)-1:0] map_rd_addr_i,
+  output logic [7:0]  map_rd_data_o,     //! map entry (valid with rd_valid)
+  output logic        map_rd_valid_o,    //! read data valid this cycle
+
+  //! --- I2S capture pair source (single stereo pair) ----------------------
+  input  wire         i2s_pair_valid_i,  //! latch pulse
+  input  wire [23:0]  i2s_l_i,
+  input  wire [23:0]  i2s_r_i,
+
+  //! --- TDM capture pair sources (indexed by pair slot) -------------------
+  input  wire         tdm_pair_valid_i,  //! latch pulse
+  input  wire [3:0]   tdm_pair_slot_i,   //! TDM pair index (0..N_TDM_P/2-1)
+  input  wire [23:0]  tdm_l_i,
+  input  wire [23:0]  tdm_r_i,
+
+  //! --- ALSA ring pair sources (KL_pcm_tx output, indexed by pair slot) ---
+  input  wire         ring_pair_valid_i, //! latch pulse
+  input  wire [3:0]   ring_pair_slot_i,  //! ring pair-channel index (0..N-1)
+  input  wire [23:0]  ring_l_i,
+  input  wire [23:0]  ring_r_i,
+
+  //! --- tone generator sample (live; drives both L/R when TONE) -----------
+  input  wire [23:0]  tone_smp_i,
+
+  //! --- media sample tick (one walk of the enabled slots per pulse) -------
+  input  wire         tick_i,
+
+  //! --- pair injection to the shared packetizer (its capture contract) ----
+  output logic        pair_valid_o,      //! one-cycle pulse per L/R pair
+  output logic [4:0]  pair_slot_o,       //! pair slot 0..31 (widened space)
+  output logic [23:0] pair_l_o,
+  output logic [23:0] pair_r_o
+);
+
+  // ---------------------------------------------------------------------- //
+  // Derived sizing                                                          //
+  // ---------------------------------------------------------------------- //
+  localparam int unsigned SLOTW_C      = $clog2(N_SLOTS_P);
+  localparam int unsigned N_TDM_PAIRS_C = (N_TDM_P < 2) ? 1 : N_TDM_P / 2;
+  localparam int unsigned TDMPW_C      = (N_TDM_PAIRS_C <= 1) ? 1
+                                                      : $clog2(N_TDM_PAIRS_C);
+  localparam int unsigned RINGPW_C     = (N_RING_P <= 1) ? 1
+                                                      : $clog2(N_RING_P);
+
+  //! map entry field encoding (src[6:4])
+  localparam logic [2:0] SRC_ZERO_C = 3'd0, SRC_I2S_C = 3'd1, SRC_TDM_C = 3'd2,
+                         SRC_RING_C = 3'd3, SRC_TONE_C = 3'd4;
+
+  // ---------------------------------------------------------------------- //
+  // Map RAM (small config store: flop register file, like KL_pcm_route)     //
+  //   one sync write process; combinational reads for the walk; the         //
+  //   readback port registers a snapshot (RAM house style read turnaround)  //
+  // ---------------------------------------------------------------------- //
+  logic [7:0] map_r [N_SLOTS_P];
+
+  always_ff @(posedge clk_i) begin : map_write_port
+    if (!rst_n) begin
+      for (int s = 0; s < N_SLOTS_P; s++) map_r[s] <= 8'h00;
+    end
+    else if (map_wr_en_i) begin
+      map_r[map_wr_addr_i] <= map_wr_data_i;
+    end
+  end : map_write_port
+
+  always_ff @(posedge clk_i) begin : map_read_port
+    if (!rst_n) begin
+      map_rd_data_o  <= 8'h00;
+      map_rd_valid_o <= 1'b0;
+    end
+    else begin
+      map_rd_valid_o <= 1'b0;
+      if (map_rd_en_i) begin
+        map_rd_data_o  <= map_r[map_rd_addr_i];
+        map_rd_valid_o <= 1'b1;
+      end
+    end
+  end : map_read_port
+
+  // ---------------------------------------------------------------------- //
+  // Source hold buckets (latch the latest pair per source; wire-truth)      //
+  // ---------------------------------------------------------------------- //
+  logic [47:0] i2s_hold_r;               //! the single stereo I2S pair
+  logic [47:0] tdm_hold_r  [N_TDM_PAIRS_C];
+  logic [47:0] ring_hold_r [N_RING_P];
+
+  always_ff @(posedge clk_i) begin : source_latch
+    if (!rst_n) begin
+      i2s_hold_r <= '0;
+      for (int t = 0; t < N_TDM_PAIRS_C; t++) tdm_hold_r[t]  <= '0;
+      for (int r = 0; r < N_RING_P;      r++) ring_hold_r[r] <= '0;
+    end
+    else begin
+      if (i2s_pair_valid_i) i2s_hold_r <= {i2s_l_i, i2s_r_i};
+      if (tdm_pair_valid_i && (32'(tdm_pair_slot_i) < N_TDM_PAIRS_C))
+        tdm_hold_r[tdm_pair_slot_i[TDMPW_C-1:0]] <= {tdm_l_i, tdm_r_i};
+      if (ring_pair_valid_i && (32'(ring_pair_slot_i) < N_RING_P))
+        ring_hold_r[ring_pair_slot_i[RINGPW_C-1:0]] <= {ring_l_i, ring_r_i};
+    end
+  end : source_latch
+
+  // ---------------------------------------------------------------------- //
+  // Source select for the current walk slot (combinational)                 //
+  // ---------------------------------------------------------------------- //
+  logic [SLOTW_C-1:0] slot_r;            //! walk pointer
+
+  wire [7:0] ent_w = map_r[slot_r];
+  wire       en_w  = ent_w[7];
+  wire [2:0] src_w = ent_w[6:4];
+  wire [3:0] idx_w = ent_w[3:0];
+
+  logic [23:0] sel_l_w, sel_r_w;
+  always_comb begin : source_mux
+    unique case (src_w)
+      SRC_I2S_C : {sel_l_w, sel_r_w} = i2s_hold_r;
+      SRC_TDM_C : {sel_l_w, sel_r_w} =
+                    (32'(idx_w) < N_TDM_PAIRS_C)
+                      ? tdm_hold_r[idx_w[TDMPW_C-1:0]] : 48'd0;
+      SRC_RING_C : {sel_l_w, sel_r_w} =
+                    (32'(idx_w) < N_RING_P)
+                      ? ring_hold_r[idx_w[RINGPW_C-1:0]] : 48'd0;
+      SRC_TONE_C : {sel_l_w, sel_r_w} = {tone_smp_i, tone_smp_i};
+      default    : {sel_l_w, sel_r_w} = 48'd0;   //! ZERO + reserved = silence
+    endcase
+  end : source_mux
+
+  // ---------------------------------------------------------------------- //
+  // Emit walk FSM                                                           //
+  // ---------------------------------------------------------------------- //
+  typedef enum logic [1:0] {
+    CM_IDLE_S,     //! wait for a media tick
+    CM_STEP_S,     //! decide the current slot: skip / emit
+    CM_GAP_S       //! settle gap after a pair pulse
+  } cstate_t;
+
+  cstate_t                    st_r;
+  logic                       tick_pend_r;   //! one-deep tick queue
+  logic [$clog2(GAP_CYC_P+1)-1:0] gap_r;
+  wire  last_slot_w = (32'(slot_r) == N_SLOTS_P - 1);
+
+  always_ff @(posedge clk_i) begin : emit_engine
+    if (!rst_n) begin
+      st_r         <= CM_IDLE_S;
+      tick_pend_r  <= 1'b0;
+      slot_r       <= '0;
+      gap_r        <= '0;
+      pair_valid_o <= 1'b0;
+      pair_slot_o  <= '0;
+      pair_l_o     <= '0;
+      pair_r_o     <= '0;
+    end
+    else begin
+      unique case (st_r)
+        // -------- wait for the media tick --------------------------------
+        CM_IDLE_S : begin
+          pair_valid_o <= 1'b0;
+          if (tick_pend_r) begin
+            tick_pend_r <= 1'b0;           //! a coincident tick re-arms below
+            slot_r      <= '0;
+            st_r        <= CM_STEP_S;
+          end
+        end
+
+        // -------- decide the current slot --------------------------------
+        CM_STEP_S : begin
+          if (en_w) begin
+            //! inject one pair for this enabled slot (1-cycle pulse next)
+            pair_valid_o <= 1'b1;
+            pair_slot_o  <= 5'(slot_r);
+            pair_l_o     <= sel_l_w;
+            pair_r_o     <= sel_r_w;
+            gap_r        <= ($clog2(GAP_CYC_P+1))'(GAP_CYC_P);
+            st_r         <= CM_GAP_S;
+          end
+          else begin
+            //! disabled slot: emit nothing, advance immediately
+            pair_valid_o <= 1'b0;
+            if (last_slot_w) st_r <= CM_IDLE_S;
+            else             slot_r <= slot_r + 1'b1;
+          end
+        end
+
+        // -------- settle gap between injects ------------------------------
+        CM_GAP_S : begin
+          pair_valid_o <= 1'b0;            //! the pulse was one cycle only
+          if (gap_r == '0) begin
+            if (last_slot_w) st_r <= CM_IDLE_S;
+            else begin
+              slot_r <= slot_r + 1'b1;
+              st_r   <= CM_STEP_S;
+            end
+          end
+          else gap_r <= gap_r - 1'b1;
+        end
+
+        default : st_r <= CM_IDLE_S;
+      endcase
+
+      //! media-tick capture (after the case: a tick coincident with an
+      //! IDLE consume re-arms the one-deep queue instead of being dropped)
+      if (tick_i) tick_pend_r <= 1'b1;
+    end
+  end : emit_engine
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/aaf/aaf_nx_wrap.sv
+++ b/tb/verilator/aaf/aaf_nx_wrap.sv
@@ -42,7 +42,7 @@ module aaf_nx_wrap (
 
   //! N=2 packetizer with direct pair injection (interleave checks)
   input  wire         p2_pair_valid_i,
-  input  wire [3:0]   p2_pair_slot_i,
+  input  wire [4:0]   p2_pair_slot_i,
   input  wire [23:0]  p2_pair_l_i,
   input  wire [23:0]  p2_pair_r_i,
   input  wire [1:0]   p2_en_i,

--- a/tb/verilator/chmap_capture/Makefile
+++ b/tb/verilator/chmap_capture/Makefile
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# KL_chan_map_capture lane: the per-pair-slot TX source mux feeding the shared
+# KL_aaf_packetizer. Lane A (N=2) checks per-slot routing / remap / disabled-
+# slot absence + the map readback; lane B (N=8 all-8ch) exercises the widened
+# pair_slot up to slot 31.
+VERILATOR ?= verilator
+TOP = chmap_wrap
+SRCS = ../../../hdl/ieee1722/aaf/KL_chan_map_capture.sv \
+       ../../../hdl/ieee1722/aaf/KL_aaf_packetizer.sv \
+       chmap_wrap.sv
+all: run
+obj_dir/V$(TOP): $(SRCS) sim_main.cpp
+	$(VERILATOR) --cc --exe --build -j 0 --top-module $(TOP) \
+	  -Wall -Wno-fatal -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC \
+	  -Wno-PINCONNECTEMPTY -Wno-UNUSEDPARAM -CFLAGS "-std=c++17 -O2" \
+	  $(SRCS) sim_main.cpp
+run: obj_dir/V$(TOP)
+	./obj_dir/V$(TOP)
+clean: ; rm -rf obj_dir
+.PHONY: all run clean

--- a/tb/verilator/chmap_capture/chmap_wrap.sv
+++ b/tb/verilator/chmap_capture/chmap_wrap.sv
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+//! Verilator harness wrapper for the per-pair-slot TX source mux
+//! (KL_chan_map_capture) feeding the shared KL_aaf_packetizer. Two lanes:
+//!   A: chmap(32 slots) -> packetizer(N=2, t0=2ch slot0 / t1=8ch slots1..4) -
+//!      routing, mid-run remap, ZERO-source and disabled-slot (absence) tests.
+//!   B: chmap(32 slots) -> packetizer(N=8, all 8ch = 32 slots) - exercises the
+//!      widened pair_slot up to slot 31 (talker 7 pair 3).
+//! Both chmaps share the source-pair stimulus pins; each has its own map
+//! write/read port and media tick.
+
+`default_nettype none
+
+module chmap_wrap (
+  input  wire         clk,
+  input  wire         rst_n,
+
+  //! --- shared packetizer config (t0 CSR aliases / all-stream fields) ------
+  input  wire [47:0]  dest_mac_i,
+  input  wire [47:0]  station_mac_i,
+  input  wire [11:0]  vlan_vid_i,
+  input  wire [31:0]  transit_ns_i,
+  input  wire [63:0]  ptp_ns_i,
+
+  //! --- shared source pair stimulus (latched free-running by both chmaps) --
+  input  wire         i2s_pair_valid_i,
+  input  wire [23:0]  i2s_l_i,
+  input  wire [23:0]  i2s_r_i,
+  input  wire         tdm_pair_valid_i,
+  input  wire [3:0]   tdm_pair_slot_i,
+  input  wire [23:0]  tdm_l_i,
+  input  wire [23:0]  tdm_r_i,
+  input  wire         ring_pair_valid_i,
+  input  wire [3:0]   ring_pair_slot_i,
+  input  wire [23:0]  ring_l_i,
+  input  wire [23:0]  ring_r_i,
+  input  wire [23:0]  tone_smp_i,
+
+  //! --- lane A: chmap map ports + tick -------------------------------------
+  input  wire         a_map_wr_en_i,
+  input  wire [4:0]   a_map_wr_addr_i,
+  input  wire [7:0]   a_map_wr_data_i,
+  input  wire         a_map_rd_en_i,
+  input  wire [4:0]   a_map_rd_addr_i,
+  output wire [7:0]   a_map_rd_data_o,
+  output wire         a_map_rd_valid_o,
+  input  wire         a_tick_i,
+
+  //! --- lane A: packetizer (N=2) gate + TCTX window + AXIS -----------------
+  input  wire [1:0]   a_en_i,
+  input  wire         a_tctx_wr_en_i,
+  input  wire [6:0]   a_tctx_wr_addr_i,
+  input  wire [31:0]  a_tctx_wr_data_i,
+  output wire         a_tctx_wr_rdy_o,
+  input  wire         a_tctx_rd_en_i,
+  input  wire [6:0]   a_tctx_rd_addr_i,
+  output wire [31:0]  a_tctx_rd_data_o,
+  output wire         a_tctx_rd_valid_o,
+  output wire [63:0]  a_tdata_o,
+  output wire [7:0]   a_tkeep_o,
+  output wire         a_tvalid_o,
+  output wire         a_tlast_o,
+  input  wire         a_tready_i,
+
+  //! --- lane B: chmap map ports + tick -------------------------------------
+  input  wire         b_map_wr_en_i,
+  input  wire [4:0]   b_map_wr_addr_i,
+  input  wire [7:0]   b_map_wr_data_i,
+  input  wire         b_map_rd_en_i,
+  input  wire [4:0]   b_map_rd_addr_i,
+  output wire [7:0]   b_map_rd_data_o,
+  output wire         b_map_rd_valid_o,
+  input  wire         b_tick_i,
+
+  //! --- lane B: packetizer (N=8) gate + TCTX window + AXIS -----------------
+  input  wire [7:0]   b_en_i,
+  input  wire         b_tctx_wr_en_i,
+  input  wire [6:0]   b_tctx_wr_addr_i,
+  input  wire [31:0]  b_tctx_wr_data_i,
+  output wire         b_tctx_wr_rdy_o,
+  input  wire         b_tctx_rd_en_i,
+  input  wire [6:0]   b_tctx_rd_addr_i,
+  output wire [31:0]  b_tctx_rd_data_o,
+  output wire         b_tctx_rd_valid_o,
+  output wire [63:0]  b_tdata_o,
+  output wire [7:0]   b_tkeep_o,
+  output wire         b_tvalid_o,
+  output wire         b_tlast_o,
+  input  wire         b_tready_i
+);
+
+  // ====================================================================== //
+  //  Lane A: chmap -> packetizer(N=2)                                       //
+  // ====================================================================== //
+  wire        a_pv_w;
+  wire [4:0]  a_slot_w;
+  wire [23:0] a_l_w, a_r_w;
+
+  KL_chan_map_capture #(
+    .N_SLOTS_P (32), .N_TDM_P (8), .N_RING_P (16), .GAP_CYC_P (24)
+  ) u_chmap_a (
+    .clk_i (clk), .rst_n (rst_n),
+    .map_wr_en_i (a_map_wr_en_i), .map_wr_addr_i (a_map_wr_addr_i),
+    .map_wr_data_i (a_map_wr_data_i),
+    .map_rd_en_i (a_map_rd_en_i), .map_rd_addr_i (a_map_rd_addr_i),
+    .map_rd_data_o (a_map_rd_data_o), .map_rd_valid_o (a_map_rd_valid_o),
+    .i2s_pair_valid_i (i2s_pair_valid_i), .i2s_l_i (i2s_l_i), .i2s_r_i (i2s_r_i),
+    .tdm_pair_valid_i (tdm_pair_valid_i), .tdm_pair_slot_i (tdm_pair_slot_i),
+    .tdm_l_i (tdm_l_i), .tdm_r_i (tdm_r_i),
+    .ring_pair_valid_i (ring_pair_valid_i), .ring_pair_slot_i (ring_pair_slot_i),
+    .ring_l_i (ring_l_i), .ring_r_i (ring_r_i),
+    .tone_smp_i (tone_smp_i),
+    .tick_i (a_tick_i),
+    .pair_valid_o (a_pv_w), .pair_slot_o (a_slot_w),
+    .pair_l_o (a_l_w), .pair_r_o (a_r_w)
+  );
+
+  KL_aaf_packetizer #(.N_TALKERS_P(2)) u_pkt_a (
+    .clk_i (clk), .rst_n (rst_n),
+    .pair_valid_i (a_pv_w), .pair_slot_i (a_slot_w),
+    .pair_l_i (a_l_w), .pair_r_i (a_r_w),
+    .stream_en_i (a_en_i),
+    .dest_mac_i (dest_mac_i), .station_mac_i (station_mac_i),
+    .vlan_vid_i (vlan_vid_i), .transit_ns_i (transit_ns_i),
+    .ptp_ns_i (ptp_ns_i),
+    .tctx_wr_en_i (a_tctx_wr_en_i), .tctx_wr_addr_i (a_tctx_wr_addr_i),
+    .tctx_wr_data_i (a_tctx_wr_data_i), .tctx_wr_rdy_o (a_tctx_wr_rdy_o),
+    .tctx_rd_en_i (a_tctx_rd_en_i), .tctx_rd_addr_i (a_tctx_rd_addr_i),
+    .tctx_rd_data_o (a_tctx_rd_data_o), .tctx_rd_valid_o (a_tctx_rd_valid_o),
+    .m_axis_tdata (a_tdata_o), .m_axis_tkeep (a_tkeep_o),
+    .m_axis_tvalid (a_tvalid_o), .m_axis_tlast (a_tlast_o),
+    .m_axis_tready (a_tready_i),
+    .frames_sent_o ()
+  );
+
+  // ====================================================================== //
+  //  Lane B: chmap -> packetizer(N=8, all 8ch = 32 slots, slot 31 reach)    //
+  // ====================================================================== //
+  wire        b_pv_w;
+  wire [4:0]  b_slot_w;
+  wire [23:0] b_l_w, b_r_w;
+
+  KL_chan_map_capture #(
+    .N_SLOTS_P (32), .N_TDM_P (8), .N_RING_P (16), .GAP_CYC_P (24)
+  ) u_chmap_b (
+    .clk_i (clk), .rst_n (rst_n),
+    .map_wr_en_i (b_map_wr_en_i), .map_wr_addr_i (b_map_wr_addr_i),
+    .map_wr_data_i (b_map_wr_data_i),
+    .map_rd_en_i (b_map_rd_en_i), .map_rd_addr_i (b_map_rd_addr_i),
+    .map_rd_data_o (b_map_rd_data_o), .map_rd_valid_o (b_map_rd_valid_o),
+    .i2s_pair_valid_i (i2s_pair_valid_i), .i2s_l_i (i2s_l_i), .i2s_r_i (i2s_r_i),
+    .tdm_pair_valid_i (tdm_pair_valid_i), .tdm_pair_slot_i (tdm_pair_slot_i),
+    .tdm_l_i (tdm_l_i), .tdm_r_i (tdm_r_i),
+    .ring_pair_valid_i (ring_pair_valid_i), .ring_pair_slot_i (ring_pair_slot_i),
+    .ring_l_i (ring_l_i), .ring_r_i (ring_r_i),
+    .tone_smp_i (tone_smp_i),
+    .tick_i (b_tick_i),
+    .pair_valid_o (b_pv_w), .pair_slot_o (b_slot_w),
+    .pair_l_o (b_l_w), .pair_r_o (b_r_w)
+  );
+
+  KL_aaf_packetizer #(.N_TALKERS_P(8)) u_pkt_b (
+    .clk_i (clk), .rst_n (rst_n),
+    .pair_valid_i (b_pv_w), .pair_slot_i (b_slot_w),
+    .pair_l_i (b_l_w), .pair_r_i (b_r_w),
+    .stream_en_i (b_en_i),
+    .dest_mac_i (dest_mac_i), .station_mac_i (station_mac_i),
+    .vlan_vid_i (vlan_vid_i), .transit_ns_i (transit_ns_i),
+    .ptp_ns_i (ptp_ns_i),
+    .tctx_wr_en_i (b_tctx_wr_en_i), .tctx_wr_addr_i (b_tctx_wr_addr_i),
+    .tctx_wr_data_i (b_tctx_wr_data_i), .tctx_wr_rdy_o (b_tctx_wr_rdy_o),
+    .tctx_rd_en_i (b_tctx_rd_en_i), .tctx_rd_addr_i (b_tctx_rd_addr_i),
+    .tctx_rd_data_o (b_tctx_rd_data_o), .tctx_rd_valid_o (b_tctx_rd_valid_o),
+    .m_axis_tdata (b_tdata_o), .m_axis_tkeep (b_tkeep_o),
+    .m_axis_tvalid (b_tvalid_o), .m_axis_tlast (b_tlast_o),
+    .m_axis_tready (b_tready_i),
+    .frames_sent_o ()
+  );
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/chmap_capture/sim_main.cpp
+++ b/tb/verilator/chmap_capture/sim_main.cpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// KL_chan_map_capture harness: the per-pair-slot TX source mux feeding the
+// shared KL_aaf_packetizer.
+//   Lane A: chmap(32) -> packetizer(N=2, t0=2ch slot0 / t1=8ch slots1..4).
+//     - per-slot source routing (I2S / TDM / RING / TONE), payload-exact;
+//     - mid-run remap (RING->ZERO, TONE->RING1);
+//     - disabled slot = absence (drop t0 by disabling its only slot);
+//     - map RAM readback port.
+//   Lane B: chmap(32) -> packetizer(N=8, ALL 8ch = 32 pair slots). Exercises
+//     the widened pair_slot: talker 7 owns slots 28..31, so slot 31 = t7's
+//     4th pair - its payload proves the >15 slot path end to end.
+#include "Vchmap_wrap.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+static Vchmap_wrap* dut;
+static long checks = 0, fails = 0;
+static void ck(const char* t, long got, long exp) {
+  checks++;
+  if (got != exp) { fails++; printf("  [FAIL] %-46s got=0x%lx exp=0x%lx\n", t, got, exp); }
+  else            printf("  [ ok ] %-46s = 0x%lx\n", t, got);
+}
+
+using Frame = std::vector<uint8_t>;
+static std::vector<Frame> afr, bfr;
+static Frame acur, bcur;
+
+static void sample() {
+  if (dut->a_tvalid_o && dut->a_tready_i) {
+    for (int i = 0; i < 8; i++) if ((dut->a_tkeep_o >> i) & 1)
+      acur.push_back((dut->a_tdata_o >> (8 * i)) & 0xFF);
+    if (dut->a_tlast_o) { afr.push_back(acur); acur.clear(); }
+  }
+  if (dut->b_tvalid_o && dut->b_tready_i) {
+    for (int i = 0; i < 8; i++) if ((dut->b_tkeep_o >> i) & 1)
+      bcur.push_back((dut->b_tdata_o >> (8 * i)) & 0xFF);
+    if (dut->b_tlast_o) { bfr.push_back(bcur); bcur.clear(); }
+  }
+}
+static void step() { dut->clk = 0; dut->eval(); dut->clk = 1; dut->eval(); sample(); }
+static void cyc(int n = 1) { for (int i = 0; i < n; i++) step(); }
+
+static unsigned long be(const Frame& b, int o, int n) {
+  unsigned long v = 0; for (int i = 0; i < n; i++) v = (v << 8) | b[o + i]; return v; }
+static int find_len(std::vector<Frame>& v, size_t len) {
+  for (size_t i = 0; i < v.size(); i++) if (v[i].size() == len) return (int)i; return -1; }
+static uint8_t ent(int en, int src, int idx) {
+  return (uint8_t)(((en & 1) << 7) | ((src & 7) << 4) | (idx & 0xF)); }
+
+// ---- map RAM write / read ------------------------------------------------
+static void a_map_wr(int slot, uint8_t d) {
+  dut->a_map_wr_en_i = 1; dut->a_map_wr_addr_i = slot; dut->a_map_wr_data_i = d;
+  cyc(); dut->a_map_wr_en_i = 0; cyc(); }
+static void b_map_wr(int slot, uint8_t d) {
+  dut->b_map_wr_en_i = 1; dut->b_map_wr_addr_i = slot; dut->b_map_wr_data_i = d;
+  cyc(); dut->b_map_wr_en_i = 0; cyc(); }
+static uint8_t a_map_rd(int slot) {
+  dut->a_map_rd_en_i = 1; dut->a_map_rd_addr_i = slot; cyc();
+  uint8_t v = dut->a_map_rd_data_o; bool ok = dut->a_map_rd_valid_o;
+  dut->a_map_rd_en_i = 0; cyc();
+  if (!ok) { printf("  [FAIL] a_map_rd(%d) no valid\n", slot); fails++; checks++; }
+  return v; }
+
+// ---- TCTX window writes (poll wr_rdy, like the NxN harness) ---------------
+static void a_tctx_wr(int t, int w, uint32_t v) {
+  dut->a_tctx_wr_en_i = 1; dut->a_tctx_wr_addr_i = (uint8_t)((t << 4) | w);
+  dut->a_tctx_wr_data_i = v;
+  for (int i = 0; i < 48; i++) {
+    dut->clk = 0; dut->eval(); bool rdy = dut->a_tctx_wr_rdy_o;
+    dut->clk = 1; dut->eval(); sample();
+    if (rdy) { dut->a_tctx_wr_en_i = 0; cyc(); return; } }
+  dut->a_tctx_wr_en_i = 0; printf("  [FAIL] a_tctx_wr timeout\n"); fails++; checks++; }
+static void b_tctx_wr(int t, int w, uint32_t v) {
+  dut->b_tctx_wr_en_i = 1; dut->b_tctx_wr_addr_i = (uint8_t)((t << 4) | w);
+  dut->b_tctx_wr_data_i = v;
+  for (int i = 0; i < 48; i++) {
+    dut->clk = 0; dut->eval(); bool rdy = dut->b_tctx_wr_rdy_o;
+    dut->clk = 1; dut->eval(); sample();
+    if (rdy) { dut->b_tctx_wr_en_i = 0; cyc(); return; } }
+  dut->b_tctx_wr_en_i = 0; printf("  [FAIL] b_tctx_wr timeout\n"); fails++; checks++; }
+
+// ---- source-pair drivers (latched free-running by both chmaps) -----------
+static void drv_i2s(uint32_t l, uint32_t r) {
+  dut->i2s_pair_valid_i = 1; dut->i2s_l_i = l & 0xFFFFFF; dut->i2s_r_i = r & 0xFFFFFF;
+  cyc(); dut->i2s_pair_valid_i = 0; cyc(); }
+static void drv_tdm(int slot, uint32_t l, uint32_t r) {
+  dut->tdm_pair_valid_i = 1; dut->tdm_pair_slot_i = slot;
+  dut->tdm_l_i = l & 0xFFFFFF; dut->tdm_r_i = r & 0xFFFFFF;
+  cyc(); dut->tdm_pair_valid_i = 0; cyc(); }
+static void drv_ring(int slot, uint32_t l, uint32_t r) {
+  dut->ring_pair_valid_i = 1; dut->ring_pair_slot_i = slot;
+  dut->ring_l_i = l & 0xFFFFFF; dut->ring_r_i = r & 0xFFFFFF;
+  cyc(); dut->ring_pair_valid_i = 0; cyc(); }
+
+// ---- media ticks (one full slot walk per tick; drain-friendly spacing) ---
+static void a_tick() { dut->a_tick_i = 1; cyc(); dut->a_tick_i = 0; cyc(300); }
+static void b_tick() { dut->b_tick_i = 1; cyc(); dut->b_tick_i = 0; cyc(340); }
+
+static const uint32_t I2S_L = 0x1A1111, I2S_R = 0x1A2222;
+static const uint32_t TONE  = 0x7A7A7A;
+static uint32_t TDM_L(int p) { return 0x2B0000 | (p << 4); }
+static uint32_t TDM_R(int p) { return 0x2BB000 | (p << 4); }
+static uint32_t RNG_L(int r) { return 0x3C0000 | (r << 4); }
+static uint32_t RNG_R(int r) { return 0x3CC000 | (r << 4); }
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new Vchmap_wrap;
+
+  dut->rst_n = 0;
+  dut->a_tready_i = 1; dut->b_tready_i = 1;
+  dut->dest_mac_i = 0x91E0F000FE01ULL; dut->station_mac_i = 0x020000000002ULL;
+  dut->vlan_vid_i = 2; dut->ptp_ns_i = 0x11223344; dut->transit_ns_i = 2000000;
+  dut->i2s_pair_valid_i = 0; dut->tdm_pair_valid_i = 0; dut->ring_pair_valid_i = 0;
+  dut->tone_smp_i = 0;
+  dut->a_map_wr_en_i = 0; dut->a_map_rd_en_i = 0; dut->a_tick_i = 0; dut->a_en_i = 0;
+  dut->a_tctx_wr_en_i = 0; dut->a_tctx_rd_en_i = 0;
+  dut->b_map_wr_en_i = 0; dut->b_map_rd_en_i = 0; dut->b_tick_i = 0; dut->b_en_i = 0;
+  dut->b_tctx_wr_en_i = 0; dut->b_tctx_rd_en_i = 0;
+  cyc(8); dut->rst_n = 1; cyc(4);
+
+  printf("== KL_chan_map_capture (per-pair-slot TX source mux) ==\n");
+
+  // ====================================================================== //
+  printf("\n[A] per-slot routing: I2S / TDM / RING / TONE across t0(2ch)+t1(8ch)\n");
+  // t1 CFG via the TCTX window (chans=8 so t1 owns pair slots 1..4)
+  a_tctx_wr(1, 1, 0xF000FE02u);            // DMAC_LO (wire bytes 2..5) = base+1
+  a_tctx_wr(1, 2, (1u << 16) | 0x91E0u);   // {UID=1, DMAC_HI}
+  a_tctx_wr(1, 0, (2u << 5) | (8u << 1) | 1u); // CTRL {en, chans=8, vid=2}
+  dut->a_en_i = 3;
+
+  a_map_wr(0, ent(1, 1, 0));   // slot0 (t0 pair0) = I2S
+  a_map_wr(1, ent(1, 2, 0));   // slot1 (t1 pair0) = TDM idx0
+  a_map_wr(2, ent(1, 2, 1));   // slot2 (t1 pair1) = TDM idx1
+  a_map_wr(3, ent(1, 3, 0));   // slot3 (t1 pair2) = RING idx0
+  a_map_wr(4, ent(1, 4, 0));   // slot4 (t1 pair3) = TONE
+
+  dut->tone_smp_i = TONE;
+  drv_i2s(I2S_L, I2S_R);
+  drv_tdm(0, TDM_L(0), TDM_R(0));
+  drv_tdm(1, TDM_L(1), TDM_R(1));
+  drv_ring(0, RNG_L(0), RNG_R(0));
+  drv_ring(1, RNG_L(1), RNG_R(1));   // preloaded for the remap phase
+  cyc(4);
+
+  afr.clear();
+  for (int i = 0; i < 6; i++) a_tick();
+  cyc(400);
+
+  ck("A: two frames (t0 + t1)", (long)afr.size(), 2);
+  int ia0 = find_len(afr, 90), ia1 = find_len(afr, 234);
+  ck("A: t0 90-byte frame present", ia0 >= 0, 1);
+  ck("A: t1 234-byte frame present", ia1 >= 0, 1);
+  if (ia0 >= 0 && ia1 >= 0) {
+    ck("A: t0 channels_per_frame = 2", afr[ia0][36], 2);
+    ck("A: t1 channels_per_frame = 8", afr[ia1][36], 8);
+    ck("A: t0 uid 0", be(afr[ia0], 22, 8) & 0xFFFF, 0);
+    ck("A: t1 uid 1", be(afr[ia1], 22, 8) & 0xFFFF, 1);
+    ck("A: t1 DMAC = base+1 (TCTX)", be(afr[ia1], 0, 6), 0x91E0F000FE02UL);
+    ck("A: t0 slot0 = I2S L", be(afr[ia0], 42, 3), I2S_L);
+    ck("A: t0 slot0 = I2S R", be(afr[ia0], 46, 3), I2S_R);
+    ck("A: t1 pair0 slot1 = TDM0 L", be(afr[ia1], 42, 3), TDM_L(0));
+    ck("A: t1 pair0 slot1 = TDM0 R", be(afr[ia1], 46, 3), TDM_R(0));
+    ck("A: t1 pair1 slot2 = TDM1 L", be(afr[ia1], 50, 3), TDM_L(1));
+    ck("A: t1 pair2 slot3 = RING0 L", be(afr[ia1], 58, 3), RNG_L(0));
+    ck("A: t1 pair2 slot3 = RING0 R", be(afr[ia1], 62, 3), RNG_R(0));
+    ck("A: t1 pair3 slot4 = TONE L", be(afr[ia1], 66, 3), TONE);
+    ck("A: t1 pair3 slot4 = TONE R", be(afr[ia1], 70, 3), TONE);
+    ck("A: t0 seq 0", afr[ia0][20], 0);
+    ck("A: t1 seq 0", afr[ia1][20], 0);
+  } else { for (int k = 0; k < 15; k++) ck("A content (skipped: frames missing)", 0, 1); }
+
+  // ====================================================================== //
+  printf("\n[A2] mid-run remap: slot3 RING0->ZERO(silence), slot4 TONE->RING1\n");
+  a_map_wr(3, ent(1, 0, 0));   // slot3 -> ZERO source (silence, en=1)
+  a_map_wr(4, ent(1, 3, 1));   // slot4 -> RING idx1
+  cyc(4);
+  afr.clear();
+  for (int i = 0; i < 6; i++) a_tick();
+  cyc(400);
+  ck("A2: two frames again", (long)afr.size(), 2);
+  int j1 = find_len(afr, 234), j0 = find_len(afr, 90);
+  if (j1 >= 0) {
+    ck("A2: t1 pair2 slot3 now silence L", be(afr[j1], 58, 3), 0);
+    ck("A2: t1 pair2 slot3 now silence R", be(afr[j1], 62, 3), 0);
+    ck("A2: t1 pair3 slot4 now RING1 L", be(afr[j1], 66, 3), RNG_L(1));
+    ck("A2: t1 pair3 slot4 now RING1 R", be(afr[j1], 70, 3), RNG_R(1));
+    ck("A2: t1 seq advanced to 1", afr[j1][20], 1);
+  } else { for (int k = 0; k < 5; k++) ck("A2 content (skipped)", 0, 1); }
+  if (j0 >= 0) ck("A2: t0 seq advanced to 1", afr[j0][20], 1);
+  else         ck("A2: t0 frame (skipped)", 0, 1);
+
+  // ====================================================================== //
+  printf("\n[A3] disabled slot = absence: disable slot0 drops t0 entirely\n");
+  a_map_wr(0, ent(0, 1, 0));   // slot0 disabled (en=0)
+  cyc(4);
+  afr.clear();
+  for (int i = 0; i < 6; i++) a_tick();
+  cyc(400);
+  ck("A3: only one frame (t0 absent)", (long)afr.size(), 1);
+  if (afr.size() == 1) {
+    ck("A3: surviving frame is 8ch (t1)", afr[0][36], 8);
+    ck("A3: t1 seq advanced to 2", afr[0][20], 2);
+  } else { ck("A3 content (skipped)", 0, 1); ck("A3 content (skipped)", 0, 1); }
+
+  // ====================================================================== //
+  printf("\n[RB] map RAM readback port\n");
+  ck("RB: slot1 = {en,TDM,0}",  a_map_rd(1), ent(1, 2, 0));
+  ck("RB: slot3 = {en,ZERO,0}", a_map_rd(3), ent(1, 0, 0));
+  ck("RB: slot4 = {en,RING,1}", a_map_rd(4), ent(1, 3, 1));
+  ck("RB: slot0 = disabled",    a_map_rd(0), ent(0, 1, 0));
+
+  // ====================================================================== //
+  printf("\n[B] widened slot: N=8 all-8ch, talker 7 owns slots 28..31 (slot 31)\n");
+  // ALL 8 talkers must be 8ch so the prefix sum gives pbase[7]=28 (t7 pair p =
+  // slot 28+p; slot 31 = t7 pair 3)
+  for (int t = 0; t < 8; t++)
+    b_tctx_wr(t, 0, (2u << 5) | (8u << 1) | (t == 7 ? 1u : 0u)); // CTRL chans=8
+  b_tctx_wr(7, 1, 0xF000FE08u);            // t7 DMAC_LO = base+7
+  b_tctx_wr(7, 2, (7u << 16) | 0x91E0u);   // {UID=7, DMAC_HI}
+  dut->b_en_i = 0x80;                        // enable talker 7 only
+
+  b_map_wr(28, ent(1, 1, 0));  // slot28 (t7 pair0) = I2S
+  b_map_wr(29, ent(1, 2, 0));  // slot29 (t7 pair1) = TDM idx0
+  b_map_wr(30, ent(1, 3, 0));  // slot30 (t7 pair2) = RING idx0
+  b_map_wr(31, ent(1, 4, 0));  // slot31 (t7 pair3) = TONE  <-- widened slot
+
+  // refresh the shared source holds for lane B
+  dut->tone_smp_i = TONE;
+  drv_i2s(I2S_L, I2S_R);
+  drv_tdm(0, TDM_L(0), TDM_R(0));
+  drv_ring(0, RNG_L(0), RNG_R(0));
+  cyc(4);
+
+  bfr.clear();
+  for (int i = 0; i < 6; i++) b_tick();
+  cyc(600);
+
+  ck("B: one frame emitted (t7)", (long)bfr.size(), 1);
+  if (bfr.size() == 1) {
+    ck("B: t7 frame is 234 bytes (8ch)", (long)bfr[0].size(), 234);
+    ck("B: t7 channels_per_frame = 8", bfr[0][36], 8);
+    ck("B: t7 uid 7", be(bfr[0], 22, 8) & 0xFFFF, 7);
+    ck("B: t7 DMAC = base+7", be(bfr[0], 0, 6), 0x91E0F000FE08UL);
+    ck("B: slot28 pair0 = I2S L", be(bfr[0], 42, 3), I2S_L);
+    ck("B: slot29 pair1 = TDM0 L", be(bfr[0], 50, 3), TDM_L(0));
+    ck("B: slot30 pair2 = RING0 L", be(bfr[0], 58, 3), RNG_L(0));
+    ck("B: slot31 pair3 = TONE L (widened >15 slot)", be(bfr[0], 66, 3), TONE);
+    ck("B: slot31 pair3 = TONE R (widened >15 slot)", be(bfr[0], 70, 3), TONE);
+  } else { for (int k = 0; k < 9; k++) ck("B content (skipped: count wrong)", 0, 1); }
+
+  printf("\n======================================================================\n");
+  printf("KL_chan_map_capture: %ld checks, %ld failures\nRESULT: %s\n",
+         checks, fails, fails ? "FAIL" : "PASS");
+  delete dut;
+  return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Status

Ready for review. One new module + one new Verilator TB, plus a **minimal, backward-compatible** shared-RTL change (the `pair_slot` widening) that keeps every pre-existing tally byte-for-byte green. New TB green: **43 checks, 0 failures, RESULT: PASS**. The map write port is exposed only; its owner (AEM audio-map / CSR window) is upstream and out of scope here.

## Description

**TASK 1 — `pair_slot` widening (shared RTL, minimal & bit-identical by default).**
`hdl/ieee1722/aaf/KL_aaf_packetizer.sv`: `pair_slot_i` widened `[3:0]`→`[4:0]` (32-slot pair space = 8 talkers × 4 pairs max). All internal slot arithmetic already ran on the 6-bit `pbase_w` prefix-sum, so this is a port-width change only — the N=1/N=2 wire bytes are unchanged and the physical capture front-ends (which drive only slots 0..15) zero-extend cleanly. `tb/verilator/aaf/aaf_nx_wrap.sv` `p2_pair_slot_i` widened to match. The datapath instance (`hdl/milan/milan_datapath.sv`) needs no edit: its 4-bit `aafcap_slot_w` zero-extends into the 5-bit port (constant-driven, not undriven).

**TASK 2 — `hdl/ieee1722/aaf/KL_chan_map_capture.sv`** — the per-pair-slot TX source multiplexer (the capture/TX counterpart of `KL_chan_map_render`).

- Params `N_SLOTS_P=32`, `N_TDM_P=8`, `N_RING_P=16`, `GAP_CYC_P=24`.
- **Map RAM** (one write process; small flop register file like `KL_pcm_route`): entry `{en[7], src[6:4], idx[3:0]}` with `src` = `0 ZERO / 1 I2S_IN / 2 TDM_IN / 3 RING / 4 TONE` (5..7 reserved → silence). Registered readback port (`map_rd_en_i` → `map_rd_data_o` + `map_rd_valid_o`, one-cycle latency).
- **Source buckets, wire-truth free-running:** the latest pair per source is latched the instant its `*_pair_valid` pulse arrives — the single stereo I2S pair, the TDM pairs (indexed by `tdm_pair_slot_i`), the ALSA ring pairs (`KL_pcm_tx` output, indexed by `ring_pair_slot_i`). TONE uses the live `tone_smp_i` on both L/R.
- **Emit:** on each media `tick_i` the engine walks the slot map low→high; every **enabled** slot injects one pair (`pair_valid_o` one-cycle pulse + `pair_slot_o[4:0]` + `pair_l_o`/`pair_r_o`) then idles `GAP_CYC_P` cycles — the proven inject cadence the packetizer admits (mirrors the golden NxN TB's `pair()` gap). **Disabled** slots emit nothing (skipped). Six media ticks fill one AVTPDU per talker on the shared 6-sample cadence; a tick arriving mid-walk is queued one deep (never dropped). Single clock, no CDC.
- House style: SPDX/banner (CERN-OHL-W-2.0), `default_nettype none`/`wire`, `//!` port docs, `_r/_w`, named `always` blocks, sync active-low `rst_n`, 2-space, SystemVerilog only.

`tb/verilator/chmap_capture/` — `KL_chan_map_capture` + `KL_aaf_packetizer` wired in a small SV wrap, two lanes (N=2 and N=8), distinct per-source patterns, byte-exact per-slot routing asserts.

## How to get into the same state

```
git fetch origin && git checkout chmap-capture
# Prereq (centralized): Verilator >= 5.0 on PATH (built & run with 5.050).
# No third-party / package deps: each TB verilates stand-alone.
```

## How to validate

```
# new TB (must PASS):
make -C tb/verilator/chmap_capture      # KL_chan_map_capture: 43 checks, 0 failures, RESULT: PASS

# TASK-1 regressions (every pre-existing tally stays green):
make -C tb/verilator/aaf                # aaf: 19/0 PASS   +   NxN talker lane: 28/0 PASS
make -C tb/verilator/tdm                # TDM front-end family: 14/0 PASS
make -C tb/verilator/milan_dp           # milan_datapath: 172/0   +   sim_nxn: 63/0 PASS
```

What the new 43 checks cover:
- **[A] per-slot routing** (t0=2ch slot0, t1=8ch slots1..4): I2S / TDM idx0 / TDM idx1 / RING idx0 / TONE each routed to a distinct slot, payload byte-exact per pair, uid/DMAC/2ch-vs-8ch discriminated.
- **[A2] mid-run remap:** slot3 RING0→ZERO (payload goes silent) and slot4 TONE→RING idx1 (payload follows), seq chains advance.
- **[A3] disabled slot = absence:** disabling t0's only slot drops the whole t0 frame; only t1 survives.
- **[RB] map readback port** returns the programmed `{en,src,idx}` entries (incl. the disabled and remapped slots).
- **[B] widened >15 slot:** packetizer at **N=8 all-8ch** — talker 7 owns slots 28..31, so **slot 31 = t7's 4th pair**; its TONE payload (frame bytes 66/70) proves the widened slot path end-to-end.

## Definition of Done

- [x] `pair_slot_i` widened to `[4:0]` parameter-cleanly; N=1/N=2 behavior bit-identical (golden byte-compare + all regressions green).
- [x] `KL_chan_map_capture.sv` implements the spec (params, map RAM + readback, I2S/TDM/RING/TONE/ZERO sources, tick-driven walk, `GAP_CYC_P` cadence, disabled-slot absence, single clock).
- [x] House style enforced.
- [x] Verilator TB with ≥ 25 meaningful checks (43 present), byte-exact, exits nonzero on fail; slot ≥16 exercised (slot 31 via N=8 all-8ch).
- [x] All existing targets green: aaf 19/0 + 28/0, tdm 14/0, milan_dp 172/0 + 63/0; build artifacts gitignored.
- [ ] Peer review (not self-approved).
