### PR TITLE
Re-land the tsn_fuzz accounting work merged past by #86

### DIFF
--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -197,8 +197,16 @@ those — not the marker — are what keep it out of `NOCOUNT`; a declared skip
 never excuses a suite from producing a count. CI builds
 the public `tsn-gen` revision pinned by `TSN_GEN_REV` in
 `.github/workflows/rtl.yml`, exports `TSN_GEN_ROOT`, and runs the 164-check AAF
-campaign. A missing, truncated, or malformed campaign tally therefore remains
-fatal to the repository sweep.
+campaign.
+
+A missing, truncated or reworded campaign tally is still fatal, but it is worth
+saying *why*, because the reason changed. It used to be fatal by accident: the
+suite printed no shape the tally knew, fell to `NOCOUNT`, and stopped the sweep.
+Giving the suite an unconditional two-check floor removed that backstop — the
+floor clears `NOCOUNT` on its own, so a reworded campaign line would have
+dropped 164 checks from the headline with everything green. So the suite's
+`aaf` target now requires one of exactly two outcomes, a readable tally or a
+declared skip, and fails loudly on anything else.
 
 **No check total is quoted here on purpose.** The campaign ends by printing its
 own `N pass, M fail, K known gaps` line, and writes that same line into a

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -219,7 +219,7 @@ described a tree that no longer exists — twelve of the suites it graded have
 since been deleted — so quoting it would be quoting a measurement of a
 different design. Its check total was also an under-count: that total came from
 `grep -o 'checks: *[0-9]*'` and suites do not all print that string (the tree
-emits six summary shapes, and 28 of 57 suite logs matched none of them and
+emits five summary shapes, and 28 of 57 suite logs matched none of them and
 contributed a silent zero — shown by adding 66 assertions to a suite and
 watching the printed total not move). Rerun the sweep for both figures.
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -227,7 +227,7 @@ described a tree that no longer exists — twelve of the suites it graded have
 since been deleted — so quoting it would be quoting a measurement of a
 different design. Its check total was also an under-count: that total came from
 `grep -o 'checks: *[0-9]*'` and suites do not all print that string (the tree
-emits five summary shapes, and 28 of 57 suite logs matched none of them and
+emits five summary shapes, and 29 of 57 suite logs matched none of them and
 contributed a silent zero — shown by adding 66 assertions to a suite and
 watching the printed total not move). Rerun the sweep for both figures.
 

--- a/scripts/suite_tally.py
+++ b/scripts/suite_tally.py
@@ -23,16 +23,18 @@ assertions to a suite and watching the printed total not move.
 So the rule this file enforces is the sweep's own version of *a structural zero
 is not a measurement*:
 
-    **An unparseable or absent check count is an UNKNOWN, and an unknown must
-    never look like agreement.  It fails the sweep, loudly.**
+    **A check count that is absent, unparseable, or measures nothing is an
+    UNKNOWN, and an unknown must never look like agreement.  It fails the
+    sweep, loudly.**
 
 Two detectors implement that:
 
-* ``NOCOUNT``  -- a suite log from which no tally line could be read at all.
-  Silence is not zero.
+* ``NOCOUNT``  -- a suite that measured nothing: either no tally line could be
+  read at all, or the tallies sum to zero checks and zero failures.  Silence is
+  not zero, and neither is a reported zero.
 * ``UNPARSED`` -- a line that *looks* like a tally (a number next to the word
   "checks") but matches none of the known shapes.  This is the one that keeps a
-  **new** suite honest without anyone having to remember: invent a seventh
+  **new** suite honest without anyone having to remember: invent a sixth
   summary shape and the sweep stops, rather than quietly dropping your checks
   on the floor.  It fires even when the suite's *other* executables did parse,
   which is the case a per-log "did anything match?" test would miss.
@@ -324,6 +326,14 @@ def selftest():
         ("e2e-one-silent-suite-among-many",
          {"a": "checks: 100   failures: 0\n", "b": "building...\n"}, 1,
          "one silent suite fails the sweep even beside a healthy one"),
+        #! UNPARSED is NOCOUNT's co-equal detector and its wiring to the exit
+        #! code was the half nothing pinned: 419 checks could be dropped beside
+        #! a healthy tally with the self-test green.
+        ("e2e-unparsed-beside-a-real-tally",
+         {"a": "checks: 100   failures: 0\ntotal 419 checks OK\n"}, 1,
+         "an unreadable tally fails the sweep even when another one parsed"),
+        ("e2e-empty-logdir", {}, 2,
+         "no logs at all is an unknown, not a zero-check pass"),
     ):
         with tempfile.TemporaryDirectory() as td:
             for stem, text in logs.items():
@@ -331,9 +341,17 @@ def selftest():
             import io
             import contextlib
             buf = io.StringIO()
+            #! NOT --quiet: the per-suite table has its own NO COUNT flag, and
+            #! it used to carry a private copy of the predicate that disagreed
+            #! with the verdict. Rendering it here is what keeps them one.
             with contextlib.redirect_stdout(buf):
-                rc = main([sys.argv[0], td, "--quiet"])
+                rc = main([sys.argv[0], td])
+        out = buf.getvalue()
         ok = rc == want_rc
+        #! the table and the verdict must agree, always
+        if want_rc == 1 and logs and ("NOCOUNT" in out) != ("NO COUNT" in out):
+            ok = False
+            why += "  [table flag and verdict DISAGREE]"
         print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} rc={rc}  -- {why}")
         if not ok:
             bad += 1
@@ -361,6 +379,7 @@ def main(argv):
 
     total_checks = total_fails = 0
     nocount = []
+    zero_tally = set()
     unparsed_findings = []
     skip_findings = []
     rows = []
@@ -375,6 +394,8 @@ def main(argv):
         rows.append((suite, c, f, len(matched), len(skipped), nc))
         if nc:
             nocount.append(suite)
+            if matched:
+                zero_tally.add(suite)
         for line in unparsed:
             unparsed_findings.append((suite, line))
         for reason in skipped:
@@ -408,12 +429,21 @@ def main(argv):
     if nocount:
         bad = True
         print()
