### PR TITLE
docs: clean round - complete module inventory, suite index, CONTRIBUTING, diagrams, QSPI truth (#39 #40 #41)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing — house rules that keep this repo shippable
+
+Short version: SystemVerilog only, banner-documented, one-line commits,
+lane-per-worktree, every change grows the test suite, and nothing merges on
+"looks right" — TB numbers or silicon numbers.
+
+## 1. HDL house style (Cemal Dogan / Oguz Kahraman school)
+
+- **SystemVerilog only** for new HDL. Python (migen/LiteX) is SoC *glue*,
+  never new datapath logic.
+- File head: SPDX line + banner comment stating what the module is and the
+  one design decision that matters. `` `default_nettype none `` at the top,
+  `` `default_nettype wire `` at the bottom.
+- Ports documented **inline with `//!`** — the port list IS the spec.
+- Naming: `_r` registered, `_w` wire/comb, `_p` one-cycle pulse, `_S` FSM
+  states, `_C`/`_P` params. Named `always_ff`/`always_comb` blocks
+  (`begin : name … end : name`).
+- Reset: synchronous, active-low `rst_n`, every register reset. 2-space
+  indent.
+- CDC: only via the blessed primitives (`cdc_pulse`, `cdc_handshake`,
+  toggle+sync); **clock-liveness observers must be `reset_less`** — never
+  place an observer inside a reset cone its consumer drives (the 07-24
+  link-guard deadlock).
+
+## 2. Workflow
+
+- **One lane = one worktree = one branch = one PR** (`~/milan-avb-multiwork`
+  pattern). Copy (`cp -r`), never symlink, `third_party/` into a worktree —
+  a symlink escapes to the main repo and builds silently stale RTL; then
+  delete the copied submodule's `.git` file.
+- **Commits: one line, no trailers.** Say CERT, never the A-word.
+- PRs use the template: Status / Description / how-to-reproduce / how-to-
+  validate / DoD. **Self-test results go in a PR comment** — a comment is
+  evidence, not approval. Maintainer merges by default.
+- `tests/steps/tsn_gen_steps.py` `LAYOUTS` merges are **semantic, never
+  marker-union**: rebuild each command's block from its owning commit
+  verbatim (naive unions broke main twice; a third time gets you named in
+  this file).
+
+## 3. Verification bar
+
+- Every functional RTL change ships with a self-checking Verilator harness
+  under `tb/verilator/<name>/` (`make` = build+run, exit code is the gate).
+  See `docs/testing/TESTING.md` for the suite index and tiers.
+- Coverage-matrix rows (`docs/testing/`) only move ✅ with a runnable test.
+  Prefer real-wiring-path tests over unit mocks.
+- **Measure, don't assume**: no number from a comment or model drives a
+  decision. HW counter first; measure before AND after; a TB-green
+  integration change still owes a datapath-regression run
+  (`tb/verilator/milan_dp`).
+- Timing claims need the full cell recipe (config + directive + seed); a
+  bare WNS number is not reproducible. 3×32-thread Vivado discipline:
+  single configs become 3-directive sweeps, keep best WNS.
+
+## 4. Bench discipline (the expensive lessons)
+
+- AX boot probes need **≥ 8 min** windows (power→network ≈ 7 min); a probe
+  timeout is not a dead board.
+- Never freeze the PCM ring mid-stream and plain re-enable (resume desync);
+  full reset-reprogram.
+- QSPI: never overwrite a slot without the current content dumped to disk
+  first; DTB changes go through the **OpenSBI FW_FDT_PATH embed** (the dtb
+  flash slot is not what the kernel boots on); regenerate the DTB from the
+  build's `csr.csv` on ANY gateware block-set change (CSR-rot rule,
+  `docs/integration/QSPI_FLASHBOOT.md`).

--- a/docs/SYSTEMS_ENGINEER_GUIDE.md
+++ b/docs/SYSTEMS_ENGINEER_GUIDE.md
@@ -10,6 +10,46 @@ stated here so this guide is accurate *today*; the doc audit (`DOC_AUDIT.md`) tr
 
 ---
 
