### PR TITLE
link_guard: manual reinit drives the full sequenced eth+sys CDC recovery (fix the residual TX-wedge)

### DIFF
--- a/hdl/common/KL_link_guard.sv
+++ b/hdl/common/KL_link_guard.sv
@@ -95,16 +95,30 @@ module KL_link_guard #(
   // Toggle synchronizers + transition detect                            //
   // ------------------------------------------------------------------ //
   logic [2:0] rx_sync_r, tx_sync_r, act_sync_r;
+  logic       man_reinit_r;   //! delay FF for the manual-reinit rising edge
 
   always_ff @(posedge clk_i) begin : sync_ffs
-    rx_sync_r  <= {rx_sync_r[1:0],  rx_tgl_i};
-    tx_sync_r  <= {tx_sync_r[1:0],  tx_tgl_i};
-    act_sync_r <= {act_sync_r[1:0], act_tgl_i};
+    rx_sync_r    <= {rx_sync_r[1:0],  rx_tgl_i};
+    tx_sync_r    <= {tx_sync_r[1:0],  tx_tgl_i};
+    act_sync_r   <= {act_sync_r[1:0], act_tgl_i};
+    man_reinit_r <= man_reinit_i;
   end : sync_ffs
 
   wire rx_trans_w  = (rx_sync_r[2]  ^ rx_sync_r[1])  && !freeze_i;
   wire tx_trans_w  = (tx_sync_r[2]  ^ tx_sync_r[1])  && !freeze_i;
   wire act_trans_w = (act_sync_r[2] ^ act_sync_r[1]);
+
+  //! Manual reinit (LINK_CTRL[1]) rising edge -> drives the SAME sequenced
+  //! eth+sys recovery as a clock-death event. Without this the manual path was
+  //! sys-only (reinit_o) and could NOT clear an eth-side CDC desync that occurred
+  //! while the eth clocks stayed ALIVE - a warm reconfigure, or a switch bounce
+  //! whose RXC never fully dropped below the death threshold. The guard then sits
+  //! in RUN_S (both clocks alive -> no auto trigger) and linkmon's reinit resets
+  //! only the sys side, so the MAC wedges until a gateware reload despite repeated
+  //! reinit strobes. Routing it through the FSM applies eth_rst for >=SETTLE/2
+  //! clean eth cycles and releases eth-first-then-sys -> both CDC pointer sets
+  //! restart matched. (The daemon no longer needs to also strobe phy_crg_reset.)
+  wire man_edge_w  = man_reinit_i && !man_reinit_r;
 
   // ------------------------------------------------------------------ //
   // Per-clock liveness (dead = no transition for DEAD_CYC_C)            //
@@ -174,6 +188,7 @@ module KL_link_guard #(
   logic [15:0]        bounce_cnt_r;
   logic               guard_rst_r;
   logic               eth_rst_r;
+  logic               bounced_r;   //! this episode already counted a cable bounce
 
   wire both_alive_w = rx_alive_r && tx_alive_r;
 
@@ -184,29 +199,49 @@ module KL_link_guard #(
       bounce_cnt_r <= '0;
       guard_rst_r  <= 1'b0;
       eth_rst_r    <= 1'b0;
+      bounced_r    <= 1'b0;
     end
     else if (dis_i) begin
       state_r     <= RUN_S;
       guard_rst_r <= 1'b0;
       eth_rst_r   <= 1'b0;
+      bounced_r   <= 1'b0;
     end
     else begin
       unique case (state_r)
         RUN_S : begin
           guard_rst_r <= 1'b0;
           eth_rst_r   <= 1'b0;
-          if (!both_alive_w) begin
+          //! trigger on clock death OR a manual reinit edge - both run the full
+          //! sequenced eth-then-sys CDC reset (manual reinit is no longer sys-only)
+          if (!both_alive_w || man_edge_w) begin
             state_r      <= HOLD_S;
             guard_rst_r  <= 1'b1;
             eth_rst_r    <= 1'b1;