-        print("ACCOUNTING FAILURE -- no check count could be read from "
+        print("ACCOUNTING FAILURE -- nothing was measured by "
               f"{len(nocount)} suite log(s):")
+        #! The two causes need different advice. Telling someone whose suite
+        #! printed "0 pass, 0 fail" to "print one of the shapes" sends them to
+        #! fix the thing they already did right.
         for suite in nocount:
-            print(f"  NOCOUNT  {suite}")
-        print("  A suite that reports no count is an UNKNOWN, not a zero. Make")
-        print("  it print one of the shapes in scripts/suite_tally.py.")
+            zero = suite in zero_tally
+            why = ("reported a tally, but it measured 0 checks and 0 failures"
+                   if zero else "printed no tally line at all")
+            print(f"  NOCOUNT  {suite}: {why}")
+        print("  A suite that measured nothing is an UNKNOWN, not agreement.")
+        print("  If it printed no tally: make it print one of the shapes in")
+        print("  scripts/suite_tally.py. If it tallied zero: make it assert")
+        print("  something, or say why it ran nothing with a SUITE-SKIP: line")
+        print("  AND still report the checks it did run.")
     if unparsed_findings:
         bad = True
         print()

--- a/scripts/suite_tally.py
+++ b/scripts/suite_tally.py
@@ -233,7 +233,19 @@ def campaign_accounted_for(text):
     tally shapes this file reads perfectly well, and accepted ``0 pass, 0 fail``.
     """
     checks, failures, matched, _unparsed, skipped = scan(text)
-    if skipped:
+    #! `and not matched`, NOT `if skipped:`. A marker excuses a campaign only
+    #! when nothing else tallied. Otherwise a log carrying a marker anywhere
+    #! would pass regardless of what else it printed -- the same "a suite
+    #! declares its own way out" that is_nocount() takes `skipped` purely in
+    #! order to refuse.
+    #!
+    #! It does NOT catch a marker beside a REWORDED tally: that line matches no
+    #! shape, so `matched` is empty and the log is indistinguishable from a
+    #! plain skip. Nothing here can see it. Unreachable today because
+    #! require_tsn_gen() prints the marker and exits immediately, so a campaign
+    #! cannot both skip and report -- and pinned by a self-test case so that
+    #! stays a decision rather than a surprise.
+    if skipped and not matched:
         return ("declared a skip: " + skipped[0], True)
     if not matched:
         return ("printed no tally in any shape scripts/suite_tally.py reads",
@@ -352,6 +364,8 @@ def selftest():
     # above still passed while the real gate went from rc=1 to rc=0 on a
     # lone-marker log. So these run the whole tool over a temporary log dir and
     # assert the EXIT CODE, which is what CI actually consumes.
+    import contextlib
+    import io
     import tempfile
     for name, logs, want_rc, want_out, why in (
         ("e2e-lone-marker", {"a": "SUITE-SKIP: campaign (dep absent)\n"}, 1,
@@ -381,6 +395,13 @@ def selftest():
         ("e2e-nocount-says-which-cause-silence",
          {"a": "building...\n"}, 1, "printed no tally line at all",
          "a silent suite is told it printed nothing"),
+        #! the FAILURES half of the headline. Every other case expects
+        #! "failures: 0", so hard-coding that half survived them all -- and the
+        #! docstring claims both halves are protected.
+        ("e2e-failures-reach-the-headline",
+         {"a": "checks: 100   failures: 3\n"}, 0,
+         "checks: 100   in-suite failures: 3",
+         "the failure count is carried, not just the check count"),
         ("e2e-nocount-says-which-cause-zero",
          {"a": "== campaign: 0 pass, 0 fail ==\n"}, 1,
          "measured 0 checks and 0 failures",
@@ -440,6 +461,25 @@ def selftest():
          "== AAF campaign (tsn-gen driven): 0 pass, 0 fail, 0 known gaps ==\n",
          False, "neither is one that ran and measured nothing"),
         ("guard-silence", "building...\n", False, "nor silence"),
+        #! a marker excuses a campaign only when it is the WHOLE story. A
+        #! review found a bare `if skipped:` here, so a log carrying a marker
+        #! ANYWHERE passed regardless of what else it printed.
+        #!
+        #! THE LIMIT, pinned rather than hidden: a marker beside a REWORDED
+        #! tally still passes, because a reworded line is indistinguishable
+        #! from ordinary log chatter -- there is nothing for the parser to see.
+        #! Unreachable today (require_tsn_gen prints the marker and exits, so a
+        #! campaign cannot both skip and report), and the case is here so that
+        #! stops being an accident.
+        ("guard-skip-beside-a-reword-is-the-known-limit",
+         "SUITE-SKIP: half of it was skipped\n== c: 164 ok / 0 bad ==\n",
+         True, "a reworded line is invisible to the parser -- documented limit"),
+        ("guard-skip-does-not-launder-a-zero",
+         "SUITE-SKIP: half of it was skipped\n== c: 0 pass, 0 fail ==\n",
+         False, "...nor a tally that measured nothing"),
+        ("guard-skip-plus-real-tally-is-fine",
+         "SUITE-SKIP: one part skipped\n== c: 164 pass, 0 fail ==\n",
+         True, "...but a real tally beside a marker is still accounted for"),
     ):
         reason, got = campaign_accounted_for(text)
         ok = got == want_ok
@@ -448,6 +488,57 @@ def selftest():
         if not ok:
             bad += 1
             print(f"       expected accounted={want_ok}, got reason: {reason}")
+
+    # --- the guard's CLI, and --quiet ----------------------------------------
+    # campaign_accounted_for() is tested above as a FUNCTION. Its command-line
+    # wiring is the half the Makefile actually consumes, and a review disabled
+    # the guard two ways -- `if ok:` -> `if True:`, and `return 1` -> `return 0`
+    # -- with every case above still green. The second is the nastier: the
+    # alarm still PRINTS, so the suite log looks alarming and make passes.
+    #
+    # --quiet is here for the same reason: run_all_suites.sh:173 is the only
+    # production caller and passes it, and returning 0 early under --quiet
+    # survived everything.
+    for name, argv_extra, text, want_rc, want_out, why in (
+        ("cli-guard-accepts",
+         ["--campaign-guard"], "== c: 164 pass, 0 fail ==\n", 0, None,
+         "the guard's CLI passes a campaign that measured something"),
+        ("cli-guard-rejects",
+         ["--campaign-guard"], "== c: 164 ok / 0 bad ==\n", 1,
+         "CAMPAIGN UNACCOUNTED FOR",
+         "...and REJECTS one that did not, with a non-zero exit"),
+        ("cli-guard-rejects-zero",
+         ["--campaign-guard"], "== c: 0 pass, 0 fail ==\n", 1,
+         "measured nothing",
+         "...including one that ran and measured nothing"),
+    ):
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td, "campaign.out")
+            log.write_text(text)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                rc = main([sys.argv[0], *argv_extra, str(log)])
+        out = buf.getvalue()
+        ok = rc == want_rc and (want_out is None or want_out in out)
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} rc={rc}  -- {why}")
+        if not ok:
+            bad += 1
+            print(f"       expected rc={want_rc}"
+                  + (f" and {want_out!r} in the output" if want_out else ""))
+
+    with tempfile.TemporaryDirectory() as td:
+        Path(td, "a.log").write_text("building...\n")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), \
+                contextlib.redirect_stderr(io.StringIO()):
+            rc = main([sys.argv[0], td, "--quiet"])
+    ok = rc == 1
+    print(f"  {'ok  ' if ok else 'FAIL'} {'quiet-still-gates':<32} rc={rc}  "
+          f"-- --quiet is the mode CI uses, and it still fails a silent suite")
+    if not ok:
+        bad += 1
+        print("       expected rc=1")
 
     print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
     return 1 if bad else 0

--- a/scripts/suite_tally.py
+++ b/scripts/suite_tally.py
@@ -185,8 +185,16 @@ def scan(text):
     return checks, failures, matched, unparsed, skipped
 
 
-def is_nocount(matched, skipped):
-    """Is this log an UNKNOWN? Yes when nothing tallied, whatever it declared.
+def is_nocount(checks, failures, matched, skipped):
+    """Is this log an UNKNOWN? Yes unless something was actually measured.
+
+    Two ways to measure nothing, and both are unknowns:
+
+    * no tally line at all -- silence;
+    * tallies that sum to **zero checks and zero failures**.  ``0 pass, 0 fail``
+      is a shape the parser accepts, so without this a suite could clear the
+      gate while reporting that it had checked nothing.  That is the file's own
+      motto turned on the instrument: a structural zero is not a measurement.
 
     ``skipped`` is taken and deliberately **ignored**.  The parameter is here so
     that the one place tempted to consult it says out loud that it does not:
@@ -195,7 +203,7 @@ def is_nocount(matched, skipped):
     not reach it, so breaking it was silent; it is a named function now for no
     other reason than that a self-test can call it.
     """
-    return not matched
+    return (not matched) or (checks == 0 and failures == 0)
 
 
 # --- self-test ---------------------------------------------------------------
@@ -287,15 +295,49 @@ def selftest():
         ("nocount-cleared-by-a-real-tally",
          "SUITE-SKIP: aaf campaign (tsn-gen absent)\n1 checks: 1 PASS, 0 FAIL\n",
          False, "...but a real tally beside it does"),
+        ("nocount-all-zero-tally",
+         "campaign skipped: 0 pass, 0 fail (dependency absent)\n", True,
+         "a tally that measured NOTHING is an unknown, not agreement"),
     ):
         c, f, matched, unparsed, skipped = scan(text)
