### PR TITLE
chmap64: integration branch — composes 5 lanes (#26/#27/#28/#29/#30), 8×8 elaborates

### DIFF
--- a/docs/CHANNEL_MAP_64.md
+++ b/docs/CHANNEL_MAP_64.md
@@ -1,0 +1,424 @@
+# 64-in / 64-out Channel Mapping — Render Crossbar + Capture Mux + AEM Audio-Map Binding
+
+Normative architecture for the channel-mapping layer on top of the NxN
+stream fabric (`docs/NXN_ARCHITECTURE.md`, roadmap item 5) and the ALSA
+lane (roadmap item 7). Status: **DESIGN — no RTL in this round.**
+Decisions in §1–§2 are USER-decided inputs, not open questions.
+
+Companion docs: `docs/NXN_ARCHITECTURE.md` (shared engines, TCTX/LCTX,
+the 0x800 indexed window), `docs/ENDSTATION_BUILDER.md` (D1: one
+STREAM_PORT per stream, config-selectable clusters),
+`docs/reference/REGISTER_MAP.md` (CSR ABI authority),
+the-private-test-repo `fpga/docs/ALSA_DRIVER_DESIGN.md` (driver side).
+
+## 0. Grounding facts (read from the tree, quoted not assumed)
+
+| # | Fact | Where verified |
+|---|------|----------------|
+| G1 | Depacketizer PCM output is a 64-bit AXIS master, one frame per AAF PDU, payload in **wire byte order = S32BE interleaved PCM**, always full 8-byte beats, with `m_axis_tuser[3:0]` = stream index `s` riding each buffered frame | `hdl/ieee1722/aaf/KL_aaf_rx_depacketizer.sv` (header + ports 89–99; "wire byte order = S32BE interleaved PCM", "NXN §1.2: {tuser=s} rides each buffered frame") |
+| G2 | Packetizer input is the pair stream `{pair_valid_i, pair_slot_i[3:0], pair_l_i[23:0], pair_r_i[23:0]}`; the pair-slot space is partitioned by a **prefix sum of chans/2** (`pbase_w[t+1] = pbase_w[t] + chans_r[t][3:1]`, `logic [5:0] pbase_w`) — talker `t` owns pair slots `[pbase(t), pbase(t)+chans/2)` | `hdl/ieee1722/aaf/KL_aaf_packetizer.sv` ports 94–98, `pair_base` block |
+| G3 | **`pair_slot_i` is 4 bits — 16 slots. 8 streams × 8 ch = 32 pairs. The 8×8 shape structurally exceeds the 4-bit slot space**; the internal ownership compare already zero-extends (`6'(pair_slot_i)` vs `pbase_w[5:0]`), so the widening is interface-level (§4.3) | `KL_aaf_packetizer.sv` line 95 (`input wire [3:0] pair_slot_i`) vs the `[5:0]` prefix sum |
+| G4 | The whole capture family shares the pair-stream contract: `KL_tdm_capture` ("emits the same {slot, L, R} pair stream toward KL_aaf_packetizer that KL_aaf_capture_i2s emits"), pairs cross into `clk_i` via a 52-bit gray-pointer `cdc_pair_fifo` (`{cap_slot_r[3:0], cap_l_r[23:0], cap_r_r[23:0]}`); `KL_pcm_tx` is "a drop-in replacement for the physical capture front-end … emits the SAME {pair_valid, pair_slot, pair_l, pair_r} contract", tick-paced ("one media sample tick emits ONE audio sample for EVERY stream and EVERY channel pair") | `KL_tdm_capture.sv`, `KL_pcm_tx.sv` headers |
+| G5 | The I2S render path already keeps a latest-sample discipline: `KL_i2s_playback` re-strides the AXIS tap by the **wire-truth** channel count (`wire_chans_i`, "0 until first accept -> 2"), repeats the last pair on underrun, and its physical render is 2-channel (stream ch0/ch1, extras virtual) | `hdl/ieee1722/aaf/KL_i2s_playback.sv` header + walker |
+| G6 | `milan_csr` plain-RW readback is a **512-word shadow BRAM covering 0x000–0x7FF only**: `shadow_ram[0:511]`, write gate `wr_fire && !(|wr_addr[ADDR_WIDTH-1:11])`, word address `wr_addr[10:2]` / `rd_addr[10:2]` (milan_csr.sv ~1173–1201). A 0x900 address has bit 11 set → it can never be shadow-served (it would alias word 0x100) | `hdl/common/csr/milan_csr.sv` `shadow_mem` block |
+| G7 | Reads **at/above 0x800 return 0 unless explicitly claimed**: `rd_in_window = ~|rd_addr_q[ADDR_WIDTH-1:11] || (rd_addr_q == A_MCSRV_STAT) || (rd_addr_q == A_MCSRV_CTRL)` (milan_csr.sv ~1363). The comment records that 0x8F8 read 0 on every build until 2026-07-23 because this term was missing | `milan_csr.sv` `rd_in_window` + `REGISTER_MAP.md` 0x8F8 note |
+| G8 | Writes to 0x900+ ARE reachable: the AXI window is 64 KB (`ADDR_WIDTH = 16`) and the write decode is a full-address exact-match `case (wr_addr)` (e.g. `A_MCSRV_CTRL: mcsrv_ctrl <= s_axi_wdata;` at 0x8FC) — new registers above 0x800 follow the MCSRV pattern: dedicated storage + explicit live-read arm + `rd_in_window` term | `milan_csr.sv` write decode ~860–915 |
+| G9 | AECP already decodes the audio-map verbs: `CMD_GET_AUDIO_MAP = 15'd43`, `CMD_ADD_AUDIO_MAPPINGS = 15'd44`, `CMD_REMOVE_AUDIO_MAPPINGS = 15'd45`, `DESC_AUDIO_MAP = 16'h0017` | `hdl/ieee17221/aecp/aecp_pkg.sv` 76–78, 128; `KL_aecp_l0_state.sv` 113 |
+| G10 | The entity model's mapping entry is `(mapping_stream_index, mapping_stream_channel, mapping_cluster_offset, mapping_cluster_channel)`; every AUDIO_CLUSTER in the model is **1-channel MBLA** (`"channel_count": 1, "format": "MBLA"`), STREAM_PORT_INPUT[0] owns clusters 0–7 (`base_cluster 0`), STREAM_PORT_OUTPUT[0] owns clusters 8–15 (`base_cluster 8`), each port has exactly one AUDIO_MAP (1722.1 7.2.13/7.2.19, builder D1) | `avdecc/milan-v12-entity.json` |
+| G11 | Per-stream DRAM PCM rings exist from the NxN work: route flag `DMA` = "payload lands in the stream's DRAM ring at `pcm base + s*stride`"; ring words are "full 64-bit words in wire byte order = S32BE interleaved PCM" | `REGISTER_MAP.md` 0x800 route-flags paragraph + PCM-ring section |
+
+## 1. The 64×64 model
+
+Both directions expose **64 stream-channels**: 8 AAF streams × up to 8
+channels/stream (Milan base formats, `ut=1` covers 1..8 ch — G10's
+format strings). Channel mapping is split into exactly two layers:
+
+1. **PipeWire composition (software)** — cross-stream / cross-channel
+   composition for ALSA clients. Driven by the AEM audio-map
+   configuration (the daemon reads GET_AUDIO_MAP); no fabric frame
+   composer exists in phase 1.
+2. **Fabric mapping (this doc)** — two small engines:
+   - **RENDER crossbar**: any RX `(stream s ∈ 0..7, wire-ch c ∈ 0..7)`
+     → any *physical* output channel (I2S-out ch0..1 + TDM8-out lane 0
+     ch0..7 = 10 physical render channels).
+   - **CAPTURE mux**: each talker **pair-slot** (the packetizer's G2
+     slot space, 32 slots at 8×8) selects its source: I2S-in pair,
+     TDM8-in pair, `KL_pcm_tx` ALSA-playback ring pair, tone, or zero.
+
+The fabric never composes frames; it only *selects*. The 64×64 "matrix"
+is therefore: RX side = 64 stream-channels fanning into 10 physical
+outputs (any-to-any) + 64 ALSA capture channels (per-stream rings,
+composed by PipeWire); TX side = 64 stream-channels each fed from a
+selected source pair + 64 ALSA playback channels (per-stream rings via
+`KL_pcm_tx`).
+
+## 2. ALSA topology + per-stream ring ABI (decided; unchanged ABI)
+
+- **8× 8-channel subdevices per direction, one per stream.** Capture
+  subdevice `s` fronts listener stream `s`'s DRAM PCM ring; playback
+  subdevice `t` fronts talker stream `t`'s ring consumed by
+  `KL_pcm_tx`.
+- **The ring ABI is today's PDU-payload ABI, unchanged** (G1/G11): full
+  64-bit words, wire byte order, S32BE interleaved, INT32
+  left-justified (`sample << 8`); ring base + `s`·stride per stream
+  (the N×N per-stream ring offsets). The depacketizer writes it; the
+  driver mmaps it; `KL_pcm_tx` de-interleaves it byte-identically to
+  the packetizer payload (G4).
+- Cross-stream/channel composition for ALSA (e.g. "one 16-ch app
+  device spanning streams 2+3") is **PipeWire's job**, configured from
+  the AEM audio map — never a fabric responsibility in phase 1.
+
+## 3. RENDER crossbar contract (`KL_chmap_render`, phase-1 name)
+
+**Input:** a clone of the depacketizer PCM AXIS (G1) — observe-only
+transfers (`tvalid && tready`), exactly like `KL_i2s_playback`'s tap;
+`tuser[3:0]` = stream `s`.
+
+**State:** `cur_sample[8][8]` — a 24-bit latest-sample array, streams ×
+wire channels. The walker re-strides each PDU frame by that stream's
+**wire-truth** channel count (per-stream `wire_chans` from the LCTX
+monitor context, the G5 rule generalized per stream): half-beat position
+`p` mod `C(s)` latches `cur_sample[s][p]`. `tlast` re-zeros the walk
+(PDU = whole sample frames, G1). Channels `c ≥ C(s)` are never written
+— they hold reset value 0 (silence).
+
+**Output:** on each media tick (the 48 kHz audio-MMCM grid), for each
+physical output channel `p ∈ 0..9`, the xbar reads its map word
+(§5) and emits `MAP.EN ? cur_sample[MAP.IDX_HI][MAP.IDX_LO] : 24'd0`
+toward the physical serializers:
+
+| Physical channel | Sink |
+|---|---|
+| 0, 1 | I2S-out L/R (`KL_i2s_playback` serializer path, CS4344) |
+| 2..9 | TDM8-out lane 0, slots 0..7 (`KL_tdm_render`, §8) |
+| 10..15 | reserved (map entries exist, read 0 / no sink) |
+
+**Semantics (normative):**
+- *Wire-truth latching:* what is latched is exactly what the wire
+  carried (no format assumption beyond the S32BE re-stride; the AEM
+  current-format never overrides the observed `wire_chans` — AAF-4 /
+  M-FMT-2 lineage).
+- *Unmapped → silence:* `EN = 0` (or an out-of-range source) emits 0.
+- *Remap takes effect at the media tick:* map words are read once per
+  tick during the output walk; a mid-tick write never tears a frame.
+  Worst-case remap latency = one sample period.
+- The xbar never backpressures the AXIS tap (G1's tap discipline) and
+  adds no per-stream FIFOs: the latch array IS the rate decoupling
+  (§9).
+
+The existing 2-channel playback walker inside `KL_i2s_playback` is
+subsumed: phase-1 integration feeds the I2S serializer's pair CDC from
+xbar channels {0,1} instead of the internal walker (the walker's
+underrun/overrun rails and prefill semantics are kept at the CDC).
+
+## 4. CAPTURE mux contract (`KL_chmap_capture`, phase-1 name)
+
+### 4.1 Model
+
+The capture mux becomes the **single authority over the packetizer's
+pair-slot space**. Physical front-ends stop being wired straight to the
+packetizer; each emits its pair stream with **local** pair numbering,
+and the mux emits the global `{pair_valid, pair_slot, pair_l, pair_r}`
+per its map.
+
+**Sources** (per pair): `I2S_IN` (one pair, `KL_aaf_capture_i2s`),
+`TDM8_IN` (4 pairs, `KL_tdm_capture` — G4), `PCM_TX` (ALSA playback
+rings, up to 4 pairs per talker stream, `KL_pcm_tx` — G4), `TONE`
+(`KL_tone_gen` 24-bit sample on both L and R), `ZERO`.
+
+**State:** per-source latest-pair latch registers (`cur_pair[src]`),
+written on each source `pair_valid` pulse — the same latest-sample
+discipline as §3, so arbitrary fan-out (many slots selecting one source
+pair) costs nothing.
+
+**Output pacing:** on each media tick the mux walks all 32 pair slots
+and emits one `{slot k, L, R}` pulse per **enabled** slot from the
+selected source's latch — exactly the pacing model `KL_pcm_tx` already
+implements for its slots (G4: "one media sample tick emits ONE audio
+sample for EVERY stream and EVERY channel pair"), so the packetizer's
+6-sample epoch cadence is preserved for every stream. Disabled slots
+emit nothing; the packetizer's slot-structural addressing (G2:
+"channel alignment is slot-structural") guarantees a disabled slot can
+never skew its stream's other channels — that stream's sample rows
+simply never complete, and the stream stays silent on the wire.
+
+### 4.2 Pair granularity (phase-1 restriction, normative)
+
+The capture path is **pair-granular**: L and R of a slot come from ONE
+source pair. AEM output-side mappings must therefore arrive
+pair-consistent (§7.3); a mapping that would split a pair across
+sources or cross L/R parity is refused. Per-channel capture routing is
+phase 2.
+
+### 4.3 The pair-slot widening (REQUIRED, normative)
+
+`KL_aaf_packetizer.pair_slot_i` is `[3:0]` today (G3) — a 16-slot
+space. The prefix-sum partition at 8 streams × 8 ch needs **32 pair
+slots**, so:
+
+> **`pair_slot` widens from `[3:0]` to `[4:0]` across the entire
+> pair-stream contract** before any stream whose cumulative pair base
+> reaches 16 can be addressed: `KL_aaf_packetizer.pair_slot_i`,
+> `KL_aaf_capture_i2s.pair_slot_o`, `KL_tdm_capture.pair_slot_o`
+> (incl. `cap_slot_r` and the CDC payload — the 52-bit
+> `cdc_pair_fifo` word `{slot[3:0], L[23:0], R[23:0]}` becomes 53
+> bits), `KL_pcm_tx`'s slot walk, and the new capture mux output.
+
+The packetizer's *internal* ownership decode needs no logic change —
+`pbase_w` is already `[5:0]` and the compares already zero-extend
+(`6'(pair_slot_i)`, G3); only the port and its `6'(...)` casts widen.
+The N=1 golden byte-compare gates stay green by construction (slot 0
+encodings are identical in 4 and 5 bits).
+
+## 5. MAP RAM — one shared word format
+
+Two map RAMs, ONE word format (16 bits stored; CSR view zero-extends
+to 32). Per the defect-4 house rule each RAM has one sync write process
+and one explicit sync read port.
+
+| RAM | Entries | Entry index |
+|-----|---------|-------------|
+| `RMAP` (render) | 16 × 16 b | physical output channel `p` (0..15; 10 used, §3) |
+| `CMAP` (capture) | 32 × 16 b | packetizer pair-slot `k` (0..31 — the §4.3 widened space) |
+
+**MAP word format (both sides, normative):**
+
+```
+[15]    EN      entry enabled. 0 = render: silence / capture: slot not emitted
+[14:12] SRC     source class
+                  render side : 0 = AVTP_RX   (only legal value; 1-7 reserved)
+                  capture side: 0 = ZERO, 1 = I2S_IN, 2 = TDM8_IN,
+                                3 = PCM_TX, 4 = TONE, 5-7 reserved
+[11:8]  rsvd    write 0, read 0
+[7:4]   IDX_HI  render : RX stream index s (0-7)
+                capture: source stream/lane — PCM_TX: talker stream t (0-7);
+                         TDM8_IN: lane (0 in phase 1); I2S_IN/TONE/ZERO: 0
+[3:0]   IDX_LO  render : wire channel c (0-7)
+                capture: source pair index — TDM8_IN: 0-3; PCM_TX:
+                         pair-within-stream 0-3; I2S_IN/TONE/ZERO: 0
+```
+
+Nibble-aligned on purpose (hex-readable on the bench: `0x8021` =
+EN | AVTP_RX | stream 2 | channel 1). The 4-bit index fields match the
+fabric-wide "spec-fixed 4-bit stream index" convention (G1's `tuser`).
+Illegal encodings (reserved SRC, out-of-range index for the elaborated
+shape) behave as `EN = 0` — never a lockup, RTL-enforced.
+
+**Reset state (N=1 bit-compat axiom):** `RMAP[0] = 0x8000` (EN,
+AVTP_RX, s=0, c=0), `RMAP[1] = 0x8001`, all other RMAP = 0 — today's
+"stream 0 renders ch0/ch1 on I2S" behavior. `CMAP[0] = 0x9000` (EN,
+I2S_IN, pair 0) — today's I2S-capture-feeds-talker-0 wiring. All other
+CMAP = 0.
+
+**Write-port arbitration (one port, normative):** AEM-projector commit
+wins the port; the CSR debug write takes idle cycles and is *refused*
+(counted, §6) if it collides with an in-flight AEM burst — mirroring
+the packetizer's `tctx_wmux` priority pattern. There is exactly one
+map truth: CSR reads shadow the same RAM the AEM writes (§6).
+
+## 6. CSR window — 0x900–0x97F (debug override + shadow readback)
+
+**Decode finding (from G6/G7/G8, drives the implementation):** offset
+0x900 is *reachable* — the AXI window is 64 KB and the write decode is
+full-address exact-match — **but** (a) the plain-RW shadow BRAM spans
+0x000–0x7FF only (`shadow_ram[0:511]`, `wr_addr[10:2]` slice,
+milan_csr.sv ~1188–1201): chmap words must NOT be listed in
+`is_plain_rw` (a 0x900 shadow write would alias word 0x100); and (b)
+the read gate `rd_in_window` (milan_csr.sv ~1363) zeroes every read ≥
+0x800 that no term claims — **integration MUST add a
+`(rd_addr_q >= 'h900 && rd_addr_q < 'h980)` term**, or every chmap
+read silently returns 0 (the exact 0x8F8 dead-read trap: the servo ran
+invisibly on every build until 2026-07-23). New registers follow the
+MCSRV pattern: dedicated storage, live/window read arm, `rd_in_window`
+term.
+
+Indexed window (O(1) decode, the 0x800-window house style; 0x900–0x97F
+reserved to this feature, 5 words used):
+
+| Offset | Name | Acc | Reset | Fields |
+|--------|------|-----|-------|--------|
+| `0x900` | `CHMAP_CTRL` | RW | `0` | `[0]` csr_write_en — debug override arm; while 0, `CHMAP_WORD` writes are ignored (AEM remains the sole programmer). Readback live |
+| `0x904` | `CHMAP_SEL` | RW | `0` | `[5:0]` entry index, `[8]` side (0 = RMAP/render, 1 = CMAP/capture). Out-of-range entries read 0, writes ignored (the 0x800-window out-of-range rule) |
+| `0x908` | `CHMAP_WORD` | RW | — | `[15:0]` the §5 map word of the selected entry. Write: commits through the shared write port (requires `CHMAP_CTRL[0]`; refused while an AEM burst holds the port). Read: the entry's CURRENT word — AEM- or CSR-written, one truth — served from the map RAM read port in walk-idle slots (AXI read stretches a few clocks; the engine-backed-word pattern of the 0x800 window) |
+| `0x90C` | `CHMAP_STAT` | RO | `0` | `[15:0]` aem_commits (map words written by the AEM projector, wraps), `[23:16]` csr_refused (CSR writes dropped: override disarmed or port collision; saturates), `[24]` aem_busy (projector burst in flight) |
+| `0x910`–`0x97C` | — | — | `0` | reserved (phase 2: flat per-entry view / composed-device controls) |
+
+`REGISTER_MAP.md` gains the `0x900` group row; `VERSION` minor bumps
+(additive change).
+
+## 7. AEM binding — IEEE 1722.1 dynamic audio maps (Milan es-4.16)
+
+The canonical programmer of both map RAMs is the AECP engine handling
+`ADD_AUDIO_MAPPINGS` / `REMOVE_AUDIO_MAPPINGS` / `GET_AUDIO_MAP`
+(command values 43/44/45 and `DESC_AUDIO_MAP = 0x0017` already decoded
+— G9). The CSR window is the debug override (§6). **Arbitration: one
+write port per RAM, AEM wins, CSR is shadow-readable always.**
+
+### 7.1 Authority model
+
+The **AEM dynamic-map store** (the descriptor-side mapping list) is the
+readback authority: `GET_AUDIO_MAP` is answered from it, never from the
+map RAMs. The map RAMs are a *projection* of the store onto the
+physical fabric — derived state. This keeps GET_AUDIO_MAP complete even
+for mappings that have no fabric backing (§7.2's PipeWire-domain
+entries) and keeps the fabric words free to be CSR-poked on the bench
+without corrupting AEM readback (a CSR override is bench-visible in
+`CHMAP_WORD`, not in GET_AUDIO_MAP).
+
+### 7.2 Cluster ↔ physical-channel table
+
+A mapping entry is `(mapping_stream_index, mapping_stream_channel,
+mapping_cluster_offset, mapping_cluster_channel)` (G10). Global cluster
+= the port's `base_cluster` + `cluster_offset`; every cluster in the
+model is 1-channel MBLA, so `mapping_cluster_channel = 0` always
+(non-zero → refused, `BAD_ARGUMENTS`).
+
+The **cluster↔physical table** is emitted by the end-station builder
+(the same config that sizes streams — `ENDSTATION_BUILDER.md` D1/D2)
+and baked into the AEM projector as a small ROM. Phase-1 default shape
+(1×1 model, G10; the 8×8 overlay generalizes the same pattern
+port-by-port):
+
+| Global cluster | Model object | Physical backing |
+|---|---|---|
+| 0, 1 (`STREAM_PORT_INPUT[0]`, offsets 0–1) | "Input" MBLA ×1 | RMAP entries 0, 1 (I2S-out L/R) |
+| 2..7 (offsets 2–7) | "Input" MBLA ×1 | RMAP entries 2..7 (TDM8-out lane 0 slots 0..5) — present only when the TDM8 render lane is built; otherwise ALSA-only |
+| 8..15 (`STREAM_PORT_OUTPUT[0]`, offsets 0–7) | "Output" MBLA ×1 | capture sources: builder assigns each output cluster a `{SRC, IDX_HI, IDX_LO}` triple (I2S-in pair, TDM8-in pair 0..3, PCM_TX ring pair, TONE) |
+
+Clusters with no physical backing (the common case at 8×8: 64 input
+clusters vs 10 physical render channels) are **ALSA/PipeWire-domain**:
+their mappings live only in the AEM store and steer PipeWire
+composition (§1 layer 1). The projector simply emits no fabric word for
+them.
+
+### 7.3 Projection rules (normative)
+
+**Input side** (`ADD_AUDIO_MAPPINGS` on a `STREAM_PORT_INPUT`), per
+entry: if the global cluster is physical-backed with RMAP entry `p`:
+
+```
+RMAP[p] = {EN=1, SRC=AVTP_RX, IDX_HI=mapping_stream_index[3:0],
+           IDX_LO=mapping_stream_channel[3:0]}
+```
+
+`REMOVE_AUDIO_MAPPINGS` of a matching entry → `RMAP[p].EN = 0`.
+`mapping_stream_index ≥ 8` or `mapping_stream_channel ≥ 8` → refused.
+
+**Output side** (`STREAM_PORT_OUTPUT`), per entry: target slot
+`k = pbase(mapping_stream_index) + mapping_stream_channel/2` (the G2
+prefix-sum partition; `pbase` from the same chans configuration the
+TCTX holds). **Pair-consistency rule (§4.2):** entries are accepted in
+L/R-consistent pairs — the even `mapping_stream_channel` entry and its
+`+1` partner must name the same source pair (adjacent even/odd
+clusters of one source pair per the §7.2 table). The even entry
+commits:
+
+```
+CMAP[k] = {EN=1, SRC=table(cluster).src, IDX_HI=table(cluster).idx_hi,
+           IDX_LO=table(cluster).idx_lo}
+```
+
+A lone half-pair mapping, mismatched parity, or a pair straddling two
+sources → the whole command is refused with `BAD_ARGUMENTS` (phase-1
+pair granularity; per-channel capture is phase 2).
+
+**Timing:** the projector writes map words through the §5 arbitrated
+port as a short burst (`aem_busy` in `CHMAP_STAT`); fabric effect lands
+at the next media tick (§3/§4 tick sampling). The AECP response is sent
+after the burst commits (the store and the projection never diverge
+observably).
+
+## 8. TDM8 render front-end (summary; module = parallel lane)
+
+`KL_tdm_render.sv` is being built as a parallel worktree lane; this doc
+pins its contract as the mirror of `KL_tdm_capture` (G4 conventions):
+
+- 8 slots × `WORD_BITS_P` (32 default) per frame, MSB first, samples
+  left-justified 24-in-slot; `DATA_DELAY_P` 0/1 applied ONCE here
+  (never also in a TB chip model — the double-Philips-delay lesson,
+  78bbabe).
+- Phase-1 clocking: **we are bus master** on the render side — bclk/
+  fsync generated from the clean audio MMCM by plain registered
+  dividers (the `KL_i2s_playback` clean-clock discipline; never a
+  fractional-N edge), `tdm_mclk_o` = clk_audio/2 shared with capture.
+- Feed: 8 mapped channels per media tick from the render xbar cross
+  one widened `cdc_pair_fifo`-style crossing into the bclk domain
+  (one crossing for the whole lane — the §4 CDC-does-not-multiply
+  rule of `NXN_ARCHITECTURE.md` §4).
+- Status: `frames_out` liveness counter, CSR-exposed later (not in the
+  0x900 window; it is a front-end, not the map).
+
+## 9. Clocking and slip policy (phase 1, normative)
+
+- All AAF streams and both physical directions share the
+  **gPTP-disciplined media clock** (the coherent chain: audio MMCM +
+  CRF/MMCM-DRP servo, silicon-proven). There is **no per-stream SRC in
+  phase 1**.
+- The latch arrays (§3 `cur_sample`, §4 `cur_pair`) implement
+  **latest-sample semantics**: at each media tick every consumer reads
+  the newest value ≤ 1 sample old. Bounded inter-stream phase skew is
+  absorbed; a stalled/unbound source simply holds its last value
+  (render: last sample, then silence on unmap; capture: last pair) —
+  the same repeat-last slip-dup the I2S path already uses (G5), with
+  the existing per-stream monitor rails counting the underlying
+  events. No new drift rails are introduced by the mapping layer
+  itself.
+- Remap effect point = media tick (§3/§4): switching sources produces
+  at worst one sample-step discontinuity; no ramping in phase 1.
+
+## 10. Phase-2 appendix — fabric 64-ch composed device
+
+Phase 2 (explicitly out of scope now) lifts the PipeWire-only
+composition into fabric as a **composed 64-channel device**: a frame
+composer that presents one contiguous 64-ch ALSA view (single ring)
+built from all 8 streams. It reuses THIS map infrastructure unchanged
+in kind:
+
+- The §5 word format already carries what composition needs
+  (`SRC/IDX_HI/IDX_LO`); phase 2 only *widens the entry spaces* (RMAP
+  grows past 16 entries to cover composed-device channels; CMAP's
+  capture side gains `SRC = AVTP_RX` for stream→stream bridging).
+- The 0x910–0x97C reserved window hosts the composed-device controls.
+- The pair-granularity restriction (§4.2) is dropped (per-channel
+  capture staging).
+
+Nothing in phase 1 may assume the map RAM is consulted only by the two
+phase-1 engines.
+
+## 11. Integration checklist (order matters)
+
+1. **Pair-slot widening (§4.3)** — `[3:0]` → `[4:0]` through
+   `KL_aaf_packetizer` / `KL_aaf_capture_i2s` / `KL_tdm_capture`
+   (CDC 52→53 b) / `KL_pcm_tx`; N=1 golden byte-compare TBs must stay
+   green untouched.
+2. **Capture mux in** — insert `KL_chmap_capture` between the
+   front-ends and the packetizer; front-ends drop to local pair
+   numbering; CMAP reset value reproduces today's wiring (§5). TB:
+   tick-paced walk, fan-out, disabled-slot silence, slot-structural
+   alignment under drops.
+3. **Render xbar in** — `KL_chmap_render` on a depacketizer AXIS
+   clone; I2S serializer fed from xbar ch {0,1} (walker subsumed,
+   rails kept); RMAP reset reproduces today's ch0/ch1 render. TB:
+   wire-truth re-stride per stream, unmapped silence, remap-at-tick.
+4. **CSR** — `milan_csr`: `A_CHMAP_*` constants, dedicated
+   storage + write-decode arms (G8 pattern), live read arms, and the
+   **`rd_in_window` 0x900–0x97F term (G7 — the dead-read trap)**; NOT
+   in `is_plain_rw` (G6). `REGISTER_MAP.md` group row + VERSION minor
+   bump. TB: csr harness window rows incl. the ≥0x800 read gate.
+5. **TDM8 render lane merge** (§8) — parallel lane lands
+   independently; until merged, RMAP entries 2..9 are writable but
+   sink-less (harmless by §3 semantics).
+6. **AEM projector** — commit path from the AECP audio-map verbs (G9)
+   to the arbitrated map write port; cluster↔physical ROM emitted by
+   the builder; GET_AUDIO_MAP from the dynamic store (§7.1);
+   pair-consistency refusal (§7.3). TB: aecp harness ADD/REMOVE/GET
+   rows + projection vectors + refusal rows.
+7. **8×8 elaboration** — `N_TALKERS_P = 8` / `N_LISTENERS_P = 8`
+   shapes with per-stream rings; builder overlays emit the 8-port
+   cluster blocks + maps (G10 pattern per port); estimator re-run
+   (the map layer is small: 2 LUTRAM-class RAMs + latch arrays ≈
+   64×24 b + walk FSMs — but measure, don't assume: OOC-synth before
+   believing any area number).
+8. **Docs/tests close-out** — SPEC_TRACEABILITY rows (1722.1
+   7.2.19 / es-4.16), behave-suite scenarios (roadmap 10), this doc
+   flipped DESIGN → AS-BUILT per phase.

--- a/docs/CHMAP64_AEM_BINDING.md
+++ b/docs/CHMAP64_AEM_BINDING.md
@@ -1,0 +1,154 @@
+<!--
+SPDX-FileCopyrightText: 2026 Kebag Logic
+SPDX-License-Identifier: CERN-OHL-W-2.0
+-->
+
+# chmap64 — AEM dynamic-audio-map → fabric map-word binding contract
+
+The `chmap64` feature adds a **render crossbar** (listener side: incoming AAF
+stream channels → physical render/DAC channels) and a **capture mux** (talker
+side: physical capture/ADC channels → outgoing stream channels), both
+programmed by a small **map RAM**. Each RAM entry is a *map word*:
+
+```
+map word  = { en, stream[2:0], ch[2:0] }      // 7 bits
+              en      1 = this physical channel is driven
+              stream  source stream index      (0..7, the 8x8 lanes)
+              ch      source channel in stream  (0..7)
+```
+
+The **canonical programmer** of that RAM is the IEEE 1722.1 / Milan dynamic
+audio-map command set, not a bespoke register poke. This document is the
+normative binding between the two; the executable form lives in
+`tests/features/item10_audio_maps.feature` +
+`tests/steps/tsn_gen_steps.py::MilanAudioMapModel` (item-10 row
+`item-10-audio-maps`, matrix `M-AECP-4`).
+
+## Commands (codes verified against `hdl/ieee17221/aecp/aecp_pkg.sv`)
+
+| Command | `aecp_pkg.sv` | code | Spec | Milan |
+|---|---|---|---|---|
+| `GET_AUDIO_MAP` | `CMD_GET_AUDIO_MAP = 15'd43` | **0x2B** | §7.4.44 | 5.4.2.26 |
+| `ADD_AUDIO_MAPPINGS` | `CMD_ADD_AUDIO_MAPPINGS = 15'd44` | **0x2C** | §7.4.45 | 5.4.2.27 |
+| `REMOVE_AUDIO_MAPPINGS` | `CMD_REMOVE_AUDIO_MAPPINGS = 15'd45` | **0x2D** | §7.4.46 | 5.4.2.28 |
+
+> The values are the AEM `command_type` (Table 7.128) — decimal 43/44/45.
+> They are **not** 0x1A/0x1B/0x1C; always read `aecp_pkg.sv`, never a comment.
+
+A mapping record (8 bytes on the wire) is
+`(stream_index, stream_channel, cluster_offset, cluster_channel)`. Clusters
+model the physical channels; per Milan 5.4.2.26 the deployed clusters are
+**mono** (one channel each), so `cluster_channel == 0` and the store key is the
+`cluster_offset` alone — *at most one dynamic mapping per Audio-Cluster
+channel*.
+
+## The projection rule (AEM → map word)
+
+The dynamic map lives on `STREAM_PORT_INPUT[0]` (the render side). The RTL
+responder is `KL_aecp_response_builder` under ``` `AEM_DYNMAP ```; the store is
+`dmap_v_r[key]` / `dmap_ch_r[key]` with `key = cluster_offset`, sized
+`AEM_DMAP_KEYS_C` (generated from the end-station JSON by
+`avdecc/gen_aem_store.py`; builder self-test defaults `KEYS=8`, `NMAPS=2`,
+`PAGE=4`).
+
+For every mapping record `(si, sc, co, cc)`:
+
+```
+address  = co                         // cluster-offset = physical render channel
+                                      //   (cc == 0, mono clusters)
+
+ADD    (accepted)  →  RAM[address] = { en=1, stream=si, ch=sc }
+REMOVE (matched)   →  RAM[address] = { en=0, stream=0,  ch=0  }
+```
+
+Packed: `word = (en<<6) | (stream<<3) | ch`. Example: adding `si=0, sc=3, co=0`
+yields `RAM[0] = 0x43` (`en=1, stream=0, ch=3`).
+
+### Validity (ADD, 5.4.2.27 — all-or-nothing)
+
+A record is valid iff **all** hold; any invalid record fails the *whole*
+command with `BAD_ARGUMENTS` and **nothing** is written:
+
+| Check | Rule | RTL term |
+|---|---|---|
+| single audio input | `stream_index == 0` | `w_dm_shape_ok` |
+| mono cluster | `cluster_channel == 0` | `w_dm_shape_ok` |
+| key in range | `cluster_offset < AEM_DMAP_KEYS_C` | `w_dm_key_ok` |
+| channel in format | `stream_channel < channels(STREAM_INPUT[0])` | `w_dm_ch_ok` |
+| no intra-command dup | same `cluster_offset` used twice in one command → reject | `dmap_claim_r[key]` |
+
+A valid ADD to an already-mapped key **replaces** it (the 5.4.2.27 accept-and-
+replace option). `stream_index` is fixed at 0 in the current single-input build;
+the chmap64 8×8 build widens `KEYS` and the `stream` field — the projection rule
+above is unchanged.
+
+### REMOVE (5.4.2.28 — lenient)
+
+REMOVE clears an **exact** `(cluster_offset, stream_channel)` match and *ignores*
+everything else (unmatched, duplicate); it always returns `SUCCESS` on the input
+port. GET then shows the key gone / the word disabled.
+
+### GET_AUDIO_MAP (getter)
+
+`STREAM_PORT_INPUT[0]` pages the live store: `number_of_maps` is the fixed
+partition count `AEM_DMAP_NMAPS_C`; each page emits `PAGE` keys, listing the
+mapped ones as `(stream_index=0, stream_channel, cluster_offset, cluster_channel=0)`.
+`map_index >= NMAPS` → `BAD_ARGUMENTS` (§7.4.44.1). `STREAM_PORT_OUTPUT[0]` is
+the static capture map (well-formed, `number_of_maps=1`). Any other
+descriptor/index → `NO_SUCH_DESCRIPTOR`.
+
+### Status codes returned (as the RTL actually returns them)
+
+| Situation | Status | value |
+|---|---|---|
+| accepted ADD/REMOVE/GET | `SUCCESS` | 0 |
+| unknown descriptor/index | `NO_SUCH_DESCRIPTOR` | 2 |
+| invalid record / dup key / bad map_index | `BAD_ARGUMENTS` | 7 |
+| ADD/REMOVE on the static output map | `NOT_SUPPORTED` | 11 |
+| locked/acquired by another controller | `ENTITY_LOCKED` / `ENTITY_ACQUIRED` | 3 / 4 |
+
+## Cluster ↔ physical-channel table (I2S 2ch + TDM8 8ch)
+
+The `AUDIO_CLUSTER` descriptors of the end-station
+(`avdecc/milan-v12-entity.json`) enumerate the physical channels; the render
+crossbar addresses them by flattened `cluster_offset` (mono clusters):
+
+| cluster_offset | physical render channel | interface |
+|---|---|---|
+| 0 | render L | I2S stereo, ch 0 |
+| 1 | render R | I2S stereo, ch 1 |
+| 2 | render 2 | TDM8 slot 0 |
+| 3 | render 3 | TDM8 slot 1 |
+| 4 | render 4 | TDM8 slot 2 |
+| 5 | render 5 | TDM8 slot 3 |
+| 6 | render 6 | TDM8 slot 4 |
+| 7 | render 7 | TDM8 slot 5 |
+| … | … | TDM8 slots 6-7 when `KEYS ≥ 10` |
+
+`AEM_DMAP_KEYS_C` is generated to cover the deployed physical channel count
+(I2S 2 + TDM8 8 = 10 for the full render; the builder unit-test fixture uses 8).
+The capture mux mirrors this on `STREAM_PORT_OUTPUT` (static in the current
+RTL: I2S/TDM8 capture channels → outgoing stream channels).
+
+## Arbitration — who owns the map write port
+
+- **The AEM engine owns the map RAM write port.** `ADD`/`REMOVE_AUDIO_MAPPINGS`
+  is the authoritative, spec-visible programmer; every accepted edit projects to
+  a map word as above, and `GET_AUDIO_MAP` is the read-back of record.
+- **The CSR window is a debug-override**, not the normal control path. It exists
+  for bring-up / bench pokes and is subordinate to the AEM engine: a controller
+  issuing dynamic maps is the source of truth, and any CSR scribble is expected
+  to be re-asserted by the next AEM edit / `GET_AUDIO_MAP` reconciliation. Do not
+  drive both concurrently in production; the CSR path carries no lock semantics.
+
+## Traceability — `PDU_GETTER_SETTER_VERIFICATION.md` audio-maps row
+
+The item-10 plan doc `docs/testing/PDU_GETTER_SETTER_VERIFICATION.md` is owned
+by the sibling open PR `item-10-pdu-getter-setter-verify` and is **not present on
+`main`** (this PR's base), so its table cannot be appended here without an
+add/add collision. When that PR lands, its AECP/AEM table row
+
+> `GET_AUDIO_MAP + ADD/REMOVE_AUDIO_MAPPINGS | getter + action (es-4.16) | matrix M-AECP-4 | item-10-audio-maps`
+
+is satisfied by this fixture; update its "Existing coverage" cell to
+`item10_audio_maps (getter + action + fabric)` and mark the row done.

--- a/docs/SYSTEMS_ENGINEER_GUIDE.md
+++ b/docs/SYSTEMS_ENGINEER_GUIDE.md
@@ -171,6 +171,9 @@ Each entry: the doc and **when to read it**. `→` marks the doc to start each s
 - **Media-clock servo** — silicon-proven MMCM-DRP servo (`hdl/ieee1722/crf/KL_mmcm_drp_servo.sv`,
   MCSRV_STAT/CTRL at 0x8F8/0x8FC), coherent chain, -83.9 dB. Documented in
   `MILAN_COMPLIANCE_GAPS.md` item 6 and the register map; the traceability rows are being updated.
+- **`docs/CHANNEL_MAP_64.md`** — the 64-in/64-out channel-map architecture: render crossbar + capture
+  mux over one shared MAP-RAM, programmed by the IEEE 1722.1 dynamic audio maps (CSR window 0x900-0x97F
+  is the bench override). Read for AAF stream-channel → physical-I/O routing and the pair-slot widening.
 
 **MAAP (address allocation)**
 - → **`docs/design/MAAP_FABRIC.md`** — the fabric MAAP engine design + byte-exact PDU contract

--- a/docs/reference/REGISTER_MAP.md
+++ b/docs/reference/REGISTER_MAP.md
@@ -534,6 +534,25 @@ is an RTL tie today).
 | `0x8F8` | `MCSRV_STAT` | RO | `0` | `[2:0]` state (0 IDLE, 1 VERIFY, 2 REPAIR, 3 ACQUIRE, 4 LOCKED, 5 HOLDOVER, 6 FAULT), `[3]` DRP config verified, `[4]` DRP config mismatch (read-verify failed; informative while auto-repair is tied off), `[5]` MMCM LOCKED (synced), `[6]` fine-PS actuator busy, `[7]` PSDONE-watchdog fault (sticky), `[8]` DRP relock-timeout fault, `[15:9]` reserved 0, `[31:16]` **signed** applied frequency trim in 1/16 ppm units (e.g. `+0x06E9` = +110.6 ppm). The servo engages only at `clock_source == 2` (CRF descriptor); in every other mode this word reads state IDLE with trim 0 and the servo generates **zero** DRP/PS activity |
 | `0x8FC` | `MCSRV_CTRL` | RW | `0` | `[0]` ps_invert: flips the servo fine-PS direction mapping (bench sign knob - 2026-07-23 mf51 silicon stepped opposite the UG472 reading and rails went 25x worse under the servo; settle the polarity on silicon via this bit, then bake the winner as the RTL default). NOTE both 0x8F8/0x8FC needed the rd_in_window >=0x800 carve-out - 0x8F8 read 0 on every build before 2026-07-23 |
 
+### 0x900  -  channel-map fabric  `(docs/CHANNEL_MAP_64.md §6, KL_chan_map_render / KL_chan_map_capture)`
+
+Debug write port + bypass arm for the 64x64 render/capture map RAMs. Same
+dedicated-arm carve-out as MCSRV (NOT in `is_plain_rw` - a 0x900 shadow write
+would alias word 0x100 - plus its own `rd_in_window` 0x900-0x93F term, or every
+read here would be the 0x8F8 dead-read trap). `CHMAP_CTRL[0]` = 0 (reset) leaves
+the CERT audio path bit-identical: the render/capture crossbars are muxed OUT of
+both the packetizer feed and the i2s_playback feed. The AEM audio-map projector
+(1722.1 7.2.19 / Milan es-4.16) is the canonical programmer; this window is the
+bench override (a documented follow-up wires the projector to the same port).
+
+| Offset | Name | Acc | Reset | Description |
+|--------|------|-----|-------|-------------|
+| `0x900` | `CHMAP_CTRL` | RW | `0` | `[0]` csr_write_en - fabric bypass arm. While 0, the CERT capture/render paths drive bit-identically and `CHMAP_WORD` writes are refused (counted in `CHMAP_STAT[23:16]`). Set 1 after programming the map to select the crossbar outputs |
+| `0x904` | `CHMAP_SEL` | RW | `0` | `[5:0]` map entry index, `[8]` side (0 = RMAP/render phys channel 0..9, 1 = CMAP/capture pair slot 0..31). Selects the target of the next `CHMAP_WORD` write |
+| `0x908` | `CHMAP_WORD` | RW | - | `[15:0]` the §5 map word `{EN[15], SRC[14:12], rsvd[11:8], IDX_HI[7:4], IDX_LO[3:0]}`. Write commits through the shared map write port when `CHMAP_CTRL[0]` = 1; readback = last committed word |
+| `0x90C` | `CHMAP_STAT` | RO | `0` | `[15:0]` aem/csr commits (wraps), `[23:16]` csr_refused (override disarmed; saturates) |
+| `0x910`-`0x93C` | - | - | `0` | reserved to this feature (read 0, never shadow-aliased) |
+
 ## DMA registers (fully-FPGA build only  -  separate CSR space)
 
 On the fully-FPGA VexiiRiscv (formerly NaxRiscv) SoC the AXIS↔memory DMA (§A.6,

--- a/hdl/common/csr/milan_csr.sv
+++ b/hdl/common/csr/milan_csr.sv
@@ -231,6 +231,13 @@ module milan_csr #(
   input  wire [31:0]             i_ltap_status,       //! RO 0x870 status field (active/stage; enable OR-ed in here)
   output wire                    o_ltap_en,           //! LTAP_CTRL[1]: measurement enable (default 1)
   output wire                    o_ltap_clr,          //! LTAP_CTRL[0] W1S: 1-cycle stats clear
+  //! chmap 0x900 window (docs/CHANNEL_MAP_64.md §6): render/capture map-RAM
+  //! debug write port + fabric bypass arm. Default 0 = today's audio path.
+  output wire                    o_chmap_enable,      //! CHMAP_CTRL 0x900[0]: fabric bypass arm (0 = legacy path)
+  output wire                    o_chmap_wr_en,       //! one-cycle map-word write strobe (gated by CHMAP_CTRL[0])
+  output wire                    o_chmap_wr_side,     //! CHMAP_SEL[8]: 0 = RMAP (render), 1 = CMAP (capture)
+  output wire [5:0]              o_chmap_wr_addr,     //! CHMAP_SEL[5:0]: map entry index
+  output wire [15:0]             o_chmap_wr_data,     //! CHMAP_WORD[15:0]: the §5 map word
   output wire                    o_crft_en,           //! CRF talker enable (0x750)
   output wire [63:0]             o_crft_sid,          //! CRF talker stream_id (0x754/0x758)
   output wire [47:0]             o_crft_dest_mac,     //! CRF talker DMAC (0x75C/0x760)
@@ -462,6 +469,14 @@ module milan_csr #(
   localparam [ADDR_WIDTH-1:0] A_LTAP_CTRL = 'h870;   //! RW: [1] enable (def 1); W1S [0] clear stats. RO: {stage/active status}
   localparam [ADDR_WIDTH-1:0] A_LTAP_BASE = 'h874;   //! first RO readback word (16 words, packed)
   localparam [ADDR_WIDTH-1:0] A_LTAP_END  = 'h8B4;   //! one past the last RO word (0x8B0)
+  //! chmap map-RAM window (docs/CHANNEL_MAP_64.md §6). Same dedicated-arm
+  //! carve-out as MCSRV (0x8F8/0x8FC): NOT in is_plain_rw (a 0x900 shadow
+  //! write would alias word 0x100), a live read arm per word, and its own
+  //! rd_in_window term (else every read here is the 0x8F8 dead-read trap).
+  localparam [ADDR_WIDTH-1:0] A_CHMAP_CTRL = 'h900;  //! RW: [0] csr_write_en (fabric bypass arm)
+  localparam [ADDR_WIDTH-1:0] A_CHMAP_SEL  = 'h904;  //! RW: [5:0] entry idx, [8] side (0=render,1=capture)
+  localparam [ADDR_WIDTH-1:0] A_CHMAP_WORD = 'h908;  //! RW: [15:0] §5 map word; write commits via the shared port (needs CTRL[0])
+  localparam [ADDR_WIDTH-1:0] A_CHMAP_STAT = 'h90C;  //! RO: [15:0] commits, [23:16] refused
   // ---- 0x800 indexed per-stream window (P11, NXN_ARCHITECTURE.md §1.5).
   //  SEL picks {dir, idx}; the 0x810-0x85C word block then views ONE stream.
   //  Legacy flat registers stay the authority for index 0 (N=1 bit-compat
@@ -625,6 +640,12 @@ module milan_csr #(
   logic [31:0] mcsrv_ctrl;               //! MCSRV_CTRL 0x8FC: [0]=ps_invert, [1]=auto_repair enable
   logic        ltap_en_r;                //! LTAP_CTRL[1]: latency-tap measurement enable (reset 1)
   logic        ltap_clr_p;               //! LTAP_CTRL[0] W1S: 1-cycle stats-clear strobe
+  logic [31:0] chmap_ctrl;               //! CHMAP_CTRL 0x900: [0]=csr_write_en (bypass arm)
+  logic [31:0] chmap_sel;                //! CHMAP_SEL 0x904: [5:0]=idx, [8]=side
+  logic [31:0] chmap_word;               //! CHMAP_WORD 0x908: last committed §5 word
+  logic [15:0] chmap_commits;            //! CHMAP_STAT[15:0]: committed CSR writes (wraps)
+  logic [7:0]  chmap_refused;            //! CHMAP_STAT[23:16]: refused writes (saturates)
+  logic        chmap_wr_p;               //! one-cycle map-word write strobe
   logic [31:0] gptp_pdelay;              //! GPTP_PDELAY: neighbor pdelay (ns)
   logic [31:0] lwsrp_vid;                //! LWSRP_VID: [11:0] SR VID
   logic [31:0] lwsrp_dmlo, lwsrp_dmhi;   //! lwSRP stream DMAC {dmhi[15:0], dmlo}
@@ -811,6 +832,8 @@ module milan_csr #(
       mcsrv_ctrl <= 32'h0;
       ltap_en_r  <= 1'b1;   //! latency taps measure by default
       ltap_clr_p <= 1'b0;
+      chmap_ctrl <= 32'h0; chmap_sel <= 32'h0; chmap_word <= 32'h0;
+      chmap_commits <= 16'h0; chmap_refused <= 8'h0; chmap_wr_p <= 1'b0;
       gptp_pdelay <= 32'h0;
       lwsrp_vid  <= 32'h0000_0002;
       lwsrp_dmlo <= 32'hF000_FE01;
@@ -841,6 +864,7 @@ module milan_csr #(
       adp_adv_p <= 1'b0; adp_dep_p <= 1'b0;
       tcam_wr_p <= 1'b0;
       ltap_clr_p <= 1'b0;
+      chmap_wr_p <= 1'b0;
       //! P12: engine CFG-word write requests hold until the engine's
       //! same-cycle accept (the engines arbitrate their single RAM write
       //! port; a one-cycle pulse could be lost to an engine-write slot)
@@ -917,6 +941,21 @@ module milan_csr #(
           A_LTAP_CTRL: begin              //! [1] enable RW; [0] W1S stats clear
             ltap_en_r <= s_axi_wdata[1];
             if (s_axi_wdata[0]) ltap_clr_p <= 1'b1;
+          end
+          A_CHMAP_CTRL: chmap_ctrl <= s_axi_wdata;
+          A_CHMAP_SEL:  chmap_sel  <= s_axi_wdata;
+          //! §6: the map word commits through the shared write port only while
+          //! the override is armed (CTRL[0]); a disarmed write is refused and
+          //! counted, never touching the map (AEM stays the sole programmer).
+          A_CHMAP_WORD: begin
+            if (chmap_ctrl[0]) begin
+              chmap_word    <= s_axi_wdata;
+              chmap_wr_p    <= 1'b1;
+              chmap_commits <= chmap_commits + 16'd1;
+            end else begin
+              chmap_refused <= (&chmap_refused) ? chmap_refused
+                                                : chmap_refused + 8'd1;
+            end
           end
           //! I2SPB rail counters W1C (gaps 5b): each half clears on a write
           //! with any bit of that half set - the saturated-and-stuck-forever
@@ -1294,6 +1333,10 @@ module milan_csr #(
       A_MCSRV_CTRL: live_mux = mcsrv_ctrl;
       //! LTAP_CTRL: module status ({stage,active}) with enable OR-ed into [1]
       A_LTAP_CTRL:  live_mux = i_ltap_status | {30'd0, ltap_en_r, 1'b0};
+      A_CHMAP_CTRL: live_mux = chmap_ctrl;
+      A_CHMAP_SEL:  live_mux = chmap_sel;
+      A_CHMAP_WORD: live_mux = {16'd0, chmap_word[15:0]};
+      A_CHMAP_STAT: live_mux = {8'd0, chmap_refused, chmap_commits};
       A_I2SPB_DBG:  live_mux = i_i2spb_dbg;
       //! E1 commit readback: {busy, done, 20'0, status, 4'0, idx}
       A_REST_CMD:   live_mux = {rest_pend_r, rest_done_r, 20'd0,
@@ -1303,6 +1346,9 @@ module milan_csr #(
           live_mux = stat_snap[soff[2 +: 4]];
         else if (rd_addr_q >= A_LTAP_BASE && rd_addr_q < A_LTAP_END)
           live_mux = i_ltap_regs[32*32'(loff[5:2]) +: 32];  //! 16 packed RO words
+        else if (rd_addr_q >= A_CHMAP_CTRL &&
+                 rd_addr_q <  A_CHMAP_CTRL + 16'h40)
+          live_mux = 32'h0;               //! reserved chmap words read 0 (never shadow)
         else
           live_hit = 1'b0;                //! -> shadow (or 0 above the window)
       end
@@ -1392,7 +1438,10 @@ module milan_csr #(
                       (rd_addr_q == A_MCSRV_CTRL) ||
                       //! item-11 LTAP group (CTRL 0x870 + 16 RO words) lives
                       //! >=0x800, so it needs the same carve-out as the servo
-                      ((rd_addr_q >= A_LTAP_CTRL) && (rd_addr_q < A_LTAP_END));
+                      ((rd_addr_q >= A_LTAP_CTRL) && (rd_addr_q < A_LTAP_END)) ||
+                      //! chmap 0x900-0x93F window (else the 0x8F8 dead-read trap)
+                      (rd_addr_q >= A_CHMAP_CTRL &&
+                       rd_addr_q <  A_CHMAP_CTRL + 16'h40);
   always_ff @(posedge aclk) begin : read_data_reg
     if (!aresetn) r_data <= 32'h0;
     else if (rd_pend)
@@ -1456,6 +1505,11 @@ module milan_csr #(
   assign o_mcsrv_auto_repair = mcsrv_ctrl[1];
   assign o_ltap_en          = ltap_en_r;
   assign o_ltap_clr         = ltap_clr_p;
+  assign o_chmap_enable   = chmap_ctrl[0];
+  assign o_chmap_wr_en    = chmap_wr_p;
+  assign o_chmap_wr_side  = chmap_sel[8];
+  assign o_chmap_wr_addr  = chmap_sel[5:0];
+  assign o_chmap_wr_data  = chmap_word[15:0];
   assign o_i2spb_clr_under  = i2spb_clru_p;
   assign o_i2spb_clr_over   = i2spb_clro_p;
   assign o_tone_att         = tone_ctrl[3:1];

--- a/hdl/ieee1722/aaf/KL_aaf_packetizer.sv
+++ b/hdl/ieee1722/aaf/KL_aaf_packetizer.sv
@@ -92,8 +92,12 @@ module KL_aaf_packetizer #(
 
   //! --- pair stream from the capture front-end (one crossing, all slots) -
   input  wire         pair_valid_i,      //! one-cycle pulse per L/R pair
-  input  wire [3:0]   pair_slot_i,       //! pair slot (talker t owns chans/2
-                                         //! consecutive slots - see header)
+  input  wire [4:0]   pair_slot_i,       //! pair slot 0..31 (talker t owns
+                                         //! chans/2 consecutive slots; 32-slot
+                                         //! space = 8 talkers x 4 pairs max -
+                                         //! see header. Physical capture drives
+                                         //! only 0..15; the chan-map mux uses
+                                         //! the full width)
   input  wire [23:0]  pair_l_i,
   input  wire [23:0]  pair_r_i,
 

--- a/hdl/ieee1722/aaf/KL_chan_map_capture.sv
+++ b/hdl/ieee1722/aaf/KL_chan_map_capture.sv
@@ -1,0 +1,291 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+/*
+------------------------------------------------------------------------------
+  File        : KL_chan_map_capture.sv
+  Author      : Kebag Logic
+
+  Date        : 2026-07-23
+  Description : Per-pair-slot TX source multiplexer (docs/NXN_ARCHITECTURE.md
+                §2.1 capture family; the SW-defined end-station channel map).
+                Sits between the several pair-stream sources and the shared
+                KL_aaf_packetizer's pair-injection interface: for every one of
+                the N_SLOTS_P TX pair slots (the prefix-sum slot space; talker
+                t owns chans/2 consecutive slots - see the packetizer header)
+                a small map RAM selects which audio source feeds that slot.
+
+                8 talker streams x up to 8 channels = up to 32 stereo PAIR
+                slots, so the map is 32 entries deep and the emitted
+                pair_slot_o is the full 5-bit (0..31) space the packetizer now
+                accepts (the pair_slot widening).
+
+                MAP ENTRY (8 bits, one per slot): {en[7], src[6:4], idx[3:0]}
+                  en  - 1 = this slot is live and injected every media tick;
+                        0 = the slot emits nothing (skipped in the walk).
+                  src - the source bucket:
+                          0 ZERO    : digital silence (L=R=0)
+                          1 I2S_IN  : the stereo I2S capture pair (idx unused)
+                          2 TDM_IN  : TDM pair idx (0..N_TDM_P/2-1; slot pair
+                                      idx carries TDM slots {2*idx, 2*idx+1})
+                          3 RING    : ALSA playback ring pair idx (the
+                                      KL_pcm_tx pair-channel index)
+                          4 TONE    : the pilot tone on BOTH channels
+                        (5..7 reserved -> silence)
+                  idx - the within-source pair index (see src).
+
+                SOURCE BUCKETS (wire-truth, free-running): the latest pair per
+                source is latched into a hold register the instant its
+                pair_valid pulse arrives, so the tick-time walk always injects
+                the freshest sample. The tone bucket is the live tone_smp_i
+                (both L/R). No CDC lives here - every source has already
+                crossed into clk_i.
+
+                EMIT (media sample tick): on tick_i the engine walks the slot
+                map low-to-high; each ENABLED slot injects one pair
+                (pair_valid_o one-cycle pulse + pair_slot_o + pair_l_o/
+                pair_r_o) then idles GAP_CYC_P cycles before the next slot -
+                the proven inject cadence the packetizer admits (one pair per
+                cycle with a settle gap, mirroring the golden NxN TB's
+                pair()). Disabled slots are skipped with no pulse. Six media
+                ticks (6 samples/ch) fill one AVTPDU per talker on the shared
+                6-sample cadence; a tick arriving mid-walk is queued one deep
+                (never dropped).
+
+  Company     : Kebag Logic
+  Project     : Milan AVTP
+------------------------------------------------------------------------------
+*/
+
+//! Per-pair-slot TX source mux (NXN §2.1 capture family): a 32-slot map RAM
+//! ({en, src, idx}) routes each packetizer pair slot to a source bucket (I2S
+//! capture / TDM / ALSA ring / tone / silence); free-running source holds,
+//! per-tick low-to-high slot walk emitting the packetizer inject cadence
+//! (one pulse + GAP_CYC_P settle), disabled slots silent. Single clock, no CDC.
+
+`default_nettype none
+
+module KL_chan_map_capture #(
+  parameter int unsigned N_SLOTS_P = 32,   //! TX pair slots (prefix-sum space)
+  parameter int unsigned N_TDM_P   = 8,    //! TDM slots (pairs = N_TDM_P/2)
+  parameter int unsigned N_RING_P  = 16,   //! ALSA ring pair sources (idx 0..15)
+  parameter int unsigned GAP_CYC_P = 24    //! settle cycles between slot injects
+)(
+  input  wire         clk_i,             //! datapath clock
+  input  wire         rst_n,             //! active-low synchronous reset
+
+  //! --- map RAM write port (CSR window / TB) ------------------------------
+  input  wire         map_wr_en_i,       //! one-cycle write strobe
+  input  wire [$clog2(N_SLOTS_P)-1:0] map_wr_addr_i, //! slot index
+  input  wire [7:0]   map_wr_data_i,     //! {en[7], src[6:4], idx[3:0]}
+
+  //! --- map RAM readback port (registered, 1-cycle latency) ---------------
+  input  wire         map_rd_en_i,       //! one-cycle read request
+  input  wire [$clog2(N_SLOTS_P)-1:0] map_rd_addr_i,
+  output logic [7:0]  map_rd_data_o,     //! map entry (valid with rd_valid)
+  output logic        map_rd_valid_o,    //! read data valid this cycle
+
+  //! --- I2S capture pair source (single stereo pair) ----------------------
+  input  wire         i2s_pair_valid_i,  //! latch pulse
+  input  wire [23:0]  i2s_l_i,
+  input  wire [23:0]  i2s_r_i,
+
+  //! --- TDM capture pair sources (indexed by pair slot) -------------------
+  input  wire         tdm_pair_valid_i,  //! latch pulse
+  input  wire [3:0]   tdm_pair_slot_i,   //! TDM pair index (0..N_TDM_P/2-1)
+  input  wire [23:0]  tdm_l_i,
+  input  wire [23:0]  tdm_r_i,
+
+  //! --- ALSA ring pair sources (KL_pcm_tx output, indexed by pair slot) ---
+  input  wire         ring_pair_valid_i, //! latch pulse
+  input  wire [3:0]   ring_pair_slot_i,  //! ring pair-channel index (0..N-1)
+  input  wire [23:0]  ring_l_i,
+  input  wire [23:0]  ring_r_i,
+
+  //! --- tone generator sample (live; drives both L/R when TONE) -----------
+  input  wire [23:0]  tone_smp_i,
+
+  //! --- media sample tick (one walk of the enabled slots per pulse) -------
+  input  wire         tick_i,
+
+  //! --- pair injection to the shared packetizer (its capture contract) ----
+  output logic        pair_valid_o,      //! one-cycle pulse per L/R pair
+  output logic [4:0]  pair_slot_o,       //! pair slot 0..31 (widened space)
+  output logic [23:0] pair_l_o,
+  output logic [23:0] pair_r_o
+);
+
+  // ---------------------------------------------------------------------- //
+  // Derived sizing                                                          //
+  // ---------------------------------------------------------------------- //
+  localparam int unsigned SLOTW_C      = $clog2(N_SLOTS_P);
+  localparam int unsigned N_TDM_PAIRS_C = (N_TDM_P < 2) ? 1 : N_TDM_P / 2;
+  localparam int unsigned TDMPW_C      = (N_TDM_PAIRS_C <= 1) ? 1
+                                                      : $clog2(N_TDM_PAIRS_C);
+  localparam int unsigned RINGPW_C     = (N_RING_P <= 1) ? 1
+                                                      : $clog2(N_RING_P);
+
+  //! map entry field encoding (src[6:4])
+  localparam logic [2:0] SRC_ZERO_C = 3'd0, SRC_I2S_C = 3'd1, SRC_TDM_C = 3'd2,
+                         SRC_RING_C = 3'd3, SRC_TONE_C = 3'd4;
+
+  // ---------------------------------------------------------------------- //
+  // Map RAM (small config store: flop register file, like KL_pcm_route)     //
+  //   one sync write process; combinational reads for the walk; the         //
+  //   readback port registers a snapshot (RAM house style read turnaround)  //
+  // ---------------------------------------------------------------------- //
+  logic [7:0] map_r [N_SLOTS_P];
+
+  always_ff @(posedge clk_i) begin : map_write_port
+    if (!rst_n) begin
+      for (int s = 0; s < N_SLOTS_P; s++) map_r[s] <= 8'h00;
+    end
+    else if (map_wr_en_i) begin
+      map_r[map_wr_addr_i] <= map_wr_data_i;
+    end
+  end : map_write_port
+
+  always_ff @(posedge clk_i) begin : map_read_port
+    if (!rst_n) begin
+      map_rd_data_o  <= 8'h00;
+      map_rd_valid_o <= 1'b0;
+    end
+    else begin
+      map_rd_valid_o <= 1'b0;
+      if (map_rd_en_i) begin
+        map_rd_data_o  <= map_r[map_rd_addr_i];
+        map_rd_valid_o <= 1'b1;
+      end
+    end
+  end : map_read_port
+
+  // ---------------------------------------------------------------------- //
+  // Source hold buckets (latch the latest pair per source; wire-truth)      //
+  // ---------------------------------------------------------------------- //
+  logic [47:0] i2s_hold_r;               //! the single stereo I2S pair
+  logic [47:0] tdm_hold_r  [N_TDM_PAIRS_C];
+  logic [47:0] ring_hold_r [N_RING_P];
+
+  always_ff @(posedge clk_i) begin : source_latch
+    if (!rst_n) begin
+      i2s_hold_r <= '0;
+      for (int t = 0; t < N_TDM_PAIRS_C; t++) tdm_hold_r[t]  <= '0;
+      for (int r = 0; r < N_RING_P;      r++) ring_hold_r[r] <= '0;
+    end
+    else begin
+      if (i2s_pair_valid_i) i2s_hold_r <= {i2s_l_i, i2s_r_i};
+      if (tdm_pair_valid_i && (32'(tdm_pair_slot_i) < N_TDM_PAIRS_C))
+        tdm_hold_r[tdm_pair_slot_i[TDMPW_C-1:0]] <= {tdm_l_i, tdm_r_i};
+      if (ring_pair_valid_i && (32'(ring_pair_slot_i) < N_RING_P))
+        ring_hold_r[ring_pair_slot_i[RINGPW_C-1:0]] <= {ring_l_i, ring_r_i};
+    end
+  end : source_latch
+
+  // ---------------------------------------------------------------------- //
+  // Source select for the current walk slot (combinational)                 //
+  // ---------------------------------------------------------------------- //
+  logic [SLOTW_C-1:0] slot_r;            //! walk pointer
+
+  wire [7:0] ent_w = map_r[slot_r];
+  wire       en_w  = ent_w[7];
+  wire [2:0] src_w = ent_w[6:4];
+  wire [3:0] idx_w = ent_w[3:0];
+
+  logic [23:0] sel_l_w, sel_r_w;
+  always_comb begin : source_mux
+    unique case (src_w)
+      SRC_I2S_C : {sel_l_w, sel_r_w} = i2s_hold_r;
+      SRC_TDM_C : {sel_l_w, sel_r_w} =
+                    (32'(idx_w) < N_TDM_PAIRS_C)
+                      ? tdm_hold_r[idx_w[TDMPW_C-1:0]] : 48'd0;
+      SRC_RING_C : {sel_l_w, sel_r_w} =
+                    (32'(idx_w) < N_RING_P)
+                      ? ring_hold_r[idx_w[RINGPW_C-1:0]] : 48'd0;
+      SRC_TONE_C : {sel_l_w, sel_r_w} = {tone_smp_i, tone_smp_i};
+      default    : {sel_l_w, sel_r_w} = 48'd0;   //! ZERO + reserved = silence
+    endcase
+  end : source_mux
+
+  // ---------------------------------------------------------------------- //
+  // Emit walk FSM                                                           //
+  // ---------------------------------------------------------------------- //
+  typedef enum logic [1:0] {
+    CM_IDLE_S,     //! wait for a media tick
+    CM_STEP_S,     //! decide the current slot: skip / emit
+    CM_GAP_S       //! settle gap after a pair pulse
+  } cstate_t;
+
+  cstate_t                    st_r;
+  logic                       tick_pend_r;   //! one-deep tick queue
+  logic [$clog2(GAP_CYC_P+1)-1:0] gap_r;
+  wire  last_slot_w = (32'(slot_r) == N_SLOTS_P - 1);
+
+  always_ff @(posedge clk_i) begin : emit_engine
+    if (!rst_n) begin
+      st_r         <= CM_IDLE_S;
+      tick_pend_r  <= 1'b0;
+      slot_r       <= '0;
+      gap_r        <= '0;
+      pair_valid_o <= 1'b0;
+      pair_slot_o  <= '0;
+      pair_l_o     <= '0;
+      pair_r_o     <= '0;
+    end
+    else begin
+      unique case (st_r)
+        // -------- wait for the media tick --------------------------------
+        CM_IDLE_S : begin
+          pair_valid_o <= 1'b0;
+          if (tick_pend_r) begin
+            tick_pend_r <= 1'b0;           //! a coincident tick re-arms below
+            slot_r      <= '0;
+            st_r        <= CM_STEP_S;
+          end
+        end
+
+        // -------- decide the current slot --------------------------------
+        CM_STEP_S : begin
+          if (en_w) begin
+            //! inject one pair for this enabled slot (1-cycle pulse next)
+            pair_valid_o <= 1'b1;
+            pair_slot_o  <= 5'(slot_r);
+            pair_l_o     <= sel_l_w;
+            pair_r_o     <= sel_r_w;
+            gap_r        <= ($clog2(GAP_CYC_P+1))'(GAP_CYC_P);
+            st_r         <= CM_GAP_S;
+          end
+          else begin
+            //! disabled slot: emit nothing, advance immediately
+            pair_valid_o <= 1'b0;
+            if (last_slot_w) st_r <= CM_IDLE_S;
+            else             slot_r <= slot_r + 1'b1;
+          end
+        end
+
+        // -------- settle gap between injects ------------------------------
+        CM_GAP_S : begin
+          pair_valid_o <= 1'b0;            //! the pulse was one cycle only
+          if (gap_r == '0) begin
+            if (last_slot_w) st_r <= CM_IDLE_S;
+            else begin
+              slot_r <= slot_r + 1'b1;
+              st_r   <= CM_STEP_S;
+            end
+          end
+          else gap_r <= gap_r - 1'b1;
+        end
+
+        default : st_r <= CM_IDLE_S;
+      endcase
+
+      //! media-tick capture (after the case: a tick coincident with an
+      //! IDLE consume re-arms the one-deep queue instead of being dropped)
+      if (tick_i) tick_pend_r <= 1'b1;
+    end
+  end : emit_engine
+
+endmodule
+
+`default_nettype wire

--- a/hdl/ieee1722/aaf/KL_chan_map_render.sv
+++ b/hdl/ieee1722/aaf/KL_chan_map_render.sv
@@ -1,0 +1,221 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+/*
+------------------------------------------------------------------------------
+  File        : KL_chan_map_render.sv
+  Author      : Kebag Logic
+
+  Date        : 2026-07-23
+  Description : 64 stream-channel -> physical render crossbar (NxN render
+                stage). Consumes a clone of the shared AAF RX depacketizer
+                payload stream (KL_aaf_rx_depacketizer m_axis: 64-bit beats
+                = 2 consecutive S32BE samples of the wire-interleaved
+                payload, tuser = stream index, one AXIS frame per PDU, full
+                8-byte beats) and maintains a latest-sample wire-truth
+                latch cur_r[s][c] of the top 24 bits of every
+                (stream, wire channel) sample - free-running, no media
+                queueing (the physical outputs run on their own 48 kHz
+                tick; slips follow the house free-run rule).
+
+                CLONE QUALIFIER: the tap never backpressures (no tready
+                here), so s_tvalid_i must be the ACCEPTED-beat strobe of
+                the tapped link (tvalid && tready), the same discipline as
+                the depacketizer's own tap side and the KL_pcm_route
+                render-tap consumers.
+
+                De-interleave: payload sample k belongs to wire channel
+                k % chans[s] (channel-interleaved wire order, 6 samples/ch
+                per Milan 48k PDU); chans[s] comes from the RX monitors'
+                wire_chans_o (flat 4-bit fields, 0 treated as 2 - same
+                pre-first-accept rule as KL_i2s_playback). The position
+                counter advances incrementally (wrap compare, no modulo
+                hardware) and restarts at every frame's tlast, so
+                back-to-back PDUs of different streams / channel counts
+                stay aligned. Wire channels beyond N_CH_P are virtual:
+                counted for the interleave, never latched.
+
+                Render: a map RAM (one write port, entry format
+                {en[7], rsvd[6], stream[5:3], ch[2:0]}) routes any of the
+                N_STREAMS_P*N_CH_P latched stream-channels to any of the
+                N_PHYS_P physical output channels (default 10: I2S-out
+                L/R = phys 0/1, TDM8-out lane0 slots 0..7 = phys 2..9).
+                On every tick_i (one pulse per 48 kHz output media frame)
+                the whole phys vector is registered in one shot and
+                phys_valid_o pulses - map writes between ticks are never
+                visible on the outputs (glitch-free at frame rate).
+                Unmapped (en = 0) phys channels render 24'd0.
+
+                Ownership of the write port (AEM audio-map engine or CSR)
+                is upstream and out of scope - the port is only exposed.
+                Single clock domain; tick_i arrives already synchronized.
+
+  Company     : Kebag Logic
+  Project     : Milan AVTP
+
+  Notes       :
+    - Map stream/ch fields are 3 bits: the format caps N_STREAMS_P and
+      N_CH_P at 8 (the 8x8 = 64 stream-channel shape). Smaller builds are
+      guarded (out-of-range entries render 0); larger need a wider entry.
+------------------------------------------------------------------------------
+*/
+
+//! 64 stream-channel -> physical render crossbar: latches the top 24 bits
+//! of every (stream, wire channel) sample from the depacketizer payload
+//! clone (latest-sample wire-truth, free-running), then on each 48 kHz
+//! tick renders N_PHYS_P outputs through a map RAM
+//! ({en[7], rsvd[6], stream[5:3], ch[2:0]}; unmapped = 0) - registered in
+//! one shot, so map writes are only ever visible at tick boundaries.
+
+`default_nettype none
+
+module KL_chan_map_render #(
+  parameter int unsigned N_STREAMS_P = 8,   //! RX streams (map field: <= 8)
+  parameter int unsigned N_CH_P      = 8,   //! wire channels kept per stream
+                                            //! (map field: <= 8)
+  parameter int unsigned N_PHYS_P    = 10   //! physical output channels
+                                            //! (default: I2S L/R = 0/1,
+                                            //! TDM8 lane0 slots = 2..9)
+)(
+  input  wire                        clk_i,         //! Global clock
+  input  wire                        rst_n,         //! Active-low synchronous
+                                                    //! reset
+
+  //! --- depacketizer payload AXIS clone (never backpressured; drive
+  //! --- s_tvalid_i with the tapped link's ACCEPTED beats) -----------------
+  input  wire [63:0]                 s_tdata_i,     //! 2 consecutive S32BE
+                                                    //! samples, wire order
+  input  wire                        s_tvalid_i,
+  input  wire                        s_tlast_i,     //! one AXIS frame per PDU
+  input  wire [3:0]                  s_tuser_i,     //! stream index s
+
+  //! --- per-stream wire channel count (RX monitors' wire_chans_o) ---------
+  input  wire [N_STREAMS_P*4-1:0]    wire_chans_i,  //! 4-bit fields; 0 -> 2
+
+  //! --- output media frame tick (one pulse per 48 kHz frame) --------------
+  input  wire                        tick_i,
+
+  //! --- map RAM write port (AEM audio-map engine / CSR upstream) ----------
+  input  wire                        map_wr_en_i,   //! one-cycle write strobe
+  input  wire [$clog2(N_PHYS_P)-1:0] map_wr_addr_i, //! phys channel p
+  input  wire [7:0]                  map_wr_data_i, //! {en[7], rsvd[6],
+                                                    //!  stream[5:3], ch[2:0]}
+
+  //! --- map readback (combinational) --------------------------------------
+  input  wire [$clog2(N_PHYS_P)-1:0] map_rd_addr_i,
+  output logic [7:0]                 map_rd_data_o,
+
+  //! --- rendered physical channels (registered at tick_i) -----------------
+  output logic [N_PHYS_P*24-1:0]     phys_smp_o,    //! phys p = [p*24 +: 24]
+  output logic                       phys_valid_o,  //! one-cycle pulse
+  output logic [N_PHYS_P-1:0]        mapped_mask_o  //! live en bits (comb)
+);
+
+  //! map entry field positions ({en, rsvd, stream[2:0], ch[2:0]})
+  localparam int unsigned MAP_EN_B_C = 7;
+
+  // ------------------------------------------------------------------ //
+  // Map RAM: N_PHYS_P x 8, one write port + combinational readback      //
+  // ------------------------------------------------------------------ //
+  logic [7:0] map_r [N_PHYS_P];
+
+  always_ff @(posedge clk_i) begin : map_write
+    if (!rst_n) begin
+      for (int p = 0; p < N_PHYS_P; p++) map_r[p] <= 8'h00;
+    end
+    else if (map_wr_en_i && (32'(map_wr_addr_i) < N_PHYS_P)) begin
+      map_r[map_wr_addr_i] <= map_wr_data_i;
+    end
+  end : map_write
+
+  always_comb begin : map_read
+    map_rd_data_o = 8'h00;
+    for (int p = 0; p < N_PHYS_P; p++) begin
+      if (32'(map_rd_addr_i) == p) map_rd_data_o = map_r[p];
+      mapped_mask_o[p] = map_r[p][MAP_EN_B_C];
+    end
+  end : map_read
+
+  // ------------------------------------------------------------------ //
+  // De-interleave walker: wire channel of each payload sample.          //
+  // 2 samples per beat; the counter wraps at the stream's channel count //
+  // and restarts at tlast (frames are atomic - tuser is frame-stable).  //
+  // ------------------------------------------------------------------ //
+  logic [3:0] chpos_r;     //! wire channel of the current beat's FIRST sample
+
+  //! channel count of the in-flight stream (constant-base mux, guarded
+  //! against tuser >= N_STREAMS_P; 0 treated as 2 - pre-first-accept rule)
+  logic [3:0] chans_raw_w;
+  always_comb begin : chans_lookup
+    chans_raw_w = 4'd0;
+    for (int s = 0; s < N_STREAMS_P; s++) begin
+      if (32'(s_tuser_i) == s) chans_raw_w = wire_chans_i[s*4 +: 4];
+    end
+  end : chans_lookup
+  wire [3:0] eff_chans_w = (chans_raw_w == 4'd0) ? 4'd2 : chans_raw_w;
+
+  //! increment-with-wrap (ch is always < chans, so +1 never overflows past
+  //! the compare)
+  function automatic [3:0] chwrap(input [3:0] ch, input [3:0] chans);
+    chwrap = ((4'(ch + 4'd1)) == chans) ? 4'd0 : 4'(ch + 4'd1);
+  endfunction
+
+  //! the two S32BE samples of the beat: wire byte first = MSB, byte lane j
+  //! = wire byte j (depacketizer out_assemble); top 24 bits keep the
+  //! 24-in-32 left-justified audio, the pad byte (lanes 3/7) is dropped
+  wire [23:0] smp0_w = {s_tdata_i[7:0],   s_tdata_i[15:8],  s_tdata_i[23:16]};
+  wire [23:0] smp1_w = {s_tdata_i[39:32], s_tdata_i[47:40], s_tdata_i[55:48]};
+  wire [3:0]  ch0_w  = chpos_r;
+  wire [3:0]  ch1_w  = chwrap(ch0_w, eff_chans_w);
+
+  // ------------------------------------------------------------------ //
+  // Latest-sample wire-truth latch: cur_r[s][c] free-runs on the clone  //
+  // ------------------------------------------------------------------ //
+  logic [23:0] cur_r [N_STREAMS_P][N_CH_P];
+
+  always_ff @(posedge clk_i) begin : sample_latch
+    if (!rst_n) begin
+      chpos_r <= '0;
+      for (int s = 0; s < N_STREAMS_P; s++) begin
+        for (int c = 0; c < N_CH_P; c++) cur_r[s][c] <= 24'd0;
+      end
+    end
+    else if (s_tvalid_i) begin
+      if (32'(s_tuser_i) < N_STREAMS_P) begin
+        //! wire channels beyond N_CH_P are virtual: walked, never latched
+        if (32'(ch0_w) < N_CH_P) cur_r[s_tuser_i[2:0]][ch0_w[2:0]] <= smp0_w;
+        if (32'(ch1_w) < N_CH_P) cur_r[s_tuser_i[2:0]][ch1_w[2:0]] <= smp1_w;
+      end
+      chpos_r <= s_tlast_i ? 4'd0 : chwrap(ch1_w, eff_chans_w);
+    end
+  end : sample_latch
+
+  // ------------------------------------------------------------------ //
+  // Render: the whole phys vector registers in one shot on tick_i, so   //
+  // map writes between ticks are never visible (glitch-free at 48 kHz)  //
+  // ------------------------------------------------------------------ //
+  always_ff @(posedge clk_i) begin : render_tick
+    if (!rst_n) begin
+      phys_smp_o   <= '0;
+      phys_valid_o <= 1'b0;
+    end
+    else begin
+      phys_valid_o <= tick_i;
+      if (tick_i) begin
+        for (int p = 0; p < N_PHYS_P; p++) begin
+          logic [7:0] m;
+          m = map_r[p];
+          phys_smp_o[p*24 +: 24] <=
+            (m[MAP_EN_B_C] && (32'(m[5:3]) < N_STREAMS_P)
+                           && (32'(m[2:0]) < N_CH_P))
+              ? cur_r[m[5:3]][m[2:0]] : 24'd0;
+        end
+      end
+    end
+  end : render_tick
+
+endmodule
+
+`default_nettype wire

--- a/hdl/ieee1722/aaf/KL_tdm_render.sv
+++ b/hdl/ieee1722/aaf/KL_tdm_render.sv
@@ -1,0 +1,278 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+/*
+------------------------------------------------------------------------------
+  File        : KL_tdm_render.sv
+  Author      : Kebag Logic
+
+  Date        : 2026-07-23
+  Description : TDM slave audio-render front-end - the OUTPUT-side symmetric
+                twin of KL_tdm_capture (item-4 audio-interface family;
+                docs/NXN_ARCHITECTURE.md §2.1 "physical interface x1"). The
+                mapping fabric writes SLOTS_P per-slot 24-bit samples into a
+                slot bank on clk_i; a whole-frame double-buffer crosses into
+                the external TDM bit-clock domain, where the module serializes
+                an SLOTS_P-slot TDM frame (MSB first, 24-in-SLOT_BITS_P
+                left-justified, low bits pad zero) onto tdm_dout_o.
+
+                SYMMETRY WITH KL_tdm_capture (the contract twin):
+                  * we are the bus SLAVE, exactly like the capture:
+                    tdm_bclk_i / tdm_fsync_i are INPUTS driven by the
+                    codec/DSP master; the capture SAMPLES tdm_data_i on the
+                    rising edge, so this render (the data driver) SHIFTS on
+                    the FALLING edge - standard TDM ("the master shifts on
+                    the falling edge"). A KL_tdm_capture wired to this
+                    render's tdm_dout_o recovers the exact slot samples.
+                  * frame sync: only the 0->1 transition is meaningful, so
+                    BOTH shapes work unchanged - the one-bclk PULSE
+                    (TI/McASP) and the 50%-duty long frame clock. A level is
+                    never trusted as an edge: detection arms only after
+                    fsync has been sampled LOW once out of reset (the same
+                    "never fake a mid-frame rise" rule as the capture).
+                  * every fsync start realigns the slot/bit counters; between
+                    fsyncs the counters free-run at the exact frame length
+                    (SLOTS_P * SLOT_BITS_P bclk).
+                  * data-to-fsync alignment matches the capture's DEFAULT
+                    DATA_DELAY_P=1 (Philips-heritage): slot-0 MSB rides the
+                    bclk period FOLLOWING the fsync-high edge. The one-bclk
+                    Philips delay is produced HERE, ONCE, by the
+                    compute-on-rising / present-on-falling output register -
+                    never doubled in a TB chip model (78bbabe history).
+
+                CLOCK-DOMAIN DISCIPLINE (mirrored from KL_tdm_capture):
+                  * the slot bank crosses clk_i -> tdm_bclk_i through the SAME
+                    gray-pointer cdc_pair_fifo the capture uses for its pair
+                    stream (there: bclk -> clk_i). No new CDC idiom is
+                    invented. The payload is one packed frame
+                    (SLOTS_P * 24 bits); the bclk read side keeps an
+                    active/next DOUBLE-BUFFER so slot-0 MSB is always ready on
+                    the fsync edge and mid-frame producer updates never tear.
+                  * an empty FIFO at a frame start is an underrun: the last
+                    frame is repeated (slip-dup) and counted, the same
+                    repeat-last discipline as KL_i2s_playback's DAC underrun.
+
+                PRODUCER INTERFACE (why slot-indexed writes, not a flat bank):
+                  KL_tdm_capture's datapath contract is a slot-indexed
+                  valid-PULSE stream (pair_valid_o + pair_slot_o + data). The
+                  render's producer interface is the symmetric INVERSE: a
+                  slot-indexed valid-pulse WRITE (smp_wr_en_i + smp_wr_slot_i
+                  + smp_wr_data_i) into the bank, committed as a frame by a
+                  one-cycle tick_i. This mirrors the capture's pulse-indexed
+                  geometry and is the natural fit for the mapping fabric,
+                  which routes one channel onto one slot at a time.
+
+  Company     : Kebag Logic
+  Project     : Milan AVTP
+------------------------------------------------------------------------------
+*/
+
+//! TDM slave serializer (item-4 front-end family, OUTPUT side): a clk_i slot
+//! bank -> packed-frame gray-pointer CDC -> active/next double-buffer ->
+//! MSB-first 24-in-SLOT_BITS_P TDM frame on tdm_dout_o. Pulse and 50%-duty
+//! fsyncs (edge-armed), Philips-heritage slot-0 alignment, slot 0 first.
+
+`default_nettype none
+
+module KL_tdm_render #(
+  parameter int unsigned SLOTS_P     = 8,   //! TDM slots per frame (8/16/32)
+  parameter int unsigned SLOT_BITS_P = 32,  //! bit clocks per slot (16/24/32)
+  parameter int unsigned FIFO_LOG2_P = 2    //! frame CDC depth = 2^N (>=2 for
+                                            //! the active/next double-buffer)
+)(
+  input  wire         clk_i,             //! datapath clock (producer domain)
+  input  wire         rst_n,             //! active-low synchronous reset (clk_i)
+
+  // ---- producer side (clk_i domain; slot-indexed writes) ---------------
+  input  wire         smp_wr_en_i,       //! one-cycle per-slot write strobe
+  input  wire [$clog2(SLOTS_P)-1:0] smp_wr_slot_i, //! target slot index
+  input  wire [23:0]  smp_wr_data_i,     //! 24-bit sample (MSB-justified)
+  input  wire         tick_i,            //! one-cycle frame commit: latch the
+                                         //! bank as written up to the prior
+                                         //! cycle into the CDC toward the bus
+
+  // ---- TDM bus (we are slave; master drives bclk/fsync) ----------------
+  input  wire         tdm_bclk_i,        //! bit clock (serializer domain)
+  input  wire         tdm_fsync_i,       //! frame sync (pulse or 50% duty)
+  output logic        tdm_dout_o,        //! serial data out, MSB first (driven
+                                         //! on the falling bclk edge)
+
+  // ---- status (Linux-observable via CSR; plain clk_i counters) ---------
+  output wire  [15:0] frames_o,          //! frames serialized onto the bus
+  output wire  [15:0] underruns_o,       //! frame starts with no fresh frame
+                                         //! (last frame repeated)
+  output wire  [15:0] overruns_o         //! tick_i frames dropped (CDC full)
+);
+
+  localparam int unsigned SW = $clog2(SLOTS_P);      //! slot-index width
+  localparam int unsigned BW = $clog2(SLOT_BITS_P);  //! bit-index width
+  localparam int unsigned DBITS =
+      (SLOT_BITS_P < 24) ? SLOT_BITS_P : 24;         //! data bits per slot
+  localparam int unsigned FRAME_BITS = SLOTS_P * 24; //! packed frame width
+
+  // ======================================================================
+  //  clk_i domain: slot bank + frame commit into the gray-pointer CDC
+  // ======================================================================
+  logic [23:0]            bank_r [SLOTS_P];  //! per-slot sample bank
+  logic [15:0]            overruns_r;
+  wire  [FRAME_BITS-1:0]  bank_flat_w;
+  wire                    wfull_w;
+
+  genvar gs;
+  generate
+    for (gs = 0; gs < SLOTS_P; gs++) begin : g_pack
+      assign bank_flat_w[gs*24 +: 24] = bank_r[gs];
+    end
+  endgenerate
+
+  //! FIFO write is combinational off tick_i (the FIFO registers internally
+  //! and self-guards on !wfull); bank_flat_w reflects writes up to the prior
+  //! cycle - the fabric pulses tick_i after its slot writes have landed.
+  wire fifo_wen_w = tick_i && !wfull_w;
+
+  always_ff @(posedge clk_i) begin : producer
+    if (!rst_n) begin
+      overruns_r <= '0;
+      for (int i = 0; i < SLOTS_P; i++) bank_r[i] <= '0;
+    end else begin
+      if (smp_wr_en_i) bank_r[smp_wr_slot_i] <= smp_wr_data_i;
+      //! a commit that finds the CDC full drops the frame (consumer behind)
+      if (tick_i && wfull_w)
+        overruns_r <= (&overruns_r) ? overruns_r : overruns_r + 16'd1;
+    end
+  end : producer
+
+  // ======================================================================
+  //  clk_i -> tdm_bclk_i frame crossing (the KL_tdm_capture CDC idiom,
+  //  gray-pointer dual-clock cdc_pair_fifo, reversed direction)
+  // ======================================================================
+  logic [1:0]            brst_n_r;        //! bclk-domain reset sync (2FF)
+  wire  [FRAME_BITS-1:0] rdata_w;
+  wire                   rempty_w;
+  logic                  ren_r;
+
+  always_ff @(posedge tdm_bclk_i) begin : t_bclk_rst
+    brst_n_r <= {brst_n_r[0], rst_n};
+  end : t_bclk_rst
+
+  cdc_pair_fifo #(.WIDTH(FRAME_BITS), .LOG2D(FIFO_LOG2_P)) u_fcdc (
+    .wclk_i  (clk_i),
+    .wrst_n  (rst_n),
+    .wen_i   (fifo_wen_w),
+    .wdata_i (bank_flat_w),
+    .wfull_o (wfull_w),
+    .rclk_i  (tdm_bclk_i),
+    .rrst_n  (brst_n_r[1]),
+    .ren_i   (ren_r),
+    .rdata_o (rdata_w),
+    .rempty_o(rempty_w)
+  );
+
+  // ======================================================================
+  //  tdm_bclk_i domain: frame tracking + double-buffer + bit serializer
+  // ======================================================================
+  logic                   fsync_q_r;   //! fsync at the previous rising edge
+  logic                   armed_r;     //! fsync sampled low once (edge valid)
+  logic                   run_r;       //! a frame start has been seen
+  logic [SW-1:0]          slot_r;
+  logic [BW-1:0]          bit_r;
+  logic [FRAME_BITS-1:0]  active_r;    //! frame currently serializing
+  logic [FRAME_BITS-1:0]  next_r;      //! prefetched frame (double-buffer)
+  logic                   have_next_r; //! next_r holds a fresh frame
+  logic                   fetch_v_r;   //! rdata_w valid this cycle (post-ren)
+  logic                   dout_nxt_r;  //! bit for the next falling edge
+  logic [15:0]            frames_b_r;  //! frames serialized (bclk domain)
+  logic [15:0]            unders_b_r;  //! underruns (bclk domain)
+
+  //! frame start = ARMED fsync 0->1 on the rising edge (same rule as capture)
+  wire                  start_w = tdm_fsync_i && !fsync_q_r && armed_r;
+  wire                  sol_w   = start_w;
+  //! effective position of THIS edge (a frame start overrides the counters)
+  wire [SW-1:0]         eslot_w = sol_w ? '0 : slot_r;
+  wire [BW-1:0]         ebit_w  = sol_w ? '0 : bit_r;
+  //! at a frame start with a fresh frame, read the incoming frame directly so
+  //! slot-0 MSB comes from next_r on the very edge active_r adopts it
+  wire                  adopt_w = sol_w && have_next_r;
+  wire [FRAME_BITS-1:0] frame_sel_w = adopt_w ? next_r : active_r;
+  wire [23:0]           smp_w   = frame_sel_w[24*eslot_w +: 24];
+  //! MSB-first, top DBITS bits of the slot are data, the remainder pad zero
+  wire [4:0]            didx_w  = 5'd23 - ebit_w[4:0];
+  wire                  dbit_w  = (32'(ebit_w) < DBITS) ? smp_w[didx_w] : 1'b0;
+
+  always_ff @(posedge tdm_bclk_i) begin : t_ser
+    if (!brst_n_r[1]) begin
+      fsync_q_r <= 1'b0; armed_r <= 1'b0; run_r <= 1'b0;
+      slot_r <= '0; bit_r <= '0;
+      active_r <= '0; next_r <= '0; have_next_r <= 1'b0;
+      ren_r <= 1'b0; fetch_v_r <= 1'b0; dout_nxt_r <= 1'b0;
+      frames_b_r <= '0; unders_b_r <= '0;
+    end else begin
+      fsync_q_r <= tdm_fsync_i;
+      if (!tdm_fsync_i) armed_r <= 1'b1;
+
+      // ---- prefetch the next frame from the CDC (2-step: ren, then data) --
+      ren_r <= 1'b0;
+      if (!have_next_r && !ren_r && !fetch_v_r && !rempty_w) ren_r <= 1'b1;
+      fetch_v_r <= ren_r;
+      if (fetch_v_r) begin
+        next_r      <= rdata_w;
+        have_next_r <= 1'b1;
+      end
+
+      // ---- frame start: adopt the fresh frame, else underrun-repeat -------
+      //  (the 256-bclk frame gap vs the 2-bclk prefetch means a fetch and a
+      //   frame start never coincide; adopt still uses the pre-edge next_r)
+      if (sol_w) begin
+        frames_b_r <= frames_b_r + 16'd1;
+        if (have_next_r) begin
+          active_r    <= next_r;
+          have_next_r <= 1'b0;             //! schedule a refill
+        end else begin
+          unders_b_r  <= unders_b_r + 16'd1;  //! keep active_r (repeat)
+        end
+      end
+
+      // ---- serialize: advance the free-running counters, latch next bit ---
+      if (run_r || sol_w) begin
+        run_r      <= 1'b1;
+        dout_nxt_r <= dbit_w;
+        if (32'(ebit_w) == SLOT_BITS_P - 1) begin
+          bit_r  <= '0;
+          slot_r <= (32'(eslot_w) == SLOTS_P - 1) ? '0 : eslot_w + 1'b1;
+        end else begin
+          bit_r  <= ebit_w + 1'b1;
+          slot_r <= eslot_w;
+        end
+      end
+    end
+  end : t_ser
+
+  //! output register on the FALLING edge: the bit computed on the rising edge
+  //! is presented half a bclk later, so it is stable across the receiver's
+  //! next rising edge - this IS the one-bclk Philips-heritage delay.
+  logic [1:0] nrst_n_r;
+  always_ff @(negedge tdm_bclk_i) begin : t_dout
+    nrst_n_r <= {nrst_n_r[0], rst_n};
+    if (!nrst_n_r[1]) tdm_dout_o <= 1'b0;
+    else              tdm_dout_o <= dout_nxt_r;
+  end : t_dout
+
+  // ======================================================================
+  //  status counters back into clk_i (quasi-static 2-FF, KL_i2s_playback
+  //  discipline: the counts are monotonic and read for trends only)
+  // ======================================================================
+  logic [15:0] fr_m_r, fr_s_r, un_m_r, un_s_r;
+  always_ff @(posedge clk_i) begin : t_cnt_sync
+    {fr_s_r, fr_m_r} <= {fr_m_r, frames_b_r};
+    {un_s_r, un_m_r} <= {un_m_r, unders_b_r};
+  end : t_cnt_sync
+
+  assign frames_o    = fr_s_r;
+  assign underruns_o = un_s_r;
+  assign overruns_o  = overruns_r;
+
+endmodule
+
+`default_nettype wire

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -255,11 +255,31 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! 97.7 kHz while advertising 48 k (silicon: 16.9k fr/s, servo pegged).
   localparam int MCLK_DIV_LOG2_C = $clog2(MILAN_CLK_FREQ_HZ / 12_500_000);
 
+  //! chmap media grid: a ~48 kHz strobe on the datapath clock that paces the
+  //! render/capture map walks (docs/CHANNEL_MAP_64.md §3/§4). Consumed ONLY by
+  //! the map fabric; the CERT audio path never sees it.
+  localparam int MEDIA_TICK_DIV_C = MILAN_CLK_FREQ_HZ / 48_000;
+
 
   KL_tone_gen #(.MCLK_DIV_LOG2(MCLK_DIV_LOG2_C)) tone_gen (
     .clk_i (clk_audio_i), .rst_n (axis_resetn), .adv_i (1'b1),
     .enable_i (cfg_tone_enable), .att_i (cfg_tone_att), .smp_o (tone_smp)
   );
+
+  logic [$clog2(MEDIA_TICK_DIV_C)-1:0] media_tick_cnt_r;
+  logic                                media_tick_p;
+  always_ff @(posedge axis_clk) begin : chmap_media_tick
+    if (!axis_resetn) begin
+      media_tick_cnt_r <= '0;
+      media_tick_p     <= 1'b0;
+    end else if (32'(media_tick_cnt_r) == MEDIA_TICK_DIV_C - 1) begin
+      media_tick_cnt_r <= '0;
+      media_tick_p     <= 1'b1;
+    end else begin
+      media_tick_cnt_r <= media_tick_cnt_r + 1'b1;
+      media_tick_p     <= 1'b0;
+    end
+  end : chmap_media_tick
 
   //! NXN P4: the flat aaf_talker_i2s splits into the physical capture
   //! front-end (x1) + the shared N-context packetizer (TCTX). Talker 0
@@ -313,9 +333,11 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //  merge, PTP-stamp and MAC-TX path downstream are unchanged. AAF_PLAYBACK_P
   //  = 0 prunes it and the packetizer sees the capture front-end bit-identically.
   // ==========================================================================
-  wire        pkt_pv_w;
-  wire [3:0]  pkt_slot_w;
-  wire [23:0] pkt_l_w, pkt_r_w;
+  //! capture-or-playback pair bus (item-7 KL_pcm_tx mux output); feeds the
+  //! chmap capture stage below - both features default-off => legacy path
+  wire        cappb_pv_w;
+  wire [3:0]  cappb_slot_w;
+  wire [23:0] cappb_l_w, cappb_r_w;
 
   //! internal sample-tick divider (local media-clock MVP, like aaf_talker_i2s:
   //! the accepted +ppm offset; a CRF-disciplined external smp_tick is the
@@ -347,15 +369,15 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
       .overrun_o (pb_overrun_o), .smp_tick_o (), .playing_o (pb_playing_o)
     );
     //! playback overrides the capture front-end at the packetizer's pair port
-    assign pkt_pv_w   = pb_enable_i ? pb_pv_w   : aafcap_pv_w;
-    assign pkt_slot_w = pb_enable_i ? pb_slot_w : aafcap_slot_w;
-    assign pkt_l_w    = pb_enable_i ? pb_l_w    : aafcap_l_w;
-    assign pkt_r_w    = pb_enable_i ? pb_r_w    : aafcap_r_w;
+    assign cappb_pv_w   = pb_enable_i ? pb_pv_w   : aafcap_pv_w;
+    assign cappb_slot_w = pb_enable_i ? pb_slot_w : aafcap_slot_w;
+    assign cappb_l_w    = pb_enable_i ? pb_l_w    : aafcap_l_w;
+    assign cappb_r_w    = pb_enable_i ? pb_r_w    : aafcap_r_w;
   end else begin : g_no_playback
-    assign pkt_pv_w   = aafcap_pv_w;
-    assign pkt_slot_w = aafcap_slot_w;
-    assign pkt_l_w    = aafcap_l_w;
-    assign pkt_r_w    = aafcap_r_w;
+    assign cappb_pv_w   = aafcap_pv_w;
+    assign cappb_slot_w = aafcap_slot_w;
+    assign cappb_l_w    = aafcap_l_w;
+    assign cappb_r_w    = aafcap_r_w;
     assign pb_mem_addr_o = 32'd0;
     assign pb_mem_rd_o   = 1'b0;
     assign pb_rd_ptr_o   = '0;
@@ -363,6 +385,50 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     assign pb_overrun_o  = '0;
     assign pb_playing_o  = 1'b0;
   end endgenerate
+  //  Channel-map CAPTURE mux (docs/CHANNEL_MAP_64.md §4) — ADD-ALONGSIDE.
+  //  Sits between the physical capture front-end and the shared packetizer.
+  //  cfg_chmap_enable = 0 (reset default) selects the front-end pair stream
+  //  BIT-IDENTICALLY (today's CERT wiring); = 1 selects the CMAP-routed source
+  //  per media tick. The map RAM resets all-zero, so the enable bit is the
+  //  single bypass truth (program CMAP through the 0x900 port, then arm).
+  //  Phase-1 sources: physical capture (I2S/TDM front-end pair) + tone; the
+  //  ALSA ring (KL_pcm_tx) and per-lane TDM sources are documented follow-ups.
+  // ==========================================================================
+  wire        cmap_pv_w;
+  wire [4:0]  cmap_slot_w;
+  wire [23:0] cmap_l_w, cmap_r_w;
+
+  KL_chan_map_capture #(
+    .N_SLOTS_P (N_STREAMS*4),
+    .N_TDM_P   (8),
+    .N_RING_P  (16)
+  ) chan_map_capture (
+    .clk_i (axis_clk), .rst_n (axis_resetn),
+    .map_wr_en_i   (cfg_chmap_wr_en && cfg_chmap_wr_side),
+    .map_wr_addr_i (cfg_chmap_wr_addr[$clog2(N_STREAMS*4)-1:0]),
+    //! §5 16-bit word -> capture 8-bit {en[7], src[6:4], idx[3:0]}
+    .map_wr_data_i ({cfg_chmap_wr_data[15], cfg_chmap_wr_data[14:12],
+                     cfg_chmap_wr_data[3:0]}),
+    .map_rd_en_i (1'b0), .map_rd_addr_i ('0),
+    .map_rd_data_o (), .map_rd_valid_o (),
+    .i2s_pair_valid_i (cappb_pv_w),
+    .i2s_l_i (cappb_l_w), .i2s_r_i (cappb_r_w),
+    .tdm_pair_valid_i (1'b0), .tdm_pair_slot_i (4'd0),
+    .tdm_l_i (24'd0), .tdm_r_i (24'd0),
+    .ring_pair_valid_i (1'b0), .ring_pair_slot_i (4'd0),
+    .ring_l_i (24'd0), .ring_r_i (24'd0),
+    .tone_smp_i (tone_smp),
+    .tick_i (media_tick_p),
+    .pair_valid_o (cmap_pv_w), .pair_slot_o (cmap_slot_w),
+    .pair_l_o (cmap_l_w), .pair_r_o (cmap_r_w)
+  );
+
+  //! bypass mux: enable=0 -> the front-end pair drives the packetizer EXACTLY
+  //! (5'(aafcap_slot_w) == today's 4-bit slot zero-extended: bit-identical).
+  wire        pkt_pv_w   = cfg_chmap_enable ? cmap_pv_w   : cappb_pv_w;
+  wire [4:0]  pkt_slot_w = cfg_chmap_enable ? cmap_slot_w : {1'b0, cappb_slot_w};
+  wire [23:0] pkt_l_w    = cfg_chmap_enable ? cmap_l_w    : cappb_l_w;
+  wire [23:0] pkt_r_w    = cfg_chmap_enable ? cmap_r_w    : cappb_r_w;
 
   KL_aaf_packetizer #(.N_TALKERS_P(N_STREAMS)) aaf_packetizer (
     .clk_i (axis_clk), .rst_n (axis_resetn),
@@ -546,6 +612,15 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   wire [31:0] mcsrv_stat_w;   //! KL_mmcm_drp_servo status (A_MCSRV_STAT 0x8F8)
   wire        mcsrv_ps_invert_w;  //! MCSRV_CTRL 0x8FC[0] bench sign knob
   wire        mcsrv_auto_repair_w;//! MCSRV_CTRL 0x8FC[1] bench-gated DRP repair enable (default 0)
+  //! chmap 0x900 fabric (docs/CHANNEL_MAP_64.md §6): CSR map-RAM write port +
+  //! bypass arm. Default (cfg_chmap_enable=0) leaves the CERT audio path
+  //! bit-identical (render/capture crossbars are muxed OUT of both the
+  //! packetizer feed and the i2s_playback feed).
+  wire        cfg_chmap_enable;
+  wire        cfg_chmap_wr_en;
+  wire        cfg_chmap_wr_side;
+  wire [5:0]  cfg_chmap_wr_addr;
+  wire [15:0] cfg_chmap_wr_data;
   wire [15:0] crf_pducnt_w;
   wire [7:0]  crf_fmterr_w, crf_seqerr_w;
   wire        crf_locked_w;
@@ -941,6 +1016,11 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     .i_ltap_status      (ltap_status_w),
     .o_ltap_en          (ltap_en_w),
     .o_ltap_clr         (ltap_clr_w),
+    .o_chmap_enable     (cfg_chmap_enable),
+    .o_chmap_wr_en      (cfg_chmap_wr_en),
+    .o_chmap_wr_side    (cfg_chmap_wr_side),
+    .o_chmap_wr_addr    (cfg_chmap_wr_addr),
+    .o_chmap_wr_data    (cfg_chmap_wr_data),
     .o_crft_en          (cfg_crft_en),
     .o_crft_sid         (cfg_crft_sid),
     .o_crft_dest_mac    (cfg_crft_dmac),
@@ -1849,13 +1929,19 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     .active_o (pcm_lpf_active)
   );
 
+  //! optional mapped-I2S data mux (docs/CHANNEL_MAP_64.md §3): enable=0 ->
+  //! rend_pcm_tdata_w (the CERT render tap) drives the DAC BIT-IDENTICALLY;
+  //! enable=1 -> the render crossbar's phys{0,1} repacked into the S32BE beat.
+  //! Driven by the render-fabric block below (nets resolve module-wide).
+  wire [TDATA_WIDTH-1:0] i2s_pcm_tdata_mux_w;
+
   KL_i2s_playback #(.MCLK_DIV_LOG2(MCLK_DIV_LOG2_C),
                     .CLK_FREQ_HZ(MILAN_CLK_FREQ_HZ),
                     .PREFILL_C(PB_PREFILL_C)) i2s_player (
     .clk_i (axis_clk), .rst_n (axis_resetn),
     .clk_audio_i  (clk_audio_i),
     .servo_en_i   (aecp_clk_src != 16'd0),
-    .pcm_tdata_i  (rend_pcm_tdata_w),
+    .pcm_tdata_i  (i2s_pcm_tdata_mux_w),
     .lpf_tdata_i  (pcm_lpf_tdata),
     .lpf_tvalid_i (pcm_lpf_tvalid),
     .lpf_active_i (pcm_lpf_active),
@@ -1871,6 +1957,102 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     .media_reset_p_o (i2spb_reset_p),
     .converged_o     (i2spb_converged),
     .dbg_frame_o     (i2spb_dbg_frame)
+  );
+
+  // ==========================================================================
+  //  Channel-map RENDER crossbar (docs/CHANNEL_MAP_64.md §3) — ADD-ALONGSIDE.
+  //  A parallel, NEVER-backpressuring tap on the depacketizer PCM AXIS: it
+  //  latches every (stream, wire-channel) sample and, on each media tick,
+  //  renders CHMAP_PHYS_C physical channels through RMAP. phys{0,1} feed the
+  //  optional mapped-I2S path above; phys{2..9} feed the parked TDM8 render
+  //  lane. cfg_chmap_enable = 0 leaves rend_pcm_tdata_w -> i2s_playback
+  //  untouched (the assign below resolves to the exact CERT net).
+  // ==========================================================================
+  localparam int CHMAP_PHYS_C = 10;
+  wire [CHMAP_PHYS_C*24-1:0] chmap_phys_w;
+  wire                       chmap_phys_v_w;
+
+  KL_chan_map_render #(
+    .N_STREAMS_P (N_STREAMS),
+    .N_CH_P      (8),
+    .N_PHYS_P    (CHMAP_PHYS_C)
+  ) chan_map_render (
+    .clk_i (axis_clk), .rst_n (axis_resetn),
+    //! clone tap: accepted-beat strobe (tvalid && tready); never backpressures
+    .s_tdata_i  (dpkt_pcm_tdata_w),
+    .s_tvalid_i (dpkt_pcm_tvalid_w && dpkt_pcm_tready_w),
+    .s_tlast_i  (dpkt_pcm_tlast_w),
+    .s_tuser_i  (dpkt_pcm_tuser_w),
+    //! per-stream wire-truth (phase-1: the render-stream count broadcast; the
+    //! per-stream LCTX wire_chans fan-out is the documented follow-up)
+    .wire_chans_i ({N_STREAMS{mon_wire_chans_w[3:0]}}),
+    .tick_i (media_tick_p),
+    .map_wr_en_i   (cfg_chmap_wr_en && !cfg_chmap_wr_side),
+    .map_wr_addr_i (cfg_chmap_wr_addr[$clog2(CHMAP_PHYS_C)-1:0]),
+    //! §5 16-bit word -> render 8-bit {en[7], rsvd[6], stream[5:3], ch[2:0]}
+    .map_wr_data_i ({cfg_chmap_wr_data[15], 1'b0,
+                     cfg_chmap_wr_data[6:4], cfg_chmap_wr_data[2:0]}),
+    .map_rd_addr_i ('0), .map_rd_data_o (),
+    .phys_smp_o (chmap_phys_w), .phys_valid_o (chmap_phys_v_w),
+    .mapped_mask_o ()
+  );
+
+  //! phys{0,1} repacked into the depacketizer's S32BE beat order (pad byte 0)
+  wire [23:0] chmap_i2s_l_w = chmap_phys_w[0*24 +: 24];
+  wire [23:0] chmap_i2s_r_w = chmap_phys_w[1*24 +: 24];
+  wire [TDATA_WIDTH-1:0] chmap_i2s_pcm_w = {
+    8'h00, chmap_i2s_r_w[7:0], chmap_i2s_r_w[15:8], chmap_i2s_r_w[23:16],
+    8'h00, chmap_i2s_l_w[7:0], chmap_i2s_l_w[15:8], chmap_i2s_l_w[23:16] };
+  assign i2s_pcm_tdata_mux_w =
+           cfg_chmap_enable ? chmap_i2s_pcm_w : rend_pcm_tdata_w;
+
+  // ---- parked TDM8 render lane (docs §8): phys{2..9} -> 8 slot writes -------
+  //! The render xbar emits the whole phys vector once per media tick; the TDM
+  //! slave serializer wants slot-indexed writes + a frame commit. A tiny burst
+  //! adapter walks phys{2..9} into the bank on each phys_valid, then commits.
+  //! tdm_dout is PARKED (no board pin routes it yet); it shares the datapath
+  //! TDM bus, so it is live only when AUDIO_IF_SLOTS_P>0 drives tdm_bclk_i.
+  logic        tdmr_wr_en_r;
+  logic [2:0]  tdmr_slot_r;
+  logic [23:0] tdmr_data_r;
+  logic        tdmr_tick_r;
+  logic        tdmr_busy_r;
+  always_ff @(posedge axis_clk) begin : chmap_tdm_adapter
+    if (!axis_resetn) begin
+      tdmr_wr_en_r <= 1'b0; tdmr_slot_r <= 3'd0; tdmr_data_r <= 24'd0;
+      tdmr_tick_r  <= 1'b0; tdmr_busy_r <= 1'b0;
+    end else begin
+      tdmr_wr_en_r <= 1'b0;
+      tdmr_tick_r  <= 1'b0;
+      if (!tdmr_busy_r) begin
+        if (chmap_phys_v_w) begin
+          tdmr_busy_r  <= 1'b1;
+          tdmr_slot_r  <= 3'd0;
+          tdmr_wr_en_r <= 1'b1;
+          tdmr_data_r  <= chmap_phys_w[2*24 +: 24];   //! slot 0 <- phys 2
+        end
+      end else if (tdmr_slot_r == 3'd7) begin
+        tdmr_busy_r <= 1'b0;
+        tdmr_tick_r <= 1'b1;                           //! commit after slot 7
+      end else begin
+        tdmr_slot_r  <= tdmr_slot_r + 3'd1;
+        tdmr_wr_en_r <= 1'b1;
+        tdmr_data_r  <= chmap_phys_w[(2 + 32'(tdmr_slot_r) + 1)*24 +: 24];
+      end
+    end
+  end : chmap_tdm_adapter
+
+  wire chmap_tdm_dout_w;   //! parked serial output (no board pin yet)
+  KL_tdm_render #(.SLOTS_P(8), .SLOT_BITS_P(32)) chan_tdm_render (
+    .clk_i (axis_clk), .rst_n (axis_resetn),
+    .smp_wr_en_i   (tdmr_wr_en_r),
+    .smp_wr_slot_i (tdmr_slot_r),
+    .smp_wr_data_i (tdmr_data_r),
+    .tick_i        (tdmr_tick_r),
+    .tdm_bclk_i    (tdm_bclk_i),
+    .tdm_fsync_i   (tdm_fsync_i),
+    .tdm_dout_o    (chmap_tdm_dout_w),
+    .frames_o (), .underruns_o (), .overruns_o ()
   );
 
   // ==========================================================================

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -358,7 +358,7 @@ _MILAN_DATAPATH_SOURCES = [
     "hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv",
     "hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv",
     "hdl/ieee1722/aaf/KL_pcm_route.sv",
-    "hdl/ieee1722/aaf/KL_aaf_capture_i2s.sv", "hdl/ieee1722/aaf/KL_tdm_capture.sv", "hdl/ieee1722/aaf/KL_aaf_packetizer.sv", "hdl/ieee1722/crf/KL_crf_rx.sv", "hdl/ieee1722/crf/KL_crf_tx.sv", "hdl/ieee1722/maap/KL_maap.sv",
+    "hdl/ieee1722/aaf/KL_aaf_capture_i2s.sv", "hdl/ieee1722/aaf/KL_tdm_capture.sv", "hdl/ieee1722/aaf/KL_tdm_render.sv", "hdl/ieee1722/aaf/KL_chan_map_render.sv", "hdl/ieee1722/aaf/KL_chan_map_capture.sv", "hdl/ieee1722/aaf/KL_aaf_packetizer.sv", "hdl/ieee1722/crf/KL_crf_rx.sv", "hdl/ieee1722/crf/KL_crf_tx.sv", "hdl/ieee1722/maap/KL_maap.sv",
     "hdl/ieee1722/aaf/KL_aaf_capture_i2s.sv", "hdl/ieee1722/aaf/KL_aaf_packetizer.sv", "hdl/ieee1722/crf/KL_crf_rx.sv", "hdl/ieee1722/crf/KL_crf_tx.sv", "hdl/ieee1722/crf/KL_mmcm_drp_servo.sv", "hdl/ieee1722/maap/KL_maap.sv",
     "hdl/common/eth_event_counter/ethernet_events.sv", "hdl/common/eth_event_counter/event_counter.sv",
     "hdl/common/csr/milan_csr.sv", "hdl/milan/milan_datapath.sv",

--- a/tb/verilator/aaf/aaf_nx_wrap.sv
+++ b/tb/verilator/aaf/aaf_nx_wrap.sv
@@ -42,7 +42,7 @@ module aaf_nx_wrap (
 
   //! N=2 packetizer with direct pair injection (interleave checks)
   input  wire         p2_pair_valid_i,
-  input  wire [3:0]   p2_pair_slot_i,
+  input  wire [4:0]   p2_pair_slot_i,
   input  wire [23:0]  p2_pair_l_i,
   input  wire [23:0]  p2_pair_r_i,
   input  wire [1:0]   p2_en_i,

--- a/tb/verilator/chmap_capture/Makefile
+++ b/tb/verilator/chmap_capture/Makefile
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# KL_chan_map_capture lane: the per-pair-slot TX source mux feeding the shared
+# KL_aaf_packetizer. Lane A (N=2) checks per-slot routing / remap / disabled-
+# slot absence + the map readback; lane B (N=8 all-8ch) exercises the widened
+# pair_slot up to slot 31.
+VERILATOR ?= verilator
+TOP = chmap_wrap
+SRCS = ../../../hdl/ieee1722/aaf/KL_chan_map_capture.sv \
+       ../../../hdl/ieee1722/aaf/KL_aaf_packetizer.sv \
+       chmap_wrap.sv
+all: run
+obj_dir/V$(TOP): $(SRCS) sim_main.cpp
+	$(VERILATOR) --cc --exe --build -j 0 --top-module $(TOP) \
+	  -Wall -Wno-fatal -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC \
+	  -Wno-PINCONNECTEMPTY -Wno-UNUSEDPARAM -CFLAGS "-std=c++17 -O2" \
+	  $(SRCS) sim_main.cpp
+run: obj_dir/V$(TOP)
+	./obj_dir/V$(TOP)
+clean: ; rm -rf obj_dir
+.PHONY: all run clean

--- a/tb/verilator/chmap_capture/chmap_wrap.sv
+++ b/tb/verilator/chmap_capture/chmap_wrap.sv
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+//! Verilator harness wrapper for the per-pair-slot TX source mux
+//! (KL_chan_map_capture) feeding the shared KL_aaf_packetizer. Two lanes:
+//!   A: chmap(32 slots) -> packetizer(N=2, t0=2ch slot0 / t1=8ch slots1..4) -
+//!      routing, mid-run remap, ZERO-source and disabled-slot (absence) tests.
+//!   B: chmap(32 slots) -> packetizer(N=8, all 8ch = 32 slots) - exercises the
+//!      widened pair_slot up to slot 31 (talker 7 pair 3).
+//! Both chmaps share the source-pair stimulus pins; each has its own map
+//! write/read port and media tick.
+
+`default_nettype none
+
+module chmap_wrap (
+  input  wire         clk,
+  input  wire         rst_n,
+
+  //! --- shared packetizer config (t0 CSR aliases / all-stream fields) ------
+  input  wire [47:0]  dest_mac_i,
+  input  wire [47:0]  station_mac_i,
+  input  wire [11:0]  vlan_vid_i,
+  input  wire [31:0]  transit_ns_i,
+  input  wire [63:0]  ptp_ns_i,
+
+  //! --- shared source pair stimulus (latched free-running by both chmaps) --
+  input  wire         i2s_pair_valid_i,
+  input  wire [23:0]  i2s_l_i,
+  input  wire [23:0]  i2s_r_i,
+  input  wire         tdm_pair_valid_i,
+  input  wire [3:0]   tdm_pair_slot_i,
+  input  wire [23:0]  tdm_l_i,
+  input  wire [23:0]  tdm_r_i,
+  input  wire         ring_pair_valid_i,
+  input  wire [3:0]   ring_pair_slot_i,
+  input  wire [23:0]  ring_l_i,
+  input  wire [23:0]  ring_r_i,
+  input  wire [23:0]  tone_smp_i,
+
+  //! --- lane A: chmap map ports + tick -------------------------------------
+  input  wire         a_map_wr_en_i,
+  input  wire [4:0]   a_map_wr_addr_i,
+  input  wire [7:0]   a_map_wr_data_i,
+  input  wire         a_map_rd_en_i,
+  input  wire [4:0]   a_map_rd_addr_i,
+  output wire [7:0]   a_map_rd_data_o,
+  output wire         a_map_rd_valid_o,
+  input  wire         a_tick_i,
+
+  //! --- lane A: packetizer (N=2) gate + TCTX window + AXIS -----------------
+  input  wire [1:0]   a_en_i,
+  input  wire         a_tctx_wr_en_i,
+  input  wire [6:0]   a_tctx_wr_addr_i,
+  input  wire [31:0]  a_tctx_wr_data_i,
+  output wire         a_tctx_wr_rdy_o,
+  input  wire         a_tctx_rd_en_i,
+  input  wire [6:0]   a_tctx_rd_addr_i,
+  output wire [31:0]  a_tctx_rd_data_o,
+  output wire         a_tctx_rd_valid_o,
+  output wire [63:0]  a_tdata_o,
+  output wire [7:0]   a_tkeep_o,
+  output wire         a_tvalid_o,
+  output wire         a_tlast_o,
+  input  wire         a_tready_i,
+
+  //! --- lane B: chmap map ports + tick -------------------------------------
+  input  wire         b_map_wr_en_i,
+  input  wire [4:0]   b_map_wr_addr_i,
+  input  wire [7:0]   b_map_wr_data_i,
+  input  wire         b_map_rd_en_i,
+  input  wire [4:0]   b_map_rd_addr_i,
+  output wire [7:0]   b_map_rd_data_o,
+  output wire         b_map_rd_valid_o,
+  input  wire         b_tick_i,
+
+  //! --- lane B: packetizer (N=8) gate + TCTX window + AXIS -----------------
+  input  wire [7:0]   b_en_i,
+  input  wire         b_tctx_wr_en_i,
+  input  wire [6:0]   b_tctx_wr_addr_i,
+  input  wire [31:0]  b_tctx_wr_data_i,
+  output wire         b_tctx_wr_rdy_o,
+  input  wire         b_tctx_rd_en_i,
+  input  wire [6:0]   b_tctx_rd_addr_i,
+  output wire [31:0]  b_tctx_rd_data_o,
+  output wire         b_tctx_rd_valid_o,
+  output wire [63:0]  b_tdata_o,
+  output wire [7:0]   b_tkeep_o,
+  output wire         b_tvalid_o,
+  output wire         b_tlast_o,
+  input  wire         b_tready_i
+);
+
+  // ====================================================================== //
+  //  Lane A: chmap -> packetizer(N=2)                                       //
+  // ====================================================================== //
+  wire        a_pv_w;
+  wire [4:0]  a_slot_w;
+  wire [23:0] a_l_w, a_r_w;
+
+  KL_chan_map_capture #(
+    .N_SLOTS_P (32), .N_TDM_P (8), .N_RING_P (16), .GAP_CYC_P (24)
+  ) u_chmap_a (
+    .clk_i (clk), .rst_n (rst_n),
+    .map_wr_en_i (a_map_wr_en_i), .map_wr_addr_i (a_map_wr_addr_i),
+    .map_wr_data_i (a_map_wr_data_i),
+    .map_rd_en_i (a_map_rd_en_i), .map_rd_addr_i (a_map_rd_addr_i),
+    .map_rd_data_o (a_map_rd_data_o), .map_rd_valid_o (a_map_rd_valid_o),
+    .i2s_pair_valid_i (i2s_pair_valid_i), .i2s_l_i (i2s_l_i), .i2s_r_i (i2s_r_i),
+    .tdm_pair_valid_i (tdm_pair_valid_i), .tdm_pair_slot_i (tdm_pair_slot_i),
+    .tdm_l_i (tdm_l_i), .tdm_r_i (tdm_r_i),
+    .ring_pair_valid_i (ring_pair_valid_i), .ring_pair_slot_i (ring_pair_slot_i),
+    .ring_l_i (ring_l_i), .ring_r_i (ring_r_i),
+    .tone_smp_i (tone_smp_i),
+    .tick_i (a_tick_i),
+    .pair_valid_o (a_pv_w), .pair_slot_o (a_slot_w),
+    .pair_l_o (a_l_w), .pair_r_o (a_r_w)
+  );
+
+  KL_aaf_packetizer #(.N_TALKERS_P(2)) u_pkt_a (
+    .clk_i (clk), .rst_n (rst_n),
+    .pair_valid_i (a_pv_w), .pair_slot_i (a_slot_w),
+    .pair_l_i (a_l_w), .pair_r_i (a_r_w),
+    .stream_en_i (a_en_i),
+    .dest_mac_i (dest_mac_i), .station_mac_i (station_mac_i),
+    .vlan_vid_i (vlan_vid_i), .transit_ns_i (transit_ns_i),
+    .ptp_ns_i (ptp_ns_i),
+    .tctx_wr_en_i (a_tctx_wr_en_i), .tctx_wr_addr_i (a_tctx_wr_addr_i),
+    .tctx_wr_data_i (a_tctx_wr_data_i), .tctx_wr_rdy_o (a_tctx_wr_rdy_o),
+    .tctx_rd_en_i (a_tctx_rd_en_i), .tctx_rd_addr_i (a_tctx_rd_addr_i),
+    .tctx_rd_data_o (a_tctx_rd_data_o), .tctx_rd_valid_o (a_tctx_rd_valid_o),
+    .m_axis_tdata (a_tdata_o), .m_axis_tkeep (a_tkeep_o),
+    .m_axis_tvalid (a_tvalid_o), .m_axis_tlast (a_tlast_o),
+    .m_axis_tready (a_tready_i),
+    .frames_sent_o ()
+  );
+
+  // ====================================================================== //
+  //  Lane B: chmap -> packetizer(N=8, all 8ch = 32 slots, slot 31 reach)    //
+  // ====================================================================== //
+  wire        b_pv_w;
+  wire [4:0]  b_slot_w;
+  wire [23:0] b_l_w, b_r_w;
+
+  KL_chan_map_capture #(
+    .N_SLOTS_P (32), .N_TDM_P (8), .N_RING_P (16), .GAP_CYC_P (24)
+  ) u_chmap_b (
+    .clk_i (clk), .rst_n (rst_n),
+    .map_wr_en_i (b_map_wr_en_i), .map_wr_addr_i (b_map_wr_addr_i),
+    .map_wr_data_i (b_map_wr_data_i),
+    .map_rd_en_i (b_map_rd_en_i), .map_rd_addr_i (b_map_rd_addr_i),
+    .map_rd_data_o (b_map_rd_data_o), .map_rd_valid_o (b_map_rd_valid_o),
+    .i2s_pair_valid_i (i2s_pair_valid_i), .i2s_l_i (i2s_l_i), .i2s_r_i (i2s_r_i),
+    .tdm_pair_valid_i (tdm_pair_valid_i), .tdm_pair_slot_i (tdm_pair_slot_i),
+    .tdm_l_i (tdm_l_i), .tdm_r_i (tdm_r_i),
+    .ring_pair_valid_i (ring_pair_valid_i), .ring_pair_slot_i (ring_pair_slot_i),
+    .ring_l_i (ring_l_i), .ring_r_i (ring_r_i),
+    .tone_smp_i (tone_smp_i),
+    .tick_i (b_tick_i),
+    .pair_valid_o (b_pv_w), .pair_slot_o (b_slot_w),
+    .pair_l_o (b_l_w), .pair_r_o (b_r_w)
+  );
+
+  KL_aaf_packetizer #(.N_TALKERS_P(8)) u_pkt_b (
+    .clk_i (clk), .rst_n (rst_n),
+    .pair_valid_i (b_pv_w), .pair_slot_i (b_slot_w),
+    .pair_l_i (b_l_w), .pair_r_i (b_r_w),
+    .stream_en_i (b_en_i),
+    .dest_mac_i (dest_mac_i), .station_mac_i (station_mac_i),
+    .vlan_vid_i (vlan_vid_i), .transit_ns_i (transit_ns_i),
+    .ptp_ns_i (ptp_ns_i),
+    .tctx_wr_en_i (b_tctx_wr_en_i), .tctx_wr_addr_i (b_tctx_wr_addr_i),
+    .tctx_wr_data_i (b_tctx_wr_data_i), .tctx_wr_rdy_o (b_tctx_wr_rdy_o),
+    .tctx_rd_en_i (b_tctx_rd_en_i), .tctx_rd_addr_i (b_tctx_rd_addr_i),
+    .tctx_rd_data_o (b_tctx_rd_data_o), .tctx_rd_valid_o (b_tctx_rd_valid_o),
+    .m_axis_tdata (b_tdata_o), .m_axis_tkeep (b_tkeep_o),
+    .m_axis_tvalid (b_tvalid_o), .m_axis_tlast (b_tlast_o),
+    .m_axis_tready (b_tready_i),
+    .frames_sent_o ()
+  );
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/chmap_capture/sim_main.cpp
+++ b/tb/verilator/chmap_capture/sim_main.cpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// KL_chan_map_capture harness: the per-pair-slot TX source mux feeding the
+// shared KL_aaf_packetizer.
+//   Lane A: chmap(32) -> packetizer(N=2, t0=2ch slot0 / t1=8ch slots1..4).
+//     - per-slot source routing (I2S / TDM / RING / TONE), payload-exact;
+//     - mid-run remap (RING->ZERO, TONE->RING1);
+//     - disabled slot = absence (drop t0 by disabling its only slot);
+//     - map RAM readback port.
+//   Lane B: chmap(32) -> packetizer(N=8, ALL 8ch = 32 pair slots). Exercises
+//     the widened pair_slot: talker 7 owns slots 28..31, so slot 31 = t7's
+//     4th pair - its payload proves the >15 slot path end to end.
+#include "Vchmap_wrap.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+static Vchmap_wrap* dut;
+static long checks = 0, fails = 0;
+static void ck(const char* t, long got, long exp) {
+  checks++;
+  if (got != exp) { fails++; printf("  [FAIL] %-46s got=0x%lx exp=0x%lx\n", t, got, exp); }
+  else            printf("  [ ok ] %-46s = 0x%lx\n", t, got);
+}
+
+using Frame = std::vector<uint8_t>;
+static std::vector<Frame> afr, bfr;
+static Frame acur, bcur;
+
+static void sample() {
+  if (dut->a_tvalid_o && dut->a_tready_i) {
+    for (int i = 0; i < 8; i++) if ((dut->a_tkeep_o >> i) & 1)
+      acur.push_back((dut->a_tdata_o >> (8 * i)) & 0xFF);
+    if (dut->a_tlast_o) { afr.push_back(acur); acur.clear(); }
+  }
+  if (dut->b_tvalid_o && dut->b_tready_i) {
+    for (int i = 0; i < 8; i++) if ((dut->b_tkeep_o >> i) & 1)
+      bcur.push_back((dut->b_tdata_o >> (8 * i)) & 0xFF);
+    if (dut->b_tlast_o) { bfr.push_back(bcur); bcur.clear(); }
+  }
+}
+static void step() { dut->clk = 0; dut->eval(); dut->clk = 1; dut->eval(); sample(); }
+static void cyc(int n = 1) { for (int i = 0; i < n; i++) step(); }
+
+static unsigned long be(const Frame& b, int o, int n) {
+  unsigned long v = 0; for (int i = 0; i < n; i++) v = (v << 8) | b[o + i]; return v; }
+static int find_len(std::vector<Frame>& v, size_t len) {
+  for (size_t i = 0; i < v.size(); i++) if (v[i].size() == len) return (int)i; return -1; }
+static uint8_t ent(int en, int src, int idx) {
+  return (uint8_t)(((en & 1) << 7) | ((src & 7) << 4) | (idx & 0xF)); }
+
+// ---- map RAM write / read ------------------------------------------------
+static void a_map_wr(int slot, uint8_t d) {
+  dut->a_map_wr_en_i = 1; dut->a_map_wr_addr_i = slot; dut->a_map_wr_data_i = d;
+  cyc(); dut->a_map_wr_en_i = 0; cyc(); }
+static void b_map_wr(int slot, uint8_t d) {
+  dut->b_map_wr_en_i = 1; dut->b_map_wr_addr_i = slot; dut->b_map_wr_data_i = d;
+  cyc(); dut->b_map_wr_en_i = 0; cyc(); }
+static uint8_t a_map_rd(int slot) {
+  dut->a_map_rd_en_i = 1; dut->a_map_rd_addr_i = slot; cyc();
+  uint8_t v = dut->a_map_rd_data_o; bool ok = dut->a_map_rd_valid_o;
+  dut->a_map_rd_en_i = 0; cyc();
+  if (!ok) { printf("  [FAIL] a_map_rd(%d) no valid\n", slot); fails++; checks++; }
+  return v; }
+
+// ---- TCTX window writes (poll wr_rdy, like the NxN harness) ---------------
+static void a_tctx_wr(int t, int w, uint32_t v) {
+  dut->a_tctx_wr_en_i = 1; dut->a_tctx_wr_addr_i = (uint8_t)((t << 4) | w);
+  dut->a_tctx_wr_data_i = v;
+  for (int i = 0; i < 48; i++) {
+    dut->clk = 0; dut->eval(); bool rdy = dut->a_tctx_wr_rdy_o;
+    dut->clk = 1; dut->eval(); sample();
+    if (rdy) { dut->a_tctx_wr_en_i = 0; cyc(); return; } }
+  dut->a_tctx_wr_en_i = 0; printf("  [FAIL] a_tctx_wr timeout\n"); fails++; checks++; }
+static void b_tctx_wr(int t, int w, uint32_t v) {
+  dut->b_tctx_wr_en_i = 1; dut->b_tctx_wr_addr_i = (uint8_t)((t << 4) | w);
+  dut->b_tctx_wr_data_i = v;
+  for (int i = 0; i < 48; i++) {
+    dut->clk = 0; dut->eval(); bool rdy = dut->b_tctx_wr_rdy_o;
+    dut->clk = 1; dut->eval(); sample();
+    if (rdy) { dut->b_tctx_wr_en_i = 0; cyc(); return; } }
+  dut->b_tctx_wr_en_i = 0; printf("  [FAIL] b_tctx_wr timeout\n"); fails++; checks++; }
+
+// ---- source-pair drivers (latched free-running by both chmaps) -----------
+static void drv_i2s(uint32_t l, uint32_t r) {
+  dut->i2s_pair_valid_i = 1; dut->i2s_l_i = l & 0xFFFFFF; dut->i2s_r_i = r & 0xFFFFFF;
+  cyc(); dut->i2s_pair_valid_i = 0; cyc(); }
+static void drv_tdm(int slot, uint32_t l, uint32_t r) {
+  dut->tdm_pair_valid_i = 1; dut->tdm_pair_slot_i = slot;
+  dut->tdm_l_i = l & 0xFFFFFF; dut->tdm_r_i = r & 0xFFFFFF;
+  cyc(); dut->tdm_pair_valid_i = 0; cyc(); }
+static void drv_ring(int slot, uint32_t l, uint32_t r) {
+  dut->ring_pair_valid_i = 1; dut->ring_pair_slot_i = slot;
+  dut->ring_l_i = l & 0xFFFFFF; dut->ring_r_i = r & 0xFFFFFF;
+  cyc(); dut->ring_pair_valid_i = 0; cyc(); }
+
+// ---- media ticks (one full slot walk per tick; drain-friendly spacing) ---
+static void a_tick() { dut->a_tick_i = 1; cyc(); dut->a_tick_i = 0; cyc(300); }
+static void b_tick() { dut->b_tick_i = 1; cyc(); dut->b_tick_i = 0; cyc(340); }
+
+static const uint32_t I2S_L = 0x1A1111, I2S_R = 0x1A2222;
+static const uint32_t TONE  = 0x7A7A7A;
+static uint32_t TDM_L(int p) { return 0x2B0000 | (p << 4); }
+static uint32_t TDM_R(int p) { return 0x2BB000 | (p << 4); }
+static uint32_t RNG_L(int r) { return 0x3C0000 | (r << 4); }
+static uint32_t RNG_R(int r) { return 0x3CC000 | (r << 4); }
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new Vchmap_wrap;
+
+  dut->rst_n = 0;
+  dut->a_tready_i = 1; dut->b_tready_i = 1;
+  dut->dest_mac_i = 0x91E0F000FE01ULL; dut->station_mac_i = 0x020000000002ULL;
+  dut->vlan_vid_i = 2; dut->ptp_ns_i = 0x11223344; dut->transit_ns_i = 2000000;
+  dut->i2s_pair_valid_i = 0; dut->tdm_pair_valid_i = 0; dut->ring_pair_valid_i = 0;
+  dut->tone_smp_i = 0;
+  dut->a_map_wr_en_i = 0; dut->a_map_rd_en_i = 0; dut->a_tick_i = 0; dut->a_en_i = 0;
+  dut->a_tctx_wr_en_i = 0; dut->a_tctx_rd_en_i = 0;
+  dut->b_map_wr_en_i = 0; dut->b_map_rd_en_i = 0; dut->b_tick_i = 0; dut->b_en_i = 0;
+  dut->b_tctx_wr_en_i = 0; dut->b_tctx_rd_en_i = 0;
+  cyc(8); dut->rst_n = 1; cyc(4);
+
+  printf("== KL_chan_map_capture (per-pair-slot TX source mux) ==\n");
+
+  // ====================================================================== //
+  printf("\n[A] per-slot routing: I2S / TDM / RING / TONE across t0(2ch)+t1(8ch)\n");
+  // t1 CFG via the TCTX window (chans=8 so t1 owns pair slots 1..4)
+  a_tctx_wr(1, 1, 0xF000FE02u);            // DMAC_LO (wire bytes 2..5) = base+1
+  a_tctx_wr(1, 2, (1u << 16) | 0x91E0u);   // {UID=1, DMAC_HI}
+  a_tctx_wr(1, 0, (2u << 5) | (8u << 1) | 1u); // CTRL {en, chans=8, vid=2}
+  dut->a_en_i = 3;
+
+  a_map_wr(0, ent(1, 1, 0));   // slot0 (t0 pair0) = I2S
+  a_map_wr(1, ent(1, 2, 0));   // slot1 (t1 pair0) = TDM idx0
+  a_map_wr(2, ent(1, 2, 1));   // slot2 (t1 pair1) = TDM idx1
+  a_map_wr(3, ent(1, 3, 0));   // slot3 (t1 pair2) = RING idx0
+  a_map_wr(4, ent(1, 4, 0));   // slot4 (t1 pair3) = TONE
+
+  dut->tone_smp_i = TONE;
+  drv_i2s(I2S_L, I2S_R);
+  drv_tdm(0, TDM_L(0), TDM_R(0));
+  drv_tdm(1, TDM_L(1), TDM_R(1));
+  drv_ring(0, RNG_L(0), RNG_R(0));
+  drv_ring(1, RNG_L(1), RNG_R(1));   // preloaded for the remap phase
+  cyc(4);
+
+  afr.clear();
+  for (int i = 0; i < 6; i++) a_tick();
+  cyc(400);
+
+  ck("A: two frames (t0 + t1)", (long)afr.size(), 2);
+  int ia0 = find_len(afr, 90), ia1 = find_len(afr, 234);
+  ck("A: t0 90-byte frame present", ia0 >= 0, 1);
+  ck("A: t1 234-byte frame present", ia1 >= 0, 1);
+  if (ia0 >= 0 && ia1 >= 0) {
+    ck("A: t0 channels_per_frame = 2", afr[ia0][36], 2);
+    ck("A: t1 channels_per_frame = 8", afr[ia1][36], 8);
+    ck("A: t0 uid 0", be(afr[ia0], 22, 8) & 0xFFFF, 0);
+    ck("A: t1 uid 1", be(afr[ia1], 22, 8) & 0xFFFF, 1);
+    ck("A: t1 DMAC = base+1 (TCTX)", be(afr[ia1], 0, 6), 0x91E0F000FE02UL);
+    ck("A: t0 slot0 = I2S L", be(afr[ia0], 42, 3), I2S_L);
+    ck("A: t0 slot0 = I2S R", be(afr[ia0], 46, 3), I2S_R);
+    ck("A: t1 pair0 slot1 = TDM0 L", be(afr[ia1], 42, 3), TDM_L(0));
+    ck("A: t1 pair0 slot1 = TDM0 R", be(afr[ia1], 46, 3), TDM_R(0));
+    ck("A: t1 pair1 slot2 = TDM1 L", be(afr[ia1], 50, 3), TDM_L(1));
+    ck("A: t1 pair2 slot3 = RING0 L", be(afr[ia1], 58, 3), RNG_L(0));
+    ck("A: t1 pair2 slot3 = RING0 R", be(afr[ia1], 62, 3), RNG_R(0));
+    ck("A: t1 pair3 slot4 = TONE L", be(afr[ia1], 66, 3), TONE);
+    ck("A: t1 pair3 slot4 = TONE R", be(afr[ia1], 70, 3), TONE);
+    ck("A: t0 seq 0", afr[ia0][20], 0);
+    ck("A: t1 seq 0", afr[ia1][20], 0);
+  } else { for (int k = 0; k < 15; k++) ck("A content (skipped: frames missing)", 0, 1); }
+
+  // ====================================================================== //
+  printf("\n[A2] mid-run remap: slot3 RING0->ZERO(silence), slot4 TONE->RING1\n");
+  a_map_wr(3, ent(1, 0, 0));   // slot3 -> ZERO source (silence, en=1)
+  a_map_wr(4, ent(1, 3, 1));   // slot4 -> RING idx1
+  cyc(4);
+  afr.clear();
+  for (int i = 0; i < 6; i++) a_tick();
+  cyc(400);
+  ck("A2: two frames again", (long)afr.size(), 2);
+  int j1 = find_len(afr, 234), j0 = find_len(afr, 90);
+  if (j1 >= 0) {
+    ck("A2: t1 pair2 slot3 now silence L", be(afr[j1], 58, 3), 0);
+    ck("A2: t1 pair2 slot3 now silence R", be(afr[j1], 62, 3), 0);
+    ck("A2: t1 pair3 slot4 now RING1 L", be(afr[j1], 66, 3), RNG_L(1));
+    ck("A2: t1 pair3 slot4 now RING1 R", be(afr[j1], 70, 3), RNG_R(1));
+    ck("A2: t1 seq advanced to 1", afr[j1][20], 1);
+  } else { for (int k = 0; k < 5; k++) ck("A2 content (skipped)", 0, 1); }
+  if (j0 >= 0) ck("A2: t0 seq advanced to 1", afr[j0][20], 1);
+  else         ck("A2: t0 frame (skipped)", 0, 1);
+
+  // ====================================================================== //
+  printf("\n[A3] disabled slot = absence: disable slot0 drops t0 entirely\n");
+  a_map_wr(0, ent(0, 1, 0));   // slot0 disabled (en=0)
+  cyc(4);
+  afr.clear();
+  for (int i = 0; i < 6; i++) a_tick();
+  cyc(400);
+  ck("A3: only one frame (t0 absent)", (long)afr.size(), 1);
+  if (afr.size() == 1) {
+    ck("A3: surviving frame is 8ch (t1)", afr[0][36], 8);
+    ck("A3: t1 seq advanced to 2", afr[0][20], 2);
+  } else { ck("A3 content (skipped)", 0, 1); ck("A3 content (skipped)", 0, 1); }
+
+  // ====================================================================== //
+  printf("\n[RB] map RAM readback port\n");
+  ck("RB: slot1 = {en,TDM,0}",  a_map_rd(1), ent(1, 2, 0));
+  ck("RB: slot3 = {en,ZERO,0}", a_map_rd(3), ent(1, 0, 0));
+  ck("RB: slot4 = {en,RING,1}", a_map_rd(4), ent(1, 3, 1));
+  ck("RB: slot0 = disabled",    a_map_rd(0), ent(0, 1, 0));
+
+  // ====================================================================== //
+  printf("\n[B] widened slot: N=8 all-8ch, talker 7 owns slots 28..31 (slot 31)\n");
+  // ALL 8 talkers must be 8ch so the prefix sum gives pbase[7]=28 (t7 pair p =
+  // slot 28+p; slot 31 = t7 pair 3)
+  for (int t = 0; t < 8; t++)
+    b_tctx_wr(t, 0, (2u << 5) | (8u << 1) | (t == 7 ? 1u : 0u)); // CTRL chans=8
+  b_tctx_wr(7, 1, 0xF000FE08u);            // t7 DMAC_LO = base+7
+  b_tctx_wr(7, 2, (7u << 16) | 0x91E0u);   // {UID=7, DMAC_HI}
+  dut->b_en_i = 0x80;                        // enable talker 7 only
+
+  b_map_wr(28, ent(1, 1, 0));  // slot28 (t7 pair0) = I2S
+  b_map_wr(29, ent(1, 2, 0));  // slot29 (t7 pair1) = TDM idx0
+  b_map_wr(30, ent(1, 3, 0));  // slot30 (t7 pair2) = RING idx0
+  b_map_wr(31, ent(1, 4, 0));  // slot31 (t7 pair3) = TONE  <-- widened slot
+
+  // refresh the shared source holds for lane B
+  dut->tone_smp_i = TONE;
+  drv_i2s(I2S_L, I2S_R);
+  drv_tdm(0, TDM_L(0), TDM_R(0));
+  drv_ring(0, RNG_L(0), RNG_R(0));
+  cyc(4);
+
+  bfr.clear();
+  for (int i = 0; i < 6; i++) b_tick();
+  cyc(600);
+
+  ck("B: one frame emitted (t7)", (long)bfr.size(), 1);
+  if (bfr.size() == 1) {
+    ck("B: t7 frame is 234 bytes (8ch)", (long)bfr[0].size(), 234);
+    ck("B: t7 channels_per_frame = 8", bfr[0][36], 8);
+    ck("B: t7 uid 7", be(bfr[0], 22, 8) & 0xFFFF, 7);
+    ck("B: t7 DMAC = base+7", be(bfr[0], 0, 6), 0x91E0F000FE08UL);
+    ck("B: slot28 pair0 = I2S L", be(bfr[0], 42, 3), I2S_L);
+    ck("B: slot29 pair1 = TDM0 L", be(bfr[0], 50, 3), TDM_L(0));
+    ck("B: slot30 pair2 = RING0 L", be(bfr[0], 58, 3), RNG_L(0));
+    ck("B: slot31 pair3 = TONE L (widened >15 slot)", be(bfr[0], 66, 3), TONE);
+    ck("B: slot31 pair3 = TONE R (widened >15 slot)", be(bfr[0], 70, 3), TONE);
+  } else { for (int k = 0; k < 9; k++) ck("B content (skipped: count wrong)", 0, 1); }
+
+  printf("\n======================================================================\n");
+  printf("KL_chan_map_capture: %ld checks, %ld failures\nRESULT: %s\n",
+         checks, fails, fails ? "FAIL" : "PASS");
+  delete dut;
+  return fails ? 1 : 0;
+}

--- a/tb/verilator/chmap_render/Makefile
+++ b/tb/verilator/chmap_render/Makefile
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# KL_chan_map_render verification: 64 stream-channel -> physical render
+# crossbar. Drives a depacketizer-clone AXIS with recognizable per-sample
+# ramps (stream/ch/seq encoded in the 24-bit payload), programs identity /
+# permuted / cross-stream / unmapped maps, and asserts byte-exact routing on
+# the phys outputs at each 48 kHz tick (map + cur_r frozen between ticks).
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+TOP        = KL_chan_map_render
+VFLAGS = --cc --exe --build -j 0 --top-module $(TOP) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
+         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-IMPORTSTAR -Wno-CASEINCOMPLETE \
+         -Wno-EOFNEWLINE -CFLAGS "-std=c++17 -O2"
+SRCS = $(RTL_DIR)/ieee1722/aaf/KL_chan_map_render.sv
+.PHONY: all run clean
+all: run
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) sim_main.cpp -o VKL_chan_map_render_sim
+	./obj_dir/VKL_chan_map_render_sim
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/chmap_render/sim_main.cpp
+++ b/tb/verilator/chmap_render/sim_main.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// KL_chan_map_render harness: drive a depacketizer-clone AXIS (64-bit beats =
+// 2 consecutive S32BE samples, wire-interleaved payload, tuser = stream, tlast
+// per PDU) with recognizable per-sample ramps whose 24-bit value encodes
+// {s[3:0], c[3:0], seq[15:0]}. Program identity / permuted / cross-stream /
+// unmapped maps and assert BYTE-EXACT routing on the phys outputs at each
+// 48 kHz tick. Also proves the glitch-free contract: both the map RAM AND the
+// free-running cur_r latch are only ever sampled onto the outputs at a tick
+// (old value until tick, new after), plus tlast beat-realignment across
+// back-to-back PDUs of different (even/odd) channel counts, and pad-byte drop.
+#include "VKL_chan_map_render.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+
+static VKL_chan_map_render* dut;
+static long checks = 0, fails = 0;
+
+static void ck(const char* w, uint32_t got, uint32_t exp) {
+  checks++;
+  if (got != exp) {
+    fails++;
+    printf("  [FAIL] %-34s got=0x%06x exp=0x%06x\n", w, got, exp);
+  }
+}
+
+static void step() {
+  dut->clk_i = 0; dut->eval();
+  dut->clk_i = 1; dut->eval();
+}
+
+// 24-bit sample payload = {s[3:0], c[3:0], seq[15:0]}
+static uint32_t value(int s, int c, int seq) {
+  return (((uint32_t)(s & 0xF)) << 20) | (((uint32_t)(c & 0xF)) << 16) |
+         ((uint32_t)(seq & 0xFFFF));
+}
+
+// pack two 24-bit samples (+ their pad bytes) into a wire-order S32BE beat:
+// lane j = wire byte j; sample byte 0 = MSB; lane 3/7 = pad (must be dropped).
+static uint64_t beat(uint32_t v0, uint8_t p0, uint32_t v1, uint8_t p1) {
+  uint64_t b = 0;
+  b |= (uint64_t)((v0 >> 16) & 0xFF) << 0;
+  b |= (uint64_t)((v0 >> 8) & 0xFF) << 8;
+  b |= (uint64_t)(v0 & 0xFF) << 16;
+  b |= (uint64_t)p0 << 24;
+  b |= (uint64_t)((v1 >> 16) & 0xFF) << 32;
+  b |= (uint64_t)((v1 >> 8) & 0xFF) << 40;
+  b |= (uint64_t)(v1 & 0xFF) << 48;
+  b |= (uint64_t)p1 << 56;
+  return b;
+}
+
+static void set_chans(const int c[8]) {
+  uint32_t v = 0;
+  for (int s = 0; s < 8; s++) v |= ((uint32_t)(c[s] & 0xF)) << (s * 4);
+  dut->wire_chans_i = v;
+}
+
+// drive one AAF PDU: C channels, 6 samples/channel (Milan 48k), 2 samples/beat.
+// sample k -> channel k%C, within-channel seq k/C (0..5); tag offsets seq so
+// each frame's latched values (seq 5 -> tag+5) are distinguishable.
+static void drive_frame(int s, int C, int tag, bool deassert = true) {
+  int nbeats = (6 * C) / 2;  // = 3*C, always whole (6*C even)
+  for (int b = 0; b < nbeats; b++) {
+    int k0 = 2 * b, k1 = 2 * b + 1;
+    uint32_t v0 = value(s, k0 % C, tag + k0 / C);
+    uint32_t v1 = value(s, k1 % C, tag + k1 / C);
+    dut->s_tdata_i  = beat(v0, 0xAA, v1, 0x55);  // nonzero pad -> must drop
+    dut->s_tvalid_i = 1;
+    dut->s_tuser_i  = s;
+    dut->s_tlast_i  = (b == nbeats - 1) ? 1 : 0;
+    step();
+  }
+  if (deassert) { dut->s_tvalid_i = 0; dut->s_tlast_i = 0; }
+}
+
+static void wr_map(int p, int en, int s, int c) {
+  dut->map_wr_en_i   = 1;
+  dut->map_wr_addr_i = p;
+  dut->map_wr_data_i = ((en & 1) << 7) | ((s & 7) << 3) | (c & 7);
+  step();
+  dut->map_wr_en_i = 0;
+}
+
+static void do_tick() {
+  dut->s_tvalid_i = 0;   // cur_r frozen while we sample it onto the outputs
+  dut->tick_i = 1; step();
+  dut->tick_i = 0;       // phys_smp_o / phys_valid_o now hold this frame
+}
+
+static uint32_t phys(int p) {
+  int lo = p * 24, wi = lo >> 5, off = lo & 31;
+  uint64_t w = (uint64_t)dut->phys_smp_o[wi] |
+               ((uint64_t)dut->phys_smp_o[wi + 1] << 32);
+  return (uint32_t)((w >> off) & 0xFFFFFF);
+}
+
+static uint8_t rd_map(int p) {
+  dut->map_rd_addr_i = p; dut->eval();
+  return dut->map_rd_data_o;
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new VKL_chan_map_render;
+
+  // ---- reset ----
+  dut->rst_n = 0; dut->s_tvalid_i = 0; dut->s_tlast_i = 0; dut->s_tuser_i = 0;
+  dut->tick_i = 0; dut->map_wr_en_i = 0; dut->map_wr_addr_i = 0;
+  dut->map_wr_data_i = 0; dut->map_rd_addr_i = 0; dut->s_tdata_i = 0;
+  int chans[8] = {2, 8, 2, 3, 2, 2, 2, 2};
+  set_chans(chans);
+  for (int i = 0; i < 6; i++) step();
+  dut->rst_n = 1;
+
+  printf("== KL_chan_map_render ==\n");
+
+  // ================================================================
+  // Phase 1: latch 4 streams, program the default identity map
+  //   (I2S L/R = phys0/1 <- stream0; TDM8 slots = phys2..9 <- stream1)
+  // ================================================================
+  drive_frame(0, 2, 0x100);   // cur[0][c] = value(0,c,0x105)
+  drive_frame(1, 8, 0x200);   // cur[1][c] = value(1,c,0x205)
+  drive_frame(2, 2, 0x300);   // cur[2][c] = value(2,c,0x305)
+  drive_frame(3, 3, 0x400);   // cur[3][c] = value(3,c,0x405)  (odd straddle)
+
+  wr_map(0, 1, 0, 0); wr_map(1, 1, 0, 1);
+  for (int p = 2; p < 10; p++) wr_map(p, 1, 1, p - 2);   // stream1 ch0..7
+  do_tick();
+  ck("id.phys_valid", dut->phys_valid_o, 1);
+  ck("id.mask", dut->mapped_mask_o, 0x3FF);
+  ck("id.phys0 s0c0", phys(0), value(0, 0, 0x105));
+  ck("id.phys1 s0c1", phys(1), value(0, 1, 0x105));
+  for (int c = 0; c < 8; c++)
+    ck("id.phys s1", phys(2 + c), value(1, c, 0x205));
+  ck("id.rdmap0", rd_map(0), (1 << 7) | (0 << 3) | 0);
+  ck("id.rdmap9", rd_map(9), (1 << 7) | (1 << 3) | 7);
+  // phys_valid is a one-cycle pulse
+  dut->tick_i = 0; step();
+  ck("id.valid_pulse_clears", dut->phys_valid_o, 0);
+
+  // ================================================================
+  // Phase 2: permuted (reverse stream1) + cross to stream2
+  // ================================================================
+  wr_map(0, 1, 2, 0); wr_map(1, 1, 2, 1);
+  for (int p = 2; p < 10; p++) wr_map(p, 1, 1, 9 - p);   // ch7..0 reversed
+  do_tick();
+  ck("perm.phys0 s2c0", phys(0), value(2, 0, 0x305));
+  ck("perm.phys1 s2c1", phys(1), value(2, 1, 0x305));
+  for (int p = 2; p < 10; p++)
+    ck("perm.phys s1rev", phys(p), value(1, 9 - p, 0x205));
+
+  // ================================================================
+  // Phase 3: full cross-stream incl. odd stream3, and a duplicated source
+  //          (phys0 and phys9 both point at stream3 ch0)
+  // ================================================================
+  int ms[10] = {3, 3, 3, 0, 0, 1, 2, 2, 1, 3};
+  int mc[10] = {0, 1, 2, 0, 1, 3, 0, 1, 0, 0};
+  int mtag[10] = {0x405, 0x405, 0x405, 0x105, 0x105,
+                  0x205, 0x305, 0x305, 0x205, 0x405};
+  for (int p = 0; p < 10; p++) wr_map(p, 1, ms[p], mc[p]);
+  do_tick();
+  for (int p = 0; p < 10; p++)
+    ck("cross.phys", phys(p), value(ms[p], mc[p], mtag[p]));
+
+  // ================================================================
+  // Phase 4: unmapped (en=0) channels render 0; mask tracks live en bits
+  // ================================================================
+  for (int p = 3; p < 10; p++) wr_map(p, 0, 0, 0);
+  do_tick();
+  ck("unmap.mask", dut->mapped_mask_o, 0x007);
+  ck("unmap.phys0", phys(0), value(3, 0, 0x405));
+  ck("unmap.phys1", phys(1), value(3, 1, 0x405));
+  ck("unmap.phys2", phys(2), value(3, 2, 0x405));
+  for (int p = 3; p < 10; p++) ck("unmap.zero", phys(p), 0);
+
+  // ================================================================
+  // Phase 5a: cur_r free-runs, but a mapped output only changes at a tick
+  // ================================================================
+  wr_map(0, 1, 0, 0); do_tick();
+  ck("free.baseline", phys(0), value(0, 0, 0x105));
+  drive_frame(0, 2, 0x700);          // cur[0][0] now value(0,0,0x705), NO tick
+  ck("free.frozen_no_tick", phys(0), value(0, 0, 0x105));  // still old
+  do_tick();
+  ck("free.after_tick", phys(0), value(0, 0, 0x705));      // now new
+
+  // ================================================================
+  // Phase 5b: a map rewrite is likewise frozen until the next tick
+  // ================================================================
+  wr_map(1, 1, 1, 0); do_tick();
+  ck("remap.baseline", phys(1), value(1, 0, 0x205));
+  wr_map(1, 1, 2, 1);                 // repoint phys1, NO tick
+  ck("remap.frozen_no_tick", phys(1), value(1, 0, 0x205));  // still old route
+  do_tick();
+  ck("remap.after_tick", phys(1), value(2, 1, 0x305));      // new route
+
+  // ================================================================
+  // Phase 6: tlast beat-realignment across back-to-back PDUs of different
+  //          channel counts (8 -> 3 odd -> 2) with tvalid never dropping.
+  //          If the tlast reset failed, the odd 3ch frame would drag chpos
+  //          into the following frames and corrupt the embedded ch field.
+  // ================================================================
+  drive_frame(1, 8, 0xA00, /*deassert=*/false);
+  drive_frame(3, 3, 0xB00, /*deassert=*/false);
+  drive_frame(0, 2, 0xC00, /*deassert=*/true);
+  wr_map(0, 1, 1, 7); wr_map(1, 1, 3, 0); wr_map(2, 1, 3, 1);
+  wr_map(3, 1, 3, 2); wr_map(4, 1, 0, 0); wr_map(5, 1, 0, 1);
+  for (int p = 6; p < 10; p++) wr_map(p, 0, 0, 0);
+  do_tick();
+  ck("b2b.s1c7", phys(0), value(1, 7, 0xA05));
+  ck("b2b.s3c0", phys(1), value(3, 0, 0xB05));
+  ck("b2b.s3c1", phys(2), value(3, 1, 0xB05));
+  ck("b2b.s3c2", phys(3), value(3, 2, 0xB05));
+  ck("b2b.s0c0", phys(4), value(0, 0, 0xC05));
+  ck("b2b.s0c1", phys(5), value(0, 1, 0xC05));
+
+  printf("%ld checks, %ld failures, RESULT: %s\n", checks, fails,
+         fails ? "FAIL" : "PASS");
+  delete dut;
+  return fails ? 1 : 0;
+}

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -57,6 +57,9 @@ SRCS = $(C)/ethernet_packet_pkg.sv $(C)/axi_stream_if.sv $(RTL_DIR)/ieee17221/ad
        $(RTL_DIR)/ieee1722/aaf/aaf_talker_i2s.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_aaf_capture_i2s.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_tdm_capture.sv \
+       $(RTL_DIR)/ieee1722/aaf/KL_tdm_render.sv \
+       $(RTL_DIR)/ieee1722/aaf/KL_chan_map_render.sv \
+       $(RTL_DIR)/ieee1722/aaf/KL_chan_map_capture.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_aaf_packetizer.sv \
        $(RTL_DIR)/ieee1722/aaf/KL_aaf_rx_depacketizer.sv \
        $(RTL_DIR)/ieee1722/avtp/avtp_subtype_pkg.sv \

--- a/tb/verilator/tdm_render/Makefile
+++ b/tb/verilator/tdm_render/Makefile
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# KL_tdm_render verification: TDM8 output serializer (item-4 audio front-end,
+# OUTPUT side). The TB drives bclk/fsync per the frame geometry, writes known
+# slot samples on clk_i, and de-serializes tdm_dout_o with a golden model that
+# samples exactly like KL_tdm_capture (rising edge, Philips-heritage delay-1) -
+# asserting bit-exact slots, frame alignment, double-buffer latching, pad-zero,
+# 24-bit sign preservation, a multi-frame run and stale-frame repeat.
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+C          = $(RTL_DIR)/common
+AAF        = $(RTL_DIR)/ieee1722/aaf
+TOP        = KL_tdm_render
+VFLAGS = --cc --exe --build -j 0 --top-module $(TOP) \
+         +incdir+$(C) +incdir+$(AAF) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
+         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-IMPORTSTAR -Wno-CASEINCOMPLETE \
+         -Wno-EOFNEWLINE -CFLAGS "-std=c++17 -O2"
+SRCS = $(C)/cdc_pair_fifo.sv $(AAF)/KL_tdm_render.sv
+.PHONY: all run clean
+all: run
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) sim_main.cpp -o VKL_tdm_render_sim
+	./obj_dir/VKL_tdm_render_sim
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/tdm_render/sim_main.cpp
+++ b/tb/verilator/tdm_render/sim_main.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Self-checking harness for KL_tdm_render — the TDM8 OUTPUT serializer (item-4
+// audio front-end family, output side; the symmetric twin of KL_tdm_capture).
+//
+// Strategy: the TB is the TDM bus MASTER. It drives bclk/fsync at the frame
+// geometry (SLOTS x SLOT_BITS bclk/frame, one-bclk fsync pulse at slot 0),
+// writes known per-slot samples on clk_i, then de-serializes tdm_dout_o with a
+// GOLDEN model that samples exactly like KL_tdm_capture — rising-edge sample,
+// edge-armed fsync, Philips-heritage DATA_DELAY_P=1 — and asserts the recovered
+// slots bit-exact. A render(delay-1) driving a capture(delay-1) is a
+// bit-transparent loopback, so the golden IS the acceptance oracle.
+//
+// Coverage: bit-exact slots (all 8), frame alignment after fsync, double-buffer
+// latching (new tick vs mid-frame stability), pad bits zero, 24-bit sign
+// preservation, a multi-frame run (9 data frames) and a stale/no-update frame
+// that must repeat the last sample (underrun), plus the clk_i status counters.
+#include "VKL_tdm_render.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <array>
+#include <deque>
+#include <vector>
+
+static const int SLOTS        = 8;
+static const int SLOT_BITS    = 32;
+static const int FRAME_PERIODS= SLOTS * SLOT_BITS;   // 256 bclk / frame
+static const int CPB          = 2;                   // clk_i cycles / bclk half
+
+static VKL_tdm_render* dut;
+static long checks = 0, fails = 0;
+static void ck(const char* t, long got, long exp) {
+  checks++;
+  if (got != exp) { fails++; printf("  [FAIL] %-46s got=%ld exp=%ld\n", t, got, exp); }
+  else            printf("  [ ok ] %-46s = %ld\n", t, got);
+}
+static void ckx(const char* t, unsigned long got, unsigned long exp) {
+  checks++;
+  if (got != exp) { fails++; printf("  [FAIL] %-46s got=0x%06lX exp=0x%06lX\n", t, got, exp); }
+  else            printf("  [ ok ] %-46s = 0x%06lX\n", t, got);
+}
+
+// ---------------------------------------------------------------------------
+// Golden de-serializer: a 1:1 model of KL_tdm_capture's rising-edge sampler
+// (edge-armed fsync, startp pipeline = DATA_DELAY_P=1, MSB-first, top-24-of-32
+// left-justified). last_word[] holds the full 32-bit slot words per frame.
+// ---------------------------------------------------------------------------
+static int      gv_fsync_q = 0, gv_armed = 0, gv_startp = 0, gv_run = 0;
+static int      gv_slot = 0, gv_bit = 0;
+static uint64_t gv_shift = 0;
+static uint32_t rec_word[SLOTS];
+static uint32_t last_word[SLOTS];
+static long     golden_frames = 0;
+static bool     golden_en = false;
+
+static void golden_reset() {
+  gv_fsync_q = gv_armed = gv_startp = gv_run = 0;
+  gv_slot = gv_bit = 0; gv_shift = 0; golden_frames = 0;
+  memset(rec_word, 0, sizeof(rec_word));
+  memset(last_word, 0, sizeof(last_word));
+}
+
+static void golden_rising(int f, int d) {
+  int start = (f && !gv_fsync_q && gv_armed) ? 1 : 0;
+  int sol   = gv_startp;                 // DATA_DELAY_P=1: previous edge's start
+  int eslot = sol ? 0 : gv_slot;
+  int ebit  = sol ? 0 : gv_bit;
+  if (gv_run || sol) {
+    gv_run   = 1;
+    gv_shift = (gv_shift << 1) | (uint64_t)(d & 1);
+    if (ebit == SLOT_BITS - 1) {
+      rec_word[eslot] = (uint32_t)(gv_shift & 0xFFFFFFFFULL);  // {sample,8'b0}
+      if (eslot == SLOTS - 1) {
+        memcpy(last_word, rec_word, sizeof(rec_word));
+        golden_frames++;
+      }
+      gv_bit  = 0;
+      gv_slot = (eslot == SLOTS - 1) ? 0 : eslot + 1;
+    } else {
+      gv_bit  = ebit + 1;
+      gv_slot = eslot;
+    }
+  }
+  gv_fsync_q = f;
+  if (!f) gv_armed = 1;
+  gv_startp = start;
+}
+
+// ---------------------------------------------------------------------------
+// Clock drivers. clk_i and tdm_bclk_i are toggled independently so the
+// gray-pointer cdc_pair_fifo crossing is exercised for real.
+// ---------------------------------------------------------------------------
+static void clk_tick() { dut->clk_i = 0; dut->eval(); dut->clk_i = 1; dut->eval(); }
+
+// one bclk period; the render drives data on the FALLING edge, so tdm_dout_o
+// sampled just after the RISING-edge eval is the bit for this period (exactly
+// how KL_tdm_capture reads it).
+static void bperiod(int fsync_level) {
+  dut->tdm_fsync_i = fsync_level;
+  dut->tdm_bclk_i = 1; dut->eval();
+  if (golden_en) golden_rising(fsync_level, dut->tdm_dout_o & 1);
+  for (int i = 0; i < CPB; i++) clk_tick();
+  dut->tdm_bclk_i = 0; dut->eval();
+  for (int i = 0; i < CPB; i++) clk_tick();
+}
+
+// slot-indexed writes then a one-cycle tick_i commit (bclk held static).
+static void write_frame(const uint32_t s[SLOTS]) {
+  for (int i = 0; i < SLOTS; i++) {
+    dut->smp_wr_slot_i = i; dut->smp_wr_data_i = s[i] & 0xFFFFFF;
+    dut->smp_wr_en_i = 1; clk_tick();
+  }
+  dut->smp_wr_en_i = 0; clk_tick();
+  dut->tick_i = 1; clk_tick(); dut->tick_i = 0; clk_tick();
+}
+
+// ---------------------------------------------------------------------------
+struct Entry { uint32_t s[SLOTS]; bool underrun; bool detailed; const char* name; };
+
+static uint32_t samp(int slot, int seq) {
+  uint32_t v = ((uint32_t)(seq * 8 + slot) * 2654435u) & 0x7FFFFFu;  // 23-bit spread
+  if ((slot ^ seq) & 1) v |= 0x800000u;                              // sign variety
+  return v & 0xFFFFFFu;
+}
+
+static std::deque<Entry> exq;
+
+static void check_frame(const Entry& e) {
+  bool all_ok = true, pad_ok = true;
+  for (int s = 0; s < SLOTS; s++) {
+    uint32_t rec = (last_word[s] >> 8) & 0xFFFFFF;
+    if (rec != (e.s[s] & 0xFFFFFF)) all_ok = false;
+    if ((last_word[s] & 0xFF) != 0)  pad_ok = false;
+  }
+  if (e.detailed) {
+    for (int s = 0; s < SLOTS; s++) {
+      char buf[80]; snprintf(buf, sizeof(buf), "%s slot%d bit-exact", e.name, s);
+      ckx(buf, (last_word[s] >> 8) & 0xFFFFFF, e.s[s] & 0xFFFFFF);
+    }
+    ck("EDGE: all pad bits zero (24-in-32)", pad_ok ? 1 : 0, 1);
+    ckx("EDGE: sign preserved slot0 0x800000", (last_word[0] >> 8) & 0xFFFFFF, 0x800000);
+    ckx("EDGE: sign preserved slot2 0xFFFFFF", (last_word[2] >> 8) & 0xFFFFFF, 0xFFFFFF);
+  } else {
+    char buf[80]; snprintf(buf, sizeof(buf), "%s: 8 slots bit-exact", e.name);
+    ck(buf, all_ok ? 1 : 0, 1);
+    snprintf(buf, sizeof(buf), "%s: pad bits zero", e.name);
+    ck(buf, pad_ok ? 1 : 0, 1);
+    if (e.underrun) {
+      ck("stale frame REPEATS last sample (bit-exact)", all_ok ? 1 : 0, 1);
+      ck("underruns_o incremented", dut->underruns_o, 1);
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new VKL_tdm_render;
+
+  dut->clk_i = 0; dut->rst_n = 0;
+  dut->smp_wr_en_i = 0; dut->smp_wr_slot_i = 0; dut->smp_wr_data_i = 0;
+  dut->tick_i = 0; dut->tdm_bclk_i = 0; dut->tdm_fsync_i = 0;
+  dut->eval();
+
+  printf("== KL_tdm_render harness (TDM8 out: %d slots x %d bclk, 48 kHz frame) ==\n",
+         SLOTS, SLOT_BITS);
+
+  // reset both domains (golden idle)
+  golden_en = false;
+  for (int i = 0; i < 8; i++) bperiod(0);
+  dut->rst_n = 1;
+  for (int i = 0; i < 4; i++) bperiod(0);
+  golden_reset(); golden_en = true;
+
+  // ---- build the frame program -------------------------------------------
+  std::vector<Entry> entries;
+  { Entry e{{0x800000,0x7FFFFF,0xFFFFFF,0x000001,0xABCDEF,0x123456,0x000000,0xA5A5A5},
+            false, true, "EDGE"}; entries.push_back(e); }
+  int seqs[] = {1, 2};                       // idx1, idx2
+  for (int q : seqs) { Entry e{}; for (int s = 0; s < SLOTS; s++) e.s[s] = samp(s, q);
+    e.underrun = false; e.detailed = false; e.name = (q == 1) ? "F1(mid-frame-stable)" : "F2";
+    entries.push_back(e); }
+  { Entry e = entries.back(); e.underrun = true; e.detailed = false; e.name = "UNDERRUN(=F2)";
+    entries.push_back(e); }                  // idx3: repeats F2 (its .s already = F2)
+  int seqs2[] = {4, 5, 6, 7, 8, 9};          // idx4..idx9  (multi-frame run)
+  for (int q : seqs2) { Entry e{}; for (int s = 0; s < SLOTS; s++) e.s[s] = samp(s, q);
+    e.underrun = false; e.detailed = false;
+    static char nm[6][8]; snprintf(nm[q-4], 8, "F%d", q); e.name = nm[q-4];
+    entries.push_back(e); }
+  { Entry e{}; for (int s = 0; s < SLOTS; s++) e.s[s] = 0x0F0F00u + s;
+    e.underrun = false; e.detailed = false; e.name = "SENTINEL"; entries.push_back(e); }
+  const int N = (int)entries.size();
+
+  // ---- preload entry 0, arm + cross into the bclk domain -----------------
+  write_frame(entries[0].s);
+  exq.push_back(entries[0]);
+  for (int i = 0; i < 12; i++) bperiod(0);          // fsync low: arm + prefetch
+
+  printf("\n[align] nothing serialized before the first fsync\n");
+  ck("no golden frame before fsync", golden_frames, 0);
+  ck("line idle (dout=0) before fsync", dut->tdm_dout_o & 1, 0);
+
+  printf("\n[run] fsync-aligned frames; golden recovers each after its boundary\n");
+  long prev_gf = 0;
+  int  calls = 0;
+  for (int i = 0; i < N; i++) {
+    for (int p = 0; p < FRAME_PERIODS; p++) {
+      bperiod(p == 0 ? 1 : 0);                       // one-bclk fsync at slot 0
+      if (p == 4 && i + 1 < N) {                     // commit the NEXT frame mid-frame
+        if (!entries[i + 1].underrun) write_frame(entries[i + 1].s);
+        exq.push_back(entries[i + 1]);               // (underrun: repeat, no commit)
+      }
+    }
+    calls++;
+    if (golden_frames > prev_gf) {                   // one frame completes per call
+      prev_gf = golden_frames;
+      Entry e = exq.front(); exq.pop_front();
+      check_frame(e);
+    }
+  }
+
+  printf("\n[status] clk_i-domain plain counters\n");
+  ck("frames_o == fsync frames issued", dut->frames_o, calls);
+  ck("underruns_o == 1 (single stale frame)", dut->underruns_o, 1);
+  ck("overruns_o == 0 (consumer kept up)", dut->overruns_o, 0);
+  ck("golden completed >= 9 frames", golden_frames >= 9 ? 1 : 0, 1);
+
+  printf("\n======================================================================\n");
+  printf("KL_tdm_render: %ld checks, %ld failures\n", checks, fails);
+  printf("RESULT: %s\n", fails ? "FAIL" : "PASS");
+  delete dut;
+  return fails ? 1 : 0;
+}

--- a/tests/features/item10_audio_maps.feature
+++ b/tests/features/item10_audio_maps.feature
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+@tsn_gen @item10 @cmd:AUDIO_MAPS @matrix:M-AECP-4
+Feature: Item-10 dynamic audio maps + chmap64 AEM->fabric binding contract
+  IEEE 1722.1-2021 GET_AUDIO_MAP (cmd 43 / 0x2B), ADD_AUDIO_MAPPINGS (44 /
+  0x2C) and REMOVE_AUDIO_MAPPINGS (45 / 0x2D) on the dynamic STREAM_PORT_INPUT[0]
+  (Milan es-4.16 / 5.4.2.26-28). Command codes are the RTL/spec values verified
+  against hdl/ieee17221/aecp/aecp_pkg.sv. Frames are tsn_gen-generated and
+  decode-cross-checked; the Milan audio-map model mirrors the `AEM_DYNMAP path
+  of KL_aecp_response_builder (KEYS=8, NMAPS=2, PAGE=4 - the RTL itself is
+  verified by tb/verilator/aecp).
+
+  Each accepted mapping projects to a chmap64 render map word
+  {en, stream[2:0], ch[2:0]} at the cluster-offset (physical-channel) address,
+  each removal disables it - the executable chmap64 binding contract
+  (docs/CHMAP64_AEM_BINDING.md).
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan audio-map model
+
+  # (a) getter, well-formed on the default (empty) dynamic map
+  @class:getter
+  Scenario: GET_AUDIO_MAP on the default input map is well-formed and empty
+    Given tsn_gen generated a GET_AUDIO_MAP frame with seed 3
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 43
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "map_index" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the last GET lists 0 mappings
+    And the fabric render crossbar has 0 enabled words
+
+  # (b) action + getter round-trip: ADD then GET reflects the added mapping
+  @class:action @paired
+  Scenario: ADD_AUDIO_MAPPINGS then GET_AUDIO_MAP reflects the added mapping
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 5
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 44
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 0
+    And I patch field "mapping_stream_channel" to 3
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 is en 1 stream 0 ch 3
+    And the fabric map word at cluster_offset 0 equals 0x43
+    And the fabric render crossbar has 1 enabled words
+    Given tsn_gen generated a GET_AUDIO_MAP frame with seed 6
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 43
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "map_index" to 0
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the last GET lists 1 mappings
+    And the last GET contains stream_channel 3 at cluster_offset 0
+
+  # (c) action + getter round-trip: REMOVE then GET reflects the removal
+  @class:action @paired
+  Scenario: REMOVE_AUDIO_MAPPINGS then GET_AUDIO_MAP reflects the removal
+    When I ADD mapping stream_channel 3 at cluster_offset 0
+    Then the audio-map model responds status 0
+    And the fabric render crossbar has 1 enabled words
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 7
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 45
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 0
+    And I patch field "mapping_stream_channel" to 3
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 is en 0 stream 0 ch 0
+    And the fabric render crossbar has 0 enabled words
+    When the audio-map model GETs input page 0
+    Then the audio-map model responds status 0
+    And the last GET lists 0 mappings
+
+  # (d) negatives - the codes the RTL actually returns (BAD_ARGUMENTS = 7)
+  @class:action @negative
+  Scenario: ADD with an out-of-range stream_index is refused, nothing projected
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 9
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 44
+    And I patch field "descriptor_type" to 0x0E
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 5
+    And I patch field "mapping_stream_channel" to 1
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    Then tsn_gen decodes every patched field back
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 7
+    And the fabric render crossbar has 0 enabled words
+
+  @class:action @negative
+  Scenario: ADD with a duplicate cluster key in one command is refused (all-or-nothing)
+    When I ADD a same-key mapping pair at cluster_offset 2 with stream_channels 1 and 2
+    Then the audio-map model responds status 7
+    And the fabric render crossbar has 0 enabled words
+
+  @class:action @negative
+  Scenario: ADD on the static STREAM_PORT_OUTPUT map is NOT_SUPPORTED
+    Given tsn_gen generated a AUDIO_MAPPINGS frame with seed 11
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 44
+    And I patch field "descriptor_type" to 0x0F
+    And I patch field "descriptor_index" to 0
+    And I patch field "number_of_mappings" to 1
+    And I patch field "mapping_stream_index" to 0
+    And I patch field "mapping_stream_channel" to 0
+    And I patch field "mapping_cluster_offset" to 0
+    And I patch field "mapping_cluster_channel" to 0
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 11
+
+  @class:getter @negative
+  Scenario: GET_AUDIO_MAP on an unknown descriptor is refused
+    Given tsn_gen generated a GET_AUDIO_MAP frame with seed 13
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 43
+    And I patch field "descriptor_type" to 0x05
+    And I patch field "descriptor_index" to 0
+    And I patch field "map_index" to 0
+    When the audio-map model processes the frame
+    Then the audio-map model responds status 2
+
+  @class:getter @negative
+  Scenario: GET_AUDIO_MAP with an out-of-range map_index is BAD_ARGUMENTS
+    When the audio-map model GETs input page 2
+    Then the audio-map model responds status 7
+
+  # (e) the chmap64 binding contract: the crossbar tracks accepted mappings
+  @class:action @fabric
+  Scenario: the render crossbar projects, replaces and clears map words
+    When I ADD mapping stream_channel 1 at cluster_offset 0
+    And I ADD mapping stream_channel 2 at cluster_offset 1
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 equals 0x41
+    And the fabric map word at cluster_offset 1 equals 0x42
+    And the fabric render crossbar has 2 enabled words
+    When I ADD mapping stream_channel 4 at cluster_offset 1
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 1 is en 1 stream 0 ch 4
+    And the fabric render crossbar has 2 enabled words
+    When I REMOVE mapping stream_channel 1 at cluster_offset 0
+    Then the audio-map model responds status 0
+    And the fabric map word at cluster_offset 0 is en 0 stream 0 ch 0
+    And the fabric map word at cluster_offset 1 equals 0x44
+    And the fabric render crossbar has 1 enabled words

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -116,6 +116,30 @@ LAYOUTS = {
                    ('u', 1), ('command_type', 15), ('reserved', 16),
                    ('configuration_index', 16)],
     },
+    'GET_AUDIO_MAP': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_get_audio_map::AECP_GET_AUDIO_MAP::'
+                      'AECP_GET_AUDIO_MAP_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('map_index', 16),
+                   ('reserved', 16)],
+    },
+    'AUDIO_MAPPINGS': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_audio_mappings::AECP_AUDIO_MAPPINGS::'
+                      'AECP_AUDIO_MAPPINGS_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('number_of_mappings', 16),
+                   ('reserved', 16), ('mapping_stream_index', 16),
+                   ('mapping_stream_channel', 16), ('mapping_cluster_offset', 16),
+                   ('mapping_cluster_channel', 16)],
+    },
     'ACMP': {
         'yaml_dir': '{repo}/tests/protocols/acmp',
         'interface': 'milan_acmp::MILAN_ACMP::MILAN_ACMP_IF',
@@ -501,6 +525,143 @@ class MilanAecpModel:
 
 
 # ---------------------------------------------------------------------------
+# Milan v1.2 dynamic audio-map model + chmap64 fabric projection
+# (mirrors KL_aecp_response_builder under `AEM_DYNMAP, and encodes the
+# AEM->fabric binding contract documented in docs/CHMAP64_AEM_BINDING.md).
+#
+# Command codes are the RTL/spec values from hdl/ieee17221/aecp/aecp_pkg.sv:
+#   GET_AUDIO_MAP        = 43 (0x2B)   §7.4.44
+#   ADD_AUDIO_MAPPINGS   = 44 (0x2C)   §7.4.45 / Milan 5.4.2.27
+#   REMOVE_AUDIO_MAPPINGS= 45 (0x2D)   §7.4.46 / Milan 5.4.2.28
+# ---------------------------------------------------------------------------
+
+CMD_GET_AUDIO_MAP = 43
+CMD_ADD_AUDIO_MAPPINGS = 44
+CMD_REMOVE_AUDIO_MAPPINGS = 45
+DESC_STREAM_PORT_INPUT = 0x0E
+DESC_STREAM_PORT_OUTPUT = 0x0F
+STATUS_NOT_SUPPORTED = 11
+
+
+class MilanAudioMapModel:
+    """Dynamic audio-map responder for STREAM_PORT_INPUT[0], mirroring the
+    `AEM_DYNMAP path of KL_aecp_response_builder (defaults KEYS=8, NMAPS=2,
+    PAGE=4 from avdecc/gen_aem_store.py; the RTL is verified by tb/aecp).
+
+    Milan 5.4.2.26 mono clusters: the store key IS the mapping_cluster_offset
+    (at most one dynamic mapping per Audio-Cluster channel). A mapping record
+    is (stream_index, stream_channel, cluster_offset, cluster_channel).
+
+      * ADD is all-or-nothing (5.4.2.27): any invalid record -> BAD_ARGUMENTS
+        and NOTHING is written; a repeated key within one command is the
+        mandated same-cluster-channel conflict -> BAD_ARGUMENTS.
+      * REMOVE is lenient (5.4.2.28): clears exact matches, ignores the rest,
+        always SUCCESS on the input port.
+
+    Each accepted record projects to a chmap64 render map word
+    {en, stream[2:0], ch[2:0]} at the cluster-offset (physical-channel)
+    address; each cleared record disables that word. That projection IS the
+    executable chmap64 binding contract (docs/CHMAP64_AEM_BINDING.md)."""
+
+    def __init__(self, keys=8, nmaps=2, page=4, stream_channels=8):
+        self.keys = keys              # AEM_DMAP_KEYS_C: render output channels
+        self.nmaps = nmaps            # AEM_DMAP_NMAPS_C: GET_AUDIO_MAP pages
+        self.page = page              # AEM_DMAP_PAGE_C: mappings per page
+        self.stream_channels = stream_channels  # channels in STREAM_INPUT[0]
+        self.store = {}               # cluster_offset -> stream_channel
+        self.fabric_map = {}          # cluster_offset -> {en,stream,ch} word
+        self.last_get = None          # rows returned by the last GET page
+
+    # -- validity (5.4.2.27) ------------------------------------------------
+    def _shape_ok(self, si, sc, co, cc):
+        # single audio-carrying input (stream_index 0), mono cluster
+        # (cluster_channel 0), cluster key in range
+        return si == 0 and cc == 0 and co < self.keys
+
+    def _ch_ok(self, sc):
+        # stream_channel inside the current STREAM_INPUT[0] format
+        return sc < self.stream_channels
+
+    # -- fabric projection --------------------------------------------------
+    def _project_add(self, si, sc, co):
+        self.fabric_map[co] = {'en': 1, 'stream': si, 'ch': sc}
+
+    def _project_remove(self, co):
+        self.fabric_map[co] = {'en': 0, 'stream': 0, 'ch': 0}
+
+    def word(self, co):
+        """The 7-bit chmap64 map word {en[6], stream[5:3], ch[2:0]}."""
+        m = self.fabric_map.get(co, {'en': 0, 'stream': 0, 'ch': 0})
+        return ((m['en'] & 1) << 6) | ((m['stream'] & 0x7) << 3) | (m['ch'] & 0x7)
+
+    def enabled_words(self):
+        return sum(1 for m in self.fabric_map.values() if m['en'])
+
+    # -- command processing -------------------------------------------------
+    def process_mappings(self, cmd, dt, di, mappings):
+        if dt == DESC_STREAM_PORT_OUTPUT and di == 0:
+            return STATUS_NOT_SUPPORTED          # static output maps
+        if dt != DESC_STREAM_PORT_INPUT or di != 0:
+            return STATUS_NO_SUCH_DESCRIPTOR
+        if len(mappings) > 60:                   # one-AECPDU engine bound
+            return STATUS_BAD_ARGUMENTS
+        if not mappings:
+            return STATUS_SUCCESS                # empty edit, no change
+
+        if cmd == CMD_ADD_AUDIO_MAPPINGS:
+            claim = set()                        # intra-command same-key guard
+            for si, sc, co, cc in mappings:      # validate pass
+                if (not self._shape_ok(si, sc, co, cc)
+                        or not self._ch_ok(sc) or co in claim):
+                    return STATUS_BAD_ARGUMENTS  # all-or-nothing
+                claim.add(co)
+            for si, sc, co, cc in mappings:      # commit pass (replace allowed)
+                self.store[co] = sc
+                self._project_add(si, sc, co)
+            return STATUS_SUCCESS
+
+        # REMOVE — lenient single commit pass
+        for si, sc, co, cc in mappings:
+            if (self._shape_ok(si, sc, co, cc) and sc < 16
+                    and self.store.get(co) == sc):
+                del self.store[co]
+                self._project_remove(co)
+        return STATUS_SUCCESS
+
+    def process_get(self, dt, di, map_index):
+        if dt == DESC_STREAM_PORT_OUTPUT and di == 0:
+            self.last_get = None                 # static output map, well-formed
+            return STATUS_SUCCESS
+        if dt != DESC_STREAM_PORT_INPUT or di != 0:
+            self.last_get = None
+            return STATUS_NO_SUCH_DESCRIPTOR
+        if map_index >= self.nmaps:              # 7.4.44.1 paging
+            self.last_get = None
+            return STATUS_BAD_ARGUMENTS
+        lo = map_index * self.page
+        self.last_get = [(0, self.store[k], k, 0)
+                         for k in range(lo, lo + self.page) if k in self.store]
+        return STATUS_SUCCESS
+
+    def process(self, fields):
+        """Drive the model from a decoded tsn_gen frame (one mapping/frame,
+        matching the aecp_aem_audio_mappings.yaml single-mapping layout)."""
+        cmd = fields['command_type']
+        dt = fields.get('descriptor_type', 0)
+        di = fields.get('descriptor_index', 0)
+        if cmd == CMD_GET_AUDIO_MAP:
+            return self.process_get(dt, di, fields.get('map_index', 0))
+        if cmd in (CMD_ADD_AUDIO_MAPPINGS, CMD_REMOVE_AUDIO_MAPPINGS):
+            n = fields.get('number_of_mappings', 1)
+            rec = (fields.get('mapping_stream_index', 0),
+                   fields.get('mapping_stream_channel', 0),
+                   fields.get('mapping_cluster_offset', 0),
+                   fields.get('mapping_cluster_channel', 0))
+            return self.process_mappings(cmd, dt, di, [rec] if n else [])
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Milan v1.2 ACMP LISTENER model — mirrors KL_acmp_listener (states, response
 # field rules; timer/ADP events surface as explicit steps).
 # ---------------------------------------------------------------------------
@@ -819,6 +980,85 @@ def step_model_milan_features(context, v):
 def step_model_milan_cert(context, v):
     assert context.aecp_model.milan_cert_version == v, \
         f'certification_version={context.aecp_model.milan_cert_version}, expected {v}'
+
+
+# ---------------------------------------------------------------------------
+# Steps — Milan dynamic audio maps + chmap64 fabric projection
+# ---------------------------------------------------------------------------
+
+@given('a fresh Milan audio-map model')
+def step_fresh_audiomap(context):
+    context.amap = MilanAudioMapModel()
+
+
+@when('the audio-map model processes the frame')
+def step_audiomap_process(context):
+    context.amap_status = context.amap.process(context.frame_fields)
+
+
+@when('I ADD mapping stream_channel {sc:d} at cluster_offset {co:d}')
+def step_amap_add(context, sc, co):
+    context.amap_status = context.amap.process_mappings(
+        CMD_ADD_AUDIO_MAPPINGS, DESC_STREAM_PORT_INPUT, 0, [(0, sc, co, 0)])
+
+
+@when('I REMOVE mapping stream_channel {sc:d} at cluster_offset {co:d}')
+def step_amap_remove(context, sc, co):
+    context.amap_status = context.amap.process_mappings(
+        CMD_REMOVE_AUDIO_MAPPINGS, DESC_STREAM_PORT_INPUT, 0, [(0, sc, co, 0)])
+
+
+@when('I ADD a same-key mapping pair at cluster_offset {co:d} with stream_channels {a:d} and {b:d}')
+def step_amap_add_dup(context, co, a, b):
+    context.amap_status = context.amap.process_mappings(
+        CMD_ADD_AUDIO_MAPPINGS, DESC_STREAM_PORT_INPUT, 0,
+        [(0, a, co, 0), (0, b, co, 0)])
+
+
+@when('the audio-map model GETs input page {mi:d}')
+def step_amap_get(context, mi):
+    context.amap_status = context.amap.process_get(
+        DESC_STREAM_PORT_INPUT, 0, mi)
+
+
+@then('the audio-map model responds status {code:d}')
+def step_amap_status(context, code):
+    assert context.amap_status == code, \
+        f'audio-map status {context.amap_status}, expected {code}'
+
+
+@then('the fabric map word at cluster_offset {co:d} is en {en:d} stream {s:d} ch {ch:d}')
+def step_fabric_word_fields(context, co, en, s, ch):
+    m = context.amap.fabric_map.get(co, {'en': 0, 'stream': 0, 'ch': 0})
+    assert (m['en'], m['stream'], m['ch']) == (en, s, ch), \
+        f'cluster_offset {co}: fabric word {m}, expected en={en} stream={s} ch={ch}'
+
+
+@then('the fabric map word at cluster_offset {co:d} equals {val}')
+def step_fabric_word_value(context, co, val):
+    v = int(val, 0)
+    assert context.amap.word(co) == v, \
+        f'cluster_offset {co}: word {context.amap.word(co):#04x}, expected {v:#04x}'
+
+
+@then('the fabric render crossbar has {n:d} enabled words')
+def step_fabric_enabled(context, n):
+    assert context.amap.enabled_words() == n, \
+        f'{context.amap.enabled_words()} enabled words, expected {n}'
+
+
+@then('the last GET lists {n:d} mappings')
+def step_get_count(context, n):
+    assert context.amap.last_get is not None, 'no GET page captured'
+    assert len(context.amap.last_get) == n, \
+        f'GET page has {len(context.amap.last_get)} mappings, expected {n}'
+
+
+@then('the last GET contains stream_channel {sc:d} at cluster_offset {co:d}')
+def step_get_contains(context, sc, co):
+    assert context.amap.last_get is not None, 'no GET page captured'
+    assert (0, sc, co, 0) in context.amap.last_get, \
+        f'(sc={sc}, co={co}) not in GET page {context.amap.last_get}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Status
🟡 **Composed + elaborates** — the 5 chmap64 lanes merge cleanly (no conflicts) and the full SoC still elaborates at `--num-streams 8`. Datapath wiring of the two crossbars is the scoped next step (below).

## Description
Integration-tracking branch merging the five verified lanes:
- #26 `KL_chan_map_render` (58/0) · #29 `KL_chan_map_capture` + `pair_slot[4:0]` (43/0, aaf byte-exact + milan_dp 172/0) · #30 `KL_tdm_render` (37/0) · #28 audio-maps behave (9/9) · #27 architecture doc.

**Datapath wiring plan (verified insertion points in `hdl/milan/milan_datapath.sv`):**
- **Capture mux** inserts at the front-end→packetizer wire (~L255): `KL_chan_map_capture` sits between the I2S/TDM front-end + tone + ring sources and `aaf_packetizer`; reset map reproduces today's wiring.
- **Render xbar** taps the depacketizer AXIS (`dpkt_pcm_*`, ~L1672) in parallel with the existing `KL_pcm_route` render tap, feeding `KL_tdm_render` (TDM8-out) + a mapped I2S-out option. The CERT-proven `KL_pcm_route`→LPF→`i2s_playback` chain stays the default (no regression).
- **CSR 0x900 window** needs a dedicated write arm + `rd_in_window` term (NOT the shadow path) per #27's decode finding.
- **AEM binding**: the audio-map engine's ADD/REMOVE writes drive the shared map RAM; CSR = debug override.

## How to get into the same state
```bash
git checkout chmap-integrate   # = main + merge of the 5 lane branches
```

## How to validate
```bash
make -C tb/verilator/chmap_render   # 58/0
make -C tb/verilator/chmap_capture  # 43/0
make -C tb/verilator/tdm_render     # 37/0
make -C tb/verilator/aaf            # regression byte-exact
cd sw/litex && python3 milan_soc.py --full --milan-clk-freq 50e6 --num-streams 8 --output-dir /tmp/e8   # elaborates
```

## Definition of Done
- [x] 5 lanes compose without conflict
- [x] all module TBs green together + aaf regression byte-exact
- [x] 8×8 SoC still elaborates with the lanes present
- [ ] two crossbars wired into milan_datapath (CERT-path-safe, elaboration+sim gated) — next
- [ ] CSR 0x900 arm + AEM map-write wired
- [ ] 8×8 silicon build (bench-gated)