-            bounce_cnt_r <= (&bounce_cnt_r) ? bounce_cnt_r
-                                            : bounce_cnt_r + 16'd1;
+            //! count only genuine physical link bounces (clock death), not
+            //! software-requested reinits, so LINKG_STAT.bounce_cnt stays a
+            //! true cable-event counter
+            if (!both_alive_w) begin
+              bounced_r    <= 1'b1;
+              bounce_cnt_r <= (&bounce_cnt_r) ? bounce_cnt_r
+                                              : bounce_cnt_r + 16'd1;
+            end
+            else begin
+              bounced_r    <= 1'b0;   //! manual-triggered episode - no bounce yet
+            end
           end
         end
 
         HOLD_S : begin
           guard_rst_r <= 1'b1;
           eth_rst_r   <= 1'b1;
+          //! a real clock death arriving during a manual-triggered hold IS a
+          //! cable bounce - count it once (bounced_r guards mid-episode re-deaths)
+          if (!both_alive_w && !bounced_r) begin
+            bounced_r    <= 1'b1;
+            bounce_cnt_r <= (&bounce_cnt_r) ? bounce_cnt_r
+                                            : bounce_cnt_r + 16'd1;
+          end
           if (both_alive_w) begin
             state_r  <= SETTLE_S;
             settle_r <= '0;