-        got = is_nocount(matched, skipped)
+        got = is_nocount(c, f, matched, skipped)
         ok = got == want_nocount
         print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} "
               f"nocount={got}  -- {why}")
         if not ok:
             bad += 1
             print(f"       expected nocount={want_nocount}")
+
+    # --- END TO END, through main() ------------------------------------------
+    # The cases above test the parser and the decision. Neither reaches the CALL
+    # -- a review changed `if nc:` back to the rejected predicate and every case
+    # above still passed while the real gate went from rc=1 to rc=0 on a
+    # lone-marker log. So these run the whole tool over a temporary log dir and
+    # assert the EXIT CODE, which is what CI actually consumes.
+    import tempfile
+    for name, logs, want_rc, why in (
+        ("e2e-lone-marker", {"a": "SUITE-SKIP: campaign (dep absent)\n"}, 1,
+         "a suite whose only content is a marker still fails the sweep"),
+        ("e2e-marker-plus-real-tally",
+         {"a": "SUITE-SKIP: campaign (dep absent)\n2 checks: 2 PASS, 0 FAIL\n"}, 0,
+         "...and passes once it reports what it DID run"),
+        ("e2e-one-silent-suite-among-many",
+         {"a": "checks: 100   failures: 0\n", "b": "building...\n"}, 1,
+         "one silent suite fails the sweep even beside a healthy one"),
+    ):
+        with tempfile.TemporaryDirectory() as td:
+            for stem, text in logs.items():
+                Path(td, stem + ".log").write_text(text)
+            import io
+            import contextlib
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = main([sys.argv[0], td, "--quiet"])
+        ok = rc == want_rc
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} rc={rc}  -- {why}")
+        if not ok:
+            bad += 1
+            print(f"       expected rc={want_rc}")
 
     print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
     return 1 if bad else 0
@@ -329,8 +371,9 @@ def main(argv):
         c, f, matched, unparsed, skipped = scan(text)
         total_checks += c
         total_fails += f
-        rows.append((suite, c, f, len(matched), len(skipped)))
-        if is_nocount(matched, skipped):
+        nc = is_nocount(c, f, matched, skipped)
+        rows.append((suite, c, f, len(matched), len(skipped), nc))
+        if nc:
             nocount.append(suite)
         for line in unparsed:
             unparsed_findings.append((suite, line))
@@ -339,8 +382,11 @@ def main(argv):
 
     if not quiet:
         print("suite                        checks   failures  tallies")
-        for suite, c, f, n, s in rows:
-            flag = "  <- NO COUNT" if (n == 0 and s == 0) else ""
+        for suite, c, f, n, s, nc in rows:
+            #! ONE predicate, shared with the verdict below. This
+            #! line used to carry its own copy and they disagreed
+            #! on exactly the case this tool is about.
+            flag = "  <- NO COUNT" if nc else ""
             if s:
                 flag += f"  <- {s} SKIPPED"
             print(f"{suite:<28} {c:>8} {f:>10} {n:>8}{flag}")

--- a/scripts/suite_tally.py
+++ b/scripts/suite_tally.py
@@ -204,8 +204,44 @@ def is_nocount(checks, failures, matched, skipped):
     found this decision sitting inline in ``main()`` where ``--selftest`` could
     not reach it, so breaking it was silent; it is a named function now for no
     other reason than that a self-test can call it.