+
+## 0. The system at a glance (start here)
+
+Two Artix-7 boards are complete Milan/AVB end-stations: gPTP-synced fabric
+PHC, lwSRP reservations, full 1722.1 entity (ADP/AECP/ACMP), 8×8 AAF
+streams, and an ALSA capture card fed straight from the fabric DMA ring.
+Everything below is measured on silicon, not simulated.
+
+```mermaid
+flowchart LR
+    subgraph AX["AX7101 (8x8, GM, flash-boots)"]
+        TONE[tone / I2S / KL_pcm_tx ring] --> TXMUX[playback + chmap muxes] --> PKT[AAF packetizer + CBS + PTP stamp]
+        RXD[depacketizer] --> RING[PCM DMA ring] --> ALSA["arecord (snd-kl-milan)"]
+    end
+    subgraph SW["AVB switch (802.1AS-aware)"] 
+    end
+    subgraph ARTY["Arty A7 (4x4, PipeWire loop)"]
+        ARX[listener] --> PW[PipeWire] --> ATX[talker]
+    end
+    PKT -->|"AAF, VID 2"| SW --> ARX
+    ATX --> SW2[" "]:::hidden --> RXD
+    SW --- SW2
+    classDef hidden fill:none,stroke:none
+```
+
+**Measured truth (2026-07-24/25):** E2E capture→render = the presentation
+offset exactly — pto 500 µs ⇒ `ts_delta` +384 µs, **0 LATE** (datapath
+pipeline ≈ 116 µs); talker wire output **bit-exact** vs the tone table
+(900/900); full board→board→PipeWire→board loop −72.7 dB THD+N; gPTP slave
+rms 44 ns through the switch.
+
+```mermaid
+flowchart LR
+    PWR((power-on)) --> CFG["FPGA self-config from QSPI\n(SPIx4/50, ~0.2 s)"] --> BIOS[LiteX BIOS] -->|"flashboot: kernel/opensbi/dtb/rootfs\nfrom their QSPI slots"| SBI["OpenSBI (carries the kernel's DTB!)"] --> LNX[Linux] --> NET["network up (~7 min total)"]
+```
+
+Fastest useful commands: `docs/integration/QSPI_FLASHBOOT.md` (flash/boot),
+`docs/testing/TESTING.md` (run any TB), `CONTRIBUTING.md` (house rules),
+`docs/fpga/FPGA_DESIGN.md` (all 77 modules).
+
 ## 1. What this system is
 
 **milan-fpga is a fully-FPGA AVB/TSN Milan end-station.** It is a RISC-V/LiteX softcore SoC with

