### PR TITLE
item-10: MAX_TRANSIT_TIME + GET_MILAN_INFO + ACQUIRE + LOCK fixtures (behave 18/18)

### DIFF
--- a/tests/features/item10_acquire_entity.feature
+++ b/tests/features/item10_acquire_entity.feature
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# item-10 per-command setter/semaphore fixture: ACQUIRE_ENTITY.
+# Codes verified 1:1 against hdl/ieee17221/aecp/aecp_pkg.sv:
+#   CMD_ACQUIRE_ENTITY   = 15'd0    (aecp_pkg.sv:49)
+#   STATUS_NOT_SUPPORTED = 5'd11    (aecp_pkg.sv:99)
+# Behaviour verified against the responder: KL_aecp_l0_state.sv:145-147 answers
+# ACQUIRE_ENTITY with STATUS_NOT_SUPPORTED and NEVER mutates state (l0_state
+# .acquired is hardwired 0 at :81); the response builder just relays l0_status
+# (KL_aecp_response_builder.sv:1403-1404). This is Milan v1.2 (es-4.1): ACQUIRE
+# is not a supported acquisition model. The model reflects the real RTL, not the
+# 1722.1-ideal SUCCESS/ENTITY_ACQUIRED handshake.
+
+@tsn_gen @item10 @cmd:ACQUIRE_ENTITY @matrix:A-5
+Feature: AECP ACQUIRE_ENTITY is NOT_SUPPORTED (Milan v1.2)
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  Scenario: ACQUIRE_ENTITY with no flags returns NOT_SUPPORTED and never acquires
+    Given tsn_gen generated a ACQUIRE_ENTITY frame with seed 2
+    When I patch field "message_type" to 0
+    And I patch field "u" to 0
+    And I patch field "command_type" to 0
+    And I patch field "acquire_entity_flags" to 0
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 11
+    And the model has not acquired the entity
+
+  Scenario: ACQUIRE_ENTITY with the PERSISTENT flag is still NOT_SUPPORTED
+    Given tsn_gen generated a ACQUIRE_ENTITY frame with seed 3
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0
+    And I patch field "acquire_entity_flags" to 0x40000000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 11
+    And the model has not acquired the entity
+
+  Scenario: ACQUIRE_ENTITY with the RELEASE flag is still NOT_SUPPORTED
+    Given tsn_gen generated a ACQUIRE_ENTITY frame with seed 4
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0
+    And I patch field "acquire_entity_flags" to 0x80000000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 11
+    And the model has not acquired the entity
+
+  Scenario: back-to-back ACQUIRE from two controllers never returns ENTITY_ACQUIRED
+    Given tsn_gen generated a ACQUIRE_ENTITY frame with seed 5
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0
+    And I patch field "acquire_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    And the Milan AECP model processes the frame
+    Then the model responds status 11
+    When I patch field "controller_entity_id" to 0x1122334455667788
+    And the Milan AECP model processes the frame
+    Then the model responds status 11
+    And the model has not acquired the entity

