### PR TITLE
chmap64: KL_tdm_render - TDM8 output serializer (TB 37/37)

### DIFF
--- a/hdl/ieee1722/aaf/KL_tdm_render.sv
+++ b/hdl/ieee1722/aaf/KL_tdm_render.sv
@@ -1,0 +1,278 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+/*
+------------------------------------------------------------------------------
+  File        : KL_tdm_render.sv
+  Author      : Kebag Logic
+
+  Date        : 2026-07-23
+  Description : TDM slave audio-render front-end - the OUTPUT-side symmetric
+                twin of KL_tdm_capture (item-4 audio-interface family;
+                docs/NXN_ARCHITECTURE.md §2.1 "physical interface x1"). The
+                mapping fabric writes SLOTS_P per-slot 24-bit samples into a
+                slot bank on clk_i; a whole-frame double-buffer crosses into
+                the external TDM bit-clock domain, where the module serializes
+                an SLOTS_P-slot TDM frame (MSB first, 24-in-SLOT_BITS_P
+                left-justified, low bits pad zero) onto tdm_dout_o.
+
+                SYMMETRY WITH KL_tdm_capture (the contract twin):
+                  * we are the bus SLAVE, exactly like the capture:
+                    tdm_bclk_i / tdm_fsync_i are INPUTS driven by the
+                    codec/DSP master; the capture SAMPLES tdm_data_i on the
+                    rising edge, so this render (the data driver) SHIFTS on
+                    the FALLING edge - standard TDM ("the master shifts on
+                    the falling edge"). A KL_tdm_capture wired to this
+                    render's tdm_dout_o recovers the exact slot samples.
+                  * frame sync: only the 0->1 transition is meaningful, so
+                    BOTH shapes work unchanged - the one-bclk PULSE
+                    (TI/McASP) and the 50%-duty long frame clock. A level is
+                    never trusted as an edge: detection arms only after
+                    fsync has been sampled LOW once out of reset (the same
+                    "never fake a mid-frame rise" rule as the capture).
+                  * every fsync start realigns the slot/bit counters; between
+                    fsyncs the counters free-run at the exact frame length
+                    (SLOTS_P * SLOT_BITS_P bclk).
+                  * data-to-fsync alignment matches the capture's DEFAULT
+                    DATA_DELAY_P=1 (Philips-heritage): slot-0 MSB rides the
+                    bclk period FOLLOWING the fsync-high edge. The one-bclk
+                    Philips delay is produced HERE, ONCE, by the
+                    compute-on-rising / present-on-falling output register -
+                    never doubled in a TB chip model (78bbabe history).
+
+                CLOCK-DOMAIN DISCIPLINE (mirrored from KL_tdm_capture):
+                  * the slot bank crosses clk_i -> tdm_bclk_i through the SAME
+                    gray-pointer cdc_pair_fifo the capture uses for its pair
+                    stream (there: bclk -> clk_i). No new CDC idiom is
+                    invented. The payload is one packed frame
+                    (SLOTS_P * 24 bits); the bclk read side keeps an
+                    active/next DOUBLE-BUFFER so slot-0 MSB is always ready on
+                    the fsync edge and mid-frame producer updates never tear.
+                  * an empty FIFO at a frame start is an underrun: the last
+                    frame is repeated (slip-dup) and counted, the same
+                    repeat-last discipline as KL_i2s_playback's DAC underrun.
+
+                PRODUCER INTERFACE (why slot-indexed writes, not a flat bank):
+                  KL_tdm_capture's datapath contract is a slot-indexed
+                  valid-PULSE stream (pair_valid_o + pair_slot_o + data). The
+                  render's producer interface is the symmetric INVERSE: a
+                  slot-indexed valid-pulse WRITE (smp_wr_en_i + smp_wr_slot_i
+                  + smp_wr_data_i) into the bank, committed as a frame by a
+                  one-cycle tick_i. This mirrors the capture's pulse-indexed
+                  geometry and is the natural fit for the mapping fabric,
+                  which routes one channel onto one slot at a time.
+
+  Company     : Kebag Logic
+  Project     : Milan AVTP
+------------------------------------------------------------------------------
+*/
+
+//! TDM slave serializer (item-4 front-end family, OUTPUT side): a clk_i slot
+//! bank -> packed-frame gray-pointer CDC -> active/next double-buffer ->
+//! MSB-first 24-in-SLOT_BITS_P TDM frame on tdm_dout_o. Pulse and 50%-duty
+//! fsyncs (edge-armed), Philips-heritage slot-0 alignment, slot 0 first.
+
+`default_nettype none
+
+module KL_tdm_render #(
+  parameter int unsigned SLOTS_P     = 8,   //! TDM slots per frame (8/16/32)
+  parameter int unsigned SLOT_BITS_P = 32,  //! bit clocks per slot (16/24/32)
+  parameter int unsigned FIFO_LOG2_P = 2    //! frame CDC depth = 2^N (>=2 for
+                                            //! the active/next double-buffer)
+)(
+  input  wire         clk_i,             //! datapath clock (producer domain)
+  input  wire         rst_n,             //! active-low synchronous reset (clk_i)
+
+  // ---- producer side (clk_i domain; slot-indexed writes) ---------------
+  input  wire         smp_wr_en_i,       //! one-cycle per-slot write strobe
+  input  wire [$clog2(SLOTS_P)-1:0] smp_wr_slot_i, //! target slot index
+  input  wire [23:0]  smp_wr_data_i,     //! 24-bit sample (MSB-justified)
+  input  wire         tick_i,            //! one-cycle frame commit: latch the
+                                         //! bank as written up to the prior
+                                         //! cycle into the CDC toward the bus
+
+  // ---- TDM bus (we are slave; master drives bclk/fsync) ----------------
+  input  wire         tdm_bclk_i,        //! bit clock (serializer domain)
+  input  wire         tdm_fsync_i,       //! frame sync (pulse or 50% duty)
+  output logic        tdm_dout_o,        //! serial data out, MSB first (driven
+                                         //! on the falling bclk edge)
+
+  // ---- status (Linux-observable via CSR; plain clk_i counters) ---------
+  output wire  [15:0] frames_o,          //! frames serialized onto the bus
+  output wire  [15:0] underruns_o,       //! frame starts with no fresh frame
+                                         //! (last frame repeated)
+  output wire  [15:0] overruns_o         //! tick_i frames dropped (CDC full)
+);
+
+  localparam int unsigned SW = $clog2(SLOTS_P);      //! slot-index width
+  localparam int unsigned BW = $clog2(SLOT_BITS_P);  //! bit-index width
+  localparam int unsigned DBITS =
+      (SLOT_BITS_P < 24) ? SLOT_BITS_P : 24;         //! data bits per slot
+  localparam int unsigned FRAME_BITS = SLOTS_P * 24; //! packed frame width
+
+  // ======================================================================
+  //  clk_i domain: slot bank + frame commit into the gray-pointer CDC
+  // ======================================================================
+  logic [23:0]            bank_r [SLOTS_P];  //! per-slot sample bank
+  logic [15:0]            overruns_r;
+  wire  [FRAME_BITS-1:0]  bank_flat_w;
+  wire                    wfull_w;
+
+  genvar gs;
+  generate
+    for (gs = 0; gs < SLOTS_P; gs++) begin : g_pack
+      assign bank_flat_w[gs*24 +: 24] = bank_r[gs];
+    end
+  endgenerate
+
+  //! FIFO write is combinational off tick_i (the FIFO registers internally
+  //! and self-guards on !wfull); bank_flat_w reflects writes up to the prior
+  //! cycle - the fabric pulses tick_i after its slot writes have landed.
+  wire fifo_wen_w = tick_i && !wfull_w;
+
+  always_ff @(posedge clk_i) begin : producer
+    if (!rst_n) begin
+      overruns_r <= '0;
+      for (int i = 0; i < SLOTS_P; i++) bank_r[i] <= '0;
+    end else begin
+      if (smp_wr_en_i) bank_r[smp_wr_slot_i] <= smp_wr_data_i;
+      //! a commit that finds the CDC full drops the frame (consumer behind)
+      if (tick_i && wfull_w)
+        overruns_r <= (&overruns_r) ? overruns_r : overruns_r + 16'd1;
+    end
+  end : producer
+
+  // ======================================================================
+  //  clk_i -> tdm_bclk_i frame crossing (the KL_tdm_capture CDC idiom,
+  //  gray-pointer dual-clock cdc_pair_fifo, reversed direction)
+  // ======================================================================
+  logic [1:0]            brst_n_r;        //! bclk-domain reset sync (2FF)
+  wire  [FRAME_BITS-1:0] rdata_w;
+  wire                   rempty_w;
+  logic                  ren_r;
+
+  always_ff @(posedge tdm_bclk_i) begin : t_bclk_rst
+    brst_n_r <= {brst_n_r[0], rst_n};
+  end : t_bclk_rst
+
+  cdc_pair_fifo #(.WIDTH(FRAME_BITS), .LOG2D(FIFO_LOG2_P)) u_fcdc (
+    .wclk_i  (clk_i),
+    .wrst_n  (rst_n),
+    .wen_i   (fifo_wen_w),
+    .wdata_i (bank_flat_w),
+    .wfull_o (wfull_w),
+    .rclk_i  (tdm_bclk_i),
+    .rrst_n  (brst_n_r[1]),
+    .ren_i   (ren_r),
+    .rdata_o (rdata_w),
+    .rempty_o(rempty_w)
+  );
+
+  // ======================================================================
+  //  tdm_bclk_i domain: frame tracking + double-buffer + bit serializer
+  // ======================================================================
+  logic                   fsync_q_r;   //! fsync at the previous rising edge
+  logic                   armed_r;     //! fsync sampled low once (edge valid)
+  logic                   run_r;       //! a frame start has been seen
+  logic [SW-1:0]          slot_r;
+  logic [BW-1:0]          bit_r;
+  logic [FRAME_BITS-1:0]  active_r;    //! frame currently serializing
+  logic [FRAME_BITS-1:0]  next_r;      //! prefetched frame (double-buffer)
+  logic                   have_next_r; //! next_r holds a fresh frame
+  logic                   fetch_v_r;   //! rdata_w valid this cycle (post-ren)
+  logic                   dout_nxt_r;  //! bit for the next falling edge
+  logic [15:0]            frames_b_r;  //! frames serialized (bclk domain)
+  logic [15:0]            unders_b_r;  //! underruns (bclk domain)
+
+  //! frame start = ARMED fsync 0->1 on the rising edge (same rule as capture)
+  wire                  start_w = tdm_fsync_i && !fsync_q_r && armed_r;
+  wire                  sol_w   = start_w;
+  //! effective position of THIS edge (a frame start overrides the counters)
+  wire [SW-1:0]         eslot_w = sol_w ? '0 : slot_r;
+  wire [BW-1:0]         ebit_w  = sol_w ? '0 : bit_r;
+  //! at a frame start with a fresh frame, read the incoming frame directly so
+  //! slot-0 MSB comes from next_r on the very edge active_r adopts it
+  wire                  adopt_w = sol_w && have_next_r;
+  wire [FRAME_BITS-1:0] frame_sel_w = adopt_w ? next_r : active_r;
+  wire [23:0]           smp_w   = frame_sel_w[24*eslot_w +: 24];
+  //! MSB-first, top DBITS bits of the slot are data, the remainder pad zero
+  wire [4:0]            didx_w  = 5'd23 - ebit_w[4:0];
+  wire                  dbit_w  = (32'(ebit_w) < DBITS) ? smp_w[didx_w] : 1'b0;
+
+  always_ff @(posedge tdm_bclk_i) begin : t_ser
+    if (!brst_n_r[1]) begin
+      fsync_q_r <= 1'b0; armed_r <= 1'b0; run_r <= 1'b0;
+      slot_r <= '0; bit_r <= '0;
+      active_r <= '0; next_r <= '0; have_next_r <= 1'b0;
+      ren_r <= 1'b0; fetch_v_r <= 1'b0; dout_nxt_r <= 1'b0;
+      frames_b_r <= '0; unders_b_r <= '0;
+    end else begin
+      fsync_q_r <= tdm_fsync_i;
+      if (!tdm_fsync_i) armed_r <= 1'b1;
+
+      // ---- prefetch the next frame from the CDC (2-step: ren, then data) --
+      ren_r <= 1'b0;
+      if (!have_next_r && !ren_r && !fetch_v_r && !rempty_w) ren_r <= 1'b1;
+      fetch_v_r <= ren_r;
+      if (fetch_v_r) begin
+        next_r      <= rdata_w;
+        have_next_r <= 1'b1;
+      end
+
+      // ---- frame start: adopt the fresh frame, else underrun-repeat -------
+      //  (the 256-bclk frame gap vs the 2-bclk prefetch means a fetch and a
+      //   frame start never coincide; adopt still uses the pre-edge next_r)
+      if (sol_w) begin
+        frames_b_r <= frames_b_r + 16'd1;
+        if (have_next_r) begin
+          active_r    <= next_r;
+          have_next_r <= 1'b0;             //! schedule a refill
+        end else begin
+          unders_b_r  <= unders_b_r + 16'd1;  //! keep active_r (repeat)
+        end
+      end
+
+      // ---- serialize: advance the free-running counters, latch next bit ---
+      if (run_r || sol_w) begin
+        run_r      <= 1'b1;
+        dout_nxt_r <= dbit_w;
+        if (32'(ebit_w) == SLOT_BITS_P - 1) begin
+          bit_r  <= '0;
+          slot_r <= (32'(eslot_w) == SLOTS_P - 1) ? '0 : eslot_w + 1'b1;
+        end else begin
+          bit_r  <= ebit_w + 1'b1;
+          slot_r <= eslot_w;
+        end
+      end
+    end
+  end : t_ser
+
+  //! output register on the FALLING edge: the bit computed on the rising edge
+  //! is presented half a bclk later, so it is stable across the receiver's
+  //! next rising edge - this IS the one-bclk Philips-heritage delay.
+  logic [1:0] nrst_n_r;
+  always_ff @(negedge tdm_bclk_i) begin : t_dout
+    nrst_n_r <= {nrst_n_r[0], rst_n};
+    if (!nrst_n_r[1]) tdm_dout_o <= 1'b0;
+    else              tdm_dout_o <= dout_nxt_r;
+  end : t_dout
+
+  // ======================================================================
+  //  status counters back into clk_i (quasi-static 2-FF, KL_i2s_playback
+  //  discipline: the counts are monotonic and read for trends only)
+  // ======================================================================
+  logic [15:0] fr_m_r, fr_s_r, un_m_r, un_s_r;
+  always_ff @(posedge clk_i) begin : t_cnt_sync
+    {fr_s_r, fr_m_r} <= {fr_m_r, frames_b_r};
+    {un_s_r, un_m_r} <= {un_m_r, unders_b_r};
+  end : t_cnt_sync
+
+  assign frames_o    = fr_s_r;
+  assign underruns_o = un_s_r;
+  assign overruns_o  = overruns_r;
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/tdm_render/Makefile
+++ b/tb/verilator/tdm_render/Makefile
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# KL_tdm_render verification: TDM8 output serializer (item-4 audio front-end,
+# OUTPUT side). The TB drives bclk/fsync per the frame geometry, writes known
+# slot samples on clk_i, and de-serializes tdm_dout_o with a golden model that
+# samples exactly like KL_tdm_capture (rising edge, Philips-heritage delay-1) -
+# asserting bit-exact slots, frame alignment, double-buffer latching, pad-zero,
+# 24-bit sign preservation, a multi-frame run and stale-frame repeat.
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+C          = $(RTL_DIR)/common
+AAF        = $(RTL_DIR)/ieee1722/aaf
+TOP        = KL_tdm_render
+VFLAGS = --cc --exe --build -j 0 --top-module $(TOP) \
+         +incdir+$(C) +incdir+$(AAF) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
+         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-IMPORTSTAR -Wno-CASEINCOMPLETE \
+         -Wno-EOFNEWLINE -CFLAGS "-std=c++17 -O2"
+SRCS = $(C)/cdc_pair_fifo.sv $(AAF)/KL_tdm_render.sv
+.PHONY: all run clean
+all: run
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) sim_main.cpp -o VKL_tdm_render_sim
+	./obj_dir/VKL_tdm_render_sim
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/tdm_render/sim_main.cpp
+++ b/tb/verilator/tdm_render/sim_main.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Self-checking harness for KL_tdm_render — the TDM8 OUTPUT serializer (item-4
+// audio front-end family, output side; the symmetric twin of KL_tdm_capture).
+//
+// Strategy: the TB is the TDM bus MASTER. It drives bclk/fsync at the frame
+// geometry (SLOTS x SLOT_BITS bclk/frame, one-bclk fsync pulse at slot 0),
+// writes known per-slot samples on clk_i, then de-serializes tdm_dout_o with a
+// GOLDEN model that samples exactly like KL_tdm_capture — rising-edge sample,
+// edge-armed fsync, Philips-heritage DATA_DELAY_P=1 — and asserts the recovered
+// slots bit-exact. A render(delay-1) driving a capture(delay-1) is a
+// bit-transparent loopback, so the golden IS the acceptance oracle.
+//
+// Coverage: bit-exact slots (all 8), frame alignment after fsync, double-buffer
+// latching (new tick vs mid-frame stability), pad bits zero, 24-bit sign
+// preservation, a multi-frame run (9 data frames) and a stale/no-update frame
+// that must repeat the last sample (underrun), plus the clk_i status counters.
+#include "VKL_tdm_render.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <array>
+#include <deque>
+#include <vector>
+
+static const int SLOTS        = 8;
+static const int SLOT_BITS    = 32;
+static const int FRAME_PERIODS= SLOTS * SLOT_BITS;   // 256 bclk / frame
+static const int CPB          = 2;                   // clk_i cycles / bclk half
+
+static VKL_tdm_render* dut;
+static long checks = 0, fails = 0;
+static void ck(const char* t, long got, long exp) {
+  checks++;
+  if (got != exp) { fails++; printf("  [FAIL] %-46s got=%ld exp=%ld\n", t, got, exp); }
+  else            printf("  [ ok ] %-46s = %ld\n", t, got);
+}
+static void ckx(const char* t, unsigned long got, unsigned long exp) {
+  checks++;
+  if (got != exp) { fails++; printf("  [FAIL] %-46s got=0x%06lX exp=0x%06lX\n", t, got, exp); }
+  else            printf("  [ ok ] %-46s = 0x%06lX\n", t, got);
+}
+
+// ---------------------------------------------------------------------------
+// Golden de-serializer: a 1:1 model of KL_tdm_capture's rising-edge sampler
+// (edge-armed fsync, startp pipeline = DATA_DELAY_P=1, MSB-first, top-24-of-32
+// left-justified). last_word[] holds the full 32-bit slot words per frame.
+// ---------------------------------------------------------------------------
+static int      gv_fsync_q = 0, gv_armed = 0, gv_startp = 0, gv_run = 0;
+static int      gv_slot = 0, gv_bit = 0;
+static uint64_t gv_shift = 0;
+static uint32_t rec_word[SLOTS];
+static uint32_t last_word[SLOTS];
+static long     golden_frames = 0;
+static bool     golden_en = false;
+
+static void golden_reset() {
+  gv_fsync_q = gv_armed = gv_startp = gv_run = 0;
+  gv_slot = gv_bit = 0; gv_shift = 0; golden_frames = 0;
+  memset(rec_word, 0, sizeof(rec_word));
+  memset(last_word, 0, sizeof(last_word));
+}
+
+static void golden_rising(int f, int d) {
+  int start = (f && !gv_fsync_q && gv_armed) ? 1 : 0;
+  int sol   = gv_startp;                 // DATA_DELAY_P=1: previous edge's start
+  int eslot = sol ? 0 : gv_slot;
+  int ebit  = sol ? 0 : gv_bit;
+  if (gv_run || sol) {
+    gv_run   = 1;
+    gv_shift = (gv_shift << 1) | (uint64_t)(d & 1);
+    if (ebit == SLOT_BITS - 1) {
+      rec_word[eslot] = (uint32_t)(gv_shift & 0xFFFFFFFFULL);  // {sample,8'b0}
+      if (eslot == SLOTS - 1) {
+        memcpy(last_word, rec_word, sizeof(rec_word));
+        golden_frames++;
+      }
+      gv_bit  = 0;
+      gv_slot = (eslot == SLOTS - 1) ? 0 : eslot + 1;
+    } else {
+      gv_bit  = ebit + 1;
+      gv_slot = eslot;
+    }
+  }
+  gv_fsync_q = f;
+  if (!f) gv_armed = 1;
+  gv_startp = start;
+}
+
+// ---------------------------------------------------------------------------
+// Clock drivers. clk_i and tdm_bclk_i are toggled independently so the
+// gray-pointer cdc_pair_fifo crossing is exercised for real.
+// ---------------------------------------------------------------------------
+static void clk_tick() { dut->clk_i = 0; dut->eval(); dut->clk_i = 1; dut->eval(); }
+
+// one bclk period; the render drives data on the FALLING edge, so tdm_dout_o
+// sampled just after the RISING-edge eval is the bit for this period (exactly
+// how KL_tdm_capture reads it).
+static void bperiod(int fsync_level) {
+  dut->tdm_fsync_i = fsync_level;
+  dut->tdm_bclk_i = 1; dut->eval();
+  if (golden_en) golden_rising(fsync_level, dut->tdm_dout_o & 1);
+  for (int i = 0; i < CPB; i++) clk_tick();
+  dut->tdm_bclk_i = 0; dut->eval();
+  for (int i = 0; i < CPB; i++) clk_tick();
+}
+
+// slot-indexed writes then a one-cycle tick_i commit (bclk held static).
+static void write_frame(const uint32_t s[SLOTS]) {
+  for (int i = 0; i < SLOTS; i++) {
+    dut->smp_wr_slot_i = i; dut->smp_wr_data_i = s[i] & 0xFFFFFF;
+    dut->smp_wr_en_i = 1; clk_tick();
+  }
+  dut->smp_wr_en_i = 0; clk_tick();
+  dut->tick_i = 1; clk_tick(); dut->tick_i = 0; clk_tick();
+}
+
+// ---------------------------------------------------------------------------
+struct Entry { uint32_t s[SLOTS]; bool underrun; bool detailed; const char* name; };
+
+static uint32_t samp(int slot, int seq) {
+  uint32_t v = ((uint32_t)(seq * 8 + slot) * 2654435u) & 0x7FFFFFu;  // 23-bit spread
+  if ((slot ^ seq) & 1) v |= 0x800000u;                              // sign variety
+  return v & 0xFFFFFFu;
+}
+
+static std::deque<Entry> exq;
+
+static void check_frame(const Entry& e) {
+  bool all_ok = true, pad_ok = true;
+  for (int s = 0; s < SLOTS; s++) {
+    uint32_t rec = (last_word[s] >> 8) & 0xFFFFFF;
+    if (rec != (e.s[s] & 0xFFFFFF)) all_ok = false;
+    if ((last_word[s] & 0xFF) != 0)  pad_ok = false;
+  }
+  if (e.detailed) {
+    for (int s = 0; s < SLOTS; s++) {
+      char buf[80]; snprintf(buf, sizeof(buf), "%s slot%d bit-exact", e.name, s);
+      ckx(buf, (last_word[s] >> 8) & 0xFFFFFF, e.s[s] & 0xFFFFFF);
+    }
+    ck("EDGE: all pad bits zero (24-in-32)", pad_ok ? 1 : 0, 1);
+    ckx("EDGE: sign preserved slot0 0x800000", (last_word[0] >> 8) & 0xFFFFFF, 0x800000);
+    ckx("EDGE: sign preserved slot2 0xFFFFFF", (last_word[2] >> 8) & 0xFFFFFF, 0xFFFFFF);
+  } else {
+    char buf[80]; snprintf(buf, sizeof(buf), "%s: 8 slots bit-exact", e.name);
+    ck(buf, all_ok ? 1 : 0, 1);
+    snprintf(buf, sizeof(buf), "%s: pad bits zero", e.name);
+    ck(buf, pad_ok ? 1 : 0, 1);
+    if (e.underrun) {
+      ck("stale frame REPEATS last sample (bit-exact)", all_ok ? 1 : 0, 1);
+      ck("underruns_o incremented", dut->underruns_o, 1);
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new VKL_tdm_render;
+
+  dut->clk_i = 0; dut->rst_n = 0;
+  dut->smp_wr_en_i = 0; dut->smp_wr_slot_i = 0; dut->smp_wr_data_i = 0;
+  dut->tick_i = 0; dut->tdm_bclk_i = 0; dut->tdm_fsync_i = 0;
+  dut->eval();
+
+  printf("== KL_tdm_render harness (TDM8 out: %d slots x %d bclk, 48 kHz frame) ==\n",
+         SLOTS, SLOT_BITS);
+
+  // reset both domains (golden idle)
+  golden_en = false;
+  for (int i = 0; i < 8; i++) bperiod(0);
+  dut->rst_n = 1;
+  for (int i = 0; i < 4; i++) bperiod(0);
+  golden_reset(); golden_en = true;
+
+  // ---- build the frame program -------------------------------------------
+  std::vector<Entry> entries;
+  { Entry e{{0x800000,0x7FFFFF,0xFFFFFF,0x000001,0xABCDEF,0x123456,0x000000,0xA5A5A5},
+            false, true, "EDGE"}; entries.push_back(e); }
+  int seqs[] = {1, 2};                       // idx1, idx2
+  for (int q : seqs) { Entry e{}; for (int s = 0; s < SLOTS; s++) e.s[s] = samp(s, q);
+    e.underrun = false; e.detailed = false; e.name = (q == 1) ? "F1(mid-frame-stable)" : "F2";
+    entries.push_back(e); }
+  { Entry e = entries.back(); e.underrun = true; e.detailed = false; e.name = "UNDERRUN(=F2)";
+    entries.push_back(e); }                  // idx3: repeats F2 (its .s already = F2)
+  int seqs2[] = {4, 5, 6, 7, 8, 9};          // idx4..idx9  (multi-frame run)
+  for (int q : seqs2) { Entry e{}; for (int s = 0; s < SLOTS; s++) e.s[s] = samp(s, q);
+    e.underrun = false; e.detailed = false;
+    static char nm[6][8]; snprintf(nm[q-4], 8, "F%d", q); e.name = nm[q-4];
+    entries.push_back(e); }
+  { Entry e{}; for (int s = 0; s < SLOTS; s++) e.s[s] = 0x0F0F00u + s;
+    e.underrun = false; e.detailed = false; e.name = "SENTINEL"; entries.push_back(e); }
+  const int N = (int)entries.size();
+
+  // ---- preload entry 0, arm + cross into the bclk domain -----------------
+  write_frame(entries[0].s);
+  exq.push_back(entries[0]);
+  for (int i = 0; i < 12; i++) bperiod(0);          // fsync low: arm + prefetch
+
+  printf("\n[align] nothing serialized before the first fsync\n");
+  ck("no golden frame before fsync", golden_frames, 0);
+  ck("line idle (dout=0) before fsync", dut->tdm_dout_o & 1, 0);
+
+  printf("\n[run] fsync-aligned frames; golden recovers each after its boundary\n");
+  long prev_gf = 0;
+  int  calls = 0;
+  for (int i = 0; i < N; i++) {
+    for (int p = 0; p < FRAME_PERIODS; p++) {
+      bperiod(p == 0 ? 1 : 0);                       // one-bclk fsync at slot 0
+      if (p == 4 && i + 1 < N) {                     // commit the NEXT frame mid-frame
+        if (!entries[i + 1].underrun) write_frame(entries[i + 1].s);
+        exq.push_back(entries[i + 1]);               // (underrun: repeat, no commit)
+      }
+    }
+    calls++;
+    if (golden_frames > prev_gf) {                   // one frame completes per call
+      prev_gf = golden_frames;
+      Entry e = exq.front(); exq.pop_front();
+      check_frame(e);
+    }
+  }
+
+  printf("\n[status] clk_i-domain plain counters\n");
+  ck("frames_o == fsync frames issued", dut->frames_o, calls);
+  ck("underruns_o == 1 (single stale frame)", dut->underruns_o, 1);
+  ck("overruns_o == 0 (consumer kept up)", dut->overruns_o, 0);
+  ck("golden completed >= 9 frames", golden_frames >= 9 ? 1 : 0, 1);
+
+  printf("\n======================================================================\n");
+  printf("KL_tdm_render: %ld checks, %ld failures\n", checks, fails);
+  printf("RESULT: %s\n", fails ? "FAIL" : "PASS");
+  delete dut;
+  return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Status

Ready for review. New RTL + self-checking Verilator TB, both included. TB is green (37/37) in this branch; author self-test output posted as a comment below (results only, not an approval).

## Description

Adds `KL_tdm_render` — the TDM8 **output** serializer, the symmetric OUTPUT-side twin of the existing capture front-end `hdl/ieee1722/aaf/KL_tdm_capture.sv` (item-4 audio-interface family, `docs/NXN_ARCHITECTURE.md` §2.1). The mapping fabric needs a TDM8 output front-end to complement the capture side; this module serializes an 8-slot × 32-bit TDM frame (24-in-32 left-justified, pad zero, MSB first, 48 kHz frames) onto `tdm_dout_o`.

Conventions mirrored from `KL_tdm_capture` (deliberately, so the pair is a bit-transparent loopback):

- **Bus stance:** SLAVE. `tdm_bclk_i` / `tdm_fsync_i` are INPUTS driven by the codec/DSP master. The capture *samples* data on the rising edge, so this render (the data driver) *shifts* on the FALLING edge — standard TDM. A `KL_tdm_capture` wired to `tdm_dout_o` recovers the exact slot samples.
- **fsync:** only the 0→1 transition is meaningful; edge-armed (must sample fsync LOW once out of reset before a rise is trusted). Pulse (TI/McASP) and 50 %-duty long frame clock both work unchanged — identical rule to the capture.
- **Alignment:** slot-0 MSB rides the bclk period following the fsync-high edge = the capture's default `DATA_DELAY_P=1` (Philips-heritage). The one-bclk Philips delay is produced ONCE, by the compute-on-rising / present-on-falling output register — never doubled in a TB chip model.
- **CDC idiom:** the slot bank crosses `clk_i → tdm_bclk_i` through the **same gray-pointer `cdc_pair_fifo`** the capture uses for its pair stream (there: bclk → clk_i) — direction reversed, no new CDC invented. Payload is one packed frame (`SLOTS_P*24` bits). The bclk read side keeps an active/next **double-buffer** so slot-0 MSB is ready on the fsync edge and mid-frame producer updates never tear. An empty FIFO at a frame start is an underrun → last frame repeated (slip-dup), the same repeat-last discipline as `KL_i2s_playback`.
- **Producer interface:** slot-indexed valid-pulse WRITE (`smp_wr_en_i` + `smp_wr_slot_i` + `smp_wr_data_i`) committed by a one-cycle `tick_i` — the symmetric inverse of the capture's slot-indexed `pair_valid_o`/`pair_slot_o` pulse contract, and the natural fit for the fabric routing one channel onto one slot at a time. (Chosen over the flat `slot_smp_i` + tick option for exactly this symmetry; documented in the header.)
- **Status:** plain `clk_i`-domain 16-bit counters `frames_o` / `underruns_o` / `overruns_o` (bclk events carried to `clk_i` by the quasi-static 2-FF sync `KL_i2s_playback` uses for its underrun rail).

House style: SPDX + banner (CERN-OHL-W-2.0), `default_nettype none/wire`, `//!` port docs, `_r`/`_w`/`_i`/`_o`, named `always` blocks, sync active-low reset in the `clk_i` domain, 2-space, SystemVerilog only.