--- a/docs/fpga/FPGA_DESIGN.md
+++ b/docs/fpga/FPGA_DESIGN.md
@@ -38,84 +38,190 @@ RX: MAC ──► ptp_ts_top(RX stamp) ──► rx_mac_filter(TCAM) ──► D
 TS: ptp_ts_top ──► m_axis_ts (timestamp metadata records) ──► DMA
 ```
 
-## 2. Module inventory
 
-Columns: **Verified by** names the `tb/verilator/` suite (see
-[../testing/TESTING.md](../testing/TESTING.md)); **Doc** is the per-module
-reference under `hdl/**/doc/`.
+### 1.1 TX audio chain as composed on main (2026-07-25 merge round)
 
-### 2.1 `hdl/ieee8021q/ts/` - classification + 802.1Qav shaping
+```mermaid
+flowchart LR
+    ADC[I2S / tone capture front-end] --> PB{{item-7 playback mux\npb_enable, def 0}}
+    RING[KL_pcm_tx DRAM ring] --> PB
+    PB --> CM{{chmap capture mux\nCHMAP_CTRL 0x900, def 0}}
+    CM --> PKT[KL_aaf_packetizer] --> MERGE[traffic merge + CBS] --> MAC[MilanMAC + PTP stamp] --> WIRE((wire))
+    WIRE --> RX[classifier + depacketizer] --> RB[PCM DMA ring _PCMRingNxN] --> ALSA[snd-kl-milan arecord]
+    RX --> XBAR[chmap render xbar] --> TDM[KL_tdm_render / I2S out]
+```
 
-| Module | Purpose | Clock | Verified by | Doc |
-|---|---|---|---|---|
-| `traffic_controller_802_1q` | subsystem top: classifier → queues → shaping core, CSR-configured | `axis_clk` | `datapath`, `controller_rate` | [doc](../../hdl/ieee8021q/ts/doc/traffic_controller_802_1q/traffic_controller_802_1q.md) |
-| `traffic_classifier` | VLAN/PCP/EtherType parse → per-frame `tdest` sideband (redesigned after the [CBS datapath bug](../findings/CBS_DATAPATH_BUG.md)); buffers via `axis_fifo` | `axis_clk` | `classifier` | [doc](../../hdl/ieee8021q/ts/doc/traffic_classifier/traffic_classifier.md) |
-| `traffic_class_map` | 802.1Q PCP→regen→traffic-class→queue decode | `axis_clk` | `cls` | - |
-| `traffic_queues` | `axis_demux` (1→4 by `tdest`) → 4× `axis_fifo` (depth 1024 as instantiated) → grant-indexed combinational egress mux | `axis_clk` | `queues` | [doc](../../hdl/ieee8021q/ts/doc/traffic_queues/traffic_queues.md) |
-| `traffic_shaping_core` | grant arbiter over N queues: strict priority + CBS gating | `axis_clk` | `shaper_core` | [doc](../../hdl/ieee8021q/ts/doc/traffic_shaping_core/traffic_shaping_core.md) |
-| `credit_based_shaper` | per-class 802.1Qav credit accumulator (signed 48-bit; `use_dsp` hint; the 100 MHz critical path - see [../integration/PORTING_GUIDE.md](../integration/PORTING_GUIDE.md) §4.5) | `axis_clk` | `cbs` (87 k checks vs fixed-point + ideal models) | [doc](../../hdl/ieee8021q/ts/doc/credit_based_shaper/credit_based_shaper.md) |
+Both new stages default to bypass: with `pb_enable=0` and `chmap_enable=0`
+the packetizer input is bit-identical to the pre-merge datapath.
 
-### 2.2 `hdl/ieee8021as/ptp_timestamp/` - PTP hardware clock + timestamping
+## 2. Module inventory — COMPLETE (auto-generated from the RTL banners, 2026-07-25)
 
-| Module | Purpose | Clock | Verified by | Doc |
-|---|---|---|---|---|
-| `ptp_ts_top` | subsystem top: PHC + TX/RX stampers + metadata buffering (3× `axis_fifo`, all `axis_clk`) | `axis_clk` + `gtx_clk` | (via `milan_dp`; legacy itest) | [doc](../../hdl/ieee8021as/ptp_timestamp/doc/ptp_ts_top.md) |
-| `ptp_ts_core` | SOP detect + timestamp capture; crosses domains via `cdc_pulse`/`cdc_handshake` | both | (via `milan_dp`) | [doc](../../hdl/ieee8021as/ptp_timestamp/doc/ptp_ts_core.md) |
-| `timestamp_counter` | free-running adjustable PHC (Q(INT).FRAC ns: rate, adjfine, settime, adjtime, snapshot) | `gtx_clk` | `ptp` (201 k checks vs 128-bit model) | [doc](../../hdl/ieee8021as/ptp_timestamp/doc/timestamp_counter.md) |
-| `ptp_csr_sync` | CSR↔PHC command/return CDC (plain-FF `ASYNC_REG` synchronizers, no XPM) | `axis_clk` ↔ `gtx_clk` | `ptp_sync` | - |
+Every `module` in `hdl/` (77 total, one row each; descriptions are the
+modules' own banner lines). Regenerate with the snippet in the commit that
+added this section whenever `hdl/` changes shape.
 
-### 2.3 `hdl/ieee17221/adp/` - IEEE 1722.1 discovery (ADP)
+### `hdl/common/`
 
-| Module | Purpose | Clock | Verified by | Doc |
-|---|---|---|---|---|
-| `adp_advertiser` | byte-exact ADPDU transmit FSM: AVAILABLE/DEPARTING, `available_index`, advertise timer, entity model from CSR group 0x600 | `axis_clk` | `adp` (121 checks) | [doc](../../hdl/ieee17221/adp/doc/adp_advertiser.md) |
-| `adp_tx_arbiter` | 2→1 packet arbiter merging ADP into the MAC TX stream | `axis_clk` | `adp_tx` | - |
-| `KL_adp_parser` | ADPDU receive parser (discover/available/departing + entity info) | `axis_clk` | (legacy utest) | [doc](../../hdl/ieee17221/adp/doc/kl-adp-parser/KL_adp_parser.md) |
-| `adp_pkg` | ADP constants/fields package | - | - | - |
+| module | description |
+|---|---|
+| `KL_link_guard` |  |
+| `axis_mux_rr_2in_1out` | Slave 0 axis interface |
+| `cdc_handshake` | File        : cdc_handshake.sv |
+| `cdc_pair_fifo` | Gray-pointer dual-clock FIFO, WIDTH x 2^LOG2D. Flags are conservative |
+| `cdc_pulse` | File        : cdc_pulse.sv |
 
-### 2.4 `hdl/ieee1722/avtp/` - IEEE 1722 AVTP
+### `hdl/common/csr/`
 
-| Module | Purpose | Clock | Verified by | Doc |
-|---|---|---|---|---|
-| `KL_avtp_common_parser` | AVTP common-header parse (subtype, control vs stream) | `axis_clk` | (legacy utest) | [doc](../../hdl/ieee1722/avtp/doc/kl-avtp-common-parser/KL_avtp_common_parser.md) |
-| `avtp_stream_parser` | RX AVTP stream-header monitor vs a programmable stream-id table (the S1 AVTP-engine foundation) | `axis_clk` | `avtp_stream` (21 checks) | - |
-| `avtp_subtype_pkg` | AVTP subtype constants | - | - | - |
+| module | description |
+|---|---|
+| `milan_csr` |  |
 
-### 2.5 `hdl/common/csr/` - control plane
+### `hdl/common/eth_event_counter/`
 
-`milan_csr` (`hdl/common/csr/milan_csr.sv`): the AXI4-Lite CSR block - ID/IRQ
-(0x000), MAC control (0x100), RMON stats (0x200), classifier (0x300), CBS
-per-queue (0x400 + q*0x20), PTP clock (0x500), ADP entity model (0x600),
-RX filter/TCAM programming (0x700). Verified by `csr` (the executable form of
-[../reference/REGISTER_MAP.md](../reference/REGISTER_MAP.md));
-doc: [milan_csr.md](../../hdl/common/csr/doc/milan_csr.md).
+| module | description |
+|---|---|
+| `ethernet_events` | This module instantiates multiple `event_counter` modules, one for each |
+| `event_counter` | This module implements a simple synchronous event counter. |
 
-### 2.6 `hdl/common/eth_event_counter/` - RMON
+### `hdl/common/`
 
-`ethernet_events` instantiates 9× `event_counter` on the MAC's RMON event
-pulse lanes (`ethernet_events.svh` enum), with snapshot/reset from CSR
-group 0x200 and rollover IRQ. Docs:
-[ethernet_events.md](../../hdl/common/eth_event_counter/doc/ethernet_events.md),
-[event_counter.md](../../hdl/common/eth_event_counter/doc/event_counter.md).
+| module | description |
+|---|---|
+| `tx_ifg_gasket` | File        : tx_ifg_gasket.sv |
 
-### 2.7 `hdl/common/` - integration, filtering, CDC, utilities
+### `hdl/ieee1722/aaf/`
 
-| Module | Purpose | Verified by | Doc |
-|---|---|---|---|
-| `milan_datapath` / `milan_top` / `milan_dma_wrapper` | the wrappers (§1) | `milan_dp` (wrapper-level) | header comments (extensive) |
-| `tcam` | register-based ternary CAM (key/mask/action, priority hit) | `tcam` (19) | [doc](../../hdl/ieee8021q/filtering/doc/tcam.md) |
-| `rx_mac_filter` | TCAM-driven dest-MAC RX filter (whitelist/blacklist/range, cut-through) | `rx_filter` (14) | - |
-| `cdc_pulse` / `cdc_handshake` | open CDC primitives (toggle-sync pulse; 4-phase req/ack value) that replaced `xpm_cdc_*` | `cdc` (16, two independent clocks) | - |
-| `axis_mux_rr_2in_1out` | round-robin 2→1 AXIS packet mux (TS stream merge) | (via `milan_dp`) | - |
-| `ethernet_packet_pkg` / `parameters.svh` / `axi_stream_if` | global constants, AXIS defines, SV interface | - | - |
+| module | description |
+|---|---|
+| `KL_aaf_capture_i2s` | Audio capture front-end (NXN §2.1 / P4): the I2S/CDC half of the old |
+| `KL_aaf_latency_chain` |  |
+| `KL_aaf_packetizer` |  |
+| `KL_aaf_rx_depacketizer` |  |
+| `KL_chan_map_capture` |  |
+| `KL_chan_map_render` |  |
+| `KL_i2s_playback` | I2S DAC serializer, clean-clocked: PCM tap (wire-order S32BE interleave, |
+| `KL_lat_history_ring` |  |
+| `KL_media_adv` | Fractional-N advance strobe: adv_o duty = TICK_HZ / CLK_FREQ_HZ exactly |
+| `KL_pcm_lpf` |  |
+| `KL_pcm_ring_bram` |  |
+| `KL_pcm_route` |  |
+| `KL_pcm_tx` |  |
+| `KL_tdm_capture` |  |
+| `KL_tdm_render` |  |
+| `KL_tone_gen` | 1 kHz / 0 dBFS pilot tone: 48-sample exact-period 24-bit sine table |
+| `aaf_talker_i2s` | File        : aaf_talker_i2s.sv |
 
-### 2.8 Vendored cores - `third_party/verilog-axis` (submodule)
+### `hdl/ieee1722/avtp/`
 
-`axis_fifo`, `axis_demux` (+ `arbiter`, `priority_encoder`; `axis_arb_mux`
-is carried in the source list and portability checks but no longer
-instantiated in the datapath). MIT-licensed, pinned by gitlink - see
-[`THIRD_PARTY.md`](../../THIRD_PARTY.md). **Must be initialized before any
-build/sim:** `git submodule update --init third_party/verilog-axis`.
+| module | description |
+|---|---|
+| `KL_avtp_common_parser` |  |
+| `KL_avtp_rx_monitor` |  |
+| `KL_avtp_rx_monitor_ctx` |  |
+| `KL_stream_table` |  |
+| `avtp_stream_parser` |  |
+
+### `hdl/ieee1722/crf/`
+
+| module | description |
+|---|---|
+| `KL_crf_rx` |  |
+| `KL_crf_tx` |  |
+| `KL_mmcm_drp_servo` |  |
+
+### `hdl/ieee1722/maap/`
+
+| module | description |
+|---|---|
+| `KL_maap` |  |
+
+### `hdl/ieee17221/acmp/`
+
+| module | description |
+|---|---|
+| `KL_acmp_listener` | File        : KL_acmp_listener.sv |
+| `KL_acmp_lstn_ctx` | File        : KL_acmp_lstn_ctx.sv |
+| `KL_acmp_responder` | File        : KL_acmp_responder.sv |
+| `KL_acmp_tlkr_ctx` | File        : KL_acmp_tlkr_ctx.sv |
+
+### `hdl/ieee17221/adp/`
+
+| module | description |
+|---|---|
+| `KL_adp_parser` |  |
+| `adp_advertiser` | File        : adp_advertiser.sv |
+| `adp_tx_arbiter` | File        : adp_tx_arbiter.sv |
+
+### `hdl/ieee17221/aecp/`
+
+| module | description |
+|---|---|
+| `KL_aecp_accessor` |  |
+| `KL_aecp_aem_dyn_mux` |  |
+| `KL_aecp_aem_store` |  |
+| `KL_aecp_common_parser` |  |
+| `KL_aecp_ingress` |  |
+| `KL_aecp_l0_state` |  |
+| `KL_aecp_packet_validator` |  |
+| `KL_aecp_response_builder` |  |
+| `KL_aecp_timers` |  |
+| `KL_aecp_top` |  |
+
+### `hdl/ieee8021as/ptp_timestamp/`
+
+| module | description |
+|---|---|
+| `ptp_csr_sync` |  |
+| `ptp_ts_core` |  |
+| `ptp_ts_top` | MAC-side convention - adp_advertiser.sv, |
+| `timestamp_counter` |  |
+
+### `hdl/ieee8021q/filtering/`
+
+| module | description |
+|---|---|
+| `rx_mac_filter` | File        : rx_mac_filter.sv |
+| `tcam` | File        : tcam.sv |
+
+### `hdl/ieee8021q/srp/`
+
+| module | description |
+|---|---|
+| `KL_lwsrp_bw_gate` | File        : KL_lwsrp_bw_gate.sv |
+| `KL_lwsrp_ctx` | File        : KL_lwsrp_ctx.sv |
+| `KL_lwsrp_ctx_tx` | File        : KL_lwsrp_ctx_tx.sv |
+| `KL_lwsrp_ingress` | File        : KL_lwsrp_ingress.sv |
+| `KL_lwsrp_registrar` | File        : KL_lwsrp_registrar.sv |
+| `KL_lwsrp_rx` | File        : KL_lwsrp_rx.sv |
+| `KL_lwsrp_ta_registrar` | File        : KL_lwsrp_ta_registrar.sv |
+| `KL_lwsrp_timers` | File        : KL_lwsrp_timers.sv |
+| `KL_lwsrp_top` | File        : KL_lwsrp_top.sv |
+| `KL_lwsrp_tx` | File        : KL_lwsrp_tx.sv |
+| `KL_lwsrp_walker` | File        : KL_lwsrp_walker.sv |
+
+### `hdl/ieee8021q/ts/`
+
+| module | description |
+|---|---|
+| `credit_based_shaper` |  |
+| `traffic_class_map` |  |
+| `traffic_classifier` | This module implements an Ethernet packet classifier that parses incoming AXIS frames and |
+| `traffic_controller_802_1q` |  |
+| `traffic_queues` | One-hot: indicates granted queue |
+| `traffic_shaping_core` |  |
+
+### `hdl/milan/`
+
+| module | description |
+|---|---|
+| `milan_datapath` | This is the single clean HW/gateware boundary the LiteX SoC (sw/litex/milan_soc.py) |
+| `milan_top` |  |
+
+<!-- 77 modules -->
+
+
+Each module's authoritative documentation is its own header banner (house
+style: `//!` port docs); this table is the index, not the spec.
 
 ## 3. Clock domains & CDC (complete inventory)
 