--- a/tests/features/item10_get_milan_info.feature
+++ b/tests/features/item10_get_milan_info.feature
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# item-10 per-command getter fixture: MVU GET_MILAN_INFO.
+# Codes verified 1:1 against hdl/ieee17221/aecp/aecp_pkg.sv:
+#   MSG_VENDOR_UNIQUE_COMMAND = 4'd6           (aecp_pkg.sv:43)
+#   VU_GET_MILAN_INFO         = 15'h0000       (aecp_pkg.sv:149)
+#   MILAN_PROTOCOL_ID_C       = 48'h001BC50AC100 (aecp_pkg.sv:33)
+# Response verified against the responder KL_aecp_response_builder.sv:1328-1341:
+# protocol_id must match (else the frame is silently dropped), and the getter
+# returns protocol_version = 1, features_flags = 0, certification_version = 0
+# (0 stays 0 until AVnu-certified). Frame generated from the tsn-gen
+# VENDOR_UNIQUE YAML; the MVU command_type rides the top 16 bits of vendor_data.
+
+@tsn_gen @item10 @cmd:GET_MILAN_INFO @matrix:A-8
+Feature: MVU GET_MILAN_INFO getter (Milan v1.2 vendor-unique)
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  Scenario: well-formed GET_MILAN_INFO returns the Milan info block
+    Given tsn_gen generated a VENDOR_UNIQUE frame with seed 2
+    When I patch field "message_type" to 6
+    And I patch field "protocol_id" to 0x001BC50AC100
+    And I patch field "vendor_data" to 0x0000000000000000
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model milan_version is 1
+    And the model milan features_flags is 0
+    And the model certification_version is 0
+
+  Scenario: GET_MILAN_INFO under a foreign protocol_id is silently ignored
+    Given tsn_gen generated a VENDOR_UNIQUE frame with seed 3
+    When I patch field "message_type" to 6
+    And I patch field "protocol_id" to 0x001122334455
+    And I patch field "vendor_data" to 0x0000000000000000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the AECP model ignores the frame
+
+  Scenario: an unknown MVU command under the Milan protocol_id is not modelled
+    Given tsn_gen generated a VENDOR_UNIQUE frame with seed 4
+    When I patch field "message_type" to 6
+    And I patch field "protocol_id" to 0x001BC50AC100
+    And I patch field "vendor_data" to 0x7FFF000000000000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the AECP model ignores the frame

--- a/tests/features/item10_lock_entity.feature
+++ b/tests/features/item10_lock_entity.feature
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# item-10 per-command setter/semaphore fixture: LOCK_ENTITY.
+# Codes verified 1:1 against hdl/ieee17221/aecp/aecp_pkg.sv:
+#   CMD_LOCK_ENTITY      = 15'd1        (aecp_pkg.sv:50)
+#   STATUS_ENTITY_LOCKED = 5'd3         (aecp_pkg.sv:91)
+#   LOCK_TIMER_TICKS_C   = 17'd60_000   (aecp_pkg.sv:168, 60 s x 1 kHz)
+# Lock SM verified against KL_aecp_l0_state.sv:132-133,199-221:
+#   * LOCK by a free entity -> SUCCESS, records the controller, arms the timer.
+#   * A LOCK_ENTITY (lock OR unlock) from a non-owner while locked -> ENTITY_LOCKED
+#     with the state untouched (w_lock_denied).
+#   * UNLOCK by the owner clears the lock; a re-LOCK by the owner reloads the timer.
+#   * The timer auto-unlocks after LOCK_TIMER_TICKS_C+1 ticks.
+# The RTL keys UNLOCK off flags bit 0 (KL_aecp_common_parser.sv:193, flags_lsb =
+# tdata[16]) — a documented deviation from the spec's 0x80000000; the model and
+# the patched frame both use bit 0.
+
+@tsn_gen @item10 @cmd:LOCK_ENTITY @matrix:A-5
+Feature: AECP LOCK_ENTITY semaphore (grant / deny / unlock / expiry)
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  Scenario: a free entity grants the lock and records the controller
+    Given tsn_gen generated a LOCK_ENTITY frame with seed 2
+    When I patch field "message_type" to 0
+    And I patch field "u" to 0
+    And I patch field "command_type" to 1
+    And I patch field "lock_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model entity is locked
+    And the model locking controller is 0xAABBCCDDEEFF0011
+
+  Scenario: a second controller is denied ENTITY_LOCKED and the owner is unchanged
+    Given tsn_gen generated a LOCK_ENTITY frame with seed 3
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 1
+    And I patch field "lock_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    And the Milan AECP model processes the frame
+    Then the model responds status 0
+    When I patch field "controller_entity_id" to 0x1122334455667788
+    And the Milan AECP model processes the frame
+    Then the model responds status 3
+    And the model entity is locked
+    And the model locking controller is 0xAABBCCDDEEFF0011
+
+  Scenario: the owner re-locks and reloads the timer (SUCCESS)
+    Given tsn_gen generated a LOCK_ENTITY frame with seed 4
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 1
+    And I patch field "lock_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    And the Milan AECP model processes the frame
+    Then the model responds status 0
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model entity is locked
+    And the model locking controller is 0xAABBCCDDEEFF0011
+
+  Scenario: the owner unlocks and frees the entity
+    Given tsn_gen generated a LOCK_ENTITY frame with seed 5
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 1
+    And I patch field "lock_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    And the Milan AECP model processes the frame
+    Then the model entity is locked
+    When I patch field "lock_entity_flags" to 1
+    And the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model entity is unlocked
+
+  Scenario: a non-owner UNLOCK is denied ENTITY_LOCKED and the lock stands
+    Given tsn_gen generated a LOCK_ENTITY frame with seed 6
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 1
+    And I patch field "lock_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    And the Milan AECP model processes the frame
+    Then the model entity is locked
+    When I patch field "controller_entity_id" to 0x1122334455667788
+    And I patch field "lock_entity_flags" to 1
+    And the Milan AECP model processes the frame
+    Then the model responds status 3
+    And the model entity is locked
+    And the model locking controller is 0xAABBCCDDEEFF0011
+
+  Scenario: the lock auto-expires after 60001 ticks and another controller can lock
+    Given tsn_gen generated a LOCK_ENTITY frame with seed 7
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 1
+    And I patch field "lock_entity_flags" to 0
+    And I patch field "controller_entity_id" to 0xAABBCCDDEEFF0011
+    And the Milan AECP model processes the frame
+    Then the model entity is locked
+    When the 1 kHz lock timer advances 60001 ticks
+    Then the model entity is unlocked
+    When I patch field "controller_entity_id" to 0x1122334455667788
+    And the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model entity is locked
+    And the model locking controller is 0x1122334455667788

