### PR TITLE
item-11: KL_lat_history_ring - DDR3 latency time-series ring (TB 84/84)

### DIFF
--- a/docs/LATENCY_HISTORY_RING.md
+++ b/docs/LATENCY_HISTORY_RING.md
@@ -1,0 +1,171 @@
+<!--
+SPDX-FileCopyrightText: 2026 Kebag Logic
+SPDX-License-Identifier: CERN-OHL-W-2.0
+-->
+
+# AAF latency history ring (`KL_lat_history_ring`)
+
+Roadmap item 11, DDR3 arm. Per-stage AAF pipeline latency, captured as a
+**time-series** in a wrapping DRAM ring the CPU / userspace reads back.
+
+## Why a ring (vs the CSR snapshot)
+
+`KL_aaf_latency_taps` (PR #17, CSR base `0x870`) measures per-stage inter-stage
+deltas and exposes only the **latest** `min / last / max` over CSR — an
+instantaneous snapshot. That answers "what is the latency now" but not "how did
+it move over the last N frames": you cannot build a jitter histogram, a tail
+(p99) latency, or catch a transient burst from a single-value register.
+
+`KL_lat_history_ring` turns **each** latency sample into a fixed 16-byte record
+and streams it into a DRAM ring (the same ring pattern as the PCM audio ring).
+Userspace mmaps the ring, chases the write pointer, and parses the records — a
+full history, post-processed offline.
+
+## Record format (16 bytes, little-endian in DRAM)
+
+`RECORD_BYTES_P = 16`. Bytes are laid out for a packed little-endian struct
+(the byte order a RISC-V LE reader gets straight from `mmap`):
+
+| offset | size | field        | meaning                                             |
+|--------|------|--------------|-----------------------------------------------------|
+| `0`    | `u64`| `ptp_ns`     | gPTP nanosecond timestamp at the sample             |
+| `8`    | `u32`| `latency_ns` | measured stage latency (ns, or datapath cycles)     |
+| `12`   | `u8` | `stage_id`   | documented tap point (see below)                    |
+| `13`   | `u8` | `stream_idx` | AAF stream index (NxN)                               |
+| `14`   | `u16`| `flags`      | `{gap[15], rsvd[14:12], seq[11:0]}`                  |
+
+- `seq` — rolling per-accepted-record counter (mod 4096). Userspace detects
+  **lost or reordered** records by a gap in `seq`.
+- `gap` (bit 15) — set on the **first** record written after one or more samples
+  were dropped (writer stalled, or ring full in stop mode). A self-describing
+  hole marker: a `1` here means "records are missing just before me".
+
+```c
+struct lat_rec {          /* 16 bytes, __attribute__((packed)) */
+    uint64_t ptp_ns;
+    uint32_t latency_ns;
+    uint8_t  stage_id;
+    uint8_t  stream_idx;
+    uint16_t flags;       /* bit15 = gap, bits[11:0] = seq */
+};
+```
+
+On the 64-bit downstream bus a record is **two beats**:
+
+- beat 0 (lowest address) = `ptp_ns[63:0]`
+- beat 1 = `{flags[15:0], stream_idx[7:0], stage_id[7:0], latency_ns[31:0]}`
+  (latency in the low 32 bits)
+
+## Ring CSR ABI (reused verbatim from the PCM ring)
+
+The ring-writer control block mirrors the PCM ring (`_PCMRingNxN` /
+`milan_dma_pcm`, LiteX bank `0xf0003120`) **field-for-field**, so the userspace
+mmap+chase recipe is identical to `pw-milan-ring-source`:
+
+| offset | name        | dir | module port  | meaning                                        |
+|--------|-------------|-----|--------------|------------------------------------------------|
+| `0x00` | `BASE_HI`   | RW  | `ring_base_i[63:32]` | ring base address, high word            |
+| `0x04` | `BASE_LO`   | RW  | `ring_base_i[31:0]`  | ring base address, low word (bytes)     |
+| `0x08` | `LENGTH`    | RW  | `ring_len_i`         | ring size in bytes (multiple of 16)     |
+| `0x0C` | `ENABLE`    | RW  | `enable_i`           | 1 = run; 0 = clear write pointer + drop |
+| `0x14` | `LOOP`      | RW  | `loop_i`             | 1 = wrap+overwrite; 0 = stop when full  |
+| `0x18` | `OFFSET`    | RO  | `wptr_o`             | byte write pointer (userspace chase)    |
+
+Plus one history-ring extension (own address, PCM-ABI untouched):
+
+| offset | name        | dir | module port  | meaning                                        |
+|--------|-------------|-----|--------------|------------------------------------------------|
+| `0x1C` | `DROPPED`   | RO  | `dropped_o`  | records dropped (writer stalled / ring full)   |
+
+`ENABLE=0` clears `OFFSET` to 0 and drops incoming samples (matches the PCM
+ring's disable). `LOOP=1` is the normal history mode (newest overwrites oldest);
+`LOOP=0` is a one-shot capture that stops when the ring fills and counts the
+overflow in `DROPPED`.
+
+The downstream write-request master (`wr_valid_o / wr_data_o / wr_addr_o /
+wr_last_o / wr_ready_i`) is the same shape as the PCM ring's
+`WishboneDMAWriter` sink, so the existing `milan_dma` DRAM writer carries it
+unchanged (`writer.sink.data = wr_data_o`, `writer.sink.address =
+wr_addr_o >> 3` for the 64-bit bus, `writer.sink.valid/ready` = the handshake).
+`wr_addr_o` is a **byte** address = `ring_base_i + wptr + beat*8`.
+
+## Documented tap points (`stage_id`)
+
+The sample bus is fed by an adapter off `KL_aaf_latency_taps`: each completed
+inter-stage delta becomes one record (`latency_ns` = delta × ns/cycle,
+`stream_idx` = the AAF stream, `ptp_ns` = the chain epoch). The two chains and
+their documented pipeline points:
+
+| `stage_id` | chain | tap point                                             |
+|------------|-------|-------------------------------------------------------|
+| `0x00`     | TX    | `CAP`     — ring / I2S capture pair in                 |
+| `0x01`     | TX    | `PKT_SOF` — packetizer first beat                      |
+| `0x02`     | TX    | `PKT_EOF` — packetizer last beat                       |
+| `0x03`     | TX    | `MAC_TX`  — frame egresses the MAC boundary            |
+| `0x10`     | RX    | `MAC_RX`  — frame ingress                              |
+| `0x11`     | RX    | `ACCEPT`  — AVTP monitor parse-complete / accept pulse |
+| `0x12`     | RX    | `DEPKT`   — payload last beat                          |
+| `0x13`     | RX    | `PCM_RING`— payload accepted at the ring writer        |
+
+`stage_id` for a record is the **destination** stage of the delta (so a record
+with `stage_id = 0x01` carries the `CAP -> PKT_SOF` latency, etc.).
+
+### Input contract
+
+`KL_lat_history_ring` takes a **fresh, clean** per-sample bus rather than PR
+#17's CSR delta outputs (the taps module publishes aggregate min/last/max, not
+a per-sample stream). The adapter that maps taps → samples is trivial and
+independent, keeping this module reusable by any latency producer:
+
+```
+sample_valid_i   1-cycle pulse: one completed latency sample
+sample_lat_ns_i  [31:0]  the measured latency
+sample_stage_i   [7:0]   stage_id from the table above
+sample_stream_i  [7:0]   AAF stream index
+ptp_ns_i         [63:0]  gPTP ns at the sample
+```
+
+The producer is **never** back-pressured: a sample offered while the previous
+record is still draining to DRAM (or while the ring is full in stop mode) is
+dropped and counted in `DROPPED`. `wr_ready_i` gates the emitter only.
+
+## Userspace read recipe (`pw-milan-ring-source` style)
+
+```c
+// 1. program the ring (record-aligned base + length), enable loop mode
+poke(BASE_HI, ring_phys >> 32);  poke(BASE_LO, ring_phys & 0xffffffff);
+poke(LENGTH,  RING_BYTES);       // multiple of 16
+poke(LOOP,    1);
+poke(ENABLE,  1);
+
+// 2. mmap the ring region (uncached / coherent) and chase the write pointer
+volatile uint8_t *ring = mmap(NULL, RING_BYTES, PROT_READ, MAP_SHARED,
+                              devmem, ring_phys);
+uint32_t rd = 0;                          // our read pointer (bytes)
+for (;;) {
+    uint32_t wr = peek(OFFSET);           // HW write pointer (bytes)
+    while (rd != wr) {
+        struct lat_rec *r = (struct lat_rec *)(ring + rd);
+        // ... consume r->ptp_ns, r->latency_ns, r->stage_id, ...
+        if (r->flags & 0x8000) note_gap();          // records missing before here
+        rd = (rd + 16) % RING_BYTES;
+    }
+    poll_dropped(peek(DROPPED));           // ring-full / stall telemetry
+}
+```
+
+Because `LOOP=1` overwrites oldest-first, a slow reader that falls more than
+`RING_BYTES/16` records behind will read overwritten slots; `seq`
+discontinuities and the `DROPPED` counter both flag that. Size the ring for the
+worst-case reader latency (e.g. 64 KiB = 4096 records ≈ tens of ms of AAF
+history at the class-A frame rate).
+
+## Verification
+
+`tb/verilator/lat_history_ring/` — the TB plays the DRAM writer, snoops every
+write beat, reconstructs each record and checks: field byte-exactness, LE record
+layout, beat addressing, record base = write pointer, rolling `seq`, `wptr`
+advance (+16/record), loop wrap to base, stop-mode full, drop-on-full (stalled
+writer + ring full) with the `DROPPED` counter, the `gap` marker, and timestamp
+monotonicity. `make -C tb/verilator/lat_history_ring run` → **84 checks, 0
+failures, RESULT: PASS**.

--- a/hdl/ieee1722/aaf/KL_lat_history_ring.sv
+++ b/hdl/ieee1722/aaf/KL_lat_history_ring.sv
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ *
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+
+//---------------------------------------------------------------------------//
+/*
+------------------------------------------------------------------------------
+  File        : KL_lat_history_ring.sv
+  Description : Per-stage AAF latency HISTORY ring (roadmap item 11, DDR3 arm).
+
+                KL_aaf_latency_taps (PR #17, CSR base 0x870) exposes only the
+                LATEST min/last/max inter-stage deltas over CSR - a snapshot.
+                This module turns each individual latency sample into a
+                fixed-size RECORD and streams it into a wrapping DRAM ring, so
+                userspace gets a TIME-SERIES it can post-process (jitter
+                histograms, tail latency, per-frame envelopes) rather than one
+                instantaneous value.
+
+                The ring-writer CSR ABI is mirrored bit-for-bit from the PCM
+                ring (_PCMRingNxN / milan_dma_pcm, LiteX bank 0xf0003120:
+                BASE_HI/BASE_LO/LENGTH/ENABLE/LOOP/OFFSET) so the userspace
+                mmap+chase recipe (pw-milan-ring-source style: program base +
+                length + enable, then chase the OFFSET write pointer and parse
+                fixed records) is reused unchanged. See
+                docs/LATENCY_HISTORY_RING.md.
+
+                RECORD (RECORD_BYTES_P = 16 bytes, LITTLE-ENDIAN in DRAM):
+                  bytes  0..7  : ptp_ns     (uint64) gPTP ns at the sample
+                  bytes  8..11 : latency_ns (uint32) measured stage latency
+                  byte  12     : stage_id   (uint8)  documented tap point
+                  byte  13     : stream_idx (uint8)  AAF stream index
+                  bytes 14..15 : flags      (uint16) {gap[15],rsvd[14:12],seq[11:0]}
+                where seq is a per-accepted-record rolling counter (userspace
+                detects lost/reordered records) and gap = the first record
+                after one or more samples were dropped (writer stalled / ring
+                full in stop mode) - a self-describing hole marker.
+
+                At DATA_W = 64 a record is two beats: beat 0 = ptp_ns, beat 1 =
+                {flags, stream_idx, stage_id, latency_ns} (latency in the low
+                32 bits). Each beat is emitted to a simple write-request master
+                (wr_valid/wr_data/wr_addr/wr_last/wr_ready) that the existing
+                milan_dma DRAM writer carries - the SAME downstream shape as
+                the PCM ring's WishboneDMAWriter sink.
+
+                NON-STALLABLE datapath rule (mf52 lesson, KL_pcm_ring_bram):
+                the latency-sample producer is a fire-and-forget pulse and is
+                NEVER back-pressured. If a sample arrives while the previous
+                record is still draining to DRAM (wr_ready low) - or, in
+                stop-mode (loop=0), after the ring is full - the sample is
+                DROPPED and `dropped_o` bumps; the write master's ready gates
+                only the emitter, never the producer.
+
+                INPUT CONTRACT is a FRESH clean per-sample bus (the taps module
+                publishes deltas, not a sample stream); a thin adapter maps each
+                completed taps inter-stage delta -> one sample here (stage_id =
+                the stage index, latency_ns = delta * ns/cycle, stream_idx =
+                the AAF stream, ptp_ns = the chain epoch). Documented in
+                docs/LATENCY_HISTORY_RING.md.
+
+  Spec refs   : docs/LATENCY_HISTORY_RING.md (record + ABI + read recipe);
+                hdl/ieee1722/aaf/KL_pcm_ring_bram.sv (ring pattern);
+                _PCMRingNxN / milan_dma_pcm (CSR ABI mirrored)
+  House style : mirrors hdl/ieee1722/aaf/KL_pcm_ring_bram.sv.
+  Company     : Kebag Logic
+  Project     : Milan AVB endstation
+------------------------------------------------------------------------------
+*/
+//---------------------------------------------------------------------------//
+
+`default_nettype none
+
+module KL_lat_history_ring #(
+  parameter int unsigned DATA_W         = 64,   //! downstream bus/word width (bits)
+  parameter int unsigned RECORD_BYTES_P = 16,   //! bytes per latency record
+  parameter int unsigned ADDR_W         = 32    //! byte-address width toward the DRAM writer
+) (
+  input  wire                   clk_i,          //! datapath clock
+  input  wire                   rst_n,          //! sync reset, active low
+
+  //! --- latency sample bus (fire-and-forget; taps adapter feeds it) --------
+  input  wire                   sample_valid_i, //! 1-cycle pulse: one completed sample
+  input  wire  [31:0]           sample_lat_ns_i,//! measured stage latency (ns or cycles)
+  input  wire  [7:0]            sample_stage_i, //! documented tap-point id
+  input  wire  [7:0]            sample_stream_i,//! AAF stream index
+  input  wire  [63:0]           ptp_ns_i,       //! gPTP ns timestamp at the sample
+
+  //! --- CSR config (mirrors the PCM ring ABI; wired in the migen glue) -----
+  input  wire  [63:0]           ring_base_i,    //! BASE_HI:BASE_LO ring base (bytes)
+  input  wire  [31:0]           ring_len_i,     //! LENGTH: ring size (bytes, multiple of RECORD_BYTES_P)
+  input  wire                   enable_i,       //! ENABLE: 0 = clear wptr + drop
+  input  wire                   loop_i,         //! LOOP: 1 = wrap+overwrite, 0 = stop when full
+  output wire  [31:0]           wptr_o,         //! OFFSET readback: byte write pointer (userspace chase)
+  output wire  [31:0]           dropped_o,      //! dropped-record counter (RO, saturating)
+
+  //! --- downstream write-request master toward the DRAM writer -------------
+  output wire                   wr_valid_o,     //! record beat valid
+  output wire  [DATA_W-1:0]     wr_data_o,      //! record beat data (LE record words)
+  output wire  [ADDR_W-1:0]     wr_addr_o,      //! byte address for this beat (base + off)
+  output wire                   wr_last_o,      //! last beat of the current record
+  input  wire                   wr_ready_i      //! DRAM writer ready (gates the emitter only)
+);
+
+  // ------------------------------------------------------------------ //
+  // Geometry                                                            //
+  // ------------------------------------------------------------------ //
+  localparam int unsigned NB       = DATA_W / 8;                 //! bytes per beat
+  localparam int unsigned SHIFT    = $clog2(NB);                 //! byte->beat shift (3 @ 64b)
+  localparam int unsigned REC_BITS = RECORD_BYTES_P * 8;         //! record width (bits)
+  localparam int unsigned BEATS    = REC_BITS / DATA_W;          //! beats per record (2 @ 64b/16B)
+  localparam int unsigned BCW      = (BEATS <= 1) ? 1 : $clog2(BEATS); //! beat-counter width
+
+  // ------------------------------------------------------------------ //
+  // Record assembly + emitter state                                     //
+  // ------------------------------------------------------------------ //
+  logic [REC_BITS-1:0] rec_r;        //! latched record being streamed
+  logic [BCW-1:0]      beat_r;       //! beat index within the record
+  logic                busy_r;       //! a record is draining to DRAM
+  logic [31:0]         wp_r;         //! byte write pointer within the ring
+  logic                full_r;       //! stop-mode: ring filled, accept no more
+  logic [11:0]         seq_r;        //! per-accepted-record rolling counter
+  logic                gap_r;        //! sticky: a drop happened since the last accept
+  logic [31:0]         dropped_r;    //! dropped-record counter
+
+  //! record bytes, LSB = lowest DRAM address: ptp_ns at bytes 0..7, then
+  //! latency_ns / stage_id / stream_idx / flags. Matches the packed LE struct
+  //! userspace reads (see docs/LATENCY_HISTORY_RING.md).
+  wire [15:0] flags_w = {gap_r, 3'b000, seq_r};
+  wire [REC_BITS-1:0] record_w =
+       {flags_w, sample_stream_i, sample_stage_i, sample_lat_ns_i, ptp_ns_i};
+
+  //! room for one more record when writing sequentially (stop-mode gate)
+  wire has_room_w  = loop_i | ~full_r;
+  //! accept a fresh sample only when enabled, idle, and space is available
+  wire accept_w    = sample_valid_i & enable_i & ~busy_r & has_room_w;
+  //! any offered sample that is NOT accepted while enabled is a counted drop
+  wire drop_w      = sample_valid_i & enable_i & ~accept_w;
+
+  //! last beat of the current record handshakes out this cycle
+  wire last_beat_w = busy_r & enable_i & wr_ready_i & (beat_r == BCW'(BEATS-1));
+
+  // ------------------------------------------------------------------ //
+  // Emitter: assemble on accept, stream beats, advance the write pointer //
+  // ------------------------------------------------------------------ //
+  always_ff @(posedge clk_i) begin : emitter
+    if (!rst_n) begin
+      rec_r     <= '0;
+      beat_r    <= '0;
+      busy_r    <= 1'b0;
+      wp_r      <= 32'd0;
+      full_r    <= 1'b0;
+      seq_r     <= 12'd0;
+      gap_r     <= 1'b0;
+      dropped_r <= 32'd0;
+    end
+    else if (!enable_i) begin
+      //! disabled: clear the write pointer + fill state (matches the PCM
+      //! ring's disable), abort any in-flight record. Lifetime stats
+      //! (seq/dropped) persist until a hard reset.
+      beat_r <= '0;
+      busy_r <= 1'b0;
+      wp_r   <= 32'd0;
+      full_r <= 1'b0;
+      gap_r  <= 1'b0;
+    end
+    else begin
+      //! -------- accept a new sample (only when idle) --------
+      if (accept_w) begin
+        rec_r  <= record_w;
+        beat_r <= '0;
+        busy_r <= 1'b1;
+        seq_r  <= seq_r + 12'd1;
+        gap_r  <= 1'b0;      //! consumed into this record's flags
+      end
+
+      //! -------- drain the current record to DRAM --------
+      if (busy_r && wr_ready_i) begin
+        if (last_beat_w) begin
+          busy_r <= 1'b0;
+          //! advance the byte write pointer by one record; wrap to 0 in loop
+          //! mode, else advance to the end and latch full (stop mode). The
+          //! wrap predicate mirrors _PCMRingNxN's `offset + nb >= length`.
+          if (wp_r + 32'(RECORD_BYTES_P) >= ring_len_i) begin
+            if (loop_i) begin
+              wp_r <= 32'd0;
+            end
+            else begin
+              wp_r   <= wp_r + 32'(RECORD_BYTES_P);  //! -> ring_len (bytes written)
+              full_r <= 1'b1;                        //! stop: accept no more
+            end
+          end
+          else begin
+            wp_r <= wp_r + 32'(RECORD_BYTES_P);
+          end
+        end
+        else begin
+          beat_r <= beat_r + BCW'(1);
+        end
+      end
+
+      //! -------- drop bookkeeping (never back-pressures the producer) ------
+      if (drop_w) begin
+        gap_r <= 1'b1;
+        if (!(&dropped_r)) dropped_r <= dropped_r + 32'd1;  //! saturating
+      end
+    end
+  end : emitter
+
+  // ------------------------------------------------------------------ //
+  // Write-request master outputs                                        //
+  // ------------------------------------------------------------------ //
+  //! current beat data sliced out of the latched record (LSB beat first)
+  wire [DATA_W-1:0] beat_data_w = rec_r[beat_r*DATA_W +: DATA_W];
+  //! byte address = ring base + record start (wp_r) + this beat's offset
+  wire [31:0]       beat_addr_w = ring_base_i[31:0] + wp_r
+                                  + ({29'd0, beat_r} << SHIFT);
+
+  assign wr_valid_o = busy_r & enable_i;
+  assign wr_data_o  = beat_data_w;
+  assign wr_addr_o  = beat_addr_w[ADDR_W-1:0];
+  assign wr_last_o  = busy_r & (beat_r == BCW'(BEATS-1));
+
+  assign wptr_o     = wp_r;
+  assign dropped_o  = dropped_r;
+
+endmodule
+
+`default_nettype wire

--- a/tb/verilator/lat_history_ring/Makefile
+++ b/tb/verilator/lat_history_ring/Makefile
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# KL_lat_history_ring verification: per-stage AAF latency samples -> fixed
+# 16-byte records -> wrapping DRAM ring. The TB plays the DRAM writer: it
+# captures every (addr,data,last) write beat, reconstructs each record, and
+# checks field byte-exactness, ring wrap, wptr advance, drop-on-full + the
+# dropped counter, the gap marker, and timestamp monotonicity.
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+A          = $(RTL_DIR)/ieee1722/aaf
+TOP        = KL_lat_history_ring
+VFLAGS = --cc --exe --build -j 0 --top-module $(TOP) \
+         +incdir+$(A) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
+         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-IMPORTSTAR -Wno-CASEINCOMPLETE \
+         -Wno-EOFNEWLINE -CFLAGS "-std=c++17 -O2"
+SRCS = $(A)/KL_lat_history_ring.sv
+.PHONY: all run clean
+all: run
+run:
+	$(VERILATOR) $(VFLAGS) $(SRCS) sim_main.cpp -o VKL_lat_history_ring_sim
+	./obj_dir/VKL_lat_history_ring_sim
+clean:
+	rm -rf obj_dir

--- a/tb/verilator/lat_history_ring/sim_main.cpp
+++ b/tb/verilator/lat_history_ring/sim_main.cpp
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// KL_lat_history_ring verification harness.
+//
+// The DUT turns each fire-and-forget latency sample into a fixed 16-byte
+// record and streams it (beat by beat) to a DRAM write-request master. This
+// TB *is* that DRAM writer: it drives wr_ready_i, snoops every accepted write
+// beat (addr,data,last), reconstructs each record, and checks:
+//   * field byte-exactness (ptp_ns, latency_ns, stage_id, stream_idx)
+//   * record LE layout (beat0 = ptp, beat1 = {flags,stream,stage,latency})
+//   * beat addressing (beat1.addr == beat0.addr + 8) and record base = wptr
+//   * per-record rolling seq in flags[11:0]
+//   * wptr advance (+16/record), loop wrap to base, stop-mode full
+//   * drop-on-full (writer stalled) + the saturating dropped counter
+//   * the gap marker flags[15] on the first record after a drop
+//   * timestamp monotonicity
+//   * enable=0 clears the write pointer
+//
+// Record (little-endian in DRAM), RECORD_BYTES_P = 16:
+//   [0..7] ptp_ns u64 | [8..11] latency_ns u32 | [12] stage u8
+//   [13] stream u8 | [14..15] flags u16 = {gap[15],rsvd[14:12],seq[11:0]}
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+#include "VKL_lat_history_ring.h"
+#include "verilated.h"
+
+static VKL_lat_history_ring* dut = nullptr;
+
+// ---- decoded record as reconstructed from the write-beat stream ----------
+struct Rec {
+  uint32_t addr;    // record base byte address (beat0 addr)
+  uint64_t ptp;
+  uint32_t lat;
+  uint8_t  stage;
+  uint8_t  stream;
+  uint16_t flags;
+};
+static std::vector<Rec> g_recs;
+
+// in-flight beat accumulator (2 beats per 16-byte record @ 64-bit bus)
+static uint64_t g_b0 = 0;
+static uint32_t g_a0 = 0;
+static bool     g_have_b0 = false;
+static bool     g_addr_ok = true;    // beat1.addr == beat0.addr + 8 for all
+static int      g_wr_ready = 1;      // TB-driven DRAM-writer ready
+
+static int checks = 0, fails = 0;
+static void ok(const char* name, bool cond, const char* detail = "") {
+  checks++;
+  if (!cond) {
+    fails++;
+    printf("  FAIL: %s %s\n", name, detail);
+  }
+}
+
+// One clock cycle. Inputs for the cycle must be set on the DUT before calling.
+// Combinational outputs are read on the low phase (with inputs applied); the
+// write beat presented while wr_ready is high is consumed by the rising edge.
+static void tick() {
+  dut->clk_i = 0;
+  dut->wr_ready_i = g_wr_ready;
+  dut->eval();
+
+  if (dut->wr_valid_o && dut->wr_ready_i) {
+    uint64_t data = dut->wr_data_o;
+    uint32_t addr = dut->wr_addr_o;
+    bool     last = dut->wr_last_o;
+    if (!last) {
+      g_b0 = data; g_a0 = addr; g_have_b0 = true;
+    } else if (g_have_b0) {
+      if (addr != g_a0 + 8) g_addr_ok = false;
+      Rec r;
+      r.addr   = g_a0;
+      r.ptp    = g_b0;
+      r.lat    = (uint32_t)(data & 0xFFFFFFFFULL);
+      r.stage  = (uint8_t)((data >> 32) & 0xFF);
+      r.stream = (uint8_t)((data >> 40) & 0xFF);
+      r.flags  = (uint16_t)((data >> 48) & 0xFFFF);
+      g_recs.push_back(r);
+      g_have_b0 = false;
+    }
+  }
+
+  dut->clk_i = 1;
+  dut->eval();
+}
+
+// idle N cycles with no sample offered
+static void idle(int n) {
+  dut->sample_valid_i = 0;
+  for (int i = 0; i < n; i++) tick();
+}
+
+// offer exactly one sample this cycle, then idle `gap` cycles
+static void sample(uint64_t ptp, uint32_t lat, uint8_t stage, uint8_t stream,
+                   int gap) {
+  dut->sample_valid_i  = 1;
+  dut->sample_lat_ns_i = lat;
+  dut->sample_stage_i  = stage;
+  dut->sample_stream_i = stream;
+  dut->ptp_ns_i        = ptp;
+  tick();
+  idle(gap);
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new VKL_lat_history_ring;
+
+  const uint64_t BASE = 0x30000000ULL;  // ring base (bytes)
+
+  // ---- reset ----
+  dut->rst_n = 0;
+  dut->sample_valid_i = 0; dut->sample_lat_ns_i = 0;
+  dut->sample_stage_i = 0; dut->sample_stream_i = 0; dut->ptp_ns_i = 0;
+  dut->ring_base_i = BASE; dut->ring_len_i = 0; dut->enable_i = 0;
+  dut->loop_i = 1; dut->wr_ready_i = 1;
+  for (int i = 0; i < 4; i++) tick();
+  dut->rst_n = 1;
+
+  ok("post_reset_wptr_zero", dut->wptr_o == 0);
+  ok("post_reset_dropped_zero", dut->dropped_o == 0);
+
+  // ==================================================================
+  //  Phase 1: a spaced burst in loop mode, large ring -> one record
+  //  per sample, fields byte-exact, seq rolling, wptr +16, no wrap.
+  // ==================================================================
+  dut->ring_len_i = 0x1000;   // 4096 B = 256 records, no wrap in this phase
+  dut->loop_i     = 1;
+  dut->enable_i   = 1;
+  idle(2);
+
+  const int N1 = 8;
+  uint64_t exp_ptp[N1]; uint32_t exp_lat[N1];
+  uint8_t  exp_stg[N1]; uint8_t  exp_str[N1];
+  for (int i = 0; i < N1; i++) {
+    exp_ptp[i] = 0x1000ULL + (uint64_t)i * 0x137;   // strictly increasing
+    exp_lat[i] = 100 + i * 7;
+    exp_stg[i] = (uint8_t)(i & 0x7);
+    exp_str[i] = (uint8_t)((i * 3) & 0x3);
+    sample(exp_ptp[i], exp_lat[i], exp_stg[i], exp_str[i], 5);
+  }
+  idle(6);
+
+  ok("p1_record_count", g_recs.size() == (size_t)N1,
+     g_recs.size() == (size_t)N1 ? "" : "wrong number of records emitted");
+  ok("p1_beat_addr_pairing", g_addr_ok, "a beat1.addr != beat0.addr+8");
+
+  uint64_t prev_ptp = 0;
+  bool mono = true;
+  for (int i = 0; i < (int)g_recs.size() && i < N1; i++) {
+    const Rec& r = g_recs[i];
+    ok("p1_ptp",    r.ptp    == exp_ptp[i]);
+    ok("p1_lat",    r.lat    == exp_lat[i]);
+    ok("p1_stage",  r.stage  == exp_stg[i]);
+    ok("p1_stream", r.stream == exp_str[i]);
+    ok("p1_seq",    (r.flags & 0x0FFF) == (uint16_t)i);     // rolling seq
+    ok("p1_no_gap", (r.flags & 0x8000) == 0);               // no drops yet
+    ok("p1_addr",   r.addr   == (uint32_t)(BASE + (uint64_t)i * 16));
+    if (r.ptp < prev_ptp) mono = false;
+    prev_ptp = r.ptp;
+  }
+  ok("p1_timestamp_monotonic", mono);
+  ok("p1_wptr_advanced", dut->wptr_o == (uint32_t)(N1 * 16),
+     "wptr != N*16 after burst");
+  ok("p1_no_drops", dut->dropped_o == 0);
+
+  // ==================================================================
+  //  Phase 2: enable=0 clears the write pointer; re-enable resumes @0.
+  // ==================================================================
+  dut->enable_i = 0; idle(2);
+  ok("p2_disable_clears_wptr", dut->wptr_o == 0);
+  uint32_t drop_before = dut->dropped_o;
+  dut->enable_i = 1; idle(2);
+  g_recs.clear();
+  sample(0x9000, 55, 2, 1, 5);
+  idle(4);
+  ok("p2_reenable_record", g_recs.size() == 1);
+  if (g_recs.size() == 1) {
+    ok("p2_reenable_addr_base", g_recs[0].addr == (uint32_t)BASE);
+    ok("p2_reenable_lat", g_recs[0].lat == 55);
+  }
+  ok("p2_dropped_unchanged_on_disable", dut->dropped_o == drop_before);
+
+  // ==================================================================
+  //  Phase 3: small ring + loop -> ring wrap. len = 64 B = 4 records;
+  //  the 5th record wraps back to base and wptr wraps to 0.
+  // ==================================================================
+  dut->enable_i = 0; idle(2);
+  dut->ring_len_i = 64;     // 4 records
+  dut->loop_i     = 1;
+  dut->enable_i   = 1;
+  idle(2);
+  g_recs.clear();
+  for (int i = 0; i < 6; i++) sample(0x2000 + i, 200 + i, 9, 9, 5);
+  idle(6);
+  ok("p3_wrap_count", g_recs.size() == 6);
+  if (g_recs.size() == 6) {
+    // slots cycle 0,16,32,48,0,16
+    ok("p3_slot0", g_recs[0].addr == (uint32_t)(BASE + 0));
+    ok("p3_slot3", g_recs[3].addr == (uint32_t)(BASE + 48));
+    ok("p3_wrap_to_base", g_recs[4].addr == (uint32_t)(BASE + 0));
+    ok("p3_wrap_slot16",  g_recs[5].addr == (uint32_t)(BASE + 16));
+  }
+  ok("p3_wptr_wrapped", dut->wptr_o == 32, "wptr should be 2*16 after 6 in a 4-slot ring");
+
+  // ==================================================================
+  //  Phase 4: STOP mode (loop=0) -> ring fills, then drop-on-full and
+  //  the dropped counter bumps; wptr parks at ring_len.
+  // ==================================================================
+  dut->enable_i = 0; idle(2);
+  dut->ring_len_i = 64;    // 4 records
+  dut->loop_i     = 0;     // stop when full
+  dut->enable_i   = 1;
+  idle(2);
+  g_recs.clear();
+  uint32_t drp0 = dut->dropped_o;
+  for (int i = 0; i < 7; i++) sample(0x3000 + i, 30 + i, 1, 0, 5); // 4 fit, 3 drop
+  idle(6);
+  ok("p4_stop_count", g_recs.size() == 4, "only ring_len/16 records must be written");
+  ok("p4_stop_full_wptr", dut->wptr_o == 64, "wptr parks at ring_len when full");
+  ok("p4_stop_dropped", dut->dropped_o == drp0 + 3, "3 overflow samples must be dropped");
+
+  // ==================================================================
+  //  Phase 5: drop-on-full via a STALLED writer (never back-pressure the
+  //  producer). Hold wr_ready low, pump samples -> they drop; the first
+  //  record after the stall carries the gap marker flags[15]=1.
+  // ==================================================================
+  dut->enable_i = 0; idle(2);
+  dut->ring_len_i = 0x1000;
+  dut->loop_i     = 1;
+  dut->enable_i   = 1;
+  idle(2);
+  g_recs.clear();
+  uint32_t drp1 = dut->dropped_o;
+
+  // rec[0]: one clean record (drains normally, no gap)
+  g_wr_ready = 1;
+  sample(0x4000, 11, 0, 0, 5);
+  idle(4);
+  ok("p5_pre_gap_clear", g_recs.size() == 1 && (g_recs[0].flags & 0x8000) == 0);
+
+  // stall the writer; the FIRST offered sample is accepted (busy latches) but
+  // cannot drain, the next four arrive while busy -> dropped (producer never
+  // back-pressured). rec[1] = the in-flight record: it predates the drops so
+  // it carries no gap.
+  g_wr_ready = 0;
+  for (int i = 0; i < 5; i++) sample(0x5000 + i, 77, 3, 2, 3);
+  // release the writer; the in-flight record drains out (gap clear)
+  g_wr_ready = 1;
+  idle(8);
+  ok("p5_stall_dropped", dut->dropped_o == drp1 + 4, "4 samples offered while busy must drop");
+
+  // rec[2]: the FIRST sample accepted AFTER the drops -> carries the gap marker
+  sample(0x6000, 88, 3, 2, 5);
+  idle(4);
+  // rec[3]: a following clean sample -> gap marker cleared again
+  sample(0x6001, 89, 3, 2, 5);
+  idle(4);
+
+  ok("p5_recs_after_stall", g_recs.size() == 4);
+  if (g_recs.size() == 4) {
+    ok("p5_inflight_no_gap",  (g_recs[1].flags & 0x8000) == 0);   // predates drops
+    ok("p5_gap_marker_set",   (g_recs[2].flags & 0x8000) != 0);   // first post-drop record
+    ok("p5_gap_marker_clear", (g_recs[3].flags & 0x8000) == 0);   // cleared after
+  }
+
+  // ==================================================================
+  //  Phase 6: dropped counter saturates, not wraps (single spot check
+  //  of the saturating guard via a forced near-max is impractical; verify
+  //  monotonic non-decrease across the whole run instead).
+  // ==================================================================
+  ok("p6_dropped_nonzero_total", dut->dropped_o > 0);
+
+  // ---- verdict ----
+  printf("%d checks, %d failures, RESULT: %s\n",
+         checks, fails, fails == 0 ? "PASS" : "FAIL");
+
+  delete dut;
+  return fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Status

RTL + Verilator TB complete, TB green (84/84). Self-contained lane: RTL module,
TB, and doc only — no SoC/CSR glue touched (SoC wiring documented for a later
integration lane to avoid cross-lane `CSRStorage` double-drive).

## Description

Roadmap item 11, DDR3 arm: a **latency history ring** on top of the per-stage
AAF latency taps. `KL_aaf_latency_taps` (PR #17, CSR `0x870`) exposes only the
latest `min/last/max` inter-stage deltas over CSR — a snapshot. This module,
`hdl/ieee1722/aaf/KL_lat_history_ring.sv`, turns **each** latency sample into a
fixed 16-byte record and streams it into a wrapping DRAM ring, so userspace gets
a time-series (jitter histograms, tail latency, transient bursts) instead of one
instantaneous value.

- **Record (16 B, little-endian in DRAM):** `ptp_ns[u64]` @0, `latency_ns[u32]`
  @8, `stage_id[u8]` @12, `stream_idx[u8]` @13, `flags[u16]` @14 where
  `flags = {gap[15], rsvd[14:12], seq[11:0]}` (rolling per-record `seq` +
  a hole marker set on the first record after a drop). Two 64-bit beats:
  beat0 = `ptp_ns`, beat1 = `{flags, stream_idx, stage_id, latency_ns}`.
- **Ring CSR ABI mirrored field-for-field from the PCM ring** (`_PCMRingNxN` /
  `milan_dma_pcm`, LiteX bank `0xf0003120`): `BASE_HI 0x00 / BASE_LO 0x04 /
  LENGTH 0x08 / ENABLE 0x0C / LOOP 0x14 / OFFSET(wptr,RO) 0x18`, plus one
  extension `DROPPED 0x1C (RO)`. The userspace mmap+chase recipe is identical to
  `pw-milan-ring-source`.
- **Downstream:** a simple write-request master (`wr_valid/wr_data/wr_addr/
  wr_last/wr_ready`) — same shape as the PCM ring's `WishboneDMAWriter` sink, so
  the existing `milan_dma` DRAM writer carries it unchanged.
- **Non-stallable datapath (mf52 lesson):** the sample producer is never
  back-pressured; a sample offered while the previous record is still draining
  (or the ring is full in stop mode) is dropped and counted in `DROPPED`.
  `wr_ready_i` gates the emitter only.
- **Input contract:** a fresh clean per-sample bus (`sample_valid_i,
  sample_lat_ns_i[31:0], sample_stage_i[7:0], sample_stream_i[7:0],
  ptp_ns_i[63:0]`), fed by a trivial adapter off the taps chains. Documented tap
  points (TX: CAP/PKT_SOF/PKT_EOF/MAC_TX; RX: MAC_RX/ACCEPT/DEPKT/PCM_RING) in
  `docs/LATENCY_HISTORY_RING.md`.

## How to get into the same state

```
git fetch origin && git checkout item11-ddr3-ring
```
Files: `hdl/ieee1722/aaf/KL_lat_history_ring.sv`,
`tb/verilator/lat_history_ring/{Makefile,sim_main.cpp}`,
`docs/LATENCY_HISTORY_RING.md`. Verilator 5.050.

## How to validate

```
make -C tb/verilator/lat_history_ring run
```
The TB plays the DRAM writer: it snoops every write beat, reconstructs each
record and checks field byte-exactness, LE layout, beat addressing, record base
= write pointer, rolling `seq`, `wptr` advance (+16/record), loop wrap to base,
stop-mode full, drop-on-full (stalled writer + ring full) with the `DROPPED`
counter, the `gap` marker, and timestamp monotonicity. Expected tail:
`84 checks, 0 failures, RESULT: PASS`.

## Definition of Done

- [x] `KL_lat_history_ring.sv` — house style (SPDX/banner CERN-OHL-W-2.0,
      `default_nettype none/wire`, `//!` port docs, `_r/_w`, named always
      blocks, sync active-low `rst_n`, SystemVerilog).
- [x] 16-byte record format documented and TB-asserted byte-exact.
- [x] Ring CSR ABI reused verbatim from the PCM ring (`0xf0003120` field layout).
- [x] Drop-on-full + `DROPPED` counter, never back-pressures the datapath.
- [x] Verilator TB ≥ 20 checks, `N checks, M failures, RESULT:` line — 84/0 PASS.
- [x] `docs/LATENCY_HISTORY_RING.md` — record, ABI, tap points, userspace recipe.