--- a/docs/integration/QSPI_FLASHBOOT.md
+++ b/docs/integration/QSPI_FLASHBOOT.md
@@ -1,6 +1,41 @@
 # QSPI flash-boot  -  skip the multi-minute serial upload
 
-## Layout v3 — QSPI-BOOTED BITSTREAM + XZ KERNEL (2026-07-12)
+## Layout "full" — THE DEPLOYED TRUTH (2026-07-24, silicon-verified end-to-end)
+
+The layout of record is the `--flashboot full` manifest baked into the
+gateware BIOS (`flashboot_layout.json` in every build dir — ALWAYS read the
+build's own copy; offsets below are the current AX/Arty builds'):
+
+| slot      | offset      | budget    | measured (AX 07-24) | notes |
+|-----------|-------------|-----------|---------------------|-------|
+| bitstream | `0x00_0000` | 4 MiB     | 3.6 MiB (raw)       | AX: platform-pinned **SPIx4 / CONFIGRATE 50, UNCOMPRESSED** — cold-config silicon-proven (the x1/33/COMPRESS pin is the **Arty-only** override; the milan_soc.py comment says why). `openFPGALoader -f --verify`, NOT fbi-wrapped. |
+| kernel    | `0x40_0000` | 3 MiB     | 2.52 MB             | Image.xz (`xz -9 --check=crc32`); BIOS xz_embedded decodes → DRAM |
+| opensbi   | `0x70_0000` | 384 KiB   | 266,824 B           | fw_jump → 0x40F0_0000. **CARRIES THE KERNEL'S DTB (FW_FDT_PATH embed)** — see the decoy warning below |
+| dtb       | `0x76_0000` | 128 KiB   | ~3 KB               | **A DECOY for the kernel**: the BIOS copies it, but the kernel boots on the *OpenSBI-embedded* FDT. Changing the DTB = rebuild opensbi (`fpga/boot/build_opensbi.sh`, always-clean rule) + flash the OPENSBI slot. Keep this slot in sync anyway (safety copy). |
+| rootfs    | `0x78_0000` | 8.5 MiB   | 8,898,244 B (**14.6 KB headroom**) | rootfs.cpio + `xz -9 -e --check=crc32` **by hand** (NOT a buildroot target in this output tree: `rm images/rootfs.cpio*; make rootfs-cpio; xz …`) |
+
+All Linux images are FBI-wrapped (`python -m litex.soc.software.crcfbigen
+<img> -f -l`) then written raw at their offsets
+(`openFPGALoader -o <offset> --write-flash --file-type raw --verify`);
+`deploy.sh flash-images` automates the set. `openFPGALoader --reset` pulses
+PROGRAM_B = reboot from flash without a power cycle.
+
+**Matched-image rule (the CSR-rot trap, bitten twice — 07-22 and 07-24):**
+the kl-eth LiteX CSR block addresses (dma-ts, dma-pcm, …) are AUTO-ALLOCATED
+and SHIFT whenever the gateware's block set changes (e.g. `--rx-queues 1`
+dropped the RX1 queue CSRs and moved dma-ts 0x3100→0x308c, dma-pcm
+0x3120→0x30ac). The DTB **must be regenerated from the build's `csr.csv`**
+and re-embedded into opensbi with every gateware change that touches the
+map — the symptom of a stale DTB is subtle (e.g. ptp4l "timed out while
+polling for tx timestamp" while everything else works).
+
+**Boot timing truth (07-24):** power-on → network-up ≈ **7 min** (FPGA
+config and kernel are seconds; the rootfs init + S50milan devmem storm is
+the bulk). Warm boots (link already negotiated) ≈ 2.5–3 min. **Reachability
+probes need ≥ 8 min windows** — two false "cold-boot dead" verdicts were
+probe timeouts.
+
+## Layout v3 — SUPERSEDED HISTORY (2026-07-12; offsets no longer deployed)
 
 The gateware lives in flash and the FPGA config-boots it (mode pins: Arty
 JP1 -> QSPI, AX7101 boot switch -> QSPI); bitstreams are COMPRESSED (pinned:

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -37,6 +37,63 @@ TX/RX); `controller_rate` is the gating regression born from the
 [CBS datapath bug](../findings/CBS_DATAPATH_BUG.md); `cbs`/`ptp` check
 arithmetic against independent reference models (10⁴-10⁵ checks each).
 
+
+### 1.1 Suite index (47 harnesses, auto-listed 2026-07-25)
+
+| suite | last verified |
+|---|---|
+| `tb/verilator/aaf` | run `make` in the dir |
+| `tb/verilator/aaf_audio_loop` | run `make` in the dir |
+| `tb/verilator/aaf_latency_taps` | 58/58 (07-25) |
+| `tb/verilator/acmp` | run `make` in the dir |
+| `tb/verilator/acmp_lstn` | run `make` in the dir |
+| `tb/verilator/adp` | run `make` in the dir |
+| `tb/verilator/adp_tx` | run `make` in the dir |
+| `tb/verilator/aecp` | run `make` in the dir |
+| `tb/verilator/avtp_rxmon` | run `make` in the dir |
+| `tb/verilator/avtp_stream` | run `make` in the dir |
+| `tb/verilator/cbs` | run `make` in the dir |
+| `tb/verilator/cdc` | run `make` in the dir |
+| `tb/verilator/chmap_capture` | PASS (07-25) |
+| `tb/verilator/chmap_render` | 58/0 (07-25) |
+| `tb/verilator/classifier` | run `make` in the dir |
+| `tb/verilator/cls` | run `make` in the dir |
+| `tb/verilator/controller_rate` | run `make` in the dir |
+| `tb/verilator/crf_tx` | run `make` in the dir |
+| `tb/verilator/csr` | 206+58+28 PASS (07-25 merge tip) |
+| `tb/verilator/datapath` | run `make` in the dir |
+| `tb/verilator/eth_tx_reset` | run `make` in the dir |
+| `tb/verilator/i2spb` | run `make` in the dir |
+| `tb/verilator/ifg` | run `make` in the dir |
+| `tb/verilator/lat_history_ring` | run `make` in the dir |
+| `tb/verilator/link_guard` | 104/104 (07-24 merge gate) |
+| `tb/verilator/lwsrp` | run `make` in the dir |
+| `tb/verilator/lwsrp_ctx` | run `make` in the dir |
+| `tb/verilator/lwsrp_rx` | run `make` in the dir |
+| `tb/verilator/lwsrp_switchpdu` | run `make` in the dir |
+| `tb/verilator/lwsrp_tx` | run `make` in the dir |
+| `tb/verilator/maap` | run `make` in the dir |
+| `tb/verilator/milan_dp` | 70/0 + 82/0 (07-25 merge tip) |
+| `tb/verilator/mmcm_servo` | run `make` in the dir |
+| `tb/verilator/mmcm_servo_autorepair` | run `make` in the dir |
+| `tb/verilator/pcm_ring_bram` | run `make` in the dir |
+| `tb/verilator/pcm_tx` | run `make` in the dir |
+| `tb/verilator/pcmlpf` | run `make` in the dir |
+| `tb/verilator/ptp` | run `make` in the dir |
+| `tb/verilator/ptp_sync` | run `make` in the dir |
+| `tb/verilator/ptp_ts` | run `make` in the dir |
+| `tb/verilator/queues` | run `make` in the dir |
+| `tb/verilator/rx_filter` | run `make` in the dir |
+| `tb/verilator/shaper_core` | run `make` in the dir |
+| `tb/verilator/tcam` | run `make` in the dir |
+| `tb/verilator/tcam_csr` | run `make` in the dir |
+| `tb/verilator/tdm` | run `make` in the dir |
+| `tb/verilator/tdm_render` | run `make` in the dir |
+
+The six counts above were re-run at the 2026-07-25 11-PR merge tip; every
+other suite is one `make` away (self-checking, exit-code gated). The standing
+rule: every round grows this table, never shrinks it.
+
 ## 2. Migen DMA-engine sims - `sw/litex/test_*.py`
 
 Behavioral sims of the ring-DMA/BD engines that live in `milan_soc.py`


### PR DESCRIPTION
Two commits:
- **QSPI_FLASHBOOT reconciled** (#40): deployed full-manifest layout with real offsets/measured sizes, AX SPIx4-uncompressed vs Arty x1/33 split, the opensbi-embedded-DTB decoy warning, the CSR-rot matched-image rule, the 7-min boot-timing truth.
- **Docs clean round** (#39, #41): FPGA_DESIGN.md complete **77-module inventory** (generated from the RTL banners) + TX-chain mermaid diagram of the freshly-merged composition; TESTING.md **47-suite index** with the merge-tip verification numbers; new **CONTRIBUTING.md** (HDL house style, workflow, verification bar, bench discipline); SYSTEMS_ENGINEER_GUIDE.md at-a-glance quickstart with system + boot mermaid diagrams and the measured E2E truth (pto=500 µs, 0 LATE, 116 µs pipeline, bit-exact wire).