--- a/tests/features/item10_max_transit_time.feature
+++ b/tests/features/item10_max_transit_time.feature
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# item-10 per-command getter/setter fixture: SET/GET_MAX_TRANSIT_TIME.
+# Codes verified 1:1 against hdl/ieee17221/aecp/aecp_pkg.sv:
+#   CMD_SET_MAX_TRANSIT_TIME = 15'h004C  (aecp_pkg.sv:82)
+#   CMD_GET_MAX_TRANSIT_TIME = 15'h004D  (aecp_pkg.sv:83)
+# Behaviour verified against the responder KL_aecp_response_builder.sv:2005-2036:
+# addresses STREAM_OUTPUT[0] (0x0006/0); the max_transit_time u64 drives the
+# framer's presentation offset (same source of truth as SET_STREAM_INFO
+# ACC_LAT). value > 0x7FFFFFFF ns -> BAD_ARGUMENTS; wrong descriptor ->
+# NO_SUCH_DESCRIPTOR. No dedicated tsn-gen YAML exists, so the frame is
+# generated from SET_STREAM_FORMAT (the nearest AEM SET whose u64 'stream_format'
+# lands at the exact bytes 6-13 the max_transit_time u64 occupies) with
+# command_type patched to 0x4C/0x4D — documented in tsn_gen_steps.py.
+
+@tsn_gen @item10 @cmd:MAX_TRANSIT_TIME @matrix:A-5
+Feature: AECP SET/GET_MAX_TRANSIT_TIME on STREAM_OUTPUT[0]
+
+  Background:
+    Given the tsn_gen packet generator is available
+    And a fresh Milan AECP model
+
+  Scenario: SET_MAX_TRANSIT_TIME stores, GET_MAX_TRANSIT_TIME reflects
+    Given tsn_gen generated a MAX_TRANSIT_TIME frame with seed 2
+    When I patch field "message_type" to 0
+    And I patch field "u" to 0
+    And I patch field "command_type" to 0x4C
+    And I patch field "descriptor_type" to 0x0006
+    And I patch field "descriptor_index" to 0
+    And I patch field "stream_format" to 2000000
+    Then tsn_gen decodes every patched field back
+    And our field extractor agrees with tsn_gen on every field
+    When the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model max_transit_time is 2000000
+    When I patch field "command_type" to 0x4D
+    And I patch field "stream_format" to 0
+    And the Milan AECP model processes the frame
+    Then the model responds status 0
+    And the model max_transit_time is 2000000
+
+  Scenario: SET_MAX_TRANSIT_TIME above 0x7FFFFFFF ns is refused
+    Given tsn_gen generated a MAX_TRANSIT_TIME frame with seed 3
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0x4C
+    And I patch field "descriptor_type" to 0x0006
+    And I patch field "descriptor_index" to 0
+    And I patch field "stream_format" to 0x80000000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 7
+    And the model max_transit_time is 0
+
+  Scenario: SET_MAX_TRANSIT_TIME with the u64 upper word set is refused
+    Given tsn_gen generated a MAX_TRANSIT_TIME frame with seed 4
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0x4C
+    And I patch field "descriptor_type" to 0x0006
+    And I patch field "descriptor_index" to 0
+    And I patch field "stream_format" to 0x0000000100000000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 7
+
+  Scenario: MAX_TRANSIT_TIME against a non-STREAM_OUTPUT descriptor
+    Given tsn_gen generated a MAX_TRANSIT_TIME frame with seed 5
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0x4D
+    And I patch field "descriptor_type" to 0x0005
+    And I patch field "descriptor_index" to 0
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 2
+
+  Scenario: MAX_TRANSIT_TIME on STREAM_OUTPUT with a non-zero index
+    Given tsn_gen generated a MAX_TRANSIT_TIME frame with seed 6
+    When I patch field "message_type" to 0
+    And I patch field "command_type" to 0x4C
+    And I patch field "descriptor_type" to 0x0006
+    And I patch field "descriptor_index" to 1
+    And I patch field "stream_format" to 1000
+    Then tsn_gen decodes every patched field back
+    When the Milan AECP model processes the frame
+    Then the model responds status 2
+    And the model max_transit_time is 0

