### PR TITLE
AECP: the review findings that landed after #77 was merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,4 +119,3 @@ syn/yosys/*.hex
 
 # local agent scratch, never shipped
 .claude/
-ax_in

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ audio-map mutation, and dynamic-info reads.
 The processor accepts and stores clock-source and sampling-rate changes. The
 clock-source selection now reaches the media plane's wrapper but nothing there
 reads it yet, and the sampling rate is stored and readable over AECP without
-being republished to the fabric at all.
+being republished to the fabric at all — as are the per-direction stream
+formats.
 The integration also reports no nonvolatile backend, so required state does not
 survive a power cycle. Solicited Stream Output counters are now served; their
 rate-limited unsolicited notification path remains a separate task. These are

--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ audio-map mutation, and dynamic-info reads.
 The processor accepts and stores clock-source and sampling-rate changes. The
 clock-source selection now reaches the media plane's wrapper but nothing there
 reads it yet, and the sampling rate is stored and readable over AECP without
-being republished to the fabric at all — as are the per-direction stream
-formats.
+being republished to the fabric at all.
 The integration also reports no nonvolatile backend, so required state does not
 survive a power cycle. Solicited Stream Output counters are now served; their
 rate-limited unsolicited notification path remains a separate task. These are

--- a/docs/MILAN_V12_ROADMAP.md
+++ b/docs/MILAN_V12_ROADMAP.md
@@ -140,14 +140,20 @@ happen (issue #78). The design and the two constraints that forced it are
 kept in §P2.1 below, because they still govern every command that has not
 landed yet.
 
-**What it does not yet do is reach its consumers.** Four of the five stored
-fields — current configuration, IDENTIFY, clock source and presentation-time
-offset — are published out to `milan_datapath` (`pp_aecp_*_w`) and read by
-nothing: the media clock still uses its compile-time select, so
-`SET_CLOCK_SOURCE` stores a value the servo does not act on. The fifth,
-**`current_sampling_rate`, is not published at all**: `KL_aecp_dyn_state` holds
-it and serves it over AECP but declares no output for it, so it stops at the
-store. Aligning the audio grid to it is #74's work. That is deliberate
+**What it does not yet do is reach its consumers.** `KL_aecp_dyn_state` holds
+**eight** fields and declares **five** value outputs. The five — current
+configuration, IDENTIFY, clock source, presentation-time offset and the
+started/stopped vector — are published out to `milan_datapath` (`pp_aecp_*_w`)
+and read by nothing: the media clock still uses its compile-time select, so
+`SET_CLOCK_SOURCE` stores a value the servo does not act on, and
+`strm_started_o` is published but permanently zero because START/STOP_STREAMING
+was withdrawn (#78).
+
+The other **three stop at the store** — `current_sampling_rate`, and
+`current_format` for Stream Inputs and for Stream Outputs. They are held and
+served over AECP but have no output port at all, so no consumer can be wired to
+them without widening the module first. Aligning the audio grid to the rate is
+#74's work; the formats wait on `SET_STREAM_FORMAT` (§1). That is deliberate
 sequencing — the AECP side is complete and provable on its own, and each
 consumer is its own change — but it means a green suite here is **not** yet a
 claim that the device behaves differently on the bench.

--- a/docs/MILAN_V12_ROADMAP.md
+++ b/docs/MILAN_V12_ROADMAP.md
@@ -141,19 +141,27 @@ kept in §P2.1 below, because they still govern every command that has not
 landed yet.
 
 **What it does not yet do is reach its consumers.** `KL_aecp_dyn_state` holds
-**eight** fields and declares **five** value outputs. The five — current
-configuration, IDENTIFY, clock source, presentation-time offset and the
-started/stopped vector — are published out to `milan_datapath` (`pp_aecp_*_w`)
-and read by nothing: the media clock still uses its compile-time select, so
-`SET_CLOCK_SOURCE` stores a value the servo does not act on, and
-`strm_started_o` is published but permanently zero because START/STOP_STREAMING
-was withdrawn (#78).
+**eight** fields, and *served over AECP* and *published to the fabric* are two
+different lists — worth setting out in full, because collapsing them is how an
+earlier revision of this section came to claim something untrue:
 
-The other **three stop at the store** — `current_sampling_rate`, and
-`current_format` for Stream Inputs and for Stream Outputs. They are held and
-served over AECP but have no output port at all, so no consumer can be wired to
-them without widening the module first. Aligning the audio grid to the rate is
-#74's work; the formats wait on `SET_STREAM_FORMAT` (§1). That is deliberate
+| field | a microprogram reads/writes it | it has an output port |
+|---|---|---|
+| `current_configuration` | yes | yes |
+| `clock_source_index` | yes | yes |
+| IDENTIFY | yes | yes |
+| `current_sampling_rate` | yes | **no** |
+| presentation-time offset | **no** | yes |
+| started/stopped | **no** (withdrawn, #78) | yes, permanently zero |
+| `current_format`, Stream Inputs | **no** | **no** |
+| `current_format`, Stream Outputs | **no** | **no** |
+
+So five fields have an output and all five are read by nothing downstream: the
+media clock still uses its compile-time select, so `SET_CLOCK_SOURCE` stores a
+value the servo does not act on. `current_sampling_rate` is the one field a
+controller can move that the fabric cannot see — aligning the audio grid to it
+is #74's work. The two `current_format` rows are storage allocated ahead of
+`SET_STREAM_FORMAT` (§1) and are reachable from neither side today. That is deliberate
 sequencing — the AECP side is complete and provable on its own, and each
 consumer is its own change — but it means a green suite here is **not** yet a
 claim that the device behaves differently on the bench.

--- a/docs/MILAN_V12_ROADMAP.md
+++ b/docs/MILAN_V12_ROADMAP.md
@@ -48,8 +48,8 @@ again.
 **not** include the unsolicited notification that Milan §5.4.5.2 and IEEE
 §7.4.7 require after a successful `SET_*`: no microprogram enqueues one, the
 only `NOTIFY_ENQ` in `gen_ucode.py` sits in an exemplar program, and
-`pp_pkg.sv` defines notification kinds for the deregistration and GET family
-only. Every `SET_*` row below therefore carries an open half, tracked as #69 —
+`pp_pkg.sv` defines notification kinds for the deregistration, LOCK_ENTITY and
+GET families only — none for any `SET_*`. Every `SET_*` row below therefore carries an open half, tracked as #69 —
 not as a per-row caveat, because it is the same missing mechanism in all of
 them. One more caveat worth naming here rather than burying: `0x0016`'s stored
 clock source reaches `milan_datapath` and is read by nothing (audit B3).

--- a/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
+++ b/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
@@ -31,7 +31,7 @@ outside this build's declared scope.
 | `tb/verilator/hostplane` after ROM fix | PASS | Both `ltn_rom.hex` and `ucode.hex` were generated before simulation. No missing `$readmem` image warning remained. |
 | `tb/verilator/pp_shadow` | PASS | Milan `ACQUIRE_ENTITY` is now checked on the wire for `NOT_SUPPORTED`, a zero owner, correct length, and correct addressing. |
 | `tests/` Behave suite | 15 features, 321 scenarios passed, 1 scenario skipped | 1,522 steps passed and 4 steps were skipped. This is an offline behavior model, not an external compliance lab result. |
-| Pinned protocol processor suites | 13,504 checks passed | All 27 processor suites passed. The processor's zero-tolerance RTL lint and documentation gates also passed. |
+| Pinned protocol processor suites | 13,507 checks passed | All 27 processor suites passed. The processor's zero-tolerance RTL lint and documentation gates also passed. |
 | Stream Output counter suites | PASS | The diagnostic context passed 83 checks, the AAF NxN harness passed 42 checks, and the CRF transmitter passed 127 checks. Matching 4x4 and 8x8 entity integrations passed 1,255 and 3,759 checks, including every declared AAF and CRF Stream Output. |
 | Official controller decoder | PASS | An actual 174-byte DUT response was decoded by [LA_avdecc v4.3.1 commit `2fd57534`](https://github.com/L-Acoustics/avdecc/tree/2fd57534ec7b32c66d9ada2c833e2c12dd5b95ea) through `protocol::aemPayload::deserializeGetCountersResponse`. It returned descriptor type `0x0006`, descriptor index `0`, valid mask `0x0000001F`, and five counter quadlets. |
 | Pinned gPTP processor skeleton | 799 checks passed | 768 uCPU checks and 31 parser checks passed. Its own README states that the normative 802.1AS state machines are not implemented, and this submodule is not integrated by the root RTL. |
@@ -39,7 +39,7 @@ outside this build's declared scope.
 | Module matrix | PASS | 63 modules, 0 untested under the current matrix rules. |
 | End-station builder gates | PASS | The AEM image, identity, shape, and base-format generation gates passed. |
 | Documentation gate | PASS | It covered 204 Markdown files with zero findings after the final edits. |
-| Pinned `tsn-gen` field campaign | 164 checks passed | The public generator revision pinned in `.github/workflows/rtl.yml` was built with parser tests disabled; the AAF/AVTP field campaign reported 164 pass, 0 fail, and 0 known gaps. |
+| `tsn-gen` field campaign | 164 checks passed | The AAF/AVTP field campaign reported 164 pass, 0 fail, and 0 known gaps, built with parser tests disabled. The number was measured against a working tree of the public generator, not against the `TSN_GEN_REV` commit `.github/workflows/rtl.yml` pins — CI does exercise that pin, but this row is not reproducible from the pin alone. Treat it as a floor. |
 | Vivado build and timing closure | NOT RUN | Vivado 2026.1 is not installed in this environment. |
 | Current physical Milan interoperability bench | NOT RUN | The external bench repository contains valuable dated evidence, but its present worktree is active and its last recorded audio result used a mismatched peer format. |
 
@@ -91,9 +91,9 @@ Milan v1.2 section 5.4.2 requires these profile behaviors. A correctly formed
 a mandatory command.
 
 Implementation evidence:
-[`KL_aecp_engine.sv`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/82281d550f04b78089d6445fc039d01ab231ddf0/hdl/aecp/KL_aecp_engine.sv) and
+[`KL_aecp_engine.sv`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/cebe26f9bd5dd4e012ddc089a8916ba41455e9a0/hdl/aecp/KL_aecp_engine.sv) and
 the current command table in
-[`06_aecp_engine.md`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/82281d550f04b78089d6445fc039d01ab231ddf0/docs/architecture/06_aecp_engine.md).
+[`06_aecp_engine.md`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/cebe26f9bd5dd4e012ddc089a8916ba41455e9a0/docs/architecture/06_aecp_engine.md).
 
 ### B2. Required state is not persistent
 

--- a/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
+++ b/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
@@ -31,8 +31,8 @@ outside this build's declared scope.
 | `tb/verilator/hostplane` after ROM fix | PASS | Both `ltn_rom.hex` and `ucode.hex` were generated before simulation. No missing `$readmem` image warning remained. |
 | `tb/verilator/pp_shadow` | PASS | Milan `ACQUIRE_ENTITY` is now checked on the wire for `NOT_SUPPORTED`, a zero owner, correct length, and correct addressing. |
 | `tests/` Behave suite | 15 features, 321 scenarios passed, 1 scenario skipped | 1,522 steps passed and 4 steps were skipped. This is an offline behavior model, not an external compliance lab result. |
-| Pinned protocol processor suites | 13,507 checks passed | All 27 processor suites passed. The processor's zero-tolerance RTL lint and documentation gates also passed. |
-| Stream Output counter suites | PASS | The diagnostic context passed 83 checks, the AAF NxN harness passed 42 checks, and the CRF transmitter passed 127 checks. Matching 4x4 and 8x8 entity integrations passed 1,255 and 3,759 checks, including every declared AAF and CRF Stream Output. |
+| Pinned protocol processor suites | 13,510 checks passed | All 27 processor suites passed. The processor's zero-tolerance RTL lint and documentation gates also passed. |
+| Stream Output counter suites | PASS | The diagnostic context passed 83 checks, the AAF NxN harness passed 42 checks, and the CRF transmitter passed 127 checks. Matching 4x4 and 8x8 entity integrations passed 1,263 and 3,767 checks, including every declared AAF and CRF Stream Output. |
 | Official controller decoder | PASS | An actual 174-byte DUT response was decoded by [LA_avdecc v4.3.1 commit `2fd57534`](https://github.com/L-Acoustics/avdecc/tree/2fd57534ec7b32c66d9ada2c833e2c12dd5b95ea) through `protocol::aemPayload::deserializeGetCountersResponse`. It returned descriptor type `0x0006`, descriptor index `0`, valid mask `0x0000001F`, and five counter quadlets. |
 | Pinned gPTP processor skeleton | 799 checks passed | 768 uCPU checks and 31 parser checks passed. Its own README states that the normative 802.1AS state machines are not implemented, and this submodule is not integrated by the root RTL. |
 | Root RTL lint | PASS under ratchet | The ratchet remains at 100 existing warnings. This is not a zero-warning result. |
@@ -91,9 +91,9 @@ Milan v1.2 section 5.4.2 requires these profile behaviors. A correctly formed
 a mandatory command.
 
 Implementation evidence:
-[`KL_aecp_engine.sv`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/cebe26f9bd5dd4e012ddc089a8916ba41455e9a0/hdl/aecp/KL_aecp_engine.sv) and
+[`KL_aecp_engine.sv`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/d260a3afb8ee83d2bbdea6ba4477c2ca52cce340/hdl/aecp/KL_aecp_engine.sv) and
 the current command table in
-[`06_aecp_engine.md`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/cebe26f9bd5dd4e012ddc089a8916ba41455e9a0/docs/architecture/06_aecp_engine.md).
+[`06_aecp_engine.md`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/d260a3afb8ee83d2bbdea6ba4477c2ca52cce340/docs/architecture/06_aecp_engine.md).
 
 ### B2. Required state is not persistent
 

--- a/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
+++ b/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
@@ -31,10 +31,10 @@ outside this build's declared scope.
 | `tb/verilator/hostplane` after ROM fix | PASS | Both `ltn_rom.hex` and `ucode.hex` were generated before simulation. No missing `$readmem` image warning remained. |
 | `tb/verilator/pp_shadow` | PASS | Milan `ACQUIRE_ENTITY` is now checked on the wire for `NOT_SUPPORTED`, a zero owner, correct length, and correct addressing. |
 | `tests/` Behave suite | 15 features, 321 scenarios passed, 1 scenario skipped | 1,522 steps passed and 4 steps were skipped. This is an offline behavior model, not an external compliance lab result. |
-| Pinned protocol processor suites | 13,510 checks passed | All 27 processor suites passed. The processor's zero-tolerance RTL lint and documentation gates also passed. |
+| Pinned protocol processor suites | 13,512 checks passed | All 27 processor suites passed. The processor's zero-tolerance RTL lint and documentation gates also passed. |
 | Stream Output counter suites | PASS | The diagnostic context passed 83 checks, the AAF NxN harness passed 42 checks, and the CRF transmitter passed 127 checks. Matching 4x4 and 8x8 entity integrations passed 1,263 and 3,767 checks, including every declared AAF and CRF Stream Output. |
 | Official controller decoder | PASS | An actual 174-byte DUT response was decoded by [LA_avdecc v4.3.1 commit `2fd57534`](https://github.com/L-Acoustics/avdecc/tree/2fd57534ec7b32c66d9ada2c833e2c12dd5b95ea) through `protocol::aemPayload::deserializeGetCountersResponse`. It returned descriptor type `0x0006`, descriptor index `0`, valid mask `0x0000001F`, and five counter quadlets. |
-| Pinned gPTP processor skeleton | 799 checks passed | 768 uCPU checks and 31 parser checks passed. Its own README states that the normative 802.1AS state machines are not implemented, and this submodule is not integrated by the root RTL. |
+| Pinned gPTP processor skeleton | 877 checks passed | 768 uCPU, 31 parser and 78 engine checks passed — an earlier revision of this row said 799 and omitted the engine suite entirely. Its own README states that the normative 802.1AS state machines are not implemented, and this submodule is not integrated by the root RTL. |
 | Root RTL lint | PASS under ratchet | The ratchet remains at 100 existing warnings. This is not a zero-warning result. |
 | Module matrix | PASS | 63 modules, 0 untested under the current matrix rules. |
 | End-station builder gates | PASS | The AEM image, identity, shape, and base-format generation gates passed. |
@@ -91,9 +91,9 @@ Milan v1.2 section 5.4.2 requires these profile behaviors. A correctly formed
 a mandatory command.
 
 Implementation evidence:
-[`KL_aecp_engine.sv`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/d260a3afb8ee83d2bbdea6ba4477c2ca52cce340/hdl/aecp/KL_aecp_engine.sv) and
+[`KL_aecp_engine.sv`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/ed62b6e099c0bf79f2d09a198c02e48786cb5071/hdl/aecp/KL_aecp_engine.sv) and
 the current command table in
-[`06_aecp_engine.md`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/d260a3afb8ee83d2bbdea6ba4477c2ca52cce340/docs/architecture/06_aecp_engine.md).
+[`06_aecp_engine.md`](https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan/blob/ed62b6e099c0bf79f2d09a198c02e48786cb5071/docs/architecture/06_aecp_engine.md).
 
 ### B2. Required state is not persistent
 

--- a/hdl/milan/KL_pp_shadow.sv
+++ b/hdl/milan/KL_pp_shadow.sv
@@ -459,10 +459,12 @@ module KL_pp_shadow #(
     output logic [7:0]                 maap_defends_o,     //! DEFEND frames sent (saturating)
 
     //! ---- the AECP SETTINGS face (Milan §5.3.x) ------------------------
-    //! NOT the whole dynamic store. It holds eight fields and exposes five;
-    //! current_sampling_rate and the two current_format fields are served over
-    //! AECP but have no output on KL_aecp_dyn_state, so they are absent here
-    //! too. What IS below is republished 1:1 so the fabric can act on a
+    //! NOT the whole dynamic store. It holds eight fields and exposes five.
+    //! Absent here because KL_aecp_dyn_state declares no output for them:
+    //! current_sampling_rate (which AECP does serve), and the two
+    //! current_format fields (which nothing reads or writes yet — storage
+    //! allocated ahead of SET_STREAM_FORMAT). What IS below is republished
+    //! 1:1 so the fabric can act on a
     //! setting rather than be told about it. Every one reads its reset
     //! default until a controller writes it, so a datapath that leaves these
     //! unread behaves exactly as it did before the store existed — which is

--- a/hdl/milan/KL_pp_shadow.sv
+++ b/hdl/milan/KL_pp_shadow.sv
@@ -459,8 +459,9 @@ module KL_pp_shadow #(
     output logic [7:0]                 maap_defends_o,     //! DEFEND frames sent (saturating)
 
     //! ---- the AECP SETTINGS face (Milan §5.3.x) ------------------------
-    //! NOT the whole dynamic store: current_sampling_rate is held and served
-    //! over AECP but has no output on KL_aecp_dyn_state, so it is absent here
+    //! NOT the whole dynamic store. It holds eight fields and exposes five;
+    //! current_sampling_rate and the two current_format fields are served over
+    //! AECP but have no output on KL_aecp_dyn_state, so they are absent here
     //! too. What IS below is republished 1:1 so the fabric can act on a
     //! setting rather than be told about it. Every one reads its reset
     //! default until a controller writes it, so a datapath that leaves these

--- a/tb/verilator/milan_dp/sim_nxn.cpp
+++ b/tb/verilator/milan_dp/sim_nxn.cpp
@@ -1125,8 +1125,10 @@ int main(int argc, char** argv) {
                 // present.
                 //
                 // ORDER MATTERS. This block must stay below every
-                // [AECP-MODEL] check that reads a field it writes — today
-                // that is GET_CLOCK_SOURCE and GET_CONTROL. Setting the clock
+                // [AECP-MODEL] check that reads a field it writes. Today that
+                // is GET_CLOCK_SOURCE alone: the block also writes IDENTIFY,
+                // but no [AECP-MODEL] GET_CONTROL check exists to disturb —
+                // add one and it must go ABOVE here. Setting the clock
                 // source arms the dynamic store's valid bit for THAT field,
                 // after which GET_CLOCK_SOURCE answers the overlay instead of
                 // the image, and a model check above would compare the


### PR DESCRIPTION
## Why this exists

PR #77 was merged at 18:10 UTC while its review was still running. Review rounds 4, 5 and 6 completed afterwards and found three more blocking defects. They are fixed on the same branch; none of them reached `main-push`.

`main-push` currently has everything through round 3. This PR carries the rest.

## The three blocking defects

**1. Five of six paths through the SET_CONFIGURATION refusal overlay were graded.**
The overlay exists in three copies (`E_SCFGRUN`, `E_SCFGLK`, `E_SCFGBAD`), each with an image arm and a store arm. `E_SCFGRUN`'s store arm was not covered: an earlier section left the dynamic store at 0, which is also the descriptor image's value, so the store arm, the image arm and a hardcoded zero were three indistinguishable answers. W17e now writes 1 and W17j asks for 0, separating all three in one check.

**2. `E_RDESCENT`'s image arm was unreachable in every window the bench tested.**
Every `READ_DESCRIPTOR(ENTITY)` in the suite ran after a successful SET, so the valid bit was armed and the fallback never fired. New W3d sits inside the existing DRAM-poke window, where the image reads `0x0007` and the store is unwritten, and compares `READ_DESCRIPTOR(ENTITY)` against `GET_CONFIGURATION` **directly** rather than each against a literal — IEEE §7.4.8.2 graded where the divergence would first appear. Without it, the two commands could disagree before the first SET.

**3. `E_RDESCENT`'s type gate was unverifiable.**
No non-ENTITY descriptor in the bench was 312 bytes, so the program's canonical-length guard bounced everything on its own and the type test could be widened to always-true silently. The image now carries a 312-byte non-ENTITY fixture with a `0xBEEF` tail.

## Also

- **`place()` and the ROM fill both trusted `rom[i] == 0`.** A bare `NOP` encodes as all-zero, so a word a program placed was indistinguishable from unallocated fill — the fill was rewriting `E_GSRATE + 10`. Both now consult an occupancy set.
- **The range check's boundary is graded.** `0xFFFF` is refused by any bound, including a wrong one. W18d2/d3 send index == `configurations_count`; a bound taken from a constant instead of the image reddens five checks that `0xFFFF` alone leaves green.
- **Documentation.** Two `current_format` store fields were described as "served over AECP" when no microprogram reads or writes them; the roadmap now carries a table because *served over AECP* and *published to the fabric* are different lists. Four measured figures re-measured, including a gPTP row that omitted a whole 78-check suite. Table 7-1 citation corrected (`0x0022` is SIGNAL_MULTIPLEXER, not MATRIX).

## Mutation results

Every fix above is backed by a mutation that was silent before and is caught now:

| mutation | before | after |
|---|---|---|
| `E_SCFGRUN` store arm forced to the image path | 0 FAIL | 1 FAIL |
| `E_RDESCENT` image arm removed | 0 FAIL | 2 FAIL |
| `E_RDESCENT` type gate widened to always-true | 0 FAIL | 1 FAIL |
| range bound taken from a constant | 0 FAIL | 5 FAIL |
| placed `NOP` overwritten by the fill | undetected | address 1098 survives |

## Bar

| | |
|---|---|
| processor suites | **13,512 checks, 0 failing** across 27 suites |
| µPC map gate | PASS, 38 engine constants ↔ 58 entry points |
| superproject | **50/50 suites, 0 failing** |
| BDD | 15 features, **321 scenarios, 0 failed** |
| gates | `lint_hdl`, `lint_rtl`, `docs_check`, `check_doc_paths`, `check_entity_shape`, `check_wire_accountability`, `check-links`, `check-matrix` clean |

## One thing to fix before or with this merge

`main-push` pins the submodule at `82281d5`, which exists only on the submodule's feature branch — the submodule's `main` is at `eb0e868`. The pin resolves today because the branch is pushed, but it is the ordering trap `CONTRIBUTING.md` §2.1 names, and it breaks if that branch is removed. The submodule's PR (`Mister-M-alt#1`) is still open; this PR's pin (`ed62b6e`) has the same property and should land on the submodule's `main` first.

## Review

Six rounds on #77: five NEGATIVE, the sixth POSITIVE. Four of the five negative rounds had the same root cause — a test whose expected value coincided with a reset, a default, or another source, so the defect underneath could not change the result. The checks added here either use a deliberately distinguishing value or compare two commands to each other.