@@ -222,6 +257,7 @@ module KL_link_guard #(
           else if (settle_r == SETW_C'(SETTLE_CYC_C)) begin
             state_r     <= RUN_S;
             guard_rst_r <= 1'b0;
+            bounced_r   <= 1'b0;   //! episode done - re-arm bounce counting
           end
           else begin
             settle_r <= settle_r + 1'b1;

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -607,9 +607,16 @@ class MilanMAC(LiteXModule):
         # declares a clock dead after 41 us without a transition, and then
         # auto-sequences the reinit strobe (hold through the outage + ~21 ms
         # clean-clock settle) - the hardware version of the linkmon recovery.
-        self.ethrx_tgl  = Signal()
-        self.ethtx_tgl  = Signal()
-        self.ethact_tgl = Signal()
+        # reset_less: the toggles OBSERVE the raw clocks, so they must sit outside
+        # every reset cone the guard itself drives. With plain FFs the AX42 ext_reset
+        # thread (eth_rst -> PHY CRG -> cd_eth_tx/rx domain resets) froze the toggles
+        # whenever the guard asserted eth_rst: both_alive dropped 41 us into SETTLE,
+        # the FSM fell back to HOLD with eth_rst still high, and the guard deadlocked
+        # holding MAC+PHY in reset forever (silicon 2026-07-24: every cold boot with
+        # an autoneg RXC bounce, and every manual LINK_CTRL[1] reinit, wire-dead).
+        self.ethrx_tgl  = Signal(reset_less=True)
+        self.ethtx_tgl  = Signal(reset_less=True)
+        self.ethact_tgl = Signal(reset_less=True)
         self.sync.eth_rx += self.ethrx_tgl.eq(~self.ethrx_tgl)
         self.sync.eth_tx += self.ethtx_tgl.eq(~self.ethtx_tgl)
         self.sync.eth_rx += If(self.phy.source.valid & self.phy.source.last,

--- a/tb/verilator/link_guard/sim_main.cpp
+++ b/tb/verilator/link_guard/sim_main.cpp
@@ -93,11 +93,20 @@ int main(int argc, char **argv) {
   run(SETTLE + DEAD + 16);
   ck("tx-recover reinit",  dut->reinit_o, 0);
 
-  // -- manual reinit OR-path -------------------------------------------
+  // -- manual reinit now drives the FULL sequenced eth+sys recovery -----
+  // (LINK_CTRL[1] rising edge -> HOLD -> SETTLE -> eth-first release), so a
+  // software reinit clears an eth-side CDC desync even with the eth clocks
+  // ALIVE - the old sys-only path could not, and the MAC stayed wedged.
+  uint64_t b_before = dut->stat_o >> 16;
   dut->man_reinit_i = 1; run(2);
-  ck("manual reinit",      dut->reinit_o, 1);
+  ck("manual reinit",       dut->reinit_o, 1);
+  ck("manual eth_rst",      dut->eth_rst_o, 1);          // eth side reset too now
   dut->man_reinit_i = 0; run(2);
-  ck("manual release",     dut->reinit_o, 0);
+  ck("manual still held",   dut->reinit_o, 1);           // sequenced, not instant
+  run(SETTLE + DEAD + 16);                               // ride out the settle
+  ck("manual recovered",    dut->reinit_o, 0);           // then releases
+  ck("manual eth released", dut->eth_rst_o, 0);
+  ck("manual not a bounce", dut->stat_o >> 16, b_before);// sw reinit != cable event
 
   // -- freeze test hook: fakes death, full sequence --------------------
   dut->freeze_i = 1;
@@ -272,11 +281,15 @@ int main(int argc, char **argv) {
     rx_period = 2; run(SETTLE + DEAD + 16);
     ck("re-death episode recovers",  dut->reinit_o, 0);
 
-    // manual reinit stays sys-only (daemon owns phy_crg_reset in that flow)
+    // manual reinit now drives the sequenced eth+sys recovery (it was sys-only,
+    // which could not clear a live-clock eth-side CDC desync -> permanent wedge)
+    rx_period = 2; tx_period = 3;
     dut->man_reinit_i = 1; run(2);
     ck("manual reinit sys held",     dut->reinit_o, 1);
-    ck("manual reinit eth idle",     ethrst(), 0);
-    dut->man_reinit_i = 0; run(2);
+    ck("manual reinit eth reset",    ethrst(), 1);
+    dut->man_reinit_i = 0;
+    run(SETTLE + DEAD + 16);                 // let the manual episode settle back
+    ck("manual reinit settled",      dut->reinit_o, 0);
 
     // disable drops the eth reset immediately (matches reinit semantics)
     rx_period = 0; run(DEAD + 8);


### PR DESCRIPTION
## Status
Ready for review. RTL fix + TB (link_guard 104/104, milan_dp regression 172+63/0). Silicon validation pending the rebuild+reflash (the reflash is itself a warm link-bounce = the exact trigger).

## Description
The MAC "TX-wedge-until-reload" on a link bounce was only *partly* fixed. AX42 + the auto guard path recover a **clock death** (RXC stops). But when the eth clocks come back **alive** while the sys<->eth CDC pointers are desynced (a warm reconfigure, or a switch bounce whose RXC never fully drops below the death threshold), the guard sits in `RUN_S` (both clocks alive -> no auto trigger) and the software fallback — linkmon's `LINK_CTRL[1]` — reset **only the sys side** (`reinit_o`), never `eth_rst_o`. So the eth-side CDC stayed desynced and the MAC wedged despite repeated reinit strobes (observed on silicon: `wr=0`, linkmon reinit ×4, unreachable).

Fix (`KL_link_guard.sv`): the manual-reinit rising edge now runs the **same sequenced eth+sys recovery** as a clock-death event — `HOLD -> SETTLE`, `eth_rst` held for >= SETTLE/2 clean eth cycles, released **eth-first-then-sys**, so both CDC pointer sets restart matched. `bounce_cnt` stays a true cable-event counter (a `bounced_r` episode flag keeps software reinits from inflating it, while a real clock death during a manual episode still counts once).

## Validate
- `tb/verilator/link_guard`: **104/104** (new: manual reinit asserts `eth_rst`, sequenced release, settles, not a bounce).
- `tb/verilator/milan_dp`: 172 + 63 checks, 0 failures (guard integration unchanged).
- Silicon: rebuild + reflash the AX7101 (warm bounce) -> linkmon reinit should now recover TX/RX. Posted as a comment.

## DoD
- [x] manual reinit drives the full eth+sys sequenced CDC reset
- [x] bounce_cnt remains cable-only
- [x] TBs green + datapath regression clean
- [ ] silicon: link recovers after a bounce (comment to follow)