--- a/tests/steps/tsn_gen_steps.py
+++ b/tests/steps/tsn_gen_steps.py
@@ -56,6 +56,59 @@ LAYOUTS = {
                    ('connection_count', 16), ('sequence_id', 16),
                    ('flags', 16), ('stream_vlan_id', 16), ('reserved', 16)],
     },
+    # -- item-10 batch-2 layouts (field order/width mirror the tsn-gen YAMLs) --
+    # LOCK_ENTITY (IEEE 1722.1-2021 §9.2.8, command_type=1): flags[0]=UNLOCK
+    # per the RESPONDER's parser (KL_aecp_common_parser.sv:193 reads flags bit0
+    # = tdata[16]; a documented deviation from the spec's 0x80000000).
+    'LOCK_ENTITY': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_lock_entity::AECP_LOCK_ENTITY::'
+                      'AECP_LOCK_ENTITY_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('lock_entity_flags', 32),
+                   ('locked_id', 64), ('descriptor_type', 16),
+                   ('descriptor_index', 16)],
+    },
+    # ACQUIRE_ENTITY (IEEE 1722.1-2021 §9.2.7, command_type=0)
+    'ACQUIRE_ENTITY': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_acquire_entity::AECP_ACQUIRE_ENTITY::'
+                      'AECP_ACQUIRE_ENTITY_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('acquire_entity_flags', 32),
+                   ('owner_id', 64), ('descriptor_type', 16),
+                   ('descriptor_index', 16)],
+    },
+    # VENDOR_UNIQUE / MVU (IEEE 1722.1-2021 §9.4): protocol_id + 8-byte vendor
+    # data whose top 16 bits carry the Milan MVU command_type.
+    'VENDOR_UNIQUE': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_vendor_unique::AECP_VENDOR_UNIQUE::'
+                      'AECP_VENDOR_UNIQUE_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('protocol_id', 48), ('vendor_data', 64)],
+    },
+    # MAX_TRANSIT_TIME has no dedicated tsn-gen YAML: reuse SET_STREAM_FORMAT
+    # (the nearest AEM SET whose u64 payload 'stream_format' sits at the exact
+    # bytes 6-13 offset MAX_TRANSIT_TIME's max_transit_time u64 occupies) and
+    # patch command_type to 0x4C/0x4D. Documented honestly — the u64 rides the
+    # 'stream_format' slot.
+    'MAX_TRANSIT_TIME': {
+        'yaml_dir': '{tsn}/protocols/application/1722_1/aecp',
+        'interface': ('atdecc_aecp_set_stream_format::AECP_SET_STREAM_FORMAT::'
+                      'AECP_SET_STREAM_FORMAT_IF'),
+        'fields': [('message_type', 4), ('status', 5),
+                   ('control_data_length', 11), ('target_entity_id', 64),
+                   ('controller_entity_id', 64), ('sequence_id', 16),
+                   ('u', 1), ('command_type', 15), ('descriptor_type', 16),
+                   ('descriptor_index', 16), ('stream_format', 64)],
+    },
 }
 
 def _layout(context, key):
