### PR TITLE
item-5: 8×8 fits+closes @100MHz — ACMP false-path fix + cfg_ax8x8 (rx-queues=1)

### DIFF
--- a/hdl/ieee17221/acmp/KL_acmp_lstn_ctx.sv
+++ b/hdl/ieee17221/acmp/KL_acmp_lstn_ctx.sv
@@ -194,11 +194,20 @@ module KL_acmp_lstn_ctx #(
   acmp_lstn_ctx_t       wr_data_w;
   logic [IDX_W_C-1:0]   rd_idx_w;
   acmp_lstn_ctx_t       rd_ctx_w;
+  acmp_lstn_ctx_t       swp_rd_ctx_w;
 
   always_ff @(posedge clk_i) begin : ctx_ram_wr    // RAM in its own process
     if (wr_en_w) ctx_ram[wr_idx_w] <= wr_data_w;
   end
-  assign rd_ctx_w = ctx_ram[rd_idx_w];             //! the single read port
+  assign rd_ctx_w = ctx_ram[rd_idx_w];             //! frame/launch/rest/tbl read
+  //! Dedicated sweep read port (addressed by swp_idx_r ONLY). The timer-wheel
+  //! sweep reads the context via this port instead of the shared rd_ctx_w so the
+  //! frame index (cap_luid_r) — which drives rd_idx_w only in the w_frame_latch
+  //! branch — can never appear on the sweep writeback cone. That cross-coupling
+  //! is FALSE (the sweep write fires only under w_swp_run == !w_frame_latch) but
+  //! the shared read mux let STA trace it as a 14-level path. During the sweep
+  //! rd_idx_w == swp_idx_r, so swp_rd_ctx_w == rd_ctx_w — behaviour is identical.
+  assign swp_rd_ctx_w = ctx_ram[swp_idx_r];
 
   //! post-reset init walk: all-zero records = UNBOUND everywhere
   reg                 init_done_r;
@@ -685,7 +694,7 @@ module KL_acmp_lstn_ctx #(
   logic           swp_probe_set_w;
   always_comb begin : sweep_next
     logic fire, adp_disc, adp_dep, sm, reg_rise, reg_fall, fail_rise;
-    sn_w            = rd_ctx_w;
+    sn_w            = swp_rd_ctx_w;
     sn_wr_w         = 1'b0;
     swp_probe_set_w = 1'b0;
     sm       = PROBE_SM_EN_P[swp_idx_r];
@@ -693,26 +702,26 @@ module KL_acmp_lstn_ctx #(
     adp_disc = 1'b0;
     adp_dep  = 1'b0;
     // ---- 1 s ADP availability aging --------------------------------
-    if (c_1s_r && rd_ctx_w.tk_avail) begin
-      if (rd_ctx_w.adp_age >= LSM_ADP_AGE_S_C) sn_w.tk_avail = 1'b0;
-      else                                     sn_w.adp_age  = rd_ctx_w.adp_age + 7'd1;
+    if (c_1s_r && swp_rd_ctx_w.tk_avail) begin
+      if (swp_rd_ctx_w.adp_age >= LSM_ADP_AGE_S_C) sn_w.tk_avail = 1'b0;
+      else                                         sn_w.adp_age  = swp_rd_ctx_w.adp_age + 7'd1;
       sn_wr_w = 1'b1;
     end
     // ---- 1 ms countdown (fire on the 1 -> 0 edge) --------------------