+
+    ``matched`` is redundant today -- ``scan()`` only ever adds non-negative
+    captures, so an empty ``matched`` already implies zero and zero.  It is kept
+    because the two conditions are different *claims* (nothing was said / what
+    was said measured nothing) and a future shape with a signed or defaulted
+    capture would separate them again.  Do not simplify it away on the grounds
+    that it is dead; it is load-bearing documentation of the rule.
     """
     return (not matched) or (checks == 0 and failures == 0)
+
+
+def campaign_accounted_for(text):
+    """Did one campaign log account for itself? (reason, ok).
+
+    A campaign has exactly two honest outcomes: it measured something, or it
+    declared that it ran nothing.  Anything else -- a summary reworded past the
+    shapes, or a tally that adds up to zero -- means its checks silently leave
+    the headline.
+
+    This exists because the suite that owns the campaign also prints an
+    unconditional floor of its own, and that floor clears ``NOCOUNT`` for the
+    whole suite.  The floor is what makes the suite countable; it is also what
+    took away the backstop the campaign used to have.  So the campaign is
+    checked on its own, in its own log, against the SAME recognisers the sweep
+    uses -- a second hand-rolled matcher in a Makefile is how the two come to
+    disagree, and a first cut of this guard did exactly that: it rejected four
+    tally shapes this file reads perfectly well, and accepted ``0 pass, 0 fail``.
+    """
+    checks, failures, matched, _unparsed, skipped = scan(text)
+    if skipped:
+        return ("declared a skip: " + skipped[0], True)
+    if not matched:
+        return ("printed no tally in any shape scripts/suite_tally.py reads",
+                False)
+    if checks == 0 and failures == 0:
+        return (f"tallied {checks} checks and {failures} failures -- it ran, "
+                f"and measured nothing", False)
+    return (f"tallied {checks} checks, {failures} failures", True)
 
 
 # --- self-test ---------------------------------------------------------------
@@ -317,23 +353,38 @@ def selftest():
     # lone-marker log. So these run the whole tool over a temporary log dir and
     # assert the EXIT CODE, which is what CI actually consumes.
     import tempfile
-    for name, logs, want_rc, why in (
+    for name, logs, want_rc, want_out, why in (
         ("e2e-lone-marker", {"a": "SUITE-SKIP: campaign (dep absent)\n"}, 1,
-         "a suite whose only content is a marker still fails the sweep"),
+         "SKIPPED  a: campaign (dep absent)",
+         "a suite whose only content is a marker still fails the sweep, and "
+         "the skip is LISTED"),
         ("e2e-marker-plus-real-tally",
          {"a": "SUITE-SKIP: campaign (dep absent)\n2 checks: 2 PASS, 0 FAIL\n"}, 0,
-         "...and passes once it reports what it DID run"),
+         "checks: 2   in-suite failures: 0",
+         "...and passes once it reports what it DID run, at the right total"),
         ("e2e-one-silent-suite-among-many",
          {"a": "checks: 100   failures: 0\n", "b": "building...\n"}, 1,
+         "checks: 100   in-suite failures: 0",
          "one silent suite fails the sweep even beside a healthy one"),
         #! UNPARSED is NOCOUNT's co-equal detector and its wiring to the exit
         #! code was the half nothing pinned: 419 checks could be dropped beside
         #! a healthy tally with the self-test green.
         ("e2e-unparsed-beside-a-real-tally",
          {"a": "checks: 100   failures: 0\ntotal 419 checks OK\n"}, 1,
+         "UNPARSED a: total 419 checks OK",
          "an unreadable tally fails the sweep even when another one parsed"),
-        ("e2e-empty-logdir", {}, 2,
+        ("e2e-empty-logdir", {}, 2, None,
          "no logs at all is an unknown, not a zero-check pass"),
+        #! the two causes of NOCOUNT get DIFFERENT advice, and that is worth
+        #! pinning: telling someone whose suite printed "0 pass, 0 fail" to
+        #! "print one of the shapes" sends them to fix what they already did.
+        ("e2e-nocount-says-which-cause-silence",
+         {"a": "building...\n"}, 1, "printed no tally line at all",
+         "a silent suite is told it printed nothing"),
+        ("e2e-nocount-says-which-cause-zero",
+         {"a": "== campaign: 0 pass, 0 fail ==\n"}, 1,
+         "measured 0 checks and 0 failures",
+         "...and a zero-tallying one is told the opposite, not the same thing"),
     ):
         with tempfile.TemporaryDirectory() as td:
             for stem, text in logs.items():
@@ -344,7 +395,10 @@ def selftest():
             #! NOT --quiet: the per-suite table has its own NO COUNT flag, and
             #! it used to carry a private copy of the predicate that disagreed
             #! with the verdict. Rendering it here is what keeps them one.
-            with contextlib.redirect_stdout(buf):
+            #! stderr too: e2e-empty-logdir writes a usage line there, and a
+            #! reader seeing an alarm above the OK list learns to ignore alarms
+            with contextlib.redirect_stdout(buf), \
+                    contextlib.redirect_stderr(io.StringIO()):
                 rc = main([sys.argv[0], td])
         out = buf.getvalue()
         ok = rc == want_rc
@@ -352,10 +406,48 @@ def selftest():
         if want_rc == 1 and logs and ("NOCOUNT" in out) != ("NO COUNT" in out):
             ok = False
             why += "  [table flag and verdict DISAGREE]"
+        #! ...and the OUTPUT itself is asserted, not just the exit code. The
+        #! headline numbers and the skip listing were both mutable in silence:
+        #! the listing is the declared marker's ONLY remaining purpose, so a
+        #! deleted listing makes the marker pointless without failing anything.
+        if want_out is not None and want_out not in out:
+            ok = False
+            why += f"  [expected {want_out!r} in the output]"
         print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} rc={rc}  -- {why}")
         if not ok:
             bad += 1
             print(f"       expected rc={want_rc}")
+
+    # --- the CAMPAIGN GUARD --------------------------------------------------
+    # The guard protects 164 checks that nothing else protects, because the
+    # suite's own 2-check floor lifts it clear of NOCOUNT. A review pointed out
+    # the guard itself had no test: revert it and reword the summary, and both
+    # the self-test and the sweep stay green.
+    for name, text, want_ok, why in (
+        ("guard-real-tally",
+         "== AAF campaign (tsn-gen driven): 164 pass, 0 fail, 0 known gaps ==\n",
+         True, "a campaign that measured something is accounted for"),
+        ("guard-other-shapes",
+         "aaf: 164 checks, 0 failures\n", True,
+         "...in ANY shape the sweep reads, not just the campaign one"),
+        ("guard-declared-skip",
+         "SUITE-SKIP: AAF campaign (tsn-gen absent)\n", True,
+         "...and so is one that declared it ran nothing"),
+        ("guard-reworded-summary",
+         "== AAF campaign: 164 ok / 0 bad ==\n", False,
+         "a summary past every shape is NOT, though it looks fine to a human"),
+        ("guard-zero-tally",
+         "== AAF campaign (tsn-gen driven): 0 pass, 0 fail, 0 known gaps ==\n",
+         False, "neither is one that ran and measured nothing"),
+        ("guard-silence", "building...\n", False, "nor silence"),
+    ):
+        reason, got = campaign_accounted_for(text)
+        ok = got == want_ok
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} "
+              f"accounted={got}  -- {why}")
+        if not ok:
+            bad += 1
+            print(f"       expected accounted={want_ok}, got reason: {reason}")
 
     print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
     return 1 if bad else 0
@@ -364,6 +456,21 @@ def selftest():
 def main(argv):
     if "--selftest" in argv[1:]:
         return selftest()
+    if "--campaign-guard" in argv[1:]:
+        #! One campaign log, checked against the same recognisers the sweep
+        #! uses. See campaign_accounted_for().
+        path = argv[argv.index("--campaign-guard") + 1]
+        reason, ok = campaign_accounted_for(
+            Path(path).read_text(errors="replace"))
+        if ok:
+            return 0
+        print(f"CAMPAIGN UNACCOUNTED FOR -- {reason}.")
+        print("  Its checks would leave the sweep's headline in silence: the")
+        print("  suite prints an unconditional floor of its own, so this does")
+        print("  NOT show up as a NOCOUNT. Print a tally in one of the shapes")
+        print("  in scripts/suite_tally.py, or a SUITE-SKIP: line saying why")
+        print("  the campaign ran nothing.")
+        return 1
     args = [a for a in argv[1:] if not a.startswith("-")]
     quiet = "--quiet" in argv[1:]
     if len(args) != 1:

--- a/tb/verilator/tsn_fuzz/Makefile
+++ b/tb/verilator/tsn_fuzz/Makefile
@@ -88,10 +88,25 @@ matrix-check:
 	@echo "traceability contracts (drift + ratchet): 2 checks: 2 PASS, 0 FAIL"
 
 
+# THE CAMPAIGN MUST ACCOUNT FOR ITSELF, and this check is here because giving
+# the suite an unconditional 2-check floor (see matrix-check) took away the
+# backstop it used to have. Before that floor, a campaign whose summary line was
+# reworded printed no shape suite_tally.py knew, the suite fell to NOCOUNT and
+# the sweep stopped. Now the floor clears NOCOUNT on its own, so the same
+# rewording would silently drop 164 checks from the headline with everything
+# green. UNPARSED still catches a reword that stays tally-shaped; it does not
+# catch "164 ok / 0 bad".
+#
+# So: exactly two outcomes are valid, a tally or a declared skip. Anything else
+# fails here, where it is loud, instead of vanishing into the total.
 aaf: obj_aaf/Vaaf_cosim
-	$(PY) fuzz_aaf.py
+	@$(PY) fuzz_aaf.py > obj_aaf/aaf.out 2>&1; rc=$$?; cat obj_aaf/aaf.out; \
+	 if [ $$rc -ne 0 ]; then exit $$rc; fi; \
+	 grep -qE '^(==.*: [0-9]+ pass, [0-9]+ fail|SUITE-SKIP:)' obj_aaf/aaf.out || { \
+	   echo "tsn_fuzz: the campaign printed NEITHER a tally suite_tally.py can"; \
+	   echo "  read NOR a declared skip. Its checks would be counted as zero"; \
+	   echo "  with the sweep still green. Restore one of the two shapes."; \
+	   exit 1; }
 
-# the original 14-command smoke driver that predates this campaign; run it
-# too so its expectations cannot drift from the RTL again
 clean:
 	rm -rf obj_aaf __pycache__

--- a/tb/verilator/tsn_fuzz/Makefile
+++ b/tb/verilator/tsn_fuzz/Makefile
@@ -3,9 +3,10 @@
 #
 # IEEE 1722.1 / 1722 field-validation campaign, tsn-gen driven.
 #
-#   make            build the co-simulation DUTs and run every campaign
+#   make            build the DUT, run the campaign and the traceability check
 #   make build      build only
-#   make aaf                 run the AAF campaign (the only one left)
+#   make aaf        run the AAF campaign (the only one left)
+#   make matrix-check   the module<->spec<->test no-drift contract
 #   make clean
 #
 # Each campaign is a Python driver talking to a Verilator server built from
@@ -94,19 +95,25 @@ matrix-check:
 # reworded printed no shape suite_tally.py knew, the suite fell to NOCOUNT and
 # the sweep stopped. Now the floor clears NOCOUNT on its own, so the same
 # rewording would silently drop 164 checks from the headline with everything
-# green. UNPARSED still catches a reword that stays tally-shaped; it does not
-# catch "164 ok / 0 bad".
+# green.
 #
-# So: exactly two outcomes are valid, a tally or a declared skip. Anything else
-# fails here, where it is loud, instead of vanishing into the total.
+# THE CHECK IS DELEGATED, NOT REIMPLEMENTED. suite_tally.py --campaign-guard
+# applies the same recognisers the sweep applies, because a second matcher
+# written here is how the two come to disagree — a first cut of this rule was a
+# hand-rolled grep, and a review found it rejected four tally shapes the sweep
+# reads perfectly well while ACCEPTING "0 pass, 0 fail", the one outcome it most
+# needed to reject.
+#
+# tee, not `> file`: run_all_suites.sh treats a timeout as UNKNOWN rather than
+# failure, and with a plain redirect a timed-out campaign leaves nothing in the
+# suite log to read. The exit code travels in a sidecar because pipefail is not
+# portable to every /bin/sh.
 aaf: obj_aaf/Vaaf_cosim
-	@$(PY) fuzz_aaf.py > obj_aaf/aaf.out 2>&1; rc=$$?; cat obj_aaf/aaf.out; \
-	 if [ $$rc -ne 0 ]; then exit $$rc; fi; \
-	 grep -qE '^(==.*: [0-9]+ pass, [0-9]+ fail|SUITE-SKIP:)' obj_aaf/aaf.out || { \
-	   echo "tsn_fuzz: the campaign printed NEITHER a tally suite_tally.py can"; \
-	   echo "  read NOR a declared skip. Its checks would be counted as zero"; \
-	   echo "  with the sweep still green. Restore one of the two shapes."; \
-	   exit 1; }
+	@rm -f obj_aaf/aaf.rc; \
+	 { $(PY) fuzz_aaf.py 2>&1; echo $$? > obj_aaf/aaf.rc; } | tee obj_aaf/aaf.out; \
+	 rc=$$(cat obj_aaf/aaf.rc); \
+	 if [ "$$rc" -ne 0 ]; then exit "$$rc"; fi; \
+	 $(PY) ../../../scripts/suite_tally.py --campaign-guard obj_aaf/aaf.out
 
 clean:
 	rm -rf obj_aaf __pycache__

--- a/tb/verilator/tsn_fuzz/Makefile
+++ b/tb/verilator/tsn_fuzz/Makefile
@@ -108,8 +108,14 @@ matrix-check:
 # failure, and with a plain redirect a timed-out campaign leaves nothing in the
 # suite log to read. The exit code travels in a sidecar because pipefail is not
 # portable to every /bin/sh.
+#
+# BOTH scratch files are removed first. tee's exit status is discarded (that is
+# the price of not having pipefail), so if it cannot open aaf.out the previous
+# run's log survives and the guard reads THAT -- a reworded summary would then
+# be waved through by a stale copy of the old one. Contrived, but the fix is a
+# filename.
 aaf: obj_aaf/Vaaf_cosim
-	@rm -f obj_aaf/aaf.rc; \
+	@rm -f obj_aaf/aaf.rc obj_aaf/aaf.out; \
 	 { $(PY) fuzz_aaf.py 2>&1; echo $$? > obj_aaf/aaf.rc; } | tee obj_aaf/aaf.out; \
 	 rc=$$(cat obj_aaf/aaf.rc); \
 	 if [ "$$rc" -ne 0 ]; then exit "$$rc"; fi; \

--- a/tb/verilator/tsn_fuzz/README.md
+++ b/tb/verilator/tsn_fuzz/README.md
@@ -130,13 +130,9 @@ ran and checked nothing. `suite_tally.py`'s self-test pins all of it —
 
 Fuzzing an entity to see if it crashes is a weak test — this RTL has no
 software to crash. What matters is that **garbage does not move state**. So
-every campaign interleaves storms with a *canary*:
+every campaign interleaves storms with a *canary*. Only AAF's remains; the
+AECP, ACMP and ADP canaries went with their campaigns on 2026-08-13:
 
-* AECP replays `READ_DESCRIPTOR(ENTITY,0)` and requires it **byte-identical**
-  to the pre-storm baseline;
-* ACMP requires `state_o` to stay inside the eight legal LSM states, never
-  wedge, and a legitimate BIND to still work afterwards;
-* ADP requires a complete, correct 82-byte ADPDU after an event storm;
 * AAF requires the stream to **stay locked** through every malformed PDU —
   an unlock is an audible dropout and a Milan compliance failure — and,
   inversely, requires it to **unlock** during a sustained accept drought: a
@@ -166,12 +162,18 @@ So the models are used as the field/constraint oracle only, never as the
 frame builder. `tsn_model.decode_pdu()` shifts the PDU left one nibble before
 handing it to `packet_gen --decode`; with that correction tsn-gen decodes
 real frames exactly and serves as a genuine independent decoder (the ADP
-campaign cross-checks 12 fields this way).
+campaign cross-checked 12 fields this way, before it was deleted).
 
 ## Tracked gaps (visible, counted, non-failing)
 
-Printed as `[GAP ]` and listed in each campaign's summary. Both were found by
-this campaign:
+Printed as `[GAP ]` and listed in each campaign's summary.
+
+> **Both belonged to the AECP campaign, which was deleted on 2026-08-13 with
+> the RTL it fuzzed.** The surviving AAF campaign reports **0 known gaps**, so
+> nothing below is currently being re-measured. They are kept because the
+> defects were real and were never fixed — deleting the record along with the
+> campaign would have quietly retired two findings rather than resolving them.
+> The second is tracked as #48.
 
 1. **`LOCK_ENTITY` ignores `descriptor_type`/`descriptor_index`** and answers
    SUCCESS for any value; §7.4.2 scopes LOCK to the ENTITY descriptor, so a

--- a/tb/verilator/tsn_fuzz/README.md
+++ b/tb/verilator/tsn_fuzz/README.md
@@ -22,7 +22,9 @@ make aaf        AAF / AVTP stream: the listener ACCEPT VERDICT + lock stability
 make legacy     the original 14-command cosim smoke driver
 ```
 
-Current tally — 3153 checks, 0 failures, 2 tracked gaps. This is what `make`
+Current tally — **164 campaign checks + 2 traceability contracts**, 0 failures,
+2 tracked gaps, with `tsn-gen` installed. (The 3153 this line used to quote
+predates the 1722.1 campaign deletions above.) This is what `make`
 prints; each campaign rewrites the same line into its `TEST_RESULTS.md` on
 every run, so the generated files are the fresher authority if this table and
 they ever disagree:
@@ -35,7 +37,7 @@ they ever disagree:
 
 - **[How it works](#how-it-works)** -- The YAML-to-RTL loop in one diagram, and the three-way split of ownership: tsn-gen is the field/constraint oracle, `wire.py` owns the actual bytes, `cosim_axis.h` owns the session — including the 4-byte control frame that requests a state dump, so campaigns observe state machines instead of guessing from replies.
 - **[Where the results go](#where-the-results-go)** -- Each campaign writes its `TEST_RESULTS.md` into the folder of the RTL it validates, not a scratch dir, so a block's `doc/` shows its verification status in place. Table of the four paths. They are generated — do not hand-edit.
-- **[What this suite reports to the sweep](#what-this-suite-reports-to-the-sweep)** -- The two lines `scripts/suite_tally.py` counts (the campaign's own total, and the traceability contracts' two checks), and the third that it deliberately does *not* count: `SUITE-SKIP:`, which says the optional campaign ran nothing. Why a skip must never be worded `0 pass, 0 fail`, and why two is the honest number for contracts that inspect 63 modules.
+- **[What this suite reports to the sweep](#what-this-suite-reports-to-the-sweep)** -- The two lines `scripts/suite_tally.py` counts (the campaign's own total, and the traceability check's two contracts), and the third it deliberately does *not*: `SUITE-SKIP:`, which says the optional campaign ran nothing. Why the marker is reporting rather than a verdict — it does not clear `NOCOUNT`, and letting it would hide a campaign behind a green sweep — and why the traceability check counts 2 and not 63.
 - **[Why "state stability" is the real gate](#why-state-stability-is-the-real-gate)** -- The argument for what this suite actually asserts: there is no software here to crash, so the test is that garbage does not *move state*. Each campaign's canary is named, including AAF's two-sided one — stay locked through malformed PDUs, but DO unlock during an accept drought, because a listener reporting MEDIA_LOCKED while accepting nothing is lying to the controller.
 - **[⚠ tsn-gen wire-layout caveat (measured 2026-07-25)](#-tsn-gen-wire-layout-caveat-measured-2026-07-25)** -- The measured defect in the generator's own models: they omit the AVTPDU `sv`+`version` nibble, so a real READ_DESCRIPTOR decodes `control_data_length` 320 instead of 20. Explains the one-nibble shift `decode_pdu()` applies and why the models are used as an oracle but never as a frame builder.
 - **[Tracked gaps (visible, counted, non-failing)](#tracked-gaps-visible-counted-non-failing)** -- Two defects this campaign found, each printed as `[GAP ]` rather than swept up: `LOCK_ENTITY` answering SUCCESS for any descriptor, and undersized frames bypassing the entity-id filter — with the honest impact assessment (the second is unreachable on a real link at Ethernet's 60-byte minimum).

--- a/tb/verilator/tsn_fuzz/README.md
+++ b/tb/verilator/tsn_fuzz/README.md
@@ -12,19 +12,21 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 > data plane and was not replaced. This is a real coverage loss on IEEE 1722.1
 > field fuzzing, not a reorganisation.
 
-Four co-simulation campaigns that drive the **real RTL** with spec-modelled
-1722.1 traffic, validate every field of every message, and prove the
-end-station's state machines are unmoved by malformed input.
+**One** co-simulation campaign that drives the **real RTL** with spec-modelled
+1722 traffic, validates every field of every message, and proves the
+end-station's state machines are unmoved by malformed input. (Four campaigns
+until 2026-08-13 — see the banner above for what went and why.)
 
 ```
-make            build the DUTs and run everything   (~3 min)
+make            build the DUT, run the campaign and the traceability check
 make aaf        AAF / AVTP stream: the listener ACCEPT VERDICT + lock stability
-make legacy     the original 14-command cosim smoke driver
+make matrix-check   the module<->spec<->test no-drift contract, run by `make`
 ```
 
 Current tally — **164 campaign checks + 2 traceability contracts**, 0 failures,
-2 tracked gaps, with `tsn-gen` installed. (The 3153 this line used to quote
-predates the 1722.1 campaign deletions above.) This is what `make`
+0 known gaps, with `tsn-gen` installed. (The 3153 checks and 2 tracked gaps
+this line used to quote both predate the 1722.1 campaign deletions above; the
+gaps belonged to the AECP campaigns that went with them.) This is what `make`
 prints; each campaign rewrites the same line into its `TEST_RESULTS.md` on
 every run, so the generated files are the fresher authority if this table and
 they ever disagree:
@@ -36,7 +38,7 @@ they ever disagree:
 ## Contents
 
 - **[How it works](#how-it-works)** -- The YAML-to-RTL loop in one diagram, and the three-way split of ownership: tsn-gen is the field/constraint oracle, `wire.py` owns the actual bytes, `cosim_axis.h` owns the session — including the 4-byte control frame that requests a state dump, so campaigns observe state machines instead of guessing from replies.
-- **[Where the results go](#where-the-results-go)** -- Each campaign writes its `TEST_RESULTS.md` into the folder of the RTL it validates, not a scratch dir, so a block's `doc/` shows its verification status in place. Table of the four paths. They are generated — do not hand-edit.
+- **[Where the results go](#where-the-results-go)** -- Each campaign writes its `TEST_RESULTS.md` into the folder of the RTL it validates, not a scratch dir, so a block's `doc/` shows its verification status in place. Table of the path. They are generated — do not hand-edit.
 - **[What this suite reports to the sweep](#what-this-suite-reports-to-the-sweep)** -- The two lines `scripts/suite_tally.py` counts (the campaign's own total, and the traceability check's two contracts), and the third it deliberately does *not*: `SUITE-SKIP:`, which says the optional campaign ran nothing. Why the marker is reporting rather than a verdict — it does not clear `NOCOUNT`, and letting it would hide a campaign behind a green sweep — and why the traceability check counts 2 and not 63.
 - **[Why "state stability" is the real gate](#why-state-stability-is-the-real-gate)** -- The argument for what this suite actually asserts: there is no software here to crash, so the test is that garbage does not *move state*. Each campaign's canary is named, including AAF's two-sided one — stay locked through malformed PDUs, but DO unlock during an accept drought, because a listener reporting MEDIA_LOCKED while accepting nothing is lying to the controller.
 - **[⚠ tsn-gen wire-layout caveat (measured 2026-07-25)](#-tsn-gen-wire-layout-caveat-measured-2026-07-25)** -- The measured defect in the generator's own models: they omit the AVTPDU `sv`+`version` nibble, so a real READ_DESCRIPTOR decodes `control_data_length` 320 instead of 20. Explains the one-nibble shift `decode_pdu()` applies and why the models are used as an oracle but never as a frame builder.

--- a/tb/verilator/tsn_fuzz/cosim.py
+++ b/tb/verilator/tsn_fuzz/cosim.py
@@ -291,12 +291,19 @@ def read_state(dut):
 def require_tsn_gen(report):
     """Skip cleanly (exit 0) when tsn-gen is not installed on this machine.
 