@@ -123,6 +176,19 @@ STATUS_SUCCESS, STATUS_NO_SUCH_DESCRIPTOR, STATUS_BAD_ARGUMENTS = 0, 2, 7
 DESC_CLOCK_DOMAIN, DESC_CONTROL = 0x24, 0x1A
 CMD_SET_CLOCK_SOURCE, CMD_SET_CONTROL = 22, 24
 
+# -- item-10 batch-2 constants: every code below verified 1:1 against
+# -- hdl/ieee17221/aecp/aecp_pkg.sv and the responder RTL, never memory.
+STATUS_ENTITY_LOCKED, STATUS_NOT_SUPPORTED = 3, 11   # aecp_pkg.sv:91, :99
+CMD_ACQUIRE_ENTITY, CMD_LOCK_ENTITY = 0, 1           # aecp_pkg.sv:49, :50
+CMD_SET_MAX_TRANSIT_TIME = 0x4C                      # aecp_pkg.sv:82
+CMD_GET_MAX_TRANSIT_TIME = 0x4D                      # aecp_pkg.sv:83
+DESC_STREAM_OUTPUT = 0x0006                          # aecp_pkg.sv:111
+MSG_VENDOR_UNIQUE_COMMAND = 6                        # aecp_pkg.sv:43
+VU_GET_MILAN_INFO = 0x0000                           # aecp_pkg.sv:149
+MILAN_PROTOCOL_ID = 0x001BC50AC100                   # aecp_pkg.sv:33
+LOCK_TIMER_TICKS = 60000                             # aecp_pkg.sv:168 (60 s x 1 kHz)
+MAX_TRANSIT_TIME_MAX = 0x7FFFFFFF   # responder: value >0x7FFFFFFF -> BAD_ARGUMENTS
+
 
 class MilanAecpModel:
     """clock_source_index in 0..2 on CLOCK_DOMAIN[0]; IDENTIFY control is
@@ -131,10 +197,39 @@ class MilanAecpModel:
     def __init__(self):
         self.clock_source_index = 0
         self.identify = 0
+        # -- item-10 batch-2 state --
+        # LOCK_ENTITY SM (KL_aecp_l0_state.sv): no ACQUIRE state exists.
+        self.locked = False
+        self.locking_controller = 0
+        self.lock_timer = 0
+        self.acquired = False           # Milan: ACQUIRE never mutates -> stays 0
+        # SET/GET_MAX_TRANSIT_TIME reflects STREAM_OUTPUT[0] presentation offset.
+        self.max_transit_time = 0
+        # GET_MILAN_INFO (MVU) getter response payload (mirrors const_q).
+        self.milan_version = None
+        self.milan_features = None
+        self.milan_cert_version = None
 
     def process(self, fields):
+        # Vendor-Unique / MVU frames carry a protocol_id (not an AEM
+        # command_type) — dispatch on message_type before touching AEM fields.
+        if fields.get('message_type') == MSG_VENDOR_UNIQUE_COMMAND:
+            return self._process_mvu(fields)
         cmd = fields['command_type']
-        dt, di = fields['descriptor_type'], fields['descriptor_index']
+        # entity-level cmds (ACQUIRE/LOCK) carry a descriptor, but VU/other
+        # layouts may not: fall back with .get()
+        dt = fields.get('descriptor_type', 0)
+        di = fields.get('descriptor_index', 0)
+        # ---- ACQUIRE_ENTITY: Milan NOT_SUPPORTED, state untouched -------------
+        # (KL_aecp_l0_state.sv:145-147 + :81 acquired hardwired 0)
+        if cmd == CMD_ACQUIRE_ENTITY:
+            return STATUS_NOT_SUPPORTED
+        # ---- LOCK_ENTITY / UNLOCK (KL_aecp_l0_state.sv:132-133,199-221) -------
+        if cmd == CMD_LOCK_ENTITY:
+            return self._process_lock(fields)
+        # ---- SET/GET_MAX_TRANSIT_TIME (KL_aecp_response_builder.sv:2005-2036) -
+        if cmd in (CMD_SET_MAX_TRANSIT_TIME, CMD_GET_MAX_TRANSIT_TIME):
+            return self._process_mtt(cmd, dt, di, fields)
         if cmd == CMD_SET_CLOCK_SOURCE:
             if dt != DESC_CLOCK_DOMAIN or di != 0:
                 return STATUS_NO_SUCH_DESCRIPTOR
@@ -151,6 +246,73 @@ class MilanAecpModel:
             self.identify = value
             return STATUS_SUCCESS
         return None
+
+    # -- LOCK_ENTITY semaphore (KL_aecp_l0_state.sv) ------------------------
+    def _process_lock(self, fields):
+        ctrl = fields['controller_entity_id']
+        # RTL keys UNLOCK off flags bit0 (common_parser flags_lsb = tdata[16]);
+        # a documented deviation from the spec's 0x80000000.
+        unlock = (fields.get('lock_entity_flags', 0) & 1) != 0
+        from_owner = self.locked and (ctrl == self.locking_controller)
+        # A LOCK_ENTITY (lock OR unlock) from a non-owner while locked is
+        # denied ENTITY_LOCKED and leaves state untouched (w_lock_denied).
+        if self.locked and not from_owner:
+            return STATUS_ENTITY_LOCKED
+        if unlock:
+            if from_owner:                      # UNLOCK by the owner
+                self.locked = False
+                self.locking_controller = 0
+                self.lock_timer = 0
+            return STATUS_SUCCESS               # UNLOCK while free: no-op SUCCESS
+        if not self.locked:                     # grant
+            self.locked = True
+            self.locking_controller = ctrl
+            self.lock_timer = LOCK_TIMER_TICKS
+        else:                                   # re-lock by owner reloads timer
+            self.lock_timer = LOCK_TIMER_TICKS
+        return STATUS_SUCCESS
+
+    def tick(self, n=1):
+        """1 kHz lock-timer countdown; auto-unlock exactly like the RTL
+        (locked & timer==0 -> unlock, else decrement: LOCK_TIMER_TICKS+1
+        ticks to expire)."""
+        for _ in range(n):
+            if self.locked:
+                if self.lock_timer == 0:
+                    self.locked = False
+                    self.locking_controller = 0
+                else:
+                    self.lock_timer -= 1
+
+    # -- SET/GET_MAX_TRANSIT_TIME (STREAM_OUTPUT[0] presentation offset) ----
+    def _mtt_value(self, fields):
+        # base layout rides the u64 in the 'stream_format' slot (bytes 6-13),
+        # exactly the max_transit_time position; prefer a real field if present
+        return fields.get('max_transit_time', fields.get('stream_format', 0))
+
+    def _process_mtt(self, cmd, dt, di, fields):
+        if dt != DESC_STREAM_OUTPUT or di != 0:
+            return STATUS_NO_SUCH_DESCRIPTOR
+        if cmd == CMD_SET_MAX_TRANSIT_TIME:
+            val = self._mtt_value(fields)
+            if val > MAX_TRANSIT_TIME_MAX:      # >0x7FFFFFFF ns -> refused
+                return STATUS_BAD_ARGUMENTS
+            self.max_transit_time = val & 0xFFFFFFFF   # responder stores low 32b
+            return STATUS_SUCCESS
+        return STATUS_SUCCESS                   # GET reflects the stored value
+
+    # -- MVU GET_MILAN_INFO (KL_aecp_response_builder.sv:1328-1341) ---------
+    def _process_mvu(self, fields):
+        if fields.get('protocol_id', 0) != MILAN_PROTOCOL_ID:
+            return None                         # not Milan MVU: silently dropped
+        vd = fields.get('vendor_data', 0)
+        mvu_cmd = (vd >> 48) & 0x7FFF           # top 15 bits (r-bit at 63 dropped)
+        if mvu_cmd == VU_GET_MILAN_INFO:
+            self.milan_version = 1              # protocol_version = 1
+            self.milan_features = 0             # features_flags = 0
+            self.milan_cert_version = 0         # certification_version = 0 (uncert.)
+            return STATUS_SUCCESS
+        return None                             # other MVU: not modelled here
 
 
 # ---------------------------------------------------------------------------
@@ -403,6 +565,65 @@ def step_fuzz_invariant(context):
                 f'model rejected a legal write with {status}: {f}'
     csi = context.aecp_model.clock_source_index
     assert csi < 3, f'state corrupted: clock_source_index={csi}'
+
+
+# ---- item-10 batch-2 assertions (LOCK / ACQUIRE / MAX_TRANSIT / MVU) ------
+
+@then('the AECP model ignores the frame')
+def step_aecp_ignored(context):
+    assert context.model_status is None, \
+        f'expected the frame to be ignored, got status {context.model_status}'
+
+
+@then('the model entity is {state}')
+def step_model_lock_state(context, state):
+    assert state in ('locked', 'unlocked'), f'bad state literal {state!r}'
+    assert context.aecp_model.locked == (state == 'locked'), \
+        f'locked={context.aecp_model.locked}, expected {state}'
+
+
+@then('the model locking controller is {v}')
+def step_model_lock_owner(context, v):
+    want = int(v, 0)
+    assert context.aecp_model.locking_controller == want, \
+        f'locking_controller={context.aecp_model.locking_controller:#x}, ' \
+        f'expected {want:#x}'
+
+
+@then('the model has not acquired the entity')
+def step_model_not_acquired(context):
+    assert context.aecp_model.acquired is False, \
+        'ACQUIRE must never mutate state (Milan: NOT_SUPPORTED)'
+
+
+@when('the 1 kHz lock timer advances {n:d} ticks')
+def step_lock_tick(context, n):
+    context.aecp_model.tick(n)
+
+
+@then('the model max_transit_time is {v}')
+def step_model_mtt(context, v):
+    want = int(v, 0)
+    assert context.aecp_model.max_transit_time == want, \
+        f'max_transit_time={context.aecp_model.max_transit_time}, expected {want}'
+
+
+@then('the model milan_version is {v:d}')
+def step_model_milan_version(context, v):
+    assert context.aecp_model.milan_version == v, \
+        f'milan_version={context.aecp_model.milan_version}, expected {v}'
+
+
+@then('the model milan features_flags is {v:d}')
+def step_model_milan_features(context, v):
+    assert context.aecp_model.milan_features == v, \
+        f'features_flags={context.aecp_model.milan_features}, expected {v}'
+
+
+@then('the model certification_version is {v:d}')
+def step_model_milan_cert(context, v):
+    assert context.aecp_model.milan_cert_version == v, \
+        f'certification_version={context.aecp_model.milan_cert_version}, expected {v}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Status

Next batch of item-10 per-command behave fixtures (roadmap item 10), following
the proven tsn_gen pattern (frames from `packet_gen`, checked by the Python
Milan AECP model that mirrors the responder RTL). 4 commands added; author
self-test **18/18 scenarios green** and the whole suite parses clean under
`--dry-run`. Self-test output is posted below as a comment (results only, not
an approval).

## Description

Adds four `tests/features/item10_<cmd>.feature` fixtures + the LAYOUTS, model
extensions and step defs in `tests/steps/tsn_gen_steps.py`. **Every command and
status code was verified 1:1 against `hdl/ieee17221/aecp/aecp_pkg.sv` and the
responder (`KL_aecp_response_builder.sv` / `KL_aecp_l0_state.sv`)** — nothing
from memory. The model reflects the *actual RTL behaviour*, not the 1722.1
ideal.

| Cmd | Codes (verified) | Modelled behaviour |
|-----|------------------|--------------------|
| **MAX_TRANSIT_TIME** | `SET=0x4C` (aecp_pkg.sv:82), `GET=0x4D` (:83) | STREAM_OUTPUT[0] (0x0006/0); SET stores → GET reflects the presentation offset; value `> 0x7FFFFFFF` → `BAD_ARGUMENTS(7)`; wrong descriptor → `NO_SUCH_DESCRIPTOR(2)` (`KL_aecp_response_builder.sv:2005-2036`) |
| **GET_MILAN_INFO** (MVU) | `msg_type=6` (:43), `VU cmd=0x0000` (:149), `protocol_id=00-1B-C5-0A-C1-00` (:33) | protocol_id must match (else silently dropped); getter returns `protocol_version=1`, `features_flags=0`, `certification_version=0` (`KL_aecp_response_builder.sv:1328-1341`) |
| **ACQUIRE_ENTITY** | `cmd=0` (:49), `NOT_SUPPORTED=11` (:99) | **Milan: always `NOT_SUPPORTED(11)`, never mutates state** — `l0_state.acquired` is hardwired 0 (`KL_aecp_l0_state.sv:145-147, :81`). es-4.1. |
| **LOCK_ENTITY** | `cmd=1` (:50), `ENTITY_LOCKED=3` (:91), `LOCK_TIMER=60000` (:168) | grant→SUCCESS+owner+timer; non-owner LOCK/UNLOCK while locked→`ENTITY_LOCKED(3)`, state untouched; owner UNLOCK clears; owner re-LOCK reloads timer; auto-unlock after 60001 ticks (`KL_aecp_l0_state.sv:132-133, 199-221`) |

Honest notes:
- **MAX_TRANSIT_TIME has no dedicated tsn-gen YAML.** The frame is generated
  from `SET_STREAM_FORMAT` — the nearest AEM SET whose u64 payload
  (`stream_format`) sits at the *exact* bytes 6-13 offset the `max_transit_time`
  u64 occupies — with `command_type` patched to 0x4C/0x4D. Documented in the
  LAYOUTS comment.
- **LOCK/UNLOCK bit.** The responder keys UNLOCK off flags **bit 0**
  (`KL_aecp_common_parser.sv:193`, `flags_lsb = tdata[16]`), a documented
  deviation from the spec's `0x80000000`. The model and the patched frame both
  use bit 0, so the fixture tracks the RTL truth.

## How to get into the same state

Prereqs (centralised, per the getter/setter verification doc
`docs/testing/PDU_GETTER_SETTER_VERIFICATION.md` — **note it may not be merged
yet; it currently lives in the unmerged PR #13**):

- tsn-gen checked out + built at `TSAGEN_DIR=/home/alex/tsn-gen`
  (`$TSAGEN_DIR/build/traffic-gen/packet_gen` present).
- behave from `~/litex-milan/venv/bin/behave`.
- No board/gateware needed — these are host-side model fixtures that skip
  cleanly when `packet_gen` is absent (CI stays green).

## How to validate

```
cd milan-fpga
# per-command (green):
~/litex-milan/venv/bin/behave tests -i item10_max_transit_time
~/litex-milan/venv/bin/behave tests -i item10_get_milan_info
~/litex-milan/venv/bin/behave tests -i item10_acquire_entity
~/litex-milan/venv/bin/behave tests -i item10_lock_entity
# whole suite parses clean:
~/litex-milan/venv/bin/behave tests --dry-run
```

## Definition of Done

- [x] 4 fixtures added, one per command, each `@tsn_gen @item10 @cmd:<X>
      @matrix:<row>` tagged (MAX_TRANSIT/ACQUIRE/LOCK → A-5, MVU → A-8).
- [x] Every command + status code verified against `aecp_pkg.sv` and the
      responder RTL (cited above), not memory.
- [x] Each `behave tests -i item10_<cmd>` green (5+3+4+6 = **18/18 scenarios,
      225 steps**).
- [x] `behave tests --dry-run` parses clean (12 features / 75 scenarios / 683
      steps, 0 undefined).
- [x] Follows the proven tsn_gen pattern (LAYOUTS + MilanAecpModel.process
      insert before the SET_CLOCK_SOURCE anchor; `.get()` for descriptor fields
      on entity-level cmds).
- [x] Self-test output posted as a comment (results only, not an approval).