-    if (c_ms_r && rd_ctx_w.tmr != 14'd0) begin
-      fire     = (rd_ctx_w.tmr == 14'd1);
-      sn_w.tmr = rd_ctx_w.tmr - 14'd1;
+    if (c_ms_r && swp_rd_ctx_w.tmr != 14'd0) begin
+      fire     = (swp_rd_ctx_w.tmr == 14'd1);
+      sn_w.tmr = swp_rd_ctx_w.tmr - 14'd1;
       sn_wr_w  = 1'b1;
     end
     // ---- ADP available/departing for THIS context's bound talker -----
-    if (c_adp_r && sm && rd_ctx_w.state != LSM_UNBOUND_S &&
-        rd_ctx_w.talker == adp_eid_r) begin
+    if (c_adp_r && sm && swp_rd_ctx_w.state != LSM_UNBOUND_S &&
+        swp_rd_ctx_w.talker == adp_eid_r) begin
       if (adp_avail_r) begin
-        adp_disc      = !rd_ctx_w.tk_avail;
+        adp_disc      = !swp_rd_ctx_w.tk_avail;
         sn_w.tk_avail = 1'b1;
         sn_w.adp_age  = 7'd0;
       end else begin
-        adp_dep       = rd_ctx_w.tk_avail;
+        adp_dep       = swp_rd_ctx_w.tk_avail;
         sn_w.tk_avail = 1'b0;
       end
       sn_wr_w = 1'b1;
@@ -723,7 +732,7 @@ module KL_acmp_lstn_ctx #(
     fail_rise = sm &&  ta_failed_i[swp_idx_r]     && !srv_fail_r[swp_idx_r];
     // ---- per-state transitions (single-sink SM table, per context) ---
     if (sm) begin
-      unique case (rd_ctx_w.state)
+      unique case (swp_rd_ctx_w.state)
         LSM_PRB_W_DELAY_S: begin
           if (fire) begin
             swp_probe_set_w = 1'b1;

--- a/sw/litex/build.sh
+++ b/sw/litex/build.sh
@@ -124,6 +124,25 @@ cfg_ax7101() {   # bench/cert shape (USER 2026-07-21: 1 hart + L2 32K - the
           --uart-baudrate 115200 --rx-queues 2 --strip-probes --hs-page-bytes 16384 \
           --place-directive ExtraPostPlacementOpt"
 }
+cfg_ax8x8() {    # 8-stream (64ch) fits+closes shape. The 8x8 was NOT area-bound
+                 # (it placed at ~88%); it was a single-path TIMING miss. Two
+                 # measured moves close it @100 MHz with the CPU/audio/control
+                 # plane untouched: (1) --rx-queues 1 drops the RX1 DMA RSC/TCP
+                 # coalescing engine - pure Linux-throughput logic that audio
+                 # never touches - which removed the sys_clk critical path AND
+                 # freed ~3% LUT; (2) default (timing) synth instead of the blunt
+                 # AreaOptimized flag. The remaining -0.155 was a FALSE path
+                 # (cap_luid_r -> shared ctx read mux -> ACMP sweep writeback,
+                 # impossible: sweep write needs !w_frame_latch) fixed in RTL by
+                 # a dedicated sweep read port in KL_acmp_lstn_ctx.sv. Result
+                 # 2026-07-24: WNS +0.080, LUT 85.15%, TNS 0 (all seeds close).
+    echo "--board ax7101 --cpu vexiiriscv --cpu-count 1 --all-blocks --coherent-dma \
+          --milan-clk-freq 100e6 --with-spiflash --flashboot full --gtx-tx-invert \
+          --timing-opt --floorplan --l2-bytes 16384 \
+          --scala-args=--lsu-l1-refill-count=8 --scala-args=--lsu-hardware-prefetch=rpt \
+          --uart-baudrate 115200 --rx-queues 1 --strip-probes --hs-page-bytes 16384 \
+          --num-streams 8 --place-directive AltSpreadLogic_high"
+}
 cfg_arty() {     # Arty A7-100 small endstation: MII 100M, QSPI flashboot (probes stripped since v8 - AVDECC stack needs the slices: v7-style probes overflowed by 181)
     # -1 die: 100 MHz datapath does NOT close (measured -1.0 WNS); 50 MHz is
     # 3.2 Gb/s of 64-bit datapath for a 100 Mbit wire. sys 83.333 = the clean

--- a/sw/litex/build.sh
+++ b/sw/litex/build.sh
@@ -141,7 +141,11 @@ cfg_ax8x8() {    # 8-stream (64ch) fits+closes shape. The 8x8 was NOT area-bound
           --timing-opt --floorplan --l2-bytes 16384 \
           --scala-args=--lsu-l1-refill-count=8 --scala-args=--lsu-hardware-prefetch=rpt \
           --uart-baudrate 115200 --rx-queues 1 --strip-probes --hs-page-bytes 16384 \
-          --num-streams 8 --place-directive AltSpreadLogic_high"
+          --num-streams 8 --eth-port e2 --place-directive AltSpreadLogic_high"
+                 # --eth-port e2: the bench cable is on the AX7101's e2 RGMII port
+                 # (default e1 leaves the driven PHY unlinked -> MAC quiet -> "no
+                 # route to host"). AX42's guard-reset scope already covers e2's
+                 # PHY tx/gtx path; this just selects the physically-cabled port.
 }
 cfg_arty() {     # Arty A7-100 small endstation: MII 100M, QSPI flashboot (probes stripped since v8 - AVDECC stack needs the slices: v7-style probes overflowed by 181)
     # -1 die: 100 MHz datapath does NOT close (measured -1.0 WNS); 50 MHz is

--- a/sw/litex/build.sh
+++ b/sw/litex/build.sh
@@ -141,11 +141,10 @@ cfg_ax8x8() {    # 8-stream (64ch) fits+closes shape. The 8x8 was NOT area-bound
           --timing-opt --floorplan --l2-bytes 16384 \
           --scala-args=--lsu-l1-refill-count=8 --scala-args=--lsu-hardware-prefetch=rpt \
           --uart-baudrate 115200 --rx-queues 1 --strip-probes --hs-page-bytes 16384 \
-          --num-streams 8 --eth-port e2 --place-directive AltSpreadLogic_high"
-                 # --eth-port e2: the bench cable is on the AX7101's e2 RGMII port
-                 # (default e1 leaves the driven PHY unlinked -> MAC quiet -> "no
-                 # route to host"). AX42's guard-reset scope already covers e2's
-                 # PHY tx/gtx path; this just selects the physically-cabled port.
+          --num-streams 8 --place-directive AltSpreadLogic_high"
+                 # eth-port defaults to e1 (the bench default, same as cfg_ax7101).
+                 # If the AX cable is on e2, append `-- --eth-port e2`; AX42's guard
+                 # reset scope covers either PHY's tx/gtx path.
 }
 cfg_arty() {     # Arty A7-100 small endstation: MII 100M, QSPI flashboot (probes stripped since v8 - AVDECC stack needs the slices: v7-style probes overflowed by 181)
     # -1 die: 100 MHz datapath does NOT close (measured -1.0 WNS); 50 MHz is


### PR DESCRIPTION
## Status
Ready for review. RTL fix + reproducible build config. Timing **CLOSED** (WNS +0.080, TNS 0, all seeds). Board-to-board audio validation in progress (posted as a comment when done). **Do not merge without maintainer approval.**

## Description
The 8×8 (8-stream / 64-ch) build was assumed to be an area problem (issue #35, campaign #42). Measurement showed otherwise: it **placed at ~88%** — it was a single-path **timing** miss (WNS −1.184 → −0.155), not over-utilization. Two measured moves close it @100 MHz with the **CPU, audio datapath, and control plane all untouched**:

1. **`cfg_ax8x8` with `--rx-queues 1`** (build.sh) — drops the RX1 DMA ring writer + its RSC/TCP-coalescing engine. That engine is pure Linux-throughput machinery; gPTP/ATDECC/SRP/AVB-audio all pass through it as single-frame BDs, unaffected. Removed the `sys_clk` −1.184 path **and** freed ~3% LUT. Cost: Linux TCP RX fan-out (~201→ single-queue), irrelevant to a Milan audio end-station. Also drops the blunt `AreaOptimized_high` synth flag (it was itself hurting timing).
2. **Dedicated ACMP sweep read port** (`KL_acmp_lstn_ctx.sv`) — the remaining −0.155 was a **FALSE path**: `cap_luid_r` (frame index) → shared `rd_idx_w` mux → ctx read → sweep writeback. Functionally impossible (the sweep write fires only under `w_swp_run == !w_frame_latch`); the real sweep RMW already met at **+2.974 ns** (verified via `report_timing` on the routed checkpoint). Fix: give the sweep its own read port `swp_rd_ctx_w = ctx_ram[swp_idx_r]` so the frame index can never reach the sweep cone. Behaviour-identical — during the sweep `rd_idx_w == swp_idx_r`.

## Reproduce
```
sw/litex/build.sh ax8x8            # single best-seed build (AltSpreadLogic_high)
sw/litex/build.sh ax8x8 --sweep    # 3 place-seeds
```

## Validate
- `report_timing_summary` on the routed checkpoint: **WNS +0.080, WHS +0.050, TNS 0, "all constraints met"**, LUT 85.15% / FF 44.6% / BRAM 63.0%.
- `tb/verilator/acmp_lstn` (its designed N=4): **ctx 128/0, listener 126/0 — bit-identical** to pre-change. (The N=8 vectors in `sim_ctx.cpp` are N=4-specific and fail on the unmodified RTL too — not a regression.)
- Board-to-board audio E2E (Arty ↔ Alinx): **pending** — results posted as a comment.

## DoD
- [x] 8×8 fits + closes timing @100 MHz (all seeds)
- [x] ACMP behaviour bit-identical (acmp_lstn TB)
- [x] Reproducible via a named build config
- [ ] Board-to-board audio validated on real silicon (comment to follow)

Refs #35, #42, #16.