-    The ``SUITE-SKIP:`` line is the machine-readable declaration that lets
-    ``scripts/suite_tally.py`` report why the campaign total is smaller. It
-    deliberately carries NO pass/fail numbers: a skip worded as "0 pass, 0 fail"
-    matches the campaign shape and would read as a campaign that ran and found
-    nothing to check, which is how a smaller total becomes invisible.  Zero is a
-    measurement; this is the absence of one, and the two must not look alike.
+    The ``SUITE-SKIP:`` line is the machine-readable half, and it is REPORTING
+    ONLY: ``scripts/suite_tally.py`` lists it so a reader can see why the
+    campaign total is smaller, and that is the whole of its effect.  It does
+    **not** keep this suite out of ``NOCOUNT`` -- the traceability contracts the
+    Makefile counts on every run do that.  Do not give the marker that power: a
+    suite that can declare its own way out of ``NOCOUNT`` can hide an entire
+    campaign behind a green sweep, which is measured in that file's docstring.
+
+    It deliberately carries NO pass/fail numbers either.  A skip worded as
+    "0 pass, 0 fail" matches the campaign shape and would read as a campaign
+    that ran and found nothing to check, which is how a smaller total becomes
+    invisible.  Zero is a measurement; this is the absence of one, and the two
+    must not look alike.
     """
     import tsn_model
     if tsn_model.available():


### PR DESCRIPTION
Closes #87.

## Status

🟢 READY | full sweep **50/50, exit 0, 2,113,140 checks**, no `NOCOUNT` | behave 322 scenarios / 1,526 steps | `--selftest` **44 cases** | `84-tsn-fuzz-accountable-count` -> `main-push`

## Why this exists

PR #86 was merged at `2026-08-17T07:54Z` while its review was still running. The merge took the branch at `43a4c417`; the commits below were pushed after that point and never landed. This is a re-landing, not new development.

**This is not a fast-forward** — an earlier revision of this description said it was, and that was wrong. `origin/main-push` is the merge commit `2b17f7f9`, whose second parent is `43a4c417`; this branch descends from `43a4c417` directly, so `main-push` has one commit the branch lacks and merging produces a merge commit. Safe, but `--ff-only` will not work.

*Worth knowing for anyone checking this themselves:* `git log A..B` returns **empty** in this environment when it follows another git command in the same shell invocation — the proxy hook swallows it. That is how the claim got made. Use `git rev-list --count A..B` or `git merge-base --is-ancestor` instead.

The process failure itself is tracked separately as #88.

## The two gaps this closes on `main-push`

**1. A suite that measures nothing clears the accounting gate.** `scripts/suite_tally.py`'s stated rule is *a structural zero is not a measurement*, and today a reported zero is treated as agreement:

```
$ printf 'campaign skipped: 0 pass, 0 fail (dependency absent)\n' > d/a.log
main-push   -> rc 0
this branch -> rc 1   NOCOUNT a: reported a tally, but it measured 0 checks and 0 failures
```

Latent rather than active — nothing in the tree emits that wording — but it is exactly the wording an earlier PR proposed adding.

**2. `tb/verilator/tsn_fuzz` has no backstop.** The unconditional two-check floor already on `main-push` is what made the suite countable; it also removed the `NOCOUNT` that used to catch a campaign whose summary was reworded. Measured: reword the campaign summary to `164 ok / 0 bad` with `tsn-gen` present and **164 checks leave the headline with the sweep green**. Here that fails the suite at rc 2.

## What the three commits carry

| commit | |
|---|---|
| `63a4df7c` | the zero-tally rule; end-to-end self-test cases that assert the **exit code**; the table flag sharing one predicate with the verdict |
| `c5216170` | the campaign guard on the `aaf` target; the two-cause `NOCOUNT` diagnostic; `TESTING.md` and README corrections |
| `796ecb5c` | the guard delegated to `suite_tally.py --campaign-guard` rather than a second matcher; the guard's own self-test; `tee` so a timed-out campaign keeps its trail |
| `f34bebaf` | review round: a marker no longer excuses a tally beside it; a stale log cannot satisfy the guard; the guard's CLI and `--quiet` are pinned; the failures half of the headline is pinned |

The third is worth calling out. The guard began as a hand-rolled grep in the Makefile, and a review found it **rejected four tally shapes the sweep reads perfectly well while accepting `0 pass, 0 fail`** — the one outcome it most needed to reject. Delegating to `suite_tally.py` means there is one set of recognisers, so the guard and the sweep cannot disagree.

## Measured on this tree

| scenario | result |
|---|---|
| `make -C tb/verilator/tsn_fuzz` | rc 0, **2 checks**, skip listed |
| `TSN_GEN_ROOT=… make …` | rc 0, **166** (164 + 2) |
| stale `MODULE_MATRIX.md` | rc **2**, no `2 checks` line emitted |
| campaign summary reworded | rc **2**, `CAMPAIGN UNACCOUNTED FOR` |
| campaign runs but measures nothing | rc **2**, *"it ran, and measured nothing"* |
| `0 pass, 0 fail` fixture | rc **1**, `NOCOUNT` |
| full sweep | rc **0**, 50/50, 2,113,140 |
| behave | 322 scenarios, 1,526 steps, 0 failed |
| `docs_check` · `check_doc_paths` · `check_archive` · `gen_toc --check` · `--verify-anchors` · `lint_rtl` | all rc 0 |

## Regression coverage

`--selftest` runs before every sweep (`run_all_suites.sh:140`), so all 44 cases are enforced on every run: the parse, the `is_nocount` decision, the call site through `main()` asserting exit codes *and* output, and the campaign guard itself. Every case exists because a mutation survived without it.

## How to validate

```bash
python3 scripts/suite_tally.py --selftest
make -C tb/verilator/tsn_fuzz                          # 2 checks
TSN_GEN_ROOT=<path> make -C tb/verilator/tsn_fuzz      # 166
./scripts/run_all_suites.sh                            # exit 0, no NOCOUNT
(cd tests && behave)
```

## After merge

Please confirm containment, since this PR exists because that check was missing:

```bash
git merge-base --is-ancestor origin/84-tsn-fuzz-accountable-count origin/main-push \
  && echo contained || echo "STRANDED AGAIN"
```