Params: `SLOTS_P=8`, `SLOT_BITS_P=32`, `FIFO_LOG2_P=2`.

Files:
- `hdl/ieee1722/aaf/KL_tdm_render.sv`
- `tb/verilator/tdm_render/{Makefile, sim_main.cpp}`

## How to get into the same state

Standard repo prerequisites (Verilator ≥ 5.0 on `PATH`); no board or vendor tools needed for this change. From a clean checkout of this branch:

```
cd tb/verilator/tdm_render
make run
```

## How to validate

`make -C tb/verilator/tdm_render run` builds and runs the self-checking harness. The TB is the TDM bus MASTER: it drives bclk/fsync at the frame geometry (8×32 bclk/frame, one-bclk fsync pulse at slot 0), writes known per-slot samples on `clk_i`, and de-serializes `tdm_dout_o` with a **golden model that samples exactly like `KL_tdm_capture`** (rising-edge, edge-armed, delay-1) — so the recovered slots are the acceptance oracle for a render→capture loopback.

Checks (37 total, 0 failures):
- bit-exact recovery of all 8 slots across the run;
- frame alignment (nothing serialized before the first fsync; line idle);
- 24-bit **sign preservation** and edge values (`0x800000`, `0x7FFFFF`, `0xFFFFFF`, `0x000001`, …);
- **pad bits zero** (the low 8 of every 32-bit slot);
- **double-buffer latching**: a differing next frame committed mid-frame does not tear the frame in flight; the new samples appear on the next frame;
- a **multi-frame run** (9 data frames);
- a **stale / no-update frame** that must repeat the last sample, with `underruns_o` ticking;
- `frames_o` / `underruns_o` / `overruns_o` status counters.

Expected tail:

```
KL_tdm_render: 37 checks, 0 failures
RESULT: PASS
```

## Definition of Done

- [x] `KL_tdm_render.sv` delivered, mirroring `KL_tdm_capture` conventions (slave stance, fsync geometry, CDC idiom, house style).
- [x] TDM-domain serializer: MSB-first, 24-in-32 left-justified pad-zero, slot 0 first after fsync, Philips-heritage alignment.
- [x] Slot bank double-buffered across the domain via the existing gray-pointer `cdc_pair_fifo` (no new CDC idiom).
- [x] `clk_i`-domain plain status counters (frames / underruns / overruns).
- [x] Verilator TB with a capture-faithful golden de-serializer, ≥ 20 checks, "N checks, M failures, RESULT: PASS/FAIL"; mirrors `tb/verilator/avtp_rxmon` Makefile flags.
- [x] `make run` green (37/37).
- [x] House style, SPDX/banner, one-line commit, no external refs.
