### PR TITLE
Make a merge that lands past its branch say so

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,12 @@ flowchart LR
     PR --> RV[In review<br/>multiple agents, CLEARED context]
     RV -->|findings| W
     W -->|fixed| RV
-    RV -->|2 positive:<br/>1 own + 1 EXTERNAL| M[merge to main-push]
-    M --> G[re-run the FULL bar<br/>on the merge result]
+    RV -->|2 positive:<br/>1 own + 1 EXTERNAL| G[validate candidate merge result<br/>with the FULL local bar]
     G -->|regression| W
-    G -->|clean| D[Done]
+    G -->|clean| M[merge to main-push]
+    M --> C[branch stops moving<br/>run containment]
+    C -->|finding| F[follow-up issue + PR]
+    C -->|clean| D[close issue manually<br/>Done]
 ```
 
 1. **Move the issue to *In progress*** on the project board before the first
@@ -60,8 +62,9 @@ flowchart LR
    built twice on 2026-08-16 because the issue was filed after the work
    started.
 2. **Cut the branch from the issue**: `gh issue develop <N> --base main-push`.
-   This links branch to issue on GitHub, so the PR closes the issue and the
-   board moves itself. A hand-named branch does neither.
+   This links the branch and issue on GitHub. Because `main-push` is not the
+   repository's default branch, merging its PR does not auto-close the issue.
+   Close the issue manually only after the post-merge containment check passes.
 3. **Do the work on that branch**, with the §3 verification bar met *on the
    branch* — a PR is not the place to discover the sweep is red.
 4. **Open the PR** against `main-push`, with the template below and the
@@ -108,12 +111,14 @@ flowchart LR
    `MERGED`, CI is green, and the branch still has commits ahead of the merge.
    Nothing in the lane compares those two facts unless step 7 does.
 
-   The issue closes itself; move the card to *Done* if it does not.
-7. **Re-run the whole verification bar ON THE MERGE RESULT, every time.** A
-   merge is a change nobody wrote and nobody reviewed, and *"Merge made by the
-   'ort' strategy"* is not evidence of anything. Gate the merged tree exactly
-   as §3 gates a hand-written one — full Verilator sweep, both repos' suites,
-   behave, the lint ratchet, yosys — before the merge button, not after.
+7. **Validate the candidate merge result, then prove containment.** A merge is
+   a change nobody wrote and nobody reviewed, and *"Merge made by the 'ort'
+   strategy"* is not evidence of anything. Before pressing merge, construct a
+   candidate from the latest `origin/main-push` and the reviewed PR head, then
+   gate that tree exactly as §3 gates a hand-written one: full Verilator sweep,
+   both repos' suites, behave, the lint ratchet, and Yosys. If the reviewed head
+   directly descends from the unchanged base, its tree is the candidate merge
+   tree; record both object IDs with the local gate results.
 
    This is not defensive box-ticking. On 2026-08-16 two lanes independently
    added the *same* six AECP settings-face pins to `KL_pp_shadow.sv` — one
@@ -124,7 +129,7 @@ flowchart LR
    split out, and restored an inventory row for an opcode the engine no longer
    decodes.
 
-   **Then check the merge actually took the branch:**
+   **After merge, check that it actually took the branch:**
 
    ```bash
    python3 scripts/check_merge_containment.py origin/<branch>
@@ -138,9 +143,15 @@ flowchart LR
 
    **Run it when the branch stops moving, not at the merge button.** Both
    incidents were *contained* at the instant they merged; the commits that
-   ended up stranded were pushed afterwards, by the review round that was still
-   running. A check run at merge time cannot see them. The moment that catches
-   it is the one where the card moves to *Done*.
+   ended up stranded were pushed afterwards as review activity continued. For
+   #86 a round was in flight. For #77 the stated bar had been met, but review
+   did not stop. A check run at merge time cannot see later pushes. The moment
+   that catches them is the one where the card moves to *Done*. Once
+   containment is clean, close the issue manually and move its project item to
+   *Done*.
+
+   `--no-fetch` disables Git ref refresh only. A `--merged-prs` sweep still
+   queries GitHub for the merged PR list and branch timeline evidence.
 
    Its `--selftest` runs inside `scripts/run_all_suites.sh` next to
    `suite_tally.py`'s, so the tool cannot rot into a green that means nothing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,24 @@ flowchart LR
    validated, with the gate results. The findings, the mutation tables and the
    clause arguments belong in the review itself and in the commit messages —
    a PR thread that reprints them is a PR thread nobody reads to the end.
-6. **Merge back into `main-push`** only once the findings are answered. The
-   issue closes itself; move the card to *Done* if it does not.
+6. **Merge back into `main-push`** only once the findings are answered, and
+   **not while a review round is in flight.** A round that has not reported is
+   a round outstanding; merging past it is merging unreviewed code with a
+   review thread attached.
+
+   This has happened twice, both times losing work rather than shipping a bug:
+
+   | PR | merged | state at that moment | cost |
+   |---|---|---|---|
+   | #77 | 2026-08-16 18:10 | round 3 of 6 running | rounds 4, 5 and 6 each returned NEGATIVE **after** the merge — an ungraded refusal arm where mutating the code was silent, and a test that could not fail. Re-landed as #85 |
+   | #86 | 2026-08-17 07:54 | a round running, which then found a hole in its own fix | three commits stranded on the branch; re-landed as #89, tracked by #87 |
+
+   Both were recoverable and neither was noticed by anything except a reviewer
+   checking by hand. The failure is silent by construction: `gh pr view` says
+   `MERGED`, CI is green, and the branch still has commits ahead of the merge.
+   Nothing in the lane compares those two facts unless step 7 does.
+
+   The issue closes itself; move the card to *Done* if it does not.
 7. **Re-run the whole verification bar ON THE MERGE RESULT, every time.** A
    merge is a change nobody wrote and nobody reviewed, and *"Merge made by the
    'ort' strategy"* is not evidence of anything. Gate the merged tree exactly
@@ -104,7 +120,33 @@ flowchart LR
    split out, and restored an inventory row for an opcode the engine no longer
    decodes.
 
-   Two merge-specific traps worth naming, both paid for:
+   **Then check the merge actually took the branch:**
+
+   ```bash
+   python3 scripts/check_merge_containment.py origin/<branch>
+   python3 scripts/check_merge_containment.py --merged-prs   # the last 20 PRs
+   ```
+
+   It exits non-zero and names the count when commits are left behind. Replayed
+   against the two merge points in step 6 it reports **4** and **3** stranded
+   commits respectively, which is what nobody was told at the time.
+
+   It is a script rather than a line in this file because a check that depends
+   on somebody remembering is not a check — the same reason
+   `scripts/suite_tally.py` exists. `--selftest` gates it, including the case
+   that a ref which cannot be resolved is an UNKNOWN and **fails**, never a
+   quiet pass.
+
+   **Do not hand-roll it with `git log A..B`.** In this environment that
+   returns **empty** when it follows another git command in the same shell
+   invocation — the proxy hook swallows the output — so it reports "nothing
+   diverged" for a branch that has. That is exactly how #89's description came
+   to claim a fast-forward that was not one. The script uses
+   `git rev-list --count` and `git merge-base --is-ancestor`, both of which
+   answer through a bare number or an exit code, so a swallowed stream cannot
+   be mistaken for agreement.
+
+   Three merge-specific traps worth naming, all paid for:
 
    - **Push the submodule before the superproject.** A superproject pin to a
      processor commit that only exists on a feature branch dangles the moment
@@ -115,6 +157,13 @@ flowchart LR
      constant from one side and the microprogram's entry point from the other
      does not fail to elaborate — the µCPU executes ROM fill and answers a
      well-formed response carrying garbage.
+   - **`MERGEABLE` is not `green`.** GitHub reports `MERGEABLE/UNSTABLE` while
+     checks are still running, and the two long jobs — `verilator-suites` and
+     `yosys-portability` — are the ones that would catch a real regression.
+     Merging on `UNSTABLE` means the local bar is the only bar that ran. That
+     is sometimes an acceptable trade with the sweep verified locally, but make
+     it a decision and say so on the PR, because if a job then comes back red
+     the fix lands on `main-push` instead of being caught before it.
 
 Two board rules that go with it:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,8 +147,10 @@ flowchart LR
    between merges. The check *itself* is still a thing a person runs: nothing
    here can schedule a post-merge action, and CI does not run on `main-push`
    at all (both workflows are `on: push: branches: [main]`). That gap is worth
-   closing separately. A `push: [main-push]` trigger would run the bar on the
-   merge result and this check with it.
+   closing separately. A `push: [main-push]` trigger would run the bar and the
+   containment self-test on the merge result. It would still need an explicit
+   `check_merge_containment.py --merged-prs` step to render a live containment
+   verdict.
 
    **Do not hand-roll it by reading `git log` output.** The script uses
    `git rev-list --count` and `git merge-base --is-ancestor` because one prints

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ flowchart LR
 
    | PR | merged | state at that moment | cost |
    |---|---|---|---|
-   | #77 | 2026-08-16 18:10 | round 3 of 6 running | rounds 4, 5 and 6 each returned NEGATIVE **after** the merge — an ungraded refusal arm where mutating the code was silent, and a test that could not fail. Re-landed as #85 |
+   | #77 | 2026-08-16 18:10 | round 3 of 6 running | rounds 4 and 5 returned NEGATIVE **after** the merge (round 6 was positive) - an ungraded refusal arm where mutating the code was silent, and a test that could not fail. Re-landed as #85 |
    | #86 | 2026-08-17 07:54 | a round running, which then found a hole in its own fix | three commits stranded on the branch; re-landed as #89, tracked by #87 |
 
    Both were recoverable and neither was noticed by anything except a reviewer
@@ -128,8 +128,9 @@ flowchart LR
    ```
 
    It exits non-zero and names the count when commits are left behind. Replayed
-   against the two merge points in step 6 it reports **4** and **3** stranded
-   commits respectively, which is what nobody was told at the time.
+   against the two merge points in step 6 it reports **3** stranded commits for
+   #77 and **4** for #86 - the latter is 3 as of that merge plus the one pushed
+   during the #89 re-land. Nobody was told either number at the time.
 
    It is a script rather than a line in this file because a check that depends
    on somebody remembering is not a check — the same reason
@@ -137,14 +138,15 @@ flowchart LR
    that a ref which cannot be resolved is an UNKNOWN and **fails**, never a
    quiet pass.
 
-   **Do not hand-roll it with `git log A..B`.** In this environment that
-   returns **empty** when it follows another git command in the same shell
-   invocation — the proxy hook swallows the output — so it reports "nothing
-   diverged" for a branch that has. That is exactly how #89's description came
-   to claim a fast-forward that was not one. The script uses
-   `git rev-list --count` and `git merge-base --is-ancestor`, both of which
-   answer through a bare number or an exit code, so a swallowed stream cannot
-   be mistaken for agreement.
+   **Do not hand-roll it by reading `git log` output.** The script uses
+   `git rev-list --count` and `git merge-base --is-ancestor` because one prints
+   a single integer and the other answers only through its exit status: neither
+   needs its prose parsed, so neither can be half-read or mis-scraped. #89's
+   description claimed a fast-forward that was not one, off a `git log A..B`
+   that came back empty in the author's terminal; the cause was never pinned
+   down and a later attempt could not reproduce it, which is itself the
+   argument — a check whose failure mode you cannot characterise is not one to
+   build on.
 
    Three merge-specific traps worth naming, all paid for:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ flowchart LR
    during the #89 re-land. Nobody was told either number at the time.
 
    **Run it when the branch stops moving, not at the merge button.** Both
-   incidents were *contained* at the instant they merged — the commits that
+   incidents were *contained* at the instant they merged; the commits that
    ended up stranded were pushed afterwards, by the review round that was still
    running. A check run at merge time cannot see them. The moment that catches
    it is the one where the card moves to *Done*.
@@ -147,7 +147,7 @@ flowchart LR
    between merges. The check *itself* is still a thing a person runs: nothing
    here can schedule a post-merge action, and CI does not run on `main-push`
    at all (both workflows are `on: push: branches: [main]`). That gap is worth
-   closing separately — a `push: [main-push]` trigger would run the bar on the
+   closing separately. A `push: [main-push]` trigger would run the bar on the
    merge result and this check with it.
 
    **Do not hand-roll it by reading `git log` output.** The script uses

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ flowchart LR
    during the #89 re-land. Nobody was told either number at the time.
 
    It is a script rather than a line in this file because a check that depends
-   on somebody remembering is not a check — the same reason
+   on somebody remembering is not a check; the same reason
    `scripts/suite_tally.py` exists. `--selftest` gates it, including the case
    that a ref which cannot be resolved is an UNKNOWN and **fails**, never a
    quiet pass.
@@ -145,7 +145,7 @@ flowchart LR
    description claimed a fast-forward that was not one, off a `git log A..B`
    that came back empty in the author's terminal; the cause was never pinned
    down and a later attempt could not reproduce it, which is itself the
-   argument — a check whose failure mode you cannot characterise is not one to
+   argument: a check whose failure mode you cannot characterise is not one to
    build on.
 
    Three merge-specific traps worth naming, all paid for:
@@ -160,8 +160,8 @@ flowchart LR
      does not fail to elaborate — the µCPU executes ROM fill and answers a
      well-formed response carrying garbage.
    - **`MERGEABLE` is not `green`.** GitHub reports `MERGEABLE/UNSTABLE` while
-     checks are still running, and the two long jobs — `verilator-suites` and
-     `yosys-portability` — are the ones that would catch a real regression.
+     checks are still running, and the two long jobs, `verilator-suites` and
+     `yosys-portability`, are the ones that would catch a real regression.
      Merging on `UNSTABLE` means the local bar is the only bar that ran. That
      is sometimes an acceptable trade with the sweep verified locally, but make
      it a decision and say so on the PR, because if a job then comes back red

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,13 +172,20 @@ flowchart LR
      constant from one side and the microprogram's entry point from the other
      does not fail to elaborate — the µCPU executes ROM fill and answers a
      well-formed response carrying garbage.
-   - **`MERGEABLE` is not `green`.** GitHub reports `MERGEABLE/UNSTABLE` while
-     checks are still running, and the two long jobs, `verilator-suites` and
-     `yosys-portability`, are the ones that would catch a real regression.
-     Merging on `UNSTABLE` means the local bar is the only bar that ran. That
-     is sometimes an acceptable trade with the sweep verified locally, but make
-     it a decision and say so on the PR, because if a job then comes back red
-     the fix lands on `main-push` instead of being caught before it.
+   - **The two long GitHub jobs are optional; their local gates are not.**
+     `verilator-suites` and `yosys-portability` are informational GitHub checks.
+     A PR may merge without waiting for them, including while GitHub reports
+     `MERGEABLE/UNSTABLE`. Before the PR is marked validated, run both equivalent
+     gates locally and record their results on the PR:
+
+     ```bash
+     suite_logs=$(mktemp -d)
+     scripts/run_all_suites.sh "$suite_logs"
+     syn/yosys/run.sh
+     ```
+
+     The optional status applies only to the remote jobs. The local Verilator
+     sweep and Yosys portability sweep are mandatory merge evidence.
 
 Two board rules that go with it:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,15 @@ flowchart LR
    a round outstanding; merging past it is merging unreviewed code with a
    review thread attached.
 
-   This has happened twice, both times losing work rather than shipping a bug:
+   Twice this went wrong, and the two cases are not the same shape - which is
+   the point. One merged with a round genuinely mid-flight; the other merged
+   having met the bar, while review that was still happening went on to find
+   three more blockers. The rule that covers both is that the merge waits for
+   review to be **finished**, not for a quota of positives to be reached:
 
    | PR | merged | state at that moment | cost |
    |---|---|---|---|
-   | #77 | 2026-08-16 18:10 | round 3 of 6 running | rounds 4 and 5 returned NEGATIVE **after** the merge (round 6 was positive) - an ungraded refusal arm where mutating the code was silent, and a test that could not fail. Re-landed as #85 |
+   | #77 | 2026-08-16 18:10 | round 3 answered, a positive validation posted 32 min earlier - the stated bar was **met** | review did not stop there, and rounds 4 and 5 returned NEGATIVE afterwards (6 was positive): an ungraded refusal arm where mutating the code was silent, and a test that could not fail. Re-landed as #85 |
    | #86 | 2026-08-17 07:54 | a round running, which then found a hole in its own fix | three commits stranded on the branch; re-landed as #89, tracked by #87 |
 
    Both were recoverable and neither was noticed by anything except a reviewer
@@ -132,21 +136,30 @@ flowchart LR
    #77 and **4** for #86 - the latter is 3 as of that merge plus the one pushed
    during the #89 re-land. Nobody was told either number at the time.
 
-   It is a script rather than a line in this file because a check that depends
-   on somebody remembering is not a check; the same reason
-   `scripts/suite_tally.py` exists. `--selftest` gates it, including the case
-   that a ref which cannot be resolved is an UNKNOWN and **fails**, never a
-   quiet pass.
+   **Run it when the branch stops moving, not at the merge button.** Both
+   incidents were *contained* at the instant they merged — the commits that
+   ended up stranded were pushed afterwards, by the review round that was still
+   running. A check run at merge time cannot see them. The moment that catches
+   it is the one where the card moves to *Done*.
+
+   Its `--selftest` runs inside `scripts/run_all_suites.sh` next to
+   `suite_tally.py`'s, so the tool cannot rot into a green that means nothing
+   between merges. The check *itself* is still a thing a person runs: nothing
+   here can schedule a post-merge action, and CI does not run on `main-push`
+   at all (both workflows are `on: push: branches: [main]`). That gap is worth
+   closing separately — a `push: [main-push]` trigger would run the bar on the
+   merge result and this check with it.
 
    **Do not hand-roll it by reading `git log` output.** The script uses
    `git rev-list --count` and `git merge-base --is-ancestor` because one prints
    a single integer and the other answers only through its exit status: neither
    needs its prose parsed, so neither can be half-read or mis-scraped. #89's
    description claimed a fast-forward that was not one, off a `git log A..B`
-   that came back empty in the author's terminal; the cause was never pinned
-   down and a later attempt could not reproduce it, which is itself the
-   argument: a check whose failure mode you cannot characterise is not one to
-   build on.
+   that came back empty in the author's terminal. A cause was proposed at the
+   time and a later attempt could not reproduce it in twelve variations, so it
+   stands unexplained - which is itself the argument. A check whose failure
+   mode nobody can characterise is not one to build on, whatever the cause
+   turns out to be.
 
    Three merge-specific traps worth naming, all paid for:
 

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -221,8 +221,7 @@ def refreshed_origin_ref(ref):
         return ref
     if ref.startswith("origin/"):
         return "refs/remotes/" + ref
-    explicit_local = ref.startswith("refs/heads/")
-    if explicit_local:
+    if ref.startswith("refs/heads/"):
         name = ref[len("refs/heads/"):]
     elif ref.startswith("refs/"):
         return ref
@@ -230,12 +229,35 @@ def refreshed_origin_ref(ref):
         name = ref
 
     remote_ref = "refs/remotes/origin/" + name
-    rc, _ = _git("rev-parse", "--verify", "--quiet",
-                 remote_ref + "^{commit}")
-    #! A plain branch name after a successful fetch denotes origin's branch.
-    #! Keep the fully qualified missing ref when origin has no such branch;
-    #! falling back to the plain spelling lets Git resolve a same-named tag.
-    return remote_ref if rc == 0 or not explicit_local else ref
+    #! Normal mode has just fetched origin, so an origin-qualified answer is
+    #! authoritative even when that ref is now missing.  Falling back to an
+    #! explicit but stale refs/heads base can certify work against a branch
+    #! that origin deleted.  Deliberate local-only checks use --no-fetch.
+    return remote_ref
+
+
+def offline_ref(ref):
+    """Resolve a local-only branch spelling without falling through to tags."""
+    if is_full_oid(ref) or ref.startswith("refs/"):
+        return (ref, None)
+    if ref.startswith("origin/"):
+        return ("refs/remotes/" + ref, None)
+
+    local_ref = "refs/heads/" + ref
+    remote_ref = "refs/remotes/" + ref
+    local_rc, _ = _git("rev-parse", "--verify", "--quiet",
+                       local_ref + "^{commit}")
+    remote_rc, _ = _git("rev-parse", "--verify", "--quiet",
+                        remote_ref + "^{commit}")
+    if local_rc == 0 and remote_rc == 0:
+        return (None, f"{ref!r} names both {local_ref} and {remote_ref}; "
+                f"name the full ref")
+    if remote_rc == 0:
+        return (remote_ref, None)
+    #! A short operand denotes a branch, never a tag.  Keep a missing local
+    #! branch fully qualified so a same-named tag cannot turn UNKNOWN into a
+    #! false contained result.
+    return (local_ref, None)
 
 
 def fetched_branch_refs(ref):
@@ -286,10 +308,21 @@ def fetched_branch_refs(ref):
 
 def non_origin_remote_ref(ref):
     """Name an unrefreshable remote-tracking ref, or return None."""
+    if is_full_oid(ref):
+        return None
     if ref.startswith("refs/remotes/origin/") or ref.startswith("origin/"):
         return None
     if ref.startswith("refs/remotes/"):
         return ref
+    #! Resolve the remote namespace directly before asking Git to resolve the
+    #! caller's shorthand.  When refs/heads/upstream/work and
+    #! refs/remotes/upstream/work both exist, symbolic-full-name rejects the
+    #! ambiguous spelling.  Treating that failure as "not a remote" lets the
+    #! normal path silently measure origin/upstream/work instead.
+    rc, _ = _git("rev-parse", "--verify", "--quiet",
+                 "refs/remotes/" + ref + "^{commit}")
+    if rc == 0:
+        return "refs/remotes/" + ref
     rc, full = _git("rev-parse", "--symbolic-full-name", "--verify", ref)
     if (rc == 0 and full.startswith("refs/remotes/")
             and not full.startswith("refs/remotes/origin/")):
@@ -508,13 +541,16 @@ def merged_pr_heads(limit, base):
         base_name = base[len("refs/heads/"):]
     else:
         base_name = base
+    #! gh cannot order by mergedAt.  Fetch a complete candidate set, refuse a
+    #! truncated result, then sort locally.  Limiting an updated-desc query
+    #! first lets a comment on an old PR displace the newest merge.
+    candidate_limit = max(limit + 1, 1001)
     try:
         p = subprocess.run(
             ["gh", "pr", "list", "--state", "merged", "--base", base_name,
-             "--limit", str(limit),
+             "--limit", str(candidate_limit),
              "--json",
-             "number,headRefName,headRefOid,isCrossRepository,mergedAt",
-             "--search", "sort:updated-desc"],
+             "number,headRefName,headRefOid,isCrossRepository,mergedAt"],
             capture_output=True, text=True)
     except FileNotFoundError:
         #! distinct from "stranded": a tool we cannot run is not a finding
@@ -523,14 +559,21 @@ def merged_pr_heads(limit, base):
         return (None, "gh could not list merged PRs (authenticated?): "
                       + (p.stderr or "").strip()[:200])
     try:
+        candidates = json.loads(p.stdout)
+        if not isinstance(candidates, list):
+            raise ValueError("gh output is not a pull-request list")
+        if len(candidates) == candidate_limit:
+            return (None, f"more than {candidate_limit - 1} merged PRs target "
+                    f"{base_name}; refusing a possibly truncated sweep")
+        candidates.sort(key=lambda d: d["mergedAt"], reverse=True)
         rows = []
-        for d in json.loads(p.stdout):
+        for d in candidates[:limit]:
             ref_error = (None if d["isCrossRepository"] else
                          post_merge_ref_event_error(d["number"], d["mergedAt"]))
             rows.append((d["number"], d["headRefName"], d["headRefOid"],
                          d["isCrossRepository"], ref_error))
         return (rows, None)
-    except (ValueError, KeyError) as exc:
+    except (ValueError, KeyError, TypeError) as exc:
         return (None, f"could not parse gh output: {exc}")
 
 
@@ -760,6 +803,21 @@ def selftest():
                      "a short tag cannot stand in for a missing branch")
                 case("deleted-tag-short-word", "UNKNOWN" in out, True,
                      "...and the fetched namespace remains authoritative")
+                _git("tag", "offline-tag-only", "base")
+                rc, out = run(["--no-fetch", "--base", "base",
+                               "offline-tag-only"])
+                case("offline-tag-branch-rc", rc, RC_FINDING,
+                     "an offline short branch cannot fall through to a tag")
+                case("offline-tag-branch-word", "UNKNOWN" in out, True,
+                     "...and the missing local branch remains UNKNOWN")
+                _git("tag", "offline-base-tag-only",
+                     "refs/remotes/origin/work")
+                rc, out = run(["--no-fetch", "--base",
+                               "offline-base-tag-only", "base"])
+                case("offline-tag-base-rc", rc, RC_FINDING,
+                     "an offline short base cannot fall through to a tag")
+                case("offline-tag-base-word", "UNKNOWN" in out, True,
+                     "...and the missing local base remains UNKNOWN")
                 _git("push", "-q", "origin", "base:refs/heads/deleted-base")
                 _git("tag", "deleted-base", "refs/remotes/origin/work")
                 _git("push", "-q", "origin", "--delete", "deleted-base")
@@ -768,6 +826,25 @@ def selftest():
                      "a tag cannot stand in for a deleted base branch")
                 case("deleted-tag-base-word", "UNKNOWN" in out, True,
                      "...and the missing fetched base is UNKNOWN")
+                _git("branch", "stale-base", "refs/remotes/origin/work")
+                rc, out = run(["--base", "refs/heads/stale-base",
+                               "origin/work"])
+                case("deleted-explicit-base-rc", rc, RC_FINDING,
+                     "a stale explicit local base cannot replace origin")
+                case("deleted-explicit-base-word", "UNKNOWN" in out, True,
+                     "...and normal mode keeps the missing origin base")
+
+                _git("remote", "add", "upstream", remote)
+                _git("update-ref", "refs/remotes/upstream/work",
+                     "refs/remotes/origin/work")
+                _git("branch", "upstream/work", "base")
+                rc, out = run(["--base", "base", "upstream/work"])
+                case("ambiguous-remote-normal-rc", rc, RC_CANNOT_RUN,
+                     "an ambiguous non-origin remote shorthand is refused")
+                rc, out = run(["--no-fetch", "--base", "base",
+                               "upstream/work"])
+                case("ambiguous-remote-offline-rc", rc, RC_CANNOT_RUN,
+                     "...and offline mode requires its full ref identity")
 
                 # A merged PR's head OID is frozen at merge time.  The live
                 # branch tip is the only ref that can expose later pushes.
@@ -818,6 +895,65 @@ def selftest():
                     case("timeline-delete-parser",
                          "head_ref_deleted" in (timeline_error or ""), True,
                          "the GitHub timeline parser preserves deletion proof")
+                finally:
+                    subprocess.run = saved_subprocess_run
+
+                class MergedListResult:
+                    returncode = 0
+                    stderr = ""
+
+                    def __init__(self, stdout):
+                        self.stdout = stdout
+
+                merged_list_calls = []
+                unsorted_prs = (
+                    '[{"number":1,"headRefName":"one",'
+                    '"headRefOid":"1111111111111111111111111111111111111111",'
+                    '"isCrossRepository":true,'
+                    '"mergedAt":"2026-01-01T00:00:00Z"},'
+                    '{"number":2,"headRefName":"two",'
+                    '"headRefOid":"2222222222222222222222222222222222222222",'
+                    '"isCrossRepository":true,'
+                    '"mergedAt":"2026-03-01T00:00:00Z"},'
+                    '{"number":3,"headRefName":"three",'
+                    '"headRefOid":"3333333333333333333333333333333333333333",'
+                    '"isCrossRepository":true,'
+                    '"mergedAt":"2026-02-01T00:00:00Z"}]')
+
+                def fake_merged_list(argv, **_kwargs):
+                    merged_list_calls.append(argv)
+                    return MergedListResult(unsorted_prs)
+
+                subprocess.run = fake_merged_list
+                try:
+                    ordered_prs, list_error = merged_pr_heads(2, "base")
+                    case("merged-list-order",
+                         (list_error, [row[0] for row in ordered_prs]),
+                         (None, [2, 3]),
+                         "the sweep selects PRs by merge time")
+                    call = merged_list_calls[0]
+                    case("merged-list-complete-query",
+                         ("--search" not in call,
+                          call[call.index("--limit") + 1]),
+                         (True, "1001"),
+                         "...after requesting a bounded complete candidate set")
+
+                    one_candidate = (
+                        '{"number":1,"headRefName":"one",'
+                        '"headRefOid":'
+                        '"1111111111111111111111111111111111111111",'
+                        '"isCrossRepository":true,'
+                        '"mergedAt":"2026-01-01T00:00:00Z"}')
+                    repeated = ",".join(
+                        one_candidate for _index in range(1001))
+                    subprocess.run = lambda *a, **k: MergedListResult(
+                        "[" + repeated + "]")
+                    truncated_prs, truncated_error = merged_pr_heads(2, "base")
+                    case("merged-list-truncation",
+                         (truncated_prs,
+                          "truncated" in (truncated_error or "")),
+                         (None, True),
+                         "...and possible candidate truncation is not a pass")
                 finally:
                     subprocess.run = saved_subprocess_run
 
@@ -960,9 +1096,9 @@ def selftest():
                          "normal mode deepens before measuring containment")
                     os.chdir(td)
 
-            # A short name shared by a branch and tag is not a stable input.
-            # Git's normal precedence chooses the tag, which can hide a
-            # stranded branch.  The checker must refuse the ambiguous name.
+            # A short branch name shared with a tag keeps its branch identity.
+            # Git's normal precedence chooses the tag, which can otherwise
+            # hide the stranded branch.
             _git("checkout", "-qb", "collision", "base")
             open("collision-work", "w").write("stranded")
             _git("add", "collision-work"); _git("commit", "-qm", "collision")
@@ -970,8 +1106,8 @@ def selftest():
             rc, out = run(["--no-fetch", "--base", "base", "collision"])
             case("ambiguous-ref-rc", rc, RC_FINDING,
                  "a tag and branch sharing one name cannot false-pass")
-            case("ambiguous-ref-word", "UNKNOWN" in out, True,
-                 "...and the ambiguity is reported as UNKNOWN")
+            case("ambiguous-ref-word", "STRANDED" in out, True,
+                 "...and the typed short name measures the branch")
 
             # Replacement refs rewrite ancestry for ordinary Git plumbing.
             # Make the base appear to descend from a stranded feature, then
@@ -1383,6 +1519,23 @@ def main(argv):
 
     do_fetch = "--no-fetch" not in args
     args = [a for a in args if a != "--no-fetch"]
+    if not do_fetch:
+        base, ref_error = offline_ref(base)
+        if ref_error:
+            sys.stderr.write(ref_error + "\n")
+            return RC_CANNOT_RUN
+        if "--merged-prs" not in args:
+            normalized = []
+            for arg in args:
+                if arg.startswith("-"):
+                    normalized.append(arg)
+                    continue
+                ref, ref_error = offline_ref(arg)
+                if ref_error:
+                    sys.stderr.write(ref_error + "\n")
+                    return RC_CANNOT_RUN
+                normalized.append(ref)
+            args = normalized
     rc, shallow = _git("rev-parse", "--is-shallow-repository")
     if rc != 0 or shallow not in ("true", "false"):
         sys.stderr.write(

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -221,7 +221,8 @@ def refreshed_origin_ref(ref):
         return ref
     if ref.startswith("origin/"):
         return "refs/remotes/" + ref
-    if ref.startswith("refs/heads/"):
+    explicit_local = ref.startswith("refs/heads/")
+    if explicit_local:
         name = ref[len("refs/heads/"):]
     elif ref.startswith("refs/"):
         return ref
@@ -231,7 +232,10 @@ def refreshed_origin_ref(ref):
     remote_ref = "refs/remotes/origin/" + name
     rc, _ = _git("rev-parse", "--verify", "--quiet",
                  remote_ref + "^{commit}")
-    return remote_ref if rc == 0 else ref
+    #! A plain branch name after a successful fetch denotes origin's branch.
+    #! Keep the fully qualified missing ref when origin has no such branch;
+    #! falling back to the plain spelling lets Git resolve a same-named tag.
+    return remote_ref if rc == 0 or not explicit_local else ref
 
 
 def fetched_branch_refs(ref):
@@ -274,7 +278,10 @@ def fetched_branch_refs(ref):
         #! deliberately wants only the local ref can use --no-fetch with its
         #! full refs/heads/... name.
         return [(local_ref, "local"), (remote_ref, "origin")]
-    return [(ref, None)]
+    #! Fetch completed, so an absent branch stays absent.  Returning the
+    #! caller's short spelling here lets Git resolve a tag in its place and
+    #! certify a deleted remote branch as contained.
+    return [(remote_ref, "origin")]
 
 
 def non_origin_remote_ref(ref):
@@ -648,6 +655,15 @@ def selftest():
             case("e2e-stranded-word", "STRANDED" in out, True,
                  "...and says STRANDED")
 
+            rc, base_oid = _git("rev-parse", "base")
+            _git("checkout", "-qb", base_oid, "work")
+            rc2, out = run(["--no-fetch", "--base", "base"])
+            case("implicit-hex-branch-rc", (rc, rc2), (0, RC_FINDING),
+                 "the checked-out hex branch keeps its refs/heads identity")
+            case("implicit-hex-branch-word", "STRANDED" in out, True,
+                 "...rather than becoming its contained object-name twin")
+            _git("checkout", "-q", "refs/heads/work")
+
             rc, out = run(["--no-fetch", "--base", "work", "base"])
             case("e2e-contained-rc", rc, RC_OK,
                  "a contained branch exits 0")
@@ -728,6 +744,30 @@ def selftest():
                      "a hex-named origin branch cannot replace the base OID")
                 case("full-oid-base-word", "STRANDED" in out, True,
                      "...and the immutable base object is measured")
+
+                _git("push", "-q", "origin",
+                     "refs/remotes/origin/work:refs/heads/deleted-tag")
+                _git("tag", "origin/deleted-tag", "base")
+                _git("tag", "deleted-tag", "base")
+                _git("push", "-q", "origin", "--delete", "deleted-tag")
+                rc, out = run(["--base", "base", "origin/deleted-tag"])
+                case("deleted-tag-remote-rc", rc, RC_FINDING,
+                     "a tag cannot stand in for a deleted origin branch")
+                case("deleted-tag-remote-word", "UNKNOWN" in out, True,
+                     "...and the qualified missing branch is UNKNOWN")
+                rc, out = run(["--base", "base", "deleted-tag"])
+                case("deleted-tag-short-rc", rc, RC_FINDING,
+                     "a short tag cannot stand in for a missing branch")
+                case("deleted-tag-short-word", "UNKNOWN" in out, True,
+                     "...and the fetched namespace remains authoritative")
+                _git("push", "-q", "origin", "base:refs/heads/deleted-base")
+                _git("tag", "deleted-base", "refs/remotes/origin/work")
+                _git("push", "-q", "origin", "--delete", "deleted-base")
+                rc, out = run(["--base", "deleted-base", "origin/work"])
+                case("deleted-tag-base-rc", rc, RC_FINDING,
+                     "a tag cannot stand in for a deleted base branch")
+                case("deleted-tag-base-word", "UNKNOWN" in out, True,
+                     "...and the missing fetched base is UNKNOWN")
 
                 # A merged PR's head OID is frozen at merge time.  The live
                 # branch tip is the only ref that can expose later pushes.
@@ -1428,7 +1468,10 @@ def main(argv):
             if rc != 0 or not cur or cur == "HEAD":
                 sys.stderr.write(USAGE + "\n")
                 return RC_CANNOT_RUN
-            branches = [cur]
+            #! Git has already told us this is a branch.  Preserve that type:
+            #! a legal 40-hex branch name must not become an object ID merely
+            #! because the no-operand route removed its refs/heads/ namespace.
+            branches = ["refs/heads/" + cur]
         targets = []
         for branch in branches:
             refs = (fetched_branch_refs(branch) if do_fetch

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -73,7 +73,33 @@ RC_OK, RC_FINDING, RC_CANNOT_RUN = 0, 1, 2
 def _git(*args):
     """Run git, returning (rc, stdout).  Never raises on a non-zero rc."""
     p = subprocess.run(("git",) + args, capture_output=True, text=True)
-    return p.returncode, p.stdout.strip()
+    return p.returncode, p.stdout.rstrip("\n")
+
+
+def refreshed_origin_ref(ref):
+    """Prefer the fetched origin tip when ``ref`` names a branch.
+
+    ``git fetch origin`` refreshes ``refs/remotes/origin/*``; it deliberately
+    does not move a checked-out local branch.  Checking that local ref after a
+    fetch therefore gives exactly the stale answer this command exists to
+    prevent.  Full non-branch refs remain exact, and callers using
+    ``--no-fetch`` do not call this helper.
+    """
+    if ref.startswith("refs/remotes/origin/"):
+        return ref
+    if ref.startswith("origin/"):
+        return "refs/remotes/" + ref
+    if ref.startswith("refs/heads/"):
+        name = ref[len("refs/heads/"):]
+    elif ref.startswith("refs/"):
+        return ref
+    else:
+        name = ref
+
+    remote_ref = "refs/remotes/origin/" + name
+    rc, _ = _git("rev-parse", "--verify", "--quiet",
+                 remote_ref + "^{commit}")
+    return remote_ref if rc == 0 else ref
 
 
 def contained(branch, base):
@@ -123,10 +149,15 @@ def contained(branch, base):
     #! byte-identical -- one unrelated commit later and every squash-merged
     #! branch reads stranded again. A review demonstrated exactly that: five
     #! sequential squash merges, only the newest passing.
-    rc, mb = _git("merge-base", base, branch)
-    if rc == 0 and mb:
-        rc, names = _git("diff", "--name-only", mb, branch)
-        paths = [n for n in names.splitlines() if n]
+    mb_rc, mb = _git("merge-base", base, branch)
+    if mb_rc == 0 and mb:
+        #! Disable rename folding so a move contributes both the deleted and
+        #! added path.  Comparing only the destination can certify a base that
+        #! copied the file but never removed the source.  NUL delimiters keep
+        #! unusual but valid path names exact.
+        rc, names = _git("diff", "--name-only", "--no-renames", "-z",
+                         mb, branch)
+        paths = [n for n in names.split("\0") if n]
         if rc == 0 and paths:
             rc, _ = _git("diff", "--quiet", base, branch, "--", *paths)
             if rc == 0:
@@ -135,12 +166,23 @@ def contained(branch, base):
                         f"{base} ({ahead} commit(s) not ancestors -- squash "
                         f"or rebase merge)")
 
-    #! rebase keeps one commit per change, so patch-ids still match
-    rc, cherry = _git("cherry", base, branch)
-    if rc == 0 and cherry and all(l.startswith("-") for l in cherry.splitlines()):
-        return (True, ahead,
-                f"every commit has an equivalent in {base} ({ahead} not "
-                f"ancestors -- rebase merge)")
+    #! Rebase keeps one commit per change, so patch-ids still match.  `cherry`
+    #! omits merge commits, however.  Accepting its output for a history that
+    #! contains a merge can hide unique conflict-resolution content and turn
+    #! real stranded work into rc 0.  Use the patch-id fallback only when every
+    #! commit being assessed is linear.
+    rc, merge_count = _git("rev-list", "--min-parents=2", "--count",
+                           f"{base}..{branch}")
+    if rc != 0 or not merge_count.isdigit():
+        return (None, None,
+                f"could not determine whether {branch} contains merge commits")
+    if int(merge_count) == 0:
+        rc, cherry = _git("cherry", base, branch)
+        if (rc == 0 and cherry
+                and all(l.startswith("-") for l in cherry.splitlines())):
+            return (True, ahead,
+                    f"every commit has an equivalent in {base} ({ahead} not "
+                    f"ancestors -- rebase merge)")
 
     #! NAME THE PATHS. "3 commits not in base" does not tell anyone whether
     #! this is real, and there is one case that reads STRANDED without being
@@ -151,9 +193,10 @@ def contained(branch, base):
     #! naming the paths is what lets a reader settle it in one look instead of
     #! learning to ignore the check.
     differing = []
-    if rc == 0 and mb:
-        rc2, names = _git("diff", "--name-only", base, branch)
-        differing = [n for n in names.splitlines() if n][:6]
+    if mb_rc == 0 and mb:
+        rc2, names = _git("diff", "--name-only", "--no-renames", "-z",
+                          base, branch)
+        differing = [n for n in names.split("\0") if n][:6]
     return (False, ahead, ("paths differing: " + ", ".join(differing))
             if differing else None)
 
@@ -166,19 +209,25 @@ def merged_pr_heads(limit, base):
     branch at all, and answers "diverged" for all of them -- noise that would
     bury the one real finding.
 
-    THE HEAD OID, NOT THE BRANCH REF, because a branch deleted after merge
-    leaves no ``origin/<name>``.  Note the OID is not fetchable either once
-    nothing points at it: such a PR is reported UNKNOWN, loudly, rather than
-    guessed at.  ``delete_branch_on_merge`` is false on this repository, so
-    that path is not the normal case here -- when it becomes one, the answer
-    is GitHub's compare endpoint, and it needs its own review rather than the
-    unexercised version this file used to carry.
+    GitHub's head OID is the head that was merged, not the branch tip after the
+    merge.  It is retained only as evidence for diagnostics.  The sweep must
+    check the fetched branch ref instead: commits pushed after the merge are
+    precisely the stranded work this command exists to find.  A deleted branch
+    has no observable post-merge tip and is therefore UNKNOWN, never guessed
+    from the merge-time OID.
     """
     import json
     #! gh wants a branch NAME; `base` is a git ref and usually carries the
     #! remote. Passing "origin/main-push" here silently matched nothing, so the
     #! sweep printed an empty list and exited 0 -- a pass by vacancy.
-    base_name = base.split("/", 1)[1] if base.startswith("origin/") else base
+    if base.startswith("refs/remotes/origin/"):
+        base_name = base[len("refs/remotes/origin/"):]
+    elif base.startswith("origin/"):
+        base_name = base[len("origin/"):]
+    elif base.startswith("refs/heads/"):
+        base_name = base[len("refs/heads/"):]
+    else:
+        base_name = base
     try:
         p = subprocess.run(
             ["gh", "pr", "list", "--state", "merged", "--base", base_name,
@@ -302,6 +351,130 @@ def selftest():
             rc, out = run(["--no-fetch", "--bogus", "work"])
             case("e2e-unknown-flag", rc, RC_CANNOT_RUN,
                  "an unrecognised flag is refused, never read as a branch")
+
+            # Fetch updates origin/work but not the checked-out local work
+            # branch.  The default path must assess the fetched tip, or the
+            # exact incident this command guards becomes a quiet rc 0.
+            rc, base_oid = _git("rev-parse", "base")
+            with tempfile.TemporaryDirectory() as remote:
+                _git("init", "--bare", "-q", remote)
+                _git("remote", "add", "origin", remote)
+                _git("push", "-q", "origin", "base", "work")
+                _git("checkout", "-q", "work")
+                _git("reset", "--hard", "base")
+
+                rc, local_work = _git("rev-parse", "work")
+                rc2, remote_ahead = _git(
+                    "rev-list", "--count", "base..refs/remotes/origin/work")
+                case("fresh-fixture-local", local_work == base_oid, True,
+                     "the local branch is deliberately stale at base")
+                case("fresh-fixture-remote", (rc2, remote_ahead), (0, "3"),
+                     "the fetched branch has three later commits")
+
+                rc, out = run(["--base", "base", "work"])
+                case("fresh-local-ref-rc", rc, RC_FINDING,
+                     "fetch checks origin/work, not the stale local branch")
+                case("fresh-local-ref-word", "STRANDED" in out, True,
+                     "...and reports the work on the fetched tip")
+
+                # A merged PR's head OID is frozen at merge time.  The live
+                # branch tip is the only ref that can expose later pushes.
+                saved_merged_pr_heads = globals()["merged_pr_heads"]
+                globals()["merged_pr_heads"] = lambda _limit, _base: (
+                    [(86, "work", base_oid)], None)
+                try:
+                    rc, out = run(["--no-fetch", "--base", "base",
+                                   "--merged-prs", "1"])
+                    case("merged-live-tip-rc", rc, RC_FINDING,
+                         "the merged sweep ignores the frozen head OID")
+                    case("merged-live-tip-word", "STRANDED" in out, True,
+                         "...and assesses origin/work instead")
+                finally:
+                    globals()["merged_pr_heads"] = saved_merged_pr_heads
+
+            # A multi-commit squash remains contained after unrelated work
+            # advances the base, because only branch-touched paths matter.
+            _git("checkout", "-qb", "squash-feature", "base")
+            open("sq0", "w").write("0")
+            _git("add", "sq0"); _git("commit", "-qm", "sq0")
+            open("sq1", "w").write("1")
+            _git("add", "sq1"); _git("commit", "-qm", "sq1")
+            _git("checkout", "-qb", "squash-base", "base")
+            _git("merge", "-q", "--squash", "squash-feature")
+            _git("commit", "-qm", "squash")
+            open("unrelated", "w").write("later")
+            _git("add", "unrelated"); _git("commit", "-qm", "later")
+            rc, out = run(["--no-fetch", "--base", "squash-base",
+                           "squash-feature"])
+            case("squash-base-advanced", rc, RC_OK,
+                 "unrelated base work does not hide a squash merge")
+            case("squash-path-equivalence",
+                 "every path this branch touched" in out, True,
+                 "...through the path-scoped content check")
+
+            # A copied destination is not equivalent to a rename because the
+            # source path still exists.  Rename folding must not hide it.
+            _git("checkout", "-qb", "rename-feature", "base")
+            _git("mv", "f", "renamed")
+            _git("commit", "-qm", "rename")
+            _git("checkout", "-qb", "rename-base", "base")
+            open("renamed", "w").write("1")
+            _git("add", "renamed"); _git("commit", "-qm", "copy")
+            rc, out = run(["--no-fetch", "--base", "rename-base",
+                           "rename-feature"])
+            case("rename-source-remains", rc, RC_FINDING,
+                 "a copied destination cannot hide a missing deletion")
+
+            # Patch-id equivalence is valid for a linear rebased history even
+            # when the base later edits the same path.
+            _git("checkout", "-qb", "linear-feature", "base")
+            open("linear", "w").write("landed\n")
+            _git("add", "linear"); _git("commit", "-qm", "linear")
+            rc, linear_commit = _git("rev-parse", "HEAD")
+            _git("checkout", "-qb", "linear-base", "base")
+            open("advance", "w").write("first")
+            _git("add", "advance"); _git("commit", "-qm", "advance")
+            _git("cherry-pick", linear_commit)
+            open("linear", "a").write("superseded\n")
+            _git("add", "linear"); _git("commit", "-qm", "supersede")
+            rc, out = run(["--no-fetch", "--base", "linear-base",
+                           "linear-feature"])
+            case("linear-patch-fallback", rc, RC_OK,
+                 "patch equivalence handles a linear rebase")
+            case("linear-patch-word", "every commit has an equivalent" in out,
+                 True, "...through the patch-id fallback")
+
+            # git cherry intentionally omits merge commits.  An equivalent
+            # normal commit must not hide unique merge-resolution content.
+            _git("checkout", "-qb", "merge-side", "base")
+            open("side", "w").write("side")
+            _git("add", "side"); _git("commit", "-qm", "side")
+            _git("checkout", "-qb", "merge-feature", "base")
+            open("normal", "w").write("normal")
+            _git("add", "normal"); _git("commit", "-qm", "normal")
+            _git("checkout", "-qb", "merge-replayed", "merge-side")
+            open("normal", "w").write("normal")
+            _git("add", "normal"); _git("commit", "-qm", "replayed")
+            _git("checkout", "-q", "merge-feature")
+            _git("merge", "-q", "--no-ff", "--no-commit", "merge-side")
+            open("resolution", "w").write("unique")
+            _git("add", "resolution"); _git("commit", "-qm", "merge")
+            rc, merge_count = _git(
+                "rev-list", "--min-parents=2", "--count",
+                "merge-replayed..merge-feature")
+            rc2, cherry = _git("cherry", "merge-replayed", "merge-feature")
+            case("merge-fixture-count", (rc, merge_count), (0, "1"),
+                 "the fixture contains one unique merge commit")
+            case("merge-fixture-cherry",
+                 rc2 == 0 and bool(cherry)
+                 and all(line.startswith("-") for line in cherry.splitlines()),
+                 True, "git cherry hides that merge behind equivalent commits")
+            rc, out = run(["--no-fetch", "--base", "merge-replayed",
+                           "merge-feature"])
+            case("merge-resolution-rc", rc, RC_FINDING,
+                 "a merge commit cannot disappear from the patch fallback")
+            case("merge-resolution-path", "resolution" in out, True,
+                 "...and its unique path is reported as stranded")
         finally:
             os.chdir(cwd)
 
@@ -350,6 +523,7 @@ def main(argv):
                 "are certain the refs are current: a stale ref reports "
                 "'contained' for stranded work.\n")
             return RC_CANNOT_RUN
+        base = refreshed_origin_ref(base)
 
     if "--merged-prs" in args:
         i = args.index("--merged-prs")
@@ -362,14 +536,17 @@ def main(argv):
         if err:
             sys.stderr.write(err + "\n")
             return RC_CANNOT_RUN
-        #! the OID is the ref we ask about; the branch name is for the reader,
-        #! and may well no longer exist
         if not prs:
             sys.stderr.write(
                 f"no merged PRs found targeting {base}. That is not a pass -- "
                 f"check the base name.\n")
             return RC_CANNOT_RUN
-        targets = [(f"#{n} {b}", oid) for n, b, oid in prs]
+        #! headRefOid is frozen at merge time and therefore cannot reveal work
+        #! pushed afterwards.  Always assess the fetched live branch tip.  A
+        #! deleted branch becomes UNKNOWN through contained(), which is safer
+        #! than certifying the old merge-time OID.
+        targets = [(f"#{n} {b}", f"refs/remotes/origin/{b}")
+                   for n, b, _oid in prs]
     else:
         branches = [a for a in args if not a.startswith("-")]
         if not branches:
@@ -378,7 +555,8 @@ def main(argv):
                 sys.stderr.write(USAGE + "\n")
                 return RC_CANNOT_RUN
             branches = [cur]
-        targets = [(b, b) for b in branches]
+        targets = [(b, refreshed_origin_ref(b) if do_fetch else b)
+                   for b in branches]
 
     stranded = 0
     unknown = 0

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -335,6 +335,12 @@ def non_origin_remote_ref(ref):
     """Name an unrefreshable remote-tracking ref, or return None."""
     if is_full_oid(ref):
         return None
+    #! These spellings explicitly select the namespace refreshed by the
+    #! origin fetch below.  A pathological configured remote named
+    #! origin/team may share its tracking path, but fetching origin overwrites
+    #! that path with origin's authoritative team/... branch before use.
+    if ref.startswith("refs/remotes/origin/") or ref.startswith("origin/"):
+        return None
     if ref.startswith("refs/"):
         if not ref.startswith("refs/remotes/"):
             return None
@@ -390,8 +396,9 @@ def contained(branch, base):
         #! resolved silently by git's own precedence -- the tag wins, and a
         #! stranded branch reads as contained. git says so on stderr, which
         #! _git discards, so ask explicitly instead of trusting the default.
-        hits = [k for k in ("refs/heads/", "refs/remotes/", "refs/tags/")
-                if _git("rev-parse", "--verify", "--quiet", k + ref)[0] == 0]
+        hits = ([] if is_full_oid(ref) or ref.startswith("refs/") else
+                [k for k in ("refs/heads/", "refs/remotes/", "refs/tags/")
+                 if _git("rev-parse", "--verify", "--quiet", k + ref)[0] == 0])
         if len(hits) > 1:
             return (None, None,
                     f"{ref!r} is ambiguous ({', '.join(h + ref for h in hits)})"
@@ -827,6 +834,24 @@ def selftest():
                      "a hex-named origin branch cannot replace the base OID")
                 case("full-oid-base-word", "STRANDED" in out, True,
                      "...and the immutable base object is measured")
+                _git("update-ref", "refs/heads/" + stranded_oid, base_oid)
+                _git("tag", stranded_oid, base_oid)
+                rc, out = run(["--no-fetch", "--base", base_oid,
+                               stranded_oid])
+                case("full-oid-local-collision-branch-rc", rc, RC_FINDING,
+                     "local branch and tag names cannot obscure a branch OID")
+                case("full-oid-local-collision-branch-word",
+                     "STRANDED" in out, True,
+                     "...and the immutable branch object remains measured")
+                _git("update-ref", "refs/heads/" + base_oid, stranded_oid)
+                _git("tag", base_oid, stranded_oid)
+                rc, out = run(["--no-fetch", "--base", base_oid,
+                               stranded_oid])
+                case("full-oid-local-collision-base-rc", rc, RC_FINDING,
+                     "local branch and tag names cannot obscure a base OID")
+                case("full-oid-local-collision-base-word",
+                     "STRANDED" in out, True,
+                     "...and the immutable base object remains measured")
 
                 _git("push", "-q", "origin",
                      "refs/remotes/origin/work:refs/heads/deleted-tag")
@@ -946,6 +971,16 @@ def selftest():
                                "corp/upstream/work"])
                 case("overlapping-remote-prefix-rc", rc, RC_CANNOT_RUN,
                      "overlapping configured remote prefixes are ambiguous")
+                _git("config", "remote.origin/team.url", remote)
+                _git("config", "remote.origin/team.fetch",
+                     "+refs/heads/*:refs/remotes/origin/team/*")
+                rc, out = run(["--base", "refs/remotes/origin/base",
+                               "refs/remotes/origin/work"])
+                case("explicit-origin-overlap-rc", rc, RC_FINDING,
+                     "an explicit origin ref stays refreshable despite a "
+                     "configured prefix collision")
+                case("explicit-origin-overlap-word", "STRANDED" in out, True,
+                     "...and the fetched origin branch is measured")
 
                 # A merged PR's head OID is frozen at merge time.  The live
                 # branch tip is the only ref that can expose later pushes.

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -74,6 +74,16 @@ def contained(branch, base):
         rc, _ = _git("rev-parse", "--verify", "--quiet", ref + "^{commit}")
         if rc != 0:
             return (None, None, f"no such ref: {ref}")
+        #! An ambiguous name (a tag AND a branch called the same thing) is
+        #! resolved silently by git's own precedence -- the tag wins, and a
+        #! stranded branch reads as contained. git says so on stderr, which
+        #! _git discards, so ask explicitly instead of trusting the default.
+        hits = [k for k in ("refs/heads/", "refs/remotes/", "refs/tags/")
+                if _git("rev-parse", "--verify", "--quiet", k + ref)[0] == 0]
+        if len(hits) > 1:
+            return (None, None,
+                    f"{ref!r} is ambiguous ({', '.join(h + ref for h in hits)})"
+                    f" -- name the full ref")
 
     rc, _ = _git("merge-base", "--is-ancestor", branch, base)
     if rc == 0:
@@ -90,14 +100,28 @@ def contained(branch, base):
                 f"UNKNOWN rather than as zero")
     ahead = int(out)
 
-    #! Not an ancestor, but is the WORK there? A squash or rebase merge lands
-    #! every change without keeping the commits, and calling that stranded is
-    #! how this check would come to be ignored.
-    rc, diff = _git("diff", "--quiet", base, branch)
-    if rc == 0:
-        return (True, ahead,
-                f"content is identical to {base} ({ahead} commit(s) not "
-                f"ancestors -- squash or rebase merge)")
+    #! Not an ancestor -- but is the WORK there? A squash or rebase merge lands
+    #! every change without keeping the commits, and reporting those as
+    #! stranded forever is how this check would come to be ignored.
+    #!
+    #! Compare only the PATHS THIS BRANCH TOUCHED. A whole-tree `git diff base
+    #! branch` was the first cut and it is true only while base's tree is still
+    #! byte-identical -- one unrelated commit later and every squash-merged
+    #! branch reads stranded again. A review demonstrated exactly that: five
+    #! sequential squash merges, only the newest passing.
+    rc, mb = _git("merge-base", base, branch)
+    if rc == 0 and mb:
+        rc, names = _git("diff", "--name-only", mb, branch)
+        paths = [n for n in names.splitlines() if n]
+        if rc == 0 and paths:
+            rc, _ = _git("diff", "--quiet", base, branch, "--", *paths)
+            if rc == 0:
+                return (True, ahead,
+                        f"every path this branch touched is identical in "
+                        f"{base} ({ahead} commit(s) not ancestors -- squash "
+                        f"or rebase merge)")
+
+    #! rebase keeps one commit per change, so patch-ids still match
     rc, cherry = _git("cherry", base, branch)
     if rc == 0 and cherry and all(l.startswith("-") for l in cherry.splitlines()):
         return (True, ahead,
@@ -115,10 +139,13 @@ def merged_pr_heads(limit, base):
     branch at all, and answers "diverged" for all of them -- noise that would
     bury the one real finding.
 
-    THE HEAD OID, NOT THE BRANCH REF: deleting a branch after merge is normal
-    housekeeping and leaves no ``origin/<name>`` to resolve.  The OID is not
-    fetchable either once the ref is gone, so containment for those is asked
-    of GitHub directly -- see ``contained_via_api``.
+    THE HEAD OID, NOT THE BRANCH REF, because a branch deleted after merge
+    leaves no ``origin/<name>``.  Note the OID is not fetchable either once
+    nothing points at it: such a PR is reported UNKNOWN, loudly, rather than
+    guessed at.  ``delete_branch_on_merge`` is false on this repository, so
+    that path is not the normal case here -- when it becomes one, the answer
+    is GitHub's compare endpoint, and it needs its own review rather than the
+    unexercised version this file used to carry.
     """
     import json
     #! gh wants a branch NAME; `base` is a git ref and usually carries the
@@ -143,47 +170,6 @@ def merged_pr_heads(limit, base):
                  for d in json.loads(p.stdout)], None)
     except (ValueError, KeyError) as exc:
         return (None, f"could not parse gh output: {exc}")
-
-
-def contained_via_api(head_oid, base):
-    """(is_contained, ahead, note_or_error) asked of GitHub, not the clone.
-
-    For a branch deleted after its merge there is no local ref AND no local
-    object: `git fetch` will not retrieve an OID that nothing points at.  The
-    first cut reported every such PR as UNKNOWN, which on a repository that
-    tidies up its branches meant the prescribed command was red for 12 of the
-    last 20 PRs with nothing actually wrong -- a check that cries wolf, which
-    is the failure this file exists to prevent.
-
-    GitHub's compare endpoint still knows: `ahead_by == 0` means the base has
-    everything, and an empty file list means the content landed even though
-    the commits did not (squash or rebase).
-    """
-    import json
-    ref = base.split("/", 1)[1] if base.startswith("origin/") else base
-    try:
-        p = subprocess.run(
-            ["gh", "api", f"repos/{{owner}}/{{repo}}/compare/{ref}...{head_oid}",
-             "--jq", "{ahead: .ahead_by, files: (.files | length)}"],
-            capture_output=True, text=True)
-    except FileNotFoundError:
-        return (None, None, "gh is not installed")
-    if p.returncode != 0:
-        return (None, None,
-                "GitHub could not compare it: "
-                + (p.stderr or "").strip().splitlines()[-1][:120])
-    try:
-        d = json.loads(p.stdout)
-        ahead, files = int(d["ahead"]), int(d["files"])
-    except (ValueError, KeyError, IndexError):
-        return (None, None, "could not read the compare result")
-    if ahead == 0:
-        return (True, 0, None)
-    if files == 0:
-        return (True, ahead,
-                f"content landed ({ahead} commit(s) not ancestors -- squash "
-                f"or rebase merge)")
-    return (False, ahead, None)
 
 
 # --- self-test ---------------------------------------------------------------
@@ -233,6 +219,65 @@ def selftest():
     case("missing-base", (ok, ahead), (None, None),
          "...and so is a base that cannot be resolved")
 
+    # --- END TO END, through main() -----------------------------------------
+    # Everything above calls contained() directly, and a review showed that
+    # leaves the whole verdict-aggregation path uncovered: the exit code could
+    # be pinned to 0, STRANDED could be printed and not counted, the advertised
+    # number could be printed as a literal 0, and UNKNOWN could be made a pass
+    # -- SEVEN mutations, all silent. These run the tool and assert both the
+    # exit code and what it printed.
+    import io
+    import contextlib
+    import tempfile
+
+    def run(argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), \
+                contextlib.redirect_stderr(io.StringIO()):
+            rc = main([sys.argv[0], *argv])
+        return rc, buf.getvalue()
+
+    with tempfile.TemporaryDirectory() as td:
+        import os
+        cwd = os.getcwd()
+        try:
+            os.chdir(td)
+            _git("init", "-q", "-b", "base")
+            _git("config", "user.email", "s@s")
+            _git("config", "user.name", "s")
+            open("f", "w").write("1")
+            _git("add", "-A"); _git("commit", "-qm", "c0")
+            _git("checkout", "-qb", "work")
+            #! THREE commits, so a count hard-coded to 1 -- the mutation the
+            #! previous round named and that still survived -- cannot pass
+            for i in range(3):
+                open(f"w{i}", "w").write(str(i))
+                _git("add", "-A"); _git("commit", "-qm", f"w{i}")
+
+            rc, out = run(["--no-fetch", "--base", "base", "work"])
+            case("e2e-stranded-rc", rc, RC_FINDING,
+                 "a stranded branch exits non-zero through main()")
+            case("e2e-stranded-count", "3 commit(s)" in out, True,
+                 "...and prints the real count, not a placeholder")
+            case("e2e-stranded-word", "STRANDED" in out, True,
+                 "...and says STRANDED")
+
+            rc, out = run(["--no-fetch", "--base", "work", "base"])
+            case("e2e-contained-rc", rc, RC_OK,
+                 "a contained branch exits 0")
+
+            rc, out = run(["--no-fetch", "--base", "base", "no-such-branch"])
+            case("e2e-unknown-rc", rc, RC_FINDING,
+                 "an unresolvable ref FAILS -- an unknown is not a pass")
+            case("e2e-unknown-word", "UNKNOWN" in out, True,
+                 "...and says UNKNOWN")
+
+            rc, out = run(["--no-fetch", "--bogus", "work"])
+            case("e2e-unknown-flag", rc, RC_CANNOT_RUN,
+                 "an unrecognised flag is refused, never read as a branch")
+        finally:
+            os.chdir(cwd)
+
     print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
     return 1 if bad else 0
 
@@ -257,7 +302,10 @@ def main(argv):
     base = "origin/main-push"
     if "--base" in args:
         i = args.index("--base")
-        if i + 1 >= len(args):
+        if i + 1 >= len(args) or args[i + 1].startswith("-"):
+            #! `--base --no-fetch origin/x` used to set base to "--no-fetch"
+            #! AND consume the flag, so the fetch ran despite being asked not
+            #! to, and the run failed for the wrong reason
             sys.stderr.write(f"--base needs a ref\n{USAGE}\n")
             return RC_CANNOT_RUN
         base = args[i + 1]
@@ -295,7 +343,6 @@ def main(argv):
                 f"check the base name.\n")
             return RC_CANNOT_RUN
         targets = [(f"#{n} {b}", oid) for n, b, oid in prs]
-        api_fallback = True
     else:
         branches = [a for a in args if not a.startswith("-")]
         if not branches:
@@ -305,15 +352,11 @@ def main(argv):
                 return RC_CANNOT_RUN
             branches = [cur]
         targets = [(b, b) for b in branches]
-        api_fallback = False
 
     stranded = 0
     unknown = 0
     for label, ref in targets:
         ok, ahead, note = contained(ref, base)
-        #! a deleted branch leaves no local object to ask about, so ask GitHub
-        if ok is None and api_fallback and note and note.startswith("no such ref"):
-            ok, ahead, note = contained_via_api(ref, base)
         if ok is None:
             print(f"  UNKNOWN    {label}: {note}")
             unknown += 1

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -1,46 +1,59 @@
 #!/usr/bin/env python3
 """Did the merge actually take the branch?
 
-    python3 scripts/check_merge_containment.py [--base main-push] [<branch>...]
+    python3 scripts/check_merge_containment.py [--base <ref>] <branch>...
     python3 scripts/check_merge_containment.py --merged-prs [N]
     python3 scripts/check_merge_containment.py --selftest
+    python3 scripts/check_merge_containment.py --no-fetch ...   (offline)
 
 WHY THIS EXISTS
 ---------------
 A pull request merged while a review round is still running leaves the work
 that round produced behind: the merge takes the commit the branch had at the
 time, and everything pushed after it stays on the branch.  Nothing reports
-this.  ``gh pr view`` says ``MERGED``, CI is green, the issue closes itself,
-and the board moves to Done -- while commits sit unmerged on a branch nobody
-is looking at any more.
+this.  ``gh pr view`` says ``MERGED``, CI is green, the issue closes itself and
+the board moves to Done, while commits sit unmerged on a branch nobody is
+looking at any more.
 
-It has happened twice on this repository:
+It has happened twice here: **#77** (merged mid-review; two of the rounds that
+followed returned blocking defects, re-landed as #85) and **#86** (three
+commits stranded, tracked as #87, re-landed as #89).  Both were found by a
+reviewer checking by hand, which is why this is a command.
 
-* **#77**, merged 2026-08-16 18:10 during review round 3 of 6.  Rounds 4, 5
-  and 6 each returned NEGATIVE afterwards; their fixes had to be re-landed as
-  #85.
-* **#86**, merged 2026-08-17 07:54 mid-round.  Three commits stranded, tracked
-  as #87 and re-landed as #89.
+THREE WAYS TO GET THE WRONG ANSWER, ALL OF WHICH THIS HAS DONE
+--------------------------------------------------------------
+1. **Answering from a stale remote-tracking ref.**  The first cut never
+   fetched, so a maintainer whose clone predated the review round's push was
+   told ``contained`` -- rc 0 -- for a branch with work stranded on it.  That
+   is the incident shape verbatim.  It fetches now, and ``--no-fetch`` is
+   explicit rather than accidental.
+2. **Treating a squash or rebase merge as stranded.**  Those land the *content*
+   without making the branch commits ancestors, so an ancestry test alone calls
+   them stranded forever.  This repository allows all three merge buttons, so
+   that is one press away from a permanently red check -- and a check that
+   cries wolf is ignored, which is the failure this file exists to prevent.
+   Content equivalence is tested before anything is called stranded.
+3. **Reading silence as agreement.**  ``int(out or "0")`` was in the first cut:
+   empty output from ``rev-list`` became "0 commits ahead", i.e. contained.
+   Anything this tool cannot measure is an UNKNOWN and fails, the same rule
+   ``scripts/suite_tally.py`` enforces on the sweep.
 
-Both were found by a reviewer checking by hand.  This makes the check a
-command, because a check that depends on somebody remembering is not a check.
-
-THE TRAP THIS AVOIDS
---------------------
-The obvious way to write this is ``git log <branch>..<base>``.  Do not.  In
-this environment that returns **empty** when it follows another git command in
-the same shell invocation -- the proxy hook swallows the output -- so it
-reports "nothing diverged" for a branch that has.  That is exactly how #89's
-own description came to claim a fast-forward that was not one.
-
-``git rev-list --count`` and ``git merge-base --is-ancestor`` are used instead:
-both answer through the exit code or a bare number, so a swallowed stream
-cannot be mistaken for agreement.  Same rule as ``scripts/suite_tally.py``
-enforces on the sweep -- silence is not a measurement.
+WHY EXIT CODES AND BARE NUMBERS
+-------------------------------
+``git rev-list --count`` prints one integer and ``git merge-base
+--is-ancestor`` answers only through its exit status.  Neither needs its prose
+parsed, so neither can be half-read or mis-scraped, and both are checked here
+for having actually produced an answer.  That is the whole reason those two
+are used rather than reading ``git log`` output.
 """
 
 import subprocess
 import sys
+
+USAGE = __doc__.split("WHY THIS EXISTS")[0].strip()
+
+#! rc 0 contained · rc 1 something is stranded or unknown · rc 2 cannot run
+RC_OK, RC_FINDING, RC_CANNOT_RUN = 0, 1, 2
 
 
 def _git(*args):
@@ -50,91 +63,181 @@ def _git(*args):
 
 
 def contained(branch, base):
-    """(is_contained, commits_ahead, error).
+    """(is_contained, commits_ahead, note_or_error).
 
-    ``is_contained`` is True when every commit on ``branch`` is reachable from
-    ``base`` -- i.e. the merge took the whole branch.
+    ``is_contained`` is True when ``base`` already has this branch's work --
+    either because every commit is an ancestor, or because the content landed
+    by another route (squash, rebase).  None means the question could not be
+    answered, which is a finding, never a pass.
     """
-    rc, _ = _git("rev-parse", "--verify", "--quiet", branch + "^{commit}")
-    if rc != 0:
-        return (None, None, f"no such ref: {branch}")
-    rc, _ = _git("rev-parse", "--verify", "--quiet", base + "^{commit}")
-    if rc != 0:
-        return (None, None, f"no such ref: {base}")
+    for ref in (branch, base):
+        rc, _ = _git("rev-parse", "--verify", "--quiet", ref + "^{commit}")
+        if rc != 0:
+            return (None, None, f"no such ref: {ref}")
 
-    #! the count is the actionable number: it says HOW MUCH was left behind
+    rc, _ = _git("merge-base", "--is-ancestor", branch, base)
+    if rc == 0:
+        return (True, 0, None)
+
     rc, out = _git("rev-list", "--count", f"{base}..{branch}")
     if rc != 0:
         return (None, None, f"rev-list failed for {base}..{branch}")
-    ahead = int(out or "0")
+    #! empty is NOT zero -- rev-list always prints a number when it succeeds,
+    #! so nothing means the plumbing failed and the answer is unknown
+    if not out.isdigit():
+        return (None, None,
+                f"rev-list printed {out!r} rather than a count; treating as "
+                f"UNKNOWN rather than as zero")
+    ahead = int(out)
 
-    #! and the ancestry test is the verdict, taken from an exit code so that an
-    #! empty stream cannot be read as agreement
-    rc, _ = _git("merge-base", "--is-ancestor", branch, base)
-    return (rc == 0, ahead, None)
+    #! Not an ancestor, but is the WORK there? A squash or rebase merge lands
+    #! every change without keeping the commits, and calling that stranded is
+    #! how this check would come to be ignored.
+    rc, diff = _git("diff", "--quiet", base, branch)
+    if rc == 0:
+        return (True, ahead,
+                f"content is identical to {base} ({ahead} commit(s) not "
+                f"ancestors -- squash or rebase merge)")
+    rc, cherry = _git("cherry", base, branch)
+    if rc == 0 and cherry and all(l.startswith("-") for l in cherry.splitlines()):
+        return (True, ahead,
+                f"every commit has an equivalent in {base} ({ahead} not "
+                f"ancestors -- rebase merge)")
+
+    return (False, ahead, None)
 
 
-def merged_pr_branches(limit):
-    """[(number, branch)] for the most recently merged PRs, via gh."""
-    rc, out = _git("--version")          # cheap check that we can run tools
-    if rc != 0:
-        return None
-    p = subprocess.run(
-        ["gh", "pr", "list", "--state", "merged", "--limit", str(limit),
-         "--json", "number,headRefName"],
-        capture_output=True, text=True)
-    if p.returncode != 0:
-        return None
+def merged_pr_heads(limit, base):
+    """([(number, branch, head_oid)], error).
+
+    Scoped to PRs that actually targeted ``base``.  Sweeping every merged PR
+    asks about branches that were never meant to be in this integration
+    branch at all, and answers "diverged" for all of them -- noise that would
+    bury the one real finding.
+
+    THE HEAD OID, NOT THE BRANCH REF: deleting a branch after merge is normal
+    housekeeping and leaves no ``origin/<name>`` to resolve.  The OID is not
+    fetchable either once the ref is gone, so containment for those is asked
+    of GitHub directly -- see ``contained_via_api``.
+    """
     import json
+    #! gh wants a branch NAME; `base` is a git ref and usually carries the
+    #! remote. Passing "origin/main-push" here silently matched nothing, so the
+    #! sweep printed an empty list and exited 0 -- a pass by vacancy.
+    base_name = base.split("/", 1)[1] if base.startswith("origin/") else base
     try:
-        return [(d["number"], d["headRefName"]) for d in json.loads(p.stdout)]
-    except (ValueError, KeyError):
-        return None
+        p = subprocess.run(
+            ["gh", "pr", "list", "--state", "merged", "--base", base_name,
+             "--limit", str(limit),
+             "--json", "number,headRefName,headRefOid",
+             "--search", "sort:updated-desc"],
+            capture_output=True, text=True)
+    except FileNotFoundError:
+        #! distinct from "stranded": a tool we cannot run is not a finding
+        return (None, "gh is not installed, so merged PRs cannot be listed")
+    if p.returncode != 0:
+        return (None, "gh could not list merged PRs (authenticated?): "
+                      + (p.stderr or "").strip()[:200])
+    try:
+        return ([(d["number"], d["headRefName"], d["headRefOid"])
+                 for d in json.loads(p.stdout)], None)
+    except (ValueError, KeyError) as exc:
+        return (None, f"could not parse gh output: {exc}")
 
 
-SELFTEST = [
-    # (name, ahead, is_ancestor, expect_ok)
-    ("contained",        0, True,  True),
-    ("stranded-one",     1, False, False),
-    ("stranded-many",    7, False, False),
-    #! the case that makes the two signals worth having SEPARATELY: a branch
-    #! can be an ancestor and still report commits ahead if a ref moved under
-    #! us mid-check. Disagreement is itself a finding, never a pass.
-    ("disagreement",     2, True,  False),
-]
+def contained_via_api(head_oid, base):
+    """(is_contained, ahead, note_or_error) asked of GitHub, not the clone.
+
+    For a branch deleted after its merge there is no local ref AND no local
+    object: `git fetch` will not retrieve an OID that nothing points at.  The
+    first cut reported every such PR as UNKNOWN, which on a repository that
+    tidies up its branches meant the prescribed command was red for 12 of the
+    last 20 PRs with nothing actually wrong -- a check that cries wolf, which
+    is the failure this file exists to prevent.
+
+    GitHub's compare endpoint still knows: `ahead_by == 0` means the base has
+    everything, and an empty file list means the content landed even though
+    the commits did not (squash or rebase).
+    """
+    import json
+    ref = base.split("/", 1)[1] if base.startswith("origin/") else base
+    try:
+        p = subprocess.run(
+            ["gh", "api", f"repos/{{owner}}/{{repo}}/compare/{ref}...{head_oid}",
+             "--jq", "{ahead: .ahead_by, files: (.files | length)}"],
+            capture_output=True, text=True)
+    except FileNotFoundError:
+        return (None, None, "gh is not installed")
+    if p.returncode != 0:
+        return (None, None,
+                "GitHub could not compare it: "
+                + (p.stderr or "").strip().splitlines()[-1][:120])
+    try:
+        d = json.loads(p.stdout)
+        ahead, files = int(d["ahead"]), int(d["files"])
+    except (ValueError, KeyError, IndexError):
+        return (None, None, "could not read the compare result")
+    if ahead == 0:
+        return (True, 0, None)
+    if files == 0:
+        return (True, ahead,
+                f"content landed ({ahead} commit(s) not ancestors -- squash "
+                f"or rebase merge)")
+    return (False, ahead, None)
 
 
+# --- self-test ---------------------------------------------------------------
+# The cases below call contained() FOR REAL against this repository's own
+# history. An earlier cut had a table that re-implemented the predicate and
+# never called it, so mutating the shipped code -- swapping the two signals,
+# hard-coding the count -- left every case printing ok. The advertised number
+# had no coverage at all, which is the "test that cannot fail" this repo's own
+# review rounds keep finding.
 def selftest():
     bad = 0
-    for name, ahead, anc, want in SELFTEST:
-        got = bool(anc) and ahead == 0
+
+    def case(name, got, want, why):
+        nonlocal bad
         ok = got == want
-        print(f"  {'ok  ' if ok else 'FAIL'} {name:<16} "
-              f"ahead={ahead} ancestor={anc} -> contained={got}")
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<26} {why}")
         if not ok:
             bad += 1
-            print(f"       expected contained={want}")
+            print(f"       got {got!r}, expected {want!r}")
 
-    #! and one real call, so the git plumbing is exercised rather than assumed:
-    #! a ref is trivially contained in itself, and a missing ref is an error
-    #! rather than a quiet pass
-    ok, ahead, err = contained("HEAD", "HEAD")
-    if ok is True and ahead == 0 and err is None:
-        print("  ok   self-containment  HEAD is contained in HEAD")
-    else:
-        print(f"  FAIL self-containment  got ok={ok} ahead={ahead} err={err}")
-        bad += 1
+    rc, head = _git("rev-parse", "HEAD")
+    rc2, parent = _git("rev-parse", "HEAD~1")
+    if rc != 0 or rc2 != 0:
+        print("  FAIL selftest needs at least two commits of history")
+        return 1
 
-    ok, ahead, err = contained("refs/heads/definitely-not-a-branch", "HEAD")
-    if ok is None and err:
-        print("  ok   missing-ref       a ref that does not exist is an ERROR, "
-              "not 'contained'")
-    else:
-        print(f"  FAIL missing-ref       got ok={ok} err={err}")
-        bad += 1
+    ok, ahead, note = contained(head, head)
+    case("self-containment", (ok, ahead), (True, 0),
+         "a commit is contained in itself")
+
+    #! the STRANDED verdict AND the count, against real history: HEAD is one
+    #! commit ahead of its parent. The count is what the output advertises and
+    #! it had no coverage until this case existed.
+    ok, ahead, note = contained(head, parent)
+    case("stranded-count", (ok, ahead), (False, 1),
+         "HEAD is 1 commit ahead of HEAD~1, and says so")
+
+    ok, ahead, note = contained(parent, head)
+    case("contained-backwards", (ok, ahead), (True, 0),
+         "...and the parent IS contained in HEAD")
+
+    ok, ahead, note = contained("refs/heads/definitely-not-a-branch", head)
+    case("missing-ref", (ok, ahead), (None, None),
+         "a ref that cannot be resolved is UNKNOWN, never contained")
+
+    ok, ahead, note = contained(head, "refs/heads/definitely-not-a-base")
+    case("missing-base", (ok, ahead), (None, None),
+         "...and so is a base that cannot be resolved")
 
     print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
     return 1 if bad else 0
+
+
+KNOWN_FLAGS = {"--selftest", "--base", "--merged-prs", "--no-fetch"}
 
 
 def main(argv):
@@ -142,11 +245,36 @@ def main(argv):
     if "--selftest" in args:
         return selftest()
 
+    #! Reject unknown options rather than silently treating them as branches.
+    #! `--bse 43a4c417 origin/foo` used to check TWO branches called
+    #! "43a4c417" and "origin/foo" against the default base -- both contained,
+    #! rc 0 -- where the same command spelled correctly reported 4 stranded.
+    for a in args:
+        if a.startswith("-") and a not in KNOWN_FLAGS:
+            sys.stderr.write(f"unknown option: {a}\n{USAGE}\n")
+            return RC_CANNOT_RUN
+
     base = "origin/main-push"
     if "--base" in args:
         i = args.index("--base")
+        if i + 1 >= len(args):
+            sys.stderr.write(f"--base needs a ref\n{USAGE}\n")
+            return RC_CANNOT_RUN
         base = args[i + 1]
         del args[i:i + 2]
+
+    do_fetch = "--no-fetch" not in args
+    args = [a for a in args if a != "--no-fetch"]
+    if do_fetch:
+        #! Answering from a stale remote-tracking ref is how this tool once
+        #! reported `contained` for a branch that had work stranded on it.
+        rc, _ = _git("fetch", "--prune", "--quiet", "origin")
+        if rc != 0:
+            sys.stderr.write(
+                "could not fetch origin. Re-run with --no-fetch only if you "
+                "are certain the refs are current: a stale ref reports "
+                "'contained' for stranded work.\n")
+            return RC_CANNOT_RUN
 
     if "--merged-prs" in args:
         i = args.index("--merged-prs")
@@ -155,51 +283,58 @@ def main(argv):
             limit = int(args[i + 1])
             del args[i + 1]
         del args[i]
-        prs = merged_pr_branches(limit)
-        if prs is None:
-            sys.stderr.write("could not list merged PRs (is `gh` available "
-                             "and authenticated?)\n")
-            return 2
-        targets = [(f"#{n} {b}", "origin/" + b) for n, b in prs]
+        prs, err = merged_pr_heads(limit, base)
+        if err:
+            sys.stderr.write(err + "\n")
+            return RC_CANNOT_RUN
+        #! the OID is the ref we ask about; the branch name is for the reader,
+        #! and may well no longer exist
+        if not prs:
+            sys.stderr.write(
+                f"no merged PRs found targeting {base}. That is not a pass -- "
+                f"check the base name.\n")
+            return RC_CANNOT_RUN
+        targets = [(f"#{n} {b}", oid) for n, b, oid in prs]
+        api_fallback = True
     else:
         branches = [a for a in args if not a.startswith("-")]
         if not branches:
             rc, cur = _git("rev-parse", "--abbrev-ref", "HEAD")
             if rc != 0 or not cur or cur == "HEAD":
-                sys.stderr.write("usage: check_merge_containment.py "
-                                 "[--base <ref>] <branch>...\n")
-                return 2
+                sys.stderr.write(USAGE + "\n")
+                return RC_CANNOT_RUN
             branches = [cur]
         targets = [(b, b) for b in branches]
+        api_fallback = False
 
-    bad = 0
+    stranded = 0
     unknown = 0
     for label, ref in targets:
-        ok, ahead, err = contained(ref, base)
-        if err:
-            print(f"  UNKNOWN  {label}: {err}")
+        ok, ahead, note = contained(ref, base)
+        #! a deleted branch leaves no local object to ask about, so ask GitHub
+        if ok is None and api_fallback and note and note.startswith("no such ref"):
+            ok, ahead, note = contained_via_api(ref, base)
+        if ok is None:
+            print(f"  UNKNOWN    {label}: {note}")
             unknown += 1
-            continue
-        if ok and ahead == 0:
-            print(f"  contained  {label}")
+        elif ok:
+            print(f"  contained  {label}" + (f"  [{note}]" if note else ""))
         else:
             print(f"  STRANDED   {label}: {ahead} commit(s) not in {base}")
-            bad += 1
+            stranded += 1
 
-    if bad:
+    if stranded:
         print()
-        print(f"{bad} branch(es) have work that {base} does not.")
+        print(f"{stranded} branch(es) have work that {base} does not.")
         print("  A merge that landed before the branch stopped moving leaves")
         print("  the rest behind, and nothing else reports it. Open a")
         print("  follow-up PR for the remainder -- see CONTRIBUTING.md 2.1")
         print("  step 7.")
-    #! an unresolvable ref is an UNKNOWN and fails: a check that cannot run
-    #! must not report success
     if unknown:
         print()
-        print(f"{unknown} ref(s) could not be resolved. An unknown is not a")
-        print("  pass -- fetch, or name the ref that exists.")
-    return 1 if (bad or unknown) else 0
+        print(f"{unknown} ref(s) could not be resolved, so the question was")
+        print("  not answered. An unknown is not a pass.")
+    return RC_FINDING if (stranded or unknown) else RC_OK
 
 
 if __name__ == "__main__":

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -74,7 +74,12 @@ RAW_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv",
 
 def _git(*args):
     """Run git, returning (rc, stdout).  Never raises on a non-zero rc."""
-    p = subprocess.run(("git",) + args, capture_output=True, text=True)
+    #! Replacement objects rewrite the commit graph for every plumbing command.
+    #! A local refs/replace entry can otherwise make a stranded branch appear
+    #! to be an ancestor of the base.  Containment must measure stored commits,
+    #! not a caller-specific alternate history.
+    p = subprocess.run(("git", "--no-replace-objects") + args,
+                       capture_output=True, text=True)
     return p.returncode, p.stdout.rstrip("\n")
 
 
@@ -84,8 +89,9 @@ def _verbatim_patch_id(commit):
                      "--full-index", "--no-renames", commit)
     if rc != 0:
         return (None, f"git show could not read {commit}")
-    p = subprocess.run(("git", "patch-id", "--verbatim"), input=patch,
-                       capture_output=True, text=True)
+    p = subprocess.run(("git", "--no-replace-objects", "patch-id",
+                        "--verbatim"), input=patch, capture_output=True,
+                       text=True)
     fields = p.stdout.strip().split()
     if p.returncode != 0 or len(fields) != 2:
         return (None, f"git patch-id could not measure {commit}")
@@ -230,6 +236,19 @@ def fetched_branch_refs(ref):
     return [(ref, None)]
 
 
+def non_origin_remote_ref(ref):
+    """Name an unrefreshable remote-tracking ref, or return None."""
+    if ref.startswith("refs/remotes/origin/") or ref.startswith("origin/"):
+        return None
+    if ref.startswith("refs/remotes/"):
+        return ref
+    rc, full = _git("rev-parse", "--symbolic-full-name", "--verify", ref)
+    if (rc == 0 and full.startswith("refs/remotes/")
+            and not full.startswith("refs/remotes/origin/")):
+        return full
+    return None
+
+
 def contained(branch, base):
     """(is_contained, commits_ahead, note_or_error).
 
@@ -292,8 +311,11 @@ def contained(branch, base):
         #! unusual but valid path names exact.
         rc, names = _git("diff", *RAW_DIFF_FLAGS, "--name-only",
                          "--no-renames", "-z", mb, branch)
+        if rc != 0:
+            return (None, None,
+                    f"git diff could not enumerate paths changed by {branch}")
         paths = [n for n in names.split("\0") if n]
-        if rc == 0 and paths:
+        if paths:
             #! Names came from git, not from a pathspec language.  A real file
             #! beginning with `:(exclude)` must not turn itself into an exclude
             #! rule and make a missing change compare equal.
@@ -304,6 +326,9 @@ def contained(branch, base):
                         f"every path this branch touched is identical in "
                         f"{base} ({ahead} commit(s) not ancestors -- squash "
                         f"or rebase merge)")
+            if rc != 1:
+                return (None, None,
+                        f"git diff could not compare {branch} with {base}")
 
     #! Rebase keeps one commit per change, so patch IDs still match.  Plain
     #! `git cherry` is not proof: its patch IDs ignore whitespace, which can
@@ -339,6 +364,10 @@ def contained(branch, base):
     if mb_rc == 0 and mb:
         rc2, names = _git("diff", *RAW_DIFF_FLAGS, "--name-only",
                           "--no-renames", "-z", base, branch)
+        if rc2 != 0:
+            return (None, None,
+                    f"git diff could not enumerate paths differing between "
+                    f"{branch} and {base}")
         differing = [n for n in names.split("\0") if n][:6]
     return (False, ahead, ("paths differing: " + ", ".join(differing))
             if differing else None)
@@ -514,6 +543,11 @@ def selftest():
             case("e2e-duplicate-base", rc, RC_CANNOT_RUN,
                  "a repeated base option is refused")
 
+            rc, out = run(["--no-fetch", "--no-fetch", "--base", "base",
+                           "work"])
+            case("e2e-duplicate-no-fetch", rc, RC_CANNOT_RUN,
+                 "a repeated no-fetch option is refused")
+
             rc, out = run(["--no-fetch", "--merged-prs", "1", "work"])
             case("e2e-sweep-operand", rc, RC_CANNOT_RUN,
                  "a merged sweep cannot silently ignore a branch operand")
@@ -581,6 +615,23 @@ def selftest():
                      "local-ahead (local)" in out and "STRANDED" in out,
                      True, "...and the local tip is named in the finding")
 
+                # Normal mode refreshes origin only.  Accepting another
+                # remote-tracking namespace would give a stale local cache the
+                # authority of a fetch.  Reject both full and short spellings.
+                _git("update-ref", "refs/remotes/upstream/work", "base")
+                rc, out = run(["--base", "base",
+                               "refs/remotes/upstream/work"])
+                case("other-remote-full-rc", rc, RC_CANNOT_RUN,
+                     "an unrefreshed full remote ref is refused")
+                rc, out = run(["--base", "base", "upstream/work"])
+                case("other-remote-short-rc", rc, RC_CANNOT_RUN,
+                     "...and so is its short spelling")
+                _git("update-ref", "refs/remotes/upstream/base", "base")
+                rc, out = run(["--base", "refs/remotes/upstream/base",
+                               "work"])
+                case("other-remote-base-rc", rc, RC_CANNOT_RUN,
+                     "an unrefreshed base ref is refused too")
+
                 # After fetch --prune removes a deleted origin branch, a stale
                 # local tip must not stand in for work that may have existed on
                 # the remote.  Reproduce the incident shape in a separate repo:
@@ -647,6 +698,43 @@ def selftest():
                          "normal mode deepens before measuring containment")
                     os.chdir(td)
 
+            # A short name shared by a branch and tag is not a stable input.
+            # Git's normal precedence chooses the tag, which can hide a
+            # stranded branch.  The checker must refuse the ambiguous name.
+            _git("checkout", "-qb", "collision", "base")
+            open("collision-work", "w").write("stranded")
+            _git("add", "collision-work"); _git("commit", "-qm", "collision")
+            _git("tag", "collision", "base")
+            rc, out = run(["--no-fetch", "--base", "base", "collision"])
+            case("ambiguous-ref-rc", rc, RC_FINDING,
+                 "a tag and branch sharing one name cannot false-pass")
+            case("ambiguous-ref-word", "UNKNOWN" in out, True,
+                 "...and the ambiguity is reported as UNKNOWN")
+
+            # Replacement refs rewrite ancestry for ordinary Git plumbing.
+            # Make the base appear to descend from a stranded feature, then
+            # prove the checker ignores that caller-local alternate history.
+            _git("checkout", "-qb", "replace-feature", "base")
+            open("replace-work", "w").write("stranded")
+            _git("add", "replace-work"); _git("commit", "-qm", "replace work")
+            rc, replace_feature = _git("rev-parse", "HEAD")
+            _git("checkout", "-qb", "replace-base", "base")
+            open("replace-unrelated", "w").write("base")
+            _git("add", "replace-unrelated")
+            _git("commit", "-qm", "replace base")
+            rc2, replace_base = _git("rev-parse", "HEAD")
+            replace_rc, _ = _git("replace", "--graft", replace_base,
+                                  replace_feature)
+            rc, out = run(["--no-fetch", "--base", "replace-base",
+                           "replace-feature"])
+            case("replacement-ref-fixture", (rc2, replace_rc), (0, 0),
+                 "the fixture installs a replacement ancestry edge")
+            case("replacement-ref-rc", rc, RC_FINDING,
+                 "replacement ancestry cannot create containment")
+            case("replacement-ref-path", "replace-work" in out, True,
+                 "...and the raw stranded path is reported")
+            _git("replace", "-d", replace_base)
+
             # A multi-commit squash remains contained after unrelated work
             # advances the base, because only branch-touched paths matter.
             _git("checkout", "-qb", "squash-feature", "base")
@@ -666,6 +754,36 @@ def selftest():
             case("squash-path-equivalence",
                  "every path this branch touched" in out, True,
                  "...through the path-scoped content check")
+
+            # A failed proof-producing path enumeration is UNKNOWN, not a
+            # STRANDED verdict assembled from incomplete evidence.
+            saved_git = globals()["_git"]
+            globals()["_git"] = lambda *args: (
+                (128, "") if args and args[0] == "diff"
+                and "--name-only" in args else saved_git(*args))
+            try:
+                rc, out = run(["--no-fetch", "--base", "squash-base",
+                               "squash-feature"])
+                case("path-enumeration-error-rc", rc, RC_FINDING,
+                     "a failed path measurement exits non-zero")
+                case("path-enumeration-error-word", "UNKNOWN" in out, True,
+                     "...and is UNKNOWN rather than STRANDED")
+            finally:
+                globals()["_git"] = saved_git
+
+            saved_git = globals()["_git"]
+            globals()["_git"] = lambda *args: (
+                (128, "") if args and args[0] == "--literal-pathspecs"
+                and "--quiet" in args else saved_git(*args))
+            try:
+                rc, out = run(["--no-fetch", "--base", "squash-base",
+                               "squash-feature"])
+                case("path-comparison-error-rc", rc, RC_FINDING,
+                     "a failed path comparison exits non-zero")
+                case("path-comparison-error-word", "UNKNOWN" in out, True,
+                     "...and is UNKNOWN rather than STRANDED")
+            finally:
+                globals()["_git"] = saved_git
 
             # A copied destination is not equivalent to a rename because the
             # source path still exists.  Rename folding must not hide it.
@@ -927,7 +1045,7 @@ def main(argv):
             sys.stderr.write(f"unknown option: {a}\n{USAGE}\n")
             return RC_CANNOT_RUN
 
-    for flag in ("--selftest", "--base", "--merged-prs"):
+    for flag in ("--selftest", "--base", "--merged-prs", "--no-fetch"):
         if args.count(flag) > 1:
             sys.stderr.write(f"{flag} may be specified only once\n{USAGE}\n")
             return RC_CANNOT_RUN
@@ -963,6 +1081,17 @@ def main(argv):
             "incomplete\n")
         return RC_CANNOT_RUN
     if do_fetch:
+        refs_to_refresh = [base]
+        if "--merged-prs" not in args:
+            refs_to_refresh.extend(a for a in args if not a.startswith("-"))
+        for ref in refs_to_refresh:
+            stale_remote = non_origin_remote_ref(ref)
+            if stale_remote:
+                sys.stderr.write(
+                    f"cannot refresh {stale_remote}: normal mode fetches "
+                    f"origin only. Use an origin ref, or use --no-fetch only "
+                    f"when that other remote-tracking ref is known current.\n")
+                return RC_CANNOT_RUN
         #! Answering from a stale remote-tracking ref is how this tool once
         #! reported `contained` for a branch that had work stranded on it.
         fetch_args = ["fetch", "--prune", "--quiet"]

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -68,6 +68,8 @@ USAGE = __doc__.split("WHY THIS EXISTS")[0].strip()
 
 #! rc 0 contained · rc 1 something is stranded or unknown · rc 2 cannot run
 RC_OK, RC_FINDING, RC_CANNOT_RUN = 0, 1, 2
+RAW_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv",
+                  "--ignore-submodules=none")
 
 
 def _git(*args):
@@ -78,7 +80,7 @@ def _git(*args):
 
 def _verbatim_patch_id(commit):
     """Return a whitespace-preserving patch ID for one commit."""
-    rc, patch = _git("show", "--format=medium", "--no-ext-diff", "--binary",
+    rc, patch = _git("show", *RAW_DIFF_FLAGS, "--format=medium", "--binary",
                      "--full-index", "--no-renames", commit)
     if rc != 0:
         return (None, f"git show could not read {commit}")
@@ -92,8 +94,9 @@ def _verbatim_patch_id(commit):
 
 def _commit_paths(commit):
     """Return the literal paths one commit changed, with renames unfolded."""
-    rc, names = _git("diff-tree", "--root", "--no-commit-id", "--name-only",
-                     "--no-renames", "-z", "-r", commit)
+    rc, names = _git("diff-tree", *RAW_DIFF_FLAGS, "--root",
+                     "--no-commit-id", "--name-only", "--no-renames", "-z",
+                     "-r", commit)
     if rc != 0:
         return (None, f"diff-tree could not enumerate {commit}")
     return ([name for name in names.split("\0") if name], None)
@@ -110,8 +113,8 @@ def _same_patch_postimage(branch_commit, base_commit):
     paths = list(dict.fromkeys(branch_paths + base_paths))
     if not paths:
         return (True, None)
-    rc, _ = _git("--literal-pathspecs", "diff", "--quiet", branch_commit,
-                 base_commit, "--", *paths)
+    rc, _ = _git("--literal-pathspecs", "diff", *RAW_DIFF_FLAGS, "--quiet",
+                 branch_commit, base_commit, "--", *paths)
     if rc == 0:
         return (True, None)
     if rc == 1:
@@ -287,15 +290,15 @@ def contained(branch, base):
         #! added path.  Comparing only the destination can certify a base that
         #! copied the file but never removed the source.  NUL delimiters keep
         #! unusual but valid path names exact.
-        rc, names = _git("diff", "--name-only", "--no-renames", "-z",
-                         mb, branch)
+        rc, names = _git("diff", *RAW_DIFF_FLAGS, "--name-only",
+                         "--no-renames", "-z", mb, branch)
         paths = [n for n in names.split("\0") if n]
         if rc == 0 and paths:
             #! Names came from git, not from a pathspec language.  A real file
             #! beginning with `:(exclude)` must not turn itself into an exclude
             #! rule and make a missing change compare equal.
-            rc, _ = _git("--literal-pathspecs", "diff", "--quiet",
-                         base, branch, "--", *paths)
+            rc, _ = _git("--literal-pathspecs", "diff", *RAW_DIFF_FLAGS,
+                         "--quiet", base, branch, "--", *paths)
             if rc == 0:
                 return (True, ahead,
                         f"every path this branch touched is identical in "
@@ -334,8 +337,8 @@ def contained(branch, base):
     #! learning to ignore the check.
     differing = []
     if mb_rc == 0 and mb:
-        rc2, names = _git("diff", "--name-only", "--no-renames", "-z",
-                          base, branch)
+        rc2, names = _git("diff", *RAW_DIFF_FLAGS, "--name-only",
+                          "--no-renames", "-z", base, branch)
         differing = [n for n in names.split("\0") if n][:6]
     return (False, ahead, ("paths differing: " + ", ".join(differing))
             if differing else None)
@@ -769,6 +772,107 @@ def selftest():
                  "different repeated locations cannot false-pass")
             case("hunk-postimage-path", "repeated.txt" in out, True,
                  "...and the differing path is reported")
+
+            # Diff configuration and attributes are untrusted inputs.  A
+            # textconv that prints nothing can hide changed blobs from both
+            # the path proof and patch fallback, while ignoreSubmodules=all can
+            # hide a missing gitlink update.  Each fixture uses a separate repo
+            # so its deliberately hostile configuration cannot leak onward.
+            with tempfile.TemporaryDirectory() as config_parent:
+                textconv_path = os.path.join(config_parent, "textconv-path")
+                os.mkdir(textconv_path)
+                os.chdir(textconv_path)
+                _git("init", "-q", "-b", "root")
+                _git("config", "user.email", "s@s")
+                _git("config", "user.name", "s")
+                open("f", "w").write("root\n")
+                open(".gitattributes", "w").write("f diff=quiet\n")
+                _git("add", "f", ".gitattributes")
+                _git("commit", "-qm", "root")
+                _git("checkout", "-qb", "feature")
+                open("f", "w").write("stranded\n")
+                _git("commit", "-qam", "feature")
+                _git("checkout", "-qb", "base", "root")
+                open("unrelated", "w").write("base")
+                _git("add", "unrelated"); _git("commit", "-qm", "base")
+                _git("config", "diff.quiet.textconv", "/bin/true")
+                raw_rc, _ = _git("diff", *RAW_DIFF_FLAGS, "--quiet",
+                                 "base", "feature", "--", "f")
+                case("textconv-path-raw", raw_rc, 1,
+                     "raw diff sees content hidden by textconv")
+                rc, out = run(["--no-fetch", "--base", "base", "feature"])
+                case("textconv-path-rc", rc, RC_FINDING,
+                     "textconv cannot create path-equivalence containment")
+                case("textconv-path-name", "f" in out, True,
+                     "...and the raw differing path is reported")
+
+                textconv_patch = os.path.join(config_parent, "textconv-patch")
+                os.mkdir(textconv_patch)
+                os.chdir(textconv_patch)
+                _git("init", "-q", "-b", "root")
+                _git("config", "user.email", "s@s")
+                _git("config", "user.name", "s")
+                open("f", "w").write("root\n")
+                open(".gitattributes", "w").write("f diff=quiet\n")
+                _git("add", "f", ".gitattributes")
+                _git("commit", "-qm", "root")
+                _git("checkout", "-qb", "feature")
+                open("f", "w").write("stranded\n")
+                open("g", "w").write("landed\n")
+                _git("add", "f", "g"); _git("commit", "-qm", "first")
+                rc, branch_first = _git("rev-parse", "HEAD")
+                open("h", "w").write("landed\n")
+                _git("add", "h"); _git("commit", "-qm", "second")
+                _git("checkout", "-qb", "base", "root")
+                open("g", "w").write("landed\n")
+                _git("add", "g"); _git("commit", "-qm", "first replay")
+                rc2, base_first = _git("rev-parse", "HEAD")
+                open("h", "w").write("landed\n")
+                _git("add", "h"); _git("commit", "-qm", "second replay")
+                open("h", "w").write("superseded\n")
+                _git("commit", "-qam", "later")
+                _git("config", "diff.quiet.textconv", "/bin/true")
+                branch_id, branch_err = _verbatim_patch_id(branch_first)
+                base_id, base_err = _verbatim_patch_id(base_first)
+                case("textconv-patch-raw",
+                     (rc, rc2, branch_err, base_err, branch_id != base_id),
+                     (0, 0, None, None, True),
+                     "raw patch IDs include content hidden by textconv")
+                rc, out = run(["--no-fetch", "--base", "base", "feature"])
+                case("textconv-patch-rc", rc, RC_FINDING,
+                     "textconv cannot create patch-equivalence containment")
+                case("textconv-patch-name", "f" in out, True,
+                     "...and the hidden file is reported")
+
+                submodule_repo = os.path.join(config_parent, "submodule")
+                os.mkdir(submodule_repo)
+                os.chdir(submodule_repo)
+                _git("init", "-q", "-b", "root")
+                _git("config", "user.email", "s@s")
+                _git("config", "user.name", "s")
+                open("seed", "w").write("seed")
+                _git("add", "seed"); _git("commit", "-qm", "root")
+                rc, root_oid = _git("rev-parse", "HEAD")
+                _git("checkout", "-qb", "feature")
+                open("landed", "w").write("landed")
+                _git("add", "landed")
+                _git("update-index", "--add", "--cacheinfo",
+                     f"160000,{root_oid},submodule-pin")
+                _git("commit", "-qm", "feature")
+                _git("checkout", "-qb", "base", "root")
+                open("landed", "w").write("landed")
+                _git("add", "landed"); _git("commit", "-qm", "partial")
+                _git("config", "diff.ignoreSubmodules", "all")
+                raw_rc, _ = _git("diff", *RAW_DIFF_FLAGS, "--quiet",
+                                 "base", "feature", "--", "submodule-pin")
+                case("submodule-pin-raw", (rc, raw_rc), (0, 1),
+                     "raw diff includes a gitlink despite ignore configuration")
+                rc, out = run(["--no-fetch", "--base", "base", "feature"])
+                case("submodule-pin-rc", rc, RC_FINDING,
+                     "an ignored submodule pin cannot false-pass")
+                case("submodule-pin-name", "submodule-pin" in out, True,
+                     "...and the missing gitlink path is reported")
+                os.chdir(td)
 
             # git cherry intentionally omits merge commits.  An equivalent
             # normal commit must not hide unique merge-resolution content.

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -283,8 +283,8 @@ def merged_pr_heads(limit, base):
 
 
 # --- self-test ---------------------------------------------------------------
-# The cases below call contained() FOR REAL against this repository's own
-# history. An earlier cut had a table that re-implemented the predicate and
+# The cases below call contained() FOR REAL against controlled Git histories.
+# An earlier cut had a table that re-implemented the predicate and
 # never called it, so mutating the shipped code -- swapping the two signals,
 # hard-coding the count -- left every case printing ok. The advertised number
 # had no coverage at all, which is the "test that cannot fail" this repo's own
@@ -301,25 +301,13 @@ def selftest():
             print(f"       got {got!r}, expected {want!r}")
 
     rc, head = _git("rev-parse", "HEAD")
-    rc2, parent = _git("rev-parse", "HEAD~1")
-    if rc != 0 or rc2 != 0:
-        print("  FAIL selftest needs at least two commits of history")
+    if rc != 0:
+        print("  FAIL selftest needs a repository with one commit")
         return 1
 
     ok, ahead, note = contained(head, head)
     case("self-containment", (ok, ahead), (True, 0),
          "a commit is contained in itself")
-
-    #! the STRANDED verdict AND the count, against real history: HEAD is one
-    #! commit ahead of its parent. The count is what the output advertises and
-    #! it had no coverage until this case existed.
-    ok, ahead, note = contained(head, parent)
-    case("stranded-count", (ok, ahead), (False, 1),
-         "HEAD is 1 commit ahead of HEAD~1, and says so")
-
-    ok, ahead, note = contained(parent, head)
-    case("contained-backwards", (ok, ahead), (True, 0),
-         "...and the parent IS contained in HEAD")
 
     ok, ahead, note = contained("refs/heads/definitely-not-a-branch", head)
     case("missing-ref", (ok, ahead), (None, None),
@@ -363,6 +351,21 @@ def selftest():
             for i in range(3):
                 open(f"w{i}", "w").write(str(i))
                 _git("add", "-A"); _git("commit", "-qm", f"w{i}")
+
+            # These assertions used to rely on HEAD and HEAD~1 in the caller's
+            # repository.  At a merge result, second-parent commits make that
+            # range larger than one and the self-test falsely failed.  Keep the
+            # one-commit relationship inside the controlled linear fixture.
+            rc, tip = _git("rev-parse", "work")
+            rc2, parent = _git("rev-parse", "work~1")
+            ok, ahead, note = contained(tip, parent)
+            case("stranded-count", (rc, rc2, ok, ahead),
+                 (0, 0, False, 1),
+                 "a linear child is one commit ahead of its parent")
+
+            ok, ahead, note = contained(parent, tip)
+            case("contained-backwards", (ok, ahead), (True, 0),
+                 "...and the parent is contained in the child")
 
             rc, out = run(["--no-fetch", "--base", "base", "work"])
             case("e2e-stranded-rc", rc, RC_FINDING,

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -61,6 +61,7 @@ for having actually produced an answer.  That is the whole reason those two
 are used rather than reading ``git log`` output.
 """
 
+import os
 import subprocess
 import sys
 
@@ -81,6 +82,36 @@ def _git(*args):
     p = subprocess.run(("git", "--no-replace-objects") + args,
                        capture_output=True, text=True)
     return p.returncode, p.stdout.rstrip("\n")
+
+
+def active_graft_error():
+    """Explain an active legacy graft file, or return None."""
+    rc, path = _git("rev-parse", "--git-path", "info/grafts")
+    if rc != 0 or not path:
+        return "could not locate Git's legacy graft file"
+    try:
+        with open(path, "rb") as grafts:
+            active = bool(grafts.read().strip())
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return f"could not inspect Git's legacy graft file: {exc}"
+    if active:
+        return (f"legacy Git grafts are active in {path}; remove the grafts "
+                f"before measuring stored commit ancestry")
+    return None
+
+
+def exact_ref_syntax(ref):
+    """True for a ref name or full object ID, never a revision expression."""
+    if len(ref) in (40, 64) and all(c in "0123456789abcdefABCDEF" for c in ref):
+        rc, oid = _git("rev-parse", "--verify", "--quiet", ref + "^{commit}")
+        return rc == 0 and oid.lower() == ref.lower()
+    if ref.startswith("refs/"):
+        return _git("check-ref-format", ref)[0] == 0
+    if ref in ("HEAD", "@"):
+        return False
+    return _git("check-ref-format", "--branch", ref)[0] == 0
 
 
 def _verbatim_patch_id(commit):
@@ -204,10 +235,10 @@ def fetched_branch_refs(ref):
     The source labels are used only to make the two answers distinguishable.
     """
     if ref.startswith("refs/remotes/origin/"):
-        return [(ref, "origin")]
-    if ref.startswith("origin/"):
-        return [("refs/remotes/" + ref, "origin")]
-    if ref.startswith("refs/heads/"):
+        name = ref[len("refs/remotes/origin/"):]
+    elif ref.startswith("origin/"):
+        name = ref[len("origin/"):]
+    elif ref.startswith("refs/heads/"):
         name = ref[len("refs/heads/"):]
     elif ref.startswith("refs/"):
         return [(ref, None)]
@@ -257,6 +288,10 @@ def contained(branch, base):
     by another route (squash, rebase).  None means the question could not be
     answered, which is a finding, never a pass.
     """
+    graft_error = active_graft_error()
+    if graft_error:
+        return (None, None, graft_error)
+
     for ref in (branch, base):
         rc, _ = _git("rev-parse", "--verify", "--quiet", ref + "^{commit}")
         if rc != 0:
@@ -315,6 +350,19 @@ def contained(branch, base):
             return (None, None,
                     f"git diff could not enumerate paths changed by {branch}")
         paths = [n for n in names.split("\0") if n]
+        if not paths:
+            rc, _ = _git("diff", *RAW_DIFF_FLAGS, "--quiet", mb, branch)
+            if rc == 0:
+                return (True, ahead,
+                        f"the branch has no net tree change ({ahead} "
+                        f"commit(s) not ancestors)")
+            if rc != 1:
+                return (None, None,
+                        f"git diff could not verify the empty path set for "
+                        f"{branch}")
+            return (None, None,
+                    f"git diff reported content for {branch} after path "
+                    f"enumeration reported none")
         if paths:
             #! Names came from git, not from a pathspec language.  A real file
             #! beginning with `:(exclude)` must not turn itself into an exclude
@@ -374,7 +422,7 @@ def contained(branch, base):
 
 
 def merged_pr_heads(limit, base):
-    """([(number, branch, head_oid)], error).
+    """([(number, branch, head_oid, cross_repository)], error).
 
     Scoped to PRs that actually targeted ``base``.  Sweeping every merged PR
     asks about branches that were never meant to be in this integration
@@ -382,11 +430,10 @@ def merged_pr_heads(limit, base):
     bury the one real finding.
 
     GitHub's head OID is the head that was merged, not the branch tip after the
-    merge.  It is retained only as evidence for diagnostics.  The sweep must
-    check the fetched branch ref instead: commits pushed after the merge are
-    precisely the stranded work this command exists to find.  A deleted branch
-    has no observable post-merge tip and is therefore UNKNOWN, never guessed
-    from the merge-time OID.
+    merge.  The sweep checks a same-repository live branch only when its
+    first-parent history still contains that OID.  That continuity proof keeps
+    a fork or a deleted and recreated same-name branch from standing in for the
+    merged branch.  A missing or discontinuous tip is UNKNOWN.
     """
     import json
     #! gh wants a branch NAME; `base` is a git ref and usually carries the
@@ -404,7 +451,7 @@ def merged_pr_heads(limit, base):
         p = subprocess.run(
             ["gh", "pr", "list", "--state", "merged", "--base", base_name,
              "--limit", str(limit),
-             "--json", "number,headRefName,headRefOid",
+             "--json", "number,headRefName,headRefOid,isCrossRepository",
              "--search", "sort:updated-desc"],
             capture_output=True, text=True)
     except FileNotFoundError:
@@ -414,10 +461,28 @@ def merged_pr_heads(limit, base):
         return (None, "gh could not list merged PRs (authenticated?): "
                       + (p.stderr or "").strip()[:200])
     try:
-        return ([(d["number"], d["headRefName"], d["headRefOid"])
+        return ([(d["number"], d["headRefName"], d["headRefOid"],
+                  d["isCrossRepository"])
                  for d in json.loads(p.stdout)], None)
     except (ValueError, KeyError) as exc:
         return (None, f"could not parse gh output: {exc}")
+
+
+def continuous_merged_pr_tip(head_oid, live_ref):
+    """Return an error unless ``live_ref`` continues the merged PR branch."""
+    if not (len(head_oid) in (40, 64)
+            and all(c in "0123456789abcdefABCDEF" for c in head_oid)):
+        return "GitHub returned an invalid merged head object ID"
+    rc, _ = _git("rev-parse", "--verify", "--quiet", live_ref + "^{commit}")
+    if rc != 0:
+        return f"the live branch ref is missing: {live_ref}"
+    rc, history = _git("rev-list", "--first-parent", live_ref)
+    if rc != 0:
+        return f"could not inspect first-parent continuity for {live_ref}"
+    if head_oid.lower() not in {oid.lower() for oid in history.splitlines()}:
+        return (f"{live_ref} is not a first-parent continuation of merged "
+                f"head {head_oid}; the branch may have been replaced")
+    return None
 
 
 # --- self-test ---------------------------------------------------------------
@@ -538,6 +603,13 @@ def selftest():
             case("e2e-unknown-flag", rc, RC_CANNOT_RUN,
                  "an unrecognised flag is refused, never read as a branch")
 
+            rc, out = run(["--no-fetch", "--base", "base", "work~1"])
+            case("e2e-revision-branch", rc, RC_CANNOT_RUN,
+                 "a revision expression cannot hide the branch tip")
+            rc, out = run(["--no-fetch", "--base", "work~1", "work"])
+            case("e2e-revision-base", rc, RC_CANNOT_RUN,
+                 "a revision expression cannot replace the exact base")
+
             rc, out = run(["--no-fetch", "--base", "base", "--base",
                            "work", "work"])
             case("e2e-duplicate-base", rc, RC_CANNOT_RUN,
@@ -581,7 +653,7 @@ def selftest():
                 # branch tip is the only ref that can expose later pushes.
                 saved_merged_pr_heads = globals()["merged_pr_heads"]
                 globals()["merged_pr_heads"] = lambda _limit, _base: (
-                    [(86, "work", base_oid)], None)
+                    [(86, "work", base_oid, False)], None)
                 try:
                     rc, out = run(["--no-fetch", "--base", "base",
                                    "--merged-prs", "1"])
@@ -589,6 +661,33 @@ def selftest():
                          "the merged sweep ignores the frozen head OID")
                     case("merged-live-tip-word", "STRANDED" in out, True,
                          "...and assesses origin/work instead")
+                finally:
+                    globals()["merged_pr_heads"] = saved_merged_pr_heads
+
+                globals()["merged_pr_heads"] = lambda _limit, _base: (
+                    [(90, "work", base_oid, True)], None)
+                try:
+                    rc, out = run(["--no-fetch", "--base", "base",
+                                   "--merged-prs", "1"])
+                    case("merged-fork-rc", rc, RC_FINDING,
+                         "a fork head cannot borrow origin's same-name ref")
+                    case("merged-fork-word", "UNKNOWN" in out, True,
+                         "...and the unrefreshable live tip is UNKNOWN")
+                finally:
+                    globals()["merged_pr_heads"] = saved_merged_pr_heads
+
+                rc, work_tip = _git("rev-parse", "refs/remotes/origin/work")
+                _git("update-ref", "refs/remotes/origin/reused", base_oid)
+                globals()["merged_pr_heads"] = lambda _limit, _base: (
+                    [(91, "reused", work_tip, False)], None)
+                try:
+                    rc2, out = run(["--no-fetch", "--base", "base",
+                                    "--merged-prs", "1"])
+                    case("merged-reused-rc", (rc, rc2),
+                         (0, RC_FINDING),
+                         "a recreated same-name branch cannot false-pass")
+                    case("merged-reused-word", "UNKNOWN" in out, True,
+                         "...and failed continuity is UNKNOWN")
                 finally:
                     globals()["merged_pr_heads"] = saved_merged_pr_heads
 
@@ -614,6 +713,12 @@ def selftest():
                 case("local-ahead-word",
                      "local-ahead (local)" in out and "STRANDED" in out,
                      True, "...and the local tip is named in the finding")
+                rc, out = run(["--base", "base", "origin/local-ahead"])
+                case("origin-spelling-local", rc, RC_FINDING,
+                     "origin/name still checks an unpushed local tip")
+                case("origin-spelling-label",
+                     "origin/local-ahead (local)" in out and "STRANDED" in out,
+                     True, "...and identifies the local source")
 
                 # Normal mode refreshes origin only.  Accepting another
                 # remote-tracking namespace would give a stale local cache the
@@ -735,6 +840,26 @@ def selftest():
                  "...and the raw stranded path is reported")
             _git("replace", "-d", replace_base)
 
+            # Legacy info/grafts rewrites ancestry even when replacement refs
+            # are disabled.  Refuse the repository rather than trusting an
+            # alternate commit graph that cannot be disabled per invocation.
+            graft_rc, graft_path = _git("rev-parse", "--git-path",
+                                        "info/grafts")
+            with open(graft_path, "w") as grafts:
+                grafts.write(f"{replace_base} {replace_feature}\n")
+            try:
+                rc, out = run(["--no-fetch", "--base", "replace-base",
+                               "replace-feature"])
+                case("legacy-graft-fixture", graft_rc, 0,
+                     "the fixture locates Git's active graft file")
+                case("legacy-graft-rc", rc, RC_CANNOT_RUN,
+                     "legacy graft ancestry is refused before a verdict")
+                ok, ahead, note = contained("replace-feature", "replace-base")
+                case("legacy-graft-direct", (ok, ahead), (None, None),
+                     "the containment predicate cannot trust grafts either")
+            finally:
+                os.remove(graft_path)
+
             # A multi-commit squash remains contained after unrelated work
             # advances the base, because only branch-touched paths matter.
             _git("checkout", "-qb", "squash-feature", "base")
@@ -754,6 +879,19 @@ def selftest():
             case("squash-path-equivalence",
                  "every path this branch touched" in out, True,
                  "...through the path-scoped content check")
+
+            _git("checkout", "-qb", "net-zero", "base")
+            open("temporary-change", "w").write("added then removed")
+            _git("add", "temporary-change")
+            _git("commit", "-qm", "add temporary path")
+            os.remove("temporary-change")
+            _git("add", "-A")
+            _git("commit", "-qm", "remove temporary path")
+            rc, out = run(["--no-fetch", "--base", "base", "net-zero"])
+            case("net-zero-history-rc", rc, RC_OK,
+                 "a branch with no net tree change is already contained")
+            case("net-zero-history-word", "no net tree change" in out, True,
+                 "...and the conservative proof is named")
 
             # A failed proof-producing path enumeration is UNKNOWN, not a
             # STRANDED verdict assembled from incomplete evidence.
@@ -1050,6 +1188,11 @@ def main(argv):
             sys.stderr.write(f"{flag} may be specified only once\n{USAGE}\n")
             return RC_CANNOT_RUN
 
+    graft_error = active_graft_error()
+    if graft_error:
+        sys.stderr.write(graft_error + "\n")
+        return RC_CANNOT_RUN
+
     if "--selftest" in args:
         if args != ["--selftest"]:
             sys.stderr.write(f"--selftest accepts no other arguments\n{USAGE}\n")
@@ -1067,6 +1210,19 @@ def main(argv):
             return RC_CANNOT_RUN
         base = args[i + 1]
         del args[i:i + 2]
+
+    if not exact_ref_syntax(base):
+        sys.stderr.write(
+            f"base must be an exact ref name or full object ID, not a "
+            f"revision expression: {base}\n")
+        return RC_CANNOT_RUN
+    if "--merged-prs" not in args:
+        for ref in (a for a in args if not a.startswith("-")):
+            if not exact_ref_syntax(ref):
+                sys.stderr.write(
+                    f"branch must be an exact ref name or full object ID, "
+                    f"not a revision expression: {ref}\n")
+                return RC_CANNOT_RUN
 
     do_fetch = "--no-fetch" not in args
     args = [a for a in args if a != "--no-fetch"]
@@ -1131,12 +1287,20 @@ def main(argv):
                 f"no merged PRs found targeting {base}. That is not a pass -- "
                 f"check the base name.\n")
             return RC_CANNOT_RUN
-        #! headRefOid is frozen at merge time and therefore cannot reveal work
-        #! pushed afterwards.  Always assess the fetched live branch tip.  A
-        #! deleted branch becomes UNKNOWN through contained(), which is safer
-        #! than certifying the old merge-time OID.
-        targets = [(f"#{n} {b}", f"refs/remotes/origin/{b}")
-                   for n, b, _oid in prs]
+        #! headRefOid is frozen at merge time and cannot reveal later pushes,
+        #! but it proves that a current same-name ref is still the same branch.
+        #! A fork, force-push, deletion or branch-name reuse becomes UNKNOWN
+        #! instead of certifying an unrelated origin ref.
+        targets = []
+        for number, branch, head_oid, cross_repository in prs:
+            label = f"#{number} {branch}"
+            live_ref = f"refs/remotes/origin/{branch}"
+            if cross_repository:
+                pre_error = ("the merged head belongs to another repository; "
+                             "origin cannot refresh or identify its live tip")
+            else:
+                pre_error = continuous_merged_pr_tip(head_oid, live_ref)
+            targets.append((label, live_ref, pre_error))
     else:
         branches = [a for a in args if not a.startswith("-")]
         if not branches:
@@ -1151,11 +1315,15 @@ def main(argv):
                     else [(branch, None)])
             for ref, source in refs:
                 label = (f"{branch} ({source})" if len(refs) > 1 else branch)
-                targets.append((label, ref))
+                targets.append((label, ref, None))
 
     stranded = 0
     unknown = 0
-    for label, ref in targets:
+    for label, ref, pre_error in targets:
+        if pre_error:
+            print(f"  UNKNOWN    {label}: {pre_error}")
+            unknown += 1
+            continue
         ok, ahead, note = contained(ref, base)
         if ok is None:
             print(f"  UNKNOWN    {label}: {note}")

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Did the merge actually take the branch?
+
+    python3 scripts/check_merge_containment.py [--base main-push] [<branch>...]
+    python3 scripts/check_merge_containment.py --merged-prs [N]
+    python3 scripts/check_merge_containment.py --selftest
+
+WHY THIS EXISTS
+---------------
+A pull request merged while a review round is still running leaves the work
+that round produced behind: the merge takes the commit the branch had at the
+time, and everything pushed after it stays on the branch.  Nothing reports
+this.  ``gh pr view`` says ``MERGED``, CI is green, the issue closes itself,
+and the board moves to Done -- while commits sit unmerged on a branch nobody
+is looking at any more.
+
+It has happened twice on this repository:
+
+* **#77**, merged 2026-08-16 18:10 during review round 3 of 6.  Rounds 4, 5
+  and 6 each returned NEGATIVE afterwards; their fixes had to be re-landed as
+  #85.
+* **#86**, merged 2026-08-17 07:54 mid-round.  Three commits stranded, tracked
+  as #87 and re-landed as #89.
+
+Both were found by a reviewer checking by hand.  This makes the check a
+command, because a check that depends on somebody remembering is not a check.
+
+THE TRAP THIS AVOIDS
+--------------------
+The obvious way to write this is ``git log <branch>..<base>``.  Do not.  In
+this environment that returns **empty** when it follows another git command in
+the same shell invocation -- the proxy hook swallows the output -- so it
+reports "nothing diverged" for a branch that has.  That is exactly how #89's
+own description came to claim a fast-forward that was not one.
+
+``git rev-list --count`` and ``git merge-base --is-ancestor`` are used instead:
+both answer through the exit code or a bare number, so a swallowed stream
+cannot be mistaken for agreement.  Same rule as ``scripts/suite_tally.py``
+enforces on the sweep -- silence is not a measurement.
+"""
+
+import subprocess
+import sys
+
+
+def _git(*args):
+    """Run git, returning (rc, stdout).  Never raises on a non-zero rc."""
+    p = subprocess.run(("git",) + args, capture_output=True, text=True)
+    return p.returncode, p.stdout.strip()
+
+
+def contained(branch, base):
+    """(is_contained, commits_ahead, error).
+
+    ``is_contained`` is True when every commit on ``branch`` is reachable from
+    ``base`` -- i.e. the merge took the whole branch.
+    """
+    rc, _ = _git("rev-parse", "--verify", "--quiet", branch + "^{commit}")
+    if rc != 0:
+        return (None, None, f"no such ref: {branch}")
+    rc, _ = _git("rev-parse", "--verify", "--quiet", base + "^{commit}")
+    if rc != 0:
+        return (None, None, f"no such ref: {base}")
+
+    #! the count is the actionable number: it says HOW MUCH was left behind
+    rc, out = _git("rev-list", "--count", f"{base}..{branch}")
+    if rc != 0:
+        return (None, None, f"rev-list failed for {base}..{branch}")
+    ahead = int(out or "0")
+
+    #! and the ancestry test is the verdict, taken from an exit code so that an
+    #! empty stream cannot be read as agreement
+    rc, _ = _git("merge-base", "--is-ancestor", branch, base)
+    return (rc == 0, ahead, None)
+
+
+def merged_pr_branches(limit):
+    """[(number, branch)] for the most recently merged PRs, via gh."""
+    rc, out = _git("--version")          # cheap check that we can run tools
+    if rc != 0:
+        return None
+    p = subprocess.run(
+        ["gh", "pr", "list", "--state", "merged", "--limit", str(limit),
+         "--json", "number,headRefName"],
+        capture_output=True, text=True)
+    if p.returncode != 0:
+        return None
+    import json
+    try:
+        return [(d["number"], d["headRefName"]) for d in json.loads(p.stdout)]
+    except (ValueError, KeyError):
+        return None
+
+
+SELFTEST = [
+    # (name, ahead, is_ancestor, expect_ok)
+    ("contained",        0, True,  True),
+    ("stranded-one",     1, False, False),
+    ("stranded-many",    7, False, False),
+    #! the case that makes the two signals worth having SEPARATELY: a branch
+    #! can be an ancestor and still report commits ahead if a ref moved under
+    #! us mid-check. Disagreement is itself a finding, never a pass.
+    ("disagreement",     2, True,  False),
+]
+
+
+def selftest():
+    bad = 0
+    for name, ahead, anc, want in SELFTEST:
+        got = bool(anc) and ahead == 0
+        ok = got == want
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<16} "
+              f"ahead={ahead} ancestor={anc} -> contained={got}")
+        if not ok:
+            bad += 1
+            print(f"       expected contained={want}")
+
+    #! and one real call, so the git plumbing is exercised rather than assumed:
+    #! a ref is trivially contained in itself, and a missing ref is an error
+    #! rather than a quiet pass
+    ok, ahead, err = contained("HEAD", "HEAD")
+    if ok is True and ahead == 0 and err is None:
+        print("  ok   self-containment  HEAD is contained in HEAD")
+    else:
+        print(f"  FAIL self-containment  got ok={ok} ahead={ahead} err={err}")
+        bad += 1
+
+    ok, ahead, err = contained("refs/heads/definitely-not-a-branch", "HEAD")
+    if ok is None and err:
+        print("  ok   missing-ref       a ref that does not exist is an ERROR, "
+              "not 'contained'")
+    else:
+        print(f"  FAIL missing-ref       got ok={ok} err={err}")
+        bad += 1
+
+    print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
+    return 1 if bad else 0
+
+
+def main(argv):
+    args = argv[1:]
+    if "--selftest" in args:
+        return selftest()
+
+    base = "origin/main-push"
+    if "--base" in args:
+        i = args.index("--base")
+        base = args[i + 1]
+        del args[i:i + 2]
+
+    if "--merged-prs" in args:
+        i = args.index("--merged-prs")
+        limit = 20
+        if i + 1 < len(args) and args[i + 1].isdigit():
+            limit = int(args[i + 1])
+            del args[i + 1]
+        del args[i]
+        prs = merged_pr_branches(limit)
+        if prs is None:
+            sys.stderr.write("could not list merged PRs (is `gh` available "
+                             "and authenticated?)\n")
+            return 2
+        targets = [(f"#{n} {b}", "origin/" + b) for n, b in prs]
+    else:
+        branches = [a for a in args if not a.startswith("-")]
+        if not branches:
+            rc, cur = _git("rev-parse", "--abbrev-ref", "HEAD")
+            if rc != 0 or not cur or cur == "HEAD":
+                sys.stderr.write("usage: check_merge_containment.py "
+                                 "[--base <ref>] <branch>...\n")
+                return 2
+            branches = [cur]
+        targets = [(b, b) for b in branches]
+
+    bad = 0
+    unknown = 0
+    for label, ref in targets:
+        ok, ahead, err = contained(ref, base)
+        if err:
+            print(f"  UNKNOWN  {label}: {err}")
+            unknown += 1
+            continue
+        if ok and ahead == 0:
+            print(f"  contained  {label}")
+        else:
+            print(f"  STRANDED   {label}: {ahead} commit(s) not in {base}")
+            bad += 1
+
+    if bad:
+        print()
+        print(f"{bad} branch(es) have work that {base} does not.")
+        print("  A merge that landed before the branch stopped moving leaves")
+        print("  the rest behind, and nothing else reports it. Open a")
+        print("  follow-up PR for the remainder -- see CONTRIBUTING.md 2.1")
+        print("  step 7.")
+    #! an unresolvable ref is an UNKNOWN and fails: a check that cannot run
+    #! must not report success
+    if unknown:
+        print()
+        print(f"{unknown} ref(s) could not be resolved. An unknown is not a")
+        print("  pass -- fetch, or name the ref that exists.")
+    return 1 if (bad or unknown) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -63,6 +63,7 @@ are used rather than reading ``git log`` output.
 
 import subprocess
 import sys
+from collections import Counter
 
 USAGE = __doc__.split("WHY THIS EXISTS")[0].strip()
 
@@ -74,6 +75,52 @@ def _git(*args):
     """Run git, returning (rc, stdout).  Never raises on a non-zero rc."""
     p = subprocess.run(("git",) + args, capture_output=True, text=True)
     return p.returncode, p.stdout.rstrip("\n")
+
+
+def _verbatim_patch_id(commit):
+    """Return a whitespace-preserving patch ID for one commit."""
+    rc, patch = _git("show", "--format=medium", "--no-ext-diff", "--binary",
+                     "--full-index", "--no-renames", commit)
+    if rc != 0:
+        return (None, f"git show could not read {commit}")
+    p = subprocess.run(("git", "patch-id", "--verbatim"), input=patch,
+                       capture_output=True, text=True)
+    fields = p.stdout.strip().split()
+    if p.returncode != 0 or len(fields) != 2:
+        return (None, f"git patch-id could not measure {commit}")
+    return (fields[0], None)
+
+
+def _linear_patches_contained(branch, base):
+    """Prove linear replay equivalence without ignoring whitespace."""
+    rc, branch_out = _git("rev-list", "--no-merges", f"{base}..{branch}")
+    if rc != 0:
+        return (None, f"rev-list could not enumerate {branch}")
+    rc, base_out = _git("rev-list", "--no-merges", f"{branch}..{base}")
+    if rc != 0:
+        return (None, f"rev-list could not enumerate {base}")
+
+    branch_commits = branch_out.splitlines()
+    base_commits = base_out.splitlines()
+    if not branch_commits or not base_commits:
+        return (False, None)
+
+    base_ids = []
+    for commit in base_commits:
+        patch_id, err = _verbatim_patch_id(commit)
+        if err:
+            return (None, err)
+        base_ids.append(patch_id)
+
+    available = Counter(base_ids)
+    for commit in branch_commits:
+        patch_id, err = _verbatim_patch_id(commit)
+        if err:
+            return (None, err)
+        if available[patch_id] == 0:
+            return (False, None)
+        available[patch_id] -= 1
+    return (True, None)
 
 
 def refreshed_origin_ref(ref):
@@ -132,7 +179,14 @@ def fetched_branch_refs(ref):
     if remote_rc == 0:
         return [(remote_ref, "origin")]
     if local_rc == 0:
-        return [(local_ref, "local")]
+        #! A successful fetch with no origin ref cannot distinguish a genuinely
+        #! local-only branch from a branch deleted after later work was pushed.
+        #! Trusting the local tip can therefore certify the stale merge-time
+        #! commit while the deleted remote once held stranded work.  Report the
+        #! observable local tip and an UNKNOWN origin tip.  A caller who
+        #! deliberately wants only the local ref can use --no-fetch with its
+        #! full refs/heads/... name.
+        return [(local_ref, "local"), (remote_ref, "origin")]
     return [(ref, None)]
 
 
@@ -211,26 +265,24 @@ def contained(branch, base):
                         f"{base} ({ahead} commit(s) not ancestors -- squash "
                         f"or rebase merge)")
 
-    #! Rebase keeps one commit per change, so patch-ids still match.  `cherry`
-    #! omits merge commits, however.  Accepting its output for a history that
-    #! contains a merge can hide unique conflict-resolution content and turn
-    #! real stranded work into rc 0.  Use the patch-id fallback only when every
-    #! commit being assessed is linear.
+    #! Rebase keeps one commit per change, so patch IDs still match.  Plain
+    #! `git cherry` is not proof: its patch IDs ignore whitespace, which can
+    #! equate different HDL or software content.  Measure every unique linear
+    #! commit with `git patch-id --verbatim` instead.  Merge commits remain
+    #! excluded because patch IDs omit their conflict-resolution content.
     rc, merge_count = _git("rev-list", "--min-parents=2", "--count",
                            f"{base}..{branch}")
     if rc != 0 or not merge_count.isdigit():
         return (None, None,
                 f"could not determine whether {branch} contains merge commits")
     if int(merge_count) == 0:
-        rc, cherry = _git("cherry", base, branch)
-        if rc != 0:
-            return (None, None,
-                    f"git cherry could not compare {branch} with {base}")
-        if (rc == 0 and cherry
-                and all(l.startswith("-") for l in cherry.splitlines())):
+        equivalent, err = _linear_patches_contained(branch, base)
+        if equivalent is None:
+            return (None, None, err)
+        if equivalent:
             return (True, ahead,
-                    f"every commit has an equivalent in {base} ({ahead} not "
-                    f"ancestors -- rebase merge)")
+                    f"every commit has a whitespace-exact equivalent in "
+                    f"{base} ({ahead} not ancestors -- rebase merge)")
 
     #! NAME THE PATHS. "3 commits not in base" does not tell anyone whether
     #! this is real, and there is one case that reads STRANDED without being
@@ -486,6 +538,52 @@ def selftest():
                      "local-ahead (local)" in out and "STRANDED" in out,
                      True, "...and the local tip is named in the finding")
 
+                # After fetch --prune removes a deleted origin branch, a stale
+                # local tip must not stand in for work that may have existed on
+                # the remote.  Reproduce the incident shape in a separate repo:
+                # H was merged, S was pushed later, then origin/feature vanished
+                # while the checker's local feature remained at H.
+                with tempfile.TemporaryDirectory() as deleted_parent:
+                    checker = os.path.join(deleted_parent, "checker")
+                    deleted_remote = os.path.join(deleted_parent, "remote.git")
+                    writer = os.path.join(deleted_parent, "writer")
+                    os.mkdir(checker)
+                    os.chdir(checker)
+                    _git("init", "-q", "-b", "base")
+                    _git("config", "user.email", "s@s")
+                    _git("config", "user.name", "s")
+                    open("seed", "w").write("seed")
+                    _git("add", "seed"); _git("commit", "-qm", "seed")
+                    _git("checkout", "-qb", "feature")
+                    open("merged", "w").write("H")
+                    _git("add", "merged"); _git("commit", "-qm", "H")
+                    _git("checkout", "-q", "base")
+                    _git("merge", "-q", "--no-ff", "feature", "-m", "M")
+                    _git("init", "--bare", "-q", deleted_remote)
+                    _git("remote", "add", "origin", deleted_remote)
+                    _git("push", "-q", "origin", "base", "feature")
+                    _git("clone", "-q", deleted_remote, writer)
+                    os.chdir(writer)
+                    _git("config", "user.email", "s@s")
+                    _git("config", "user.name", "s")
+                    _git("checkout", "-q", "feature")
+                    open("stranded", "w").write("S")
+                    _git("add", "stranded"); _git("commit", "-qm", "S")
+                    rc, stranded_oid = _git("rev-parse", "HEAD")
+                    _git("push", "-q", "origin", "feature")
+                    _git("push", "-q", "origin",
+                         f"{stranded_oid}:refs/heads/evidence-S")
+                    _git("push", "-q", "origin", "--delete", "feature")
+                    os.chdir(checker)
+                    rc, out = run(["--base", "origin/base", "feature"])
+                    case("deleted-remote-rc", rc, RC_FINDING,
+                         "a deleted remote tip cannot fall back to stale local")
+                    case("deleted-remote-word", "UNKNOWN" in out, True,
+                         "...and the missing origin tip is UNKNOWN")
+                    case("deleted-remote-label", "feature (origin)" in out,
+                         True, "...while the missing source is named")
+                    os.chdir(td)
+
                 # An incomplete history cannot prove ancestry or patch
                 # equivalence.  Offline mode must refuse it, while normal mode
                 # deepens the clone before answering.
@@ -551,8 +649,8 @@ def selftest():
             case("literal-pathspec-name", rc, RC_FINDING,
                  "an exclude-shaped filename remains part of the comparison")
 
-            # Patch-id equivalence is valid for a linear rebased history even
-            # when the base later edits the same path.
+            # Verbatim patch-id equivalence is valid for a linear rebased
+            # history even when the base later edits the same path.
             _git("checkout", "-qb", "linear-feature", "base")
             open("linear", "w").write("landed\n")
             _git("add", "linear"); _git("commit", "-qm", "linear")
@@ -567,8 +665,36 @@ def selftest():
                            "linear-feature"])
             case("linear-patch-fallback", rc, RC_OK,
                  "patch equivalence handles a linear rebase")
-            case("linear-patch-word", "every commit has an equivalent" in out,
+            case("linear-patch-word",
+                 "every commit has a whitespace-exact equivalent" in out,
                  True, "...through the patch-id fallback")
+
+            # git cherry strips whitespace when it computes patch IDs.  These
+            # two values are different content and must never compare equal.
+            _git("checkout", "-qb", "whitespace-feature", "base")
+            open("spacing.py", "w").write('value = "old"\n')
+            _git("add", "spacing.py"); _git("commit", "-qm", "spacing seed")
+            _git("checkout", "-qb", "whitespace-base", "HEAD~1")
+            open("spacing.py", "w").write('value = "old"\n')
+            _git("add", "spacing.py"); _git("commit", "-qm", "spacing seed")
+            _git("checkout", "-q", "whitespace-feature")
+            open("spacing.py", "w").write('value = "a b"\n')
+            _git("commit", "-qam", "space is data")
+            _git("checkout", "-q", "whitespace-base")
+            open("spacing.py", "w").write('value = "ab"\n')
+            _git("commit", "-qam", "different content")
+            rc, cherry = _git("cherry", "whitespace-base",
+                              "whitespace-feature")
+            case("whitespace-fixture",
+                 rc == 0 and bool(cherry)
+                 and all(line.startswith("-") for line in cherry.splitlines()),
+                 True, "git cherry equates different whitespace content")
+            rc, out = run(["--no-fetch", "--base", "whitespace-base",
+                           "whitespace-feature"])
+            case("whitespace-exact-rc", rc, RC_FINDING,
+                 "verbatim patch IDs refuse different content")
+            case("whitespace-exact-path", "spacing.py" in out, True,
+                 "...and the differing path is reported")
 
             # git cherry intentionally omits merge commits.  An equivalent
             # normal commit must not hide unique merge-resolution content.

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -63,7 +63,6 @@ are used rather than reading ``git log`` output.
 
 import subprocess
 import sys
-from collections import Counter
 
 USAGE = __doc__.split("WHY THIS EXISTS")[0].strip()
 
@@ -91,6 +90,36 @@ def _verbatim_patch_id(commit):
     return (fields[0], None)
 
 
+def _commit_paths(commit):
+    """Return the literal paths one commit changed, with renames unfolded."""
+    rc, names = _git("diff-tree", "--root", "--no-commit-id", "--name-only",
+                     "--no-renames", "-z", "-r", commit)
+    if rc != 0:
+        return (None, f"diff-tree could not enumerate {commit}")
+    return ([name for name in names.split("\0") if name], None)
+
+
+def _same_patch_postimage(branch_commit, base_commit):
+    """Require candidate replays to produce the same touched-path trees."""
+    branch_paths, err = _commit_paths(branch_commit)
+    if err:
+        return (None, err)
+    base_paths, err = _commit_paths(base_commit)
+    if err:
+        return (None, err)
+    paths = list(dict.fromkeys(branch_paths + base_paths))
+    if not paths:
+        return (True, None)
+    rc, _ = _git("--literal-pathspecs", "diff", "--quiet", branch_commit,
+                 base_commit, "--", *paths)
+    if rc == 0:
+        return (True, None)
+    if rc == 1:
+        return (False, None)
+    return (None, f"git diff could not compare {branch_commit} with "
+                  f"{base_commit}")
+
+
 def _linear_patches_contained(branch, base):
     """Prove linear replay equivalence without ignoring whitespace."""
     rc, branch_out = _git("rev-list", "--no-merges", f"{base}..{branch}")
@@ -105,21 +134,29 @@ def _linear_patches_contained(branch, base):
     if not branch_commits or not base_commits:
         return (False, None)
 
-    base_ids = []
+    base_by_id = {}
     for commit in base_commits:
         patch_id, err = _verbatim_patch_id(commit)
         if err:
             return (None, err)
-        base_ids.append(patch_id)
+        base_by_id.setdefault(patch_id, []).append(commit)
 
-    available = Counter(base_ids)
     for commit in branch_commits:
         patch_id, err = _verbatim_patch_id(commit)
         if err:
             return (None, err)
-        if available[patch_id] == 0:
+        candidates = base_by_id.get(patch_id, [])
+        match = None
+        for candidate in candidates:
+            same, err = _same_patch_postimage(commit, candidate)
+            if err:
+                return (None, err)
+            if same:
+                match = candidate
+                break
+        if match is None:
             return (False, None)
-        available[patch_id] -= 1
+        candidates.remove(match)
     return (True, None)
 
 
@@ -268,8 +305,11 @@ def contained(branch, base):
     #! Rebase keeps one commit per change, so patch IDs still match.  Plain
     #! `git cherry` is not proof: its patch IDs ignore whitespace, which can
     #! equate different HDL or software content.  Measure every unique linear
-    #! commit with `git patch-id --verbatim` instead.  Merge commits remain
-    #! excluded because patch IDs omit their conflict-resolution content.
+    #! commit with `git patch-id --verbatim` instead, then require the candidate
+    #! commits' touched-path postimages to match exactly.  Even verbatim patch
+    #! IDs omit hunk line numbers, so the postimage check prevents the same edit
+    #! to a different repeated location from becoming a false pass.  Merge
+    #! commits remain excluded because patch IDs omit resolution content.
     rc, merge_count = _git("rev-list", "--min-parents=2", "--count",
                            f"{base}..{branch}")
     if rc != 0 or not merge_count.isdigit():
@@ -694,6 +734,40 @@ def selftest():
             case("whitespace-exact-rc", rc, RC_FINDING,
                  "verbatim patch IDs refuse different content")
             case("whitespace-exact-path", "spacing.py" in out, True,
+                 "...and the differing path is reported")
+
+            # Verbatim patch IDs still omit hunk line numbers.  The same edit
+            # to two repeated blocks therefore hashes alike, but the resulting
+            # files differ and must not be certified as a replay.
+            block = "a\nb\nc\nold\nd\ne\nf\n"
+            separator = "".join(f"separator-{i}\n" for i in range(10))
+            repeated = block + separator + block
+            _git("checkout", "-qb", "hunk-feature", "base")
+            open("repeated.txt", "w").write(repeated)
+            _git("add", "repeated.txt"); _git("commit", "-qm", "hunk seed")
+            _git("checkout", "-qb", "hunk-base", "HEAD~1")
+            open("repeated.txt", "w").write(repeated)
+            _git("add", "repeated.txt"); _git("commit", "-qm", "hunk seed")
+            _git("checkout", "-q", "hunk-feature")
+            open("repeated.txt", "w").write(repeated.replace("old", "new", 1))
+            _git("commit", "-qam", "first block")
+            rc, hunk_feature = _git("rev-parse", "HEAD")
+            _git("checkout", "-q", "hunk-base")
+            before, after = repeated.rsplit("old", 1)
+            open("repeated.txt", "w").write(before + "new" + after)
+            _git("commit", "-qam", "second block")
+            rc2, hunk_base = _git("rev-parse", "HEAD")
+            feature_id, feature_err = _verbatim_patch_id(hunk_feature)
+            base_id, base_err = _verbatim_patch_id(hunk_base)
+            case("hunk-position-fixture",
+                 (rc, rc2, feature_err, base_err, feature_id == base_id),
+                 (0, 0, None, None, True),
+                 "verbatim patch IDs omit the different hunk positions")
+            rc, out = run(["--no-fetch", "--base", "hunk-base",
+                           "hunk-feature"])
+            case("hunk-postimage-rc", rc, RC_FINDING,
+                 "different repeated locations cannot false-pass")
+            case("hunk-postimage-path", "repeated.txt" in out, True,
                  "...and the differing path is reported")
 
             # git cherry intentionally omits merge commits.  An equivalent

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -102,9 +102,15 @@ def active_graft_error():
     return None
 
 
+def is_full_oid(ref):
+    """True when ``ref`` has a complete SHA-1 or SHA-256 spelling."""
+    return (len(ref) in (40, 64)
+            and all(c in "0123456789abcdefABCDEF" for c in ref))
+
+
 def exact_ref_syntax(ref):
     """True for a ref name or full object ID, never a revision expression."""
-    if len(ref) in (40, 64) and all(c in "0123456789abcdefABCDEF" for c in ref):
+    if is_full_oid(ref):
         rc, oid = _git("rev-parse", "--verify", "--quiet", ref + "^{commit}")
         return rc == 0 and oid.lower() == ref.lower()
     if ref.startswith("refs/"):
@@ -209,6 +215,8 @@ def refreshed_origin_ref(ref):
     prevent.  Full non-branch refs remain exact, and callers using
     ``--no-fetch`` do not call this helper.
     """
+    if is_full_oid(ref):
+        return ref
     if ref.startswith("refs/remotes/origin/"):
         return ref
     if ref.startswith("origin/"):
@@ -234,6 +242,8 @@ def fetched_branch_refs(ref):
     modes.  When both exist and differ, containment must be proven for both.
     The source labels are used only to make the two answers distinguishable.
     """
+    if is_full_oid(ref):
+        return [(ref, None)]
     if ref.startswith("refs/remotes/origin/"):
         name = ref[len("refs/remotes/origin/"):]
     elif ref.startswith("origin/"):
@@ -421,8 +431,52 @@ def contained(branch, base):
             if differing else None)
 
 
+def post_merge_ref_event_error(number, merged_at):
+    """Report a durable GitHub event that breaks branch-tip continuity."""
+    import json
+    if not isinstance(merged_at, str) or not merged_at:
+        return "GitHub returned no merge timestamp for the pull request"
+    try:
+        p = subprocess.run(
+            ["gh", "api", "--paginate", "--slurp",
+             f"repos/{{owner}}/{{repo}}/issues/{number}/timeline?per_page=100"],
+            capture_output=True, text=True)
+    except FileNotFoundError:
+        return "gh is not installed, so branch history events are unknown"
+    if p.returncode != 0:
+        return ("gh could not read pull-request timeline events: "
+                + (p.stderr or "").strip()[:200])
+    try:
+        pages = json.loads(p.stdout)
+        if not isinstance(pages, list):
+            raise ValueError("timeline response is not a page list")
+        events = []
+        for page in pages:
+            if not isinstance(page, list):
+                raise ValueError("timeline page is not an event list")
+            events.extend(page)
+    except (ValueError, TypeError) as exc:
+        return f"could not parse pull-request timeline events: {exc}"
+
+    continuity_events = {
+        "head_ref_deleted", "head_ref_restored", "head_ref_force_pushed"
+    }
+    for event in events:
+        if not isinstance(event, dict) or event.get("event") not in continuity_events:
+            continue
+        created_at = event.get("created_at")
+        if not isinstance(created_at, str) or not created_at:
+            return (f"GitHub returned an undated {event.get('event')} event "
+                    f"for PR #{number}")
+        if created_at >= merged_at:
+            return (f"GitHub records {event['event']} at {created_at}, on or "
+                    f"after the PR merged; the current same-name ref cannot "
+                    f"prove branch continuity")
+    return None
+
+
 def merged_pr_heads(limit, base):
-    """([(number, branch, head_oid, cross_repository)], error).
+    """([(number, branch, head_oid, cross_repository, ref_error)], error).
 
     Scoped to PRs that actually targeted ``base``.  Sweeping every merged PR
     asks about branches that were never meant to be in this integration
@@ -451,7 +505,8 @@ def merged_pr_heads(limit, base):
         p = subprocess.run(
             ["gh", "pr", "list", "--state", "merged", "--base", base_name,
              "--limit", str(limit),
-             "--json", "number,headRefName,headRefOid,isCrossRepository",
+             "--json",
+             "number,headRefName,headRefOid,isCrossRepository,mergedAt",
              "--search", "sort:updated-desc"],
             capture_output=True, text=True)
     except FileNotFoundError:
@@ -461,9 +516,13 @@ def merged_pr_heads(limit, base):
         return (None, "gh could not list merged PRs (authenticated?): "
                       + (p.stderr or "").strip()[:200])
     try:
-        return ([(d["number"], d["headRefName"], d["headRefOid"],
-                  d["isCrossRepository"])
-                 for d in json.loads(p.stdout)], None)
+        rows = []
+        for d in json.loads(p.stdout):
+            ref_error = (None if d["isCrossRepository"] else
+                         post_merge_ref_event_error(d["number"], d["mergedAt"]))
+            rows.append((d["number"], d["headRefName"], d["headRefOid"],
+                         d["isCrossRepository"], ref_error))
+        return (rows, None)
     except (ValueError, KeyError) as exc:
         return (None, f"could not parse gh output: {exc}")
 
@@ -649,11 +708,32 @@ def selftest():
                 case("fresh-local-ref-word", "STRANDED" in out, True,
                      "...and reports the work on the fetched tip")
 
+                # A full object ID is immutable evidence, not a branch name.
+                # Git permits a branch whose name is the same 40 hex digits;
+                # neither the branch nor base operand may be substituted with
+                # that ref after fetch.
+                rc, stranded_oid = _git(
+                    "rev-parse", "refs/remotes/origin/work")
+                _git("--git-dir", remote, "update-ref",
+                     f"refs/heads/{stranded_oid}", base_oid)
+                _git("--git-dir", remote, "update-ref",
+                     f"refs/heads/{base_oid}", stranded_oid)
+                rc2, out = run(["--base", "base", stranded_oid])
+                case("full-oid-branch-rc", (rc, rc2), (0, RC_FINDING),
+                     "a hex-named origin branch cannot replace an object ID")
+                case("full-oid-branch-word", "STRANDED" in out, True,
+                     "...and the immutable stranded object is measured")
+                rc, out = run(["--base", base_oid, "work"])
+                case("full-oid-base-rc", rc, RC_FINDING,
+                     "a hex-named origin branch cannot replace the base OID")
+                case("full-oid-base-word", "STRANDED" in out, True,
+                     "...and the immutable base object is measured")
+
                 # A merged PR's head OID is frozen at merge time.  The live
                 # branch tip is the only ref that can expose later pushes.
                 saved_merged_pr_heads = globals()["merged_pr_heads"]
                 globals()["merged_pr_heads"] = lambda _limit, _base: (
-                    [(86, "work", base_oid, False)], None)
+                    [(86, "work", base_oid, False, None)], None)
                 try:
                     rc, out = run(["--no-fetch", "--base", "base",
                                    "--merged-prs", "1"])
@@ -664,8 +744,45 @@ def selftest():
                 finally:
                     globals()["merged_pr_heads"] = saved_merged_pr_heads
 
+                _git("update-ref", "refs/remotes/origin/recreated-exact",
+                     base_oid)
+                continuity = continuous_merged_pr_tip(
+                    base_oid, "refs/remotes/origin/recreated-exact")
                 globals()["merged_pr_heads"] = lambda _limit, _base: (
-                    [(90, "work", base_oid, True)], None)
+                    [(92, "recreated-exact", base_oid, False,
+                      "GitHub records head_ref_deleted after merge")], None)
+                try:
+                    rc, out = run(["--no-fetch", "--base", "base",
+                                   "--merged-prs", "1"])
+                    case("merged-recreated-lineage", continuity, None,
+                         "lineage alone cannot see exact-head recreation")
+                    case("merged-recreated-event", rc, RC_FINDING,
+                         "a durable deletion event prevents false success")
+                    case("merged-recreated-word", "UNKNOWN" in out, True,
+                         "...and the lost ref identity is UNKNOWN")
+                finally:
+                    globals()["merged_pr_heads"] = saved_merged_pr_heads
+
+                saved_subprocess_run = subprocess.run
+
+                class TimelineResult:
+                    returncode = 0
+                    stderr = ""
+                    stdout = ('[[{"event":"head_ref_deleted",'
+                              '"created_at":"2026-08-17T12:00:00Z"}]]')
+
+                subprocess.run = lambda *a, **k: TimelineResult()
+                try:
+                    timeline_error = post_merge_ref_event_error(
+                        92, "2026-08-17T11:00:00Z")
+                    case("timeline-delete-parser",
+                         "head_ref_deleted" in (timeline_error or ""), True,
+                         "the GitHub timeline parser preserves deletion proof")
+                finally:
+                    subprocess.run = saved_subprocess_run
+
+                globals()["merged_pr_heads"] = lambda _limit, _base: (
+                    [(90, "work", base_oid, True, None)], None)
                 try:
                     rc, out = run(["--no-fetch", "--base", "base",
                                    "--merged-prs", "1"])
@@ -679,7 +796,7 @@ def selftest():
                 rc, work_tip = _git("rev-parse", "refs/remotes/origin/work")
                 _git("update-ref", "refs/remotes/origin/reused", base_oid)
                 globals()["merged_pr_heads"] = lambda _limit, _base: (
-                    [(91, "reused", work_tip, False)], None)
+                    [(91, "reused", work_tip, False, None)], None)
                 try:
                     rc2, out = run(["--no-fetch", "--base", "base",
                                     "--merged-prs", "1"])
@@ -1292,12 +1409,15 @@ def main(argv):
         #! A fork, force-push, deletion or branch-name reuse becomes UNKNOWN
         #! instead of certifying an unrelated origin ref.
         targets = []
-        for number, branch, head_oid, cross_repository in prs:
+        for (number, branch, head_oid, cross_repository,
+             ref_event_error) in prs:
             label = f"#{number} {branch}"
             live_ref = f"refs/remotes/origin/{branch}"
             if cross_repository:
                 pre_error = ("the merged head belongs to another repository; "
                              "origin cannot refresh or identify its live tip")
+            elif ref_event_error:
+                pre_error = ref_event_error
             else:
                 pre_error = continuous_merged_pr_tip(head_oid, live_ref)
             targets.append((label, live_ref, pre_error))

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -4,21 +4,21 @@
     python3 scripts/check_merge_containment.py [--base <ref>] <branch>...
     python3 scripts/check_merge_containment.py --merged-prs [N]
     python3 scripts/check_merge_containment.py --selftest
-    python3 scripts/check_merge_containment.py --no-fetch ...   (offline)
+    python3 scripts/check_merge_containment.py --no-fetch ...   (skip Git fetch)
 
 WHY THIS EXISTS
 ---------------
-A pull request merged while a review round is still running leaves the work
-that round produced behind: the merge takes the commit the branch had at the
-time, and everything pushed after it stays on the branch.  Nothing reports
-this.  ``gh pr view`` says ``MERGED``, CI is green, the issue closes itself and
-the board moves to Done, while commits sit unmerged on a branch nobody is
-looking at any more.
+A pull request merged before review activity stops can leave later work
+behind: the merge takes the commit the branch had at the time, and everything
+pushed after it stays on the branch.  Nothing reports this.  ``gh pr view``
+says ``MERGED`` and CI is green, while the issue and board can be closed
+manually even though commits remain on a branch nobody is watching.
 
-It has happened twice here: **#77** (merged mid-review; two of the rounds that
-followed returned blocking defects, re-landed as #85) and **#86** (three
-commits stranded, tracked as #87, re-landed as #89).  Both were found by a
-reviewer checking by hand, which is why this is a command.
+It has happened twice here: **#77** (merged after a positive round, while
+later review still produced two blocking rounds; re-landed as #85) and **#86**
+(merged with a round running; three commits stranded, tracked as #87 and
+re-landed as #89).  Both were found by a reviewer checking by hand, which is
+why this is a command.
 
 THREE WAYS TO GET THE WRONG ANSWER, ALL OF WHICH THIS HAS DONE
 --------------------------------------------------------------
@@ -245,6 +245,17 @@ def offline_ref(ref):
 
     local_ref = "refs/heads/" + ref
     remote_ref = "refs/remotes/" + ref
+    remote_name, separator, _branch_name = ref.partition("/")
+    if separator:
+        rc, configured = _git("remote")
+        if rc != 0:
+            return (None, "could not identify configured remotes for "
+                    f"{ref!r}")
+        if remote_name in configured.splitlines():
+            #! --no-fetch is the deliberate route for another remote.  Its
+            #! shorthand keeps that remote identity even when a slash-named
+            #! local branch also exists or the tracking ref is missing.
+            return (remote_ref, None)
     local_rc, _ = _git("rev-parse", "--verify", "--quiet",
                        local_ref + "^{commit}")
     remote_rc, _ = _git("rev-parse", "--verify", "--quiet",
@@ -314,6 +325,17 @@ def non_origin_remote_ref(ref):
         return None
     if ref.startswith("refs/remotes/"):
         return ref
+    if ref.startswith("refs/"):
+        return None
+    remote_name, separator, _branch_name = ref.partition("/")
+    if separator:
+        rc, configured = _git("remote")
+        if rc != 0:
+            #! We cannot prove that a remote-like shorthand is refreshable by
+            #! the origin-only fetch, so refuse it instead of changing type.
+            return ref
+        if remote_name != "origin" and remote_name in configured.splitlines():
+            return "refs/remotes/" + ref
     #! Resolve the remote namespace directly before asking Git to resolve the
     #! caller's shorthand.  When refs/heads/upstream/work and
     #! refs/remotes/upstream/work both exist, symbolic-full-name rejects the
@@ -843,8 +865,32 @@ def selftest():
                      "an ambiguous non-origin remote shorthand is refused")
                 rc, out = run(["--no-fetch", "--base", "base",
                                "upstream/work"])
-                case("ambiguous-remote-offline-rc", rc, RC_CANNOT_RUN,
-                     "...and offline mode requires its full ref identity")
+                case("ambiguous-remote-offline-rc", rc, RC_FINDING,
+                     "...and offline mode keeps the remote shorthand typed")
+                case("ambiguous-remote-offline-word", "STRANDED" in out, True,
+                     "...so a same-spelled local branch cannot replace it")
+                _git("update-ref", "-d", "refs/remotes/upstream/work")
+                _git("--git-dir", remote, "update-ref",
+                     "refs/heads/upstream/work", "refs/heads/base")
+                rc, out = run(["--base", "base", "upstream/work"])
+                case("missing-remote-tracking-rc", rc, RC_CANNOT_RUN,
+                     "a configured remote shorthand stays non-origin even "
+                     "when its tracking ref is missing")
+                rc, out = run(["--no-fetch", "--base", "base",
+                               "upstream/work"])
+                case("missing-remote-offline-rc", rc, RC_FINDING,
+                     "offline remote shorthand keeps its missing identity")
+                case("missing-remote-offline-word", "UNKNOWN" in out, True,
+                     "...instead of falling back to a slash-named branch")
+                rc, out = run(["--base", "upstream/work", "base"])
+                case("missing-remote-base-rc", rc, RC_CANNOT_RUN,
+                     "a missing configured remote base is refused before fetch")
+                rc, out = run(["--no-fetch", "--base", "upstream/work",
+                               "base"])
+                case("missing-remote-base-offline-rc", rc, RC_FINDING,
+                     "offline mode keeps a missing remote base typed")
+                case("missing-remote-base-offline-word", "UNKNOWN" in out,
+                     True, "...rather than using a slash-named local base")
 
                 # A merged PR's head OID is frozen at merge time.  The live
                 # branch tip is the only ref that can expose later pushes.

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -102,6 +102,40 @@ def refreshed_origin_ref(ref):
     return remote_ref if rc == 0 else ref
 
 
+def fetched_branch_refs(ref):
+    """Return every distinct local/remote tip named by a branch argument.
+
+    A local branch can be either behind its fetched remote tip or ahead with
+    unpushed work.  Replacing one with the other hides one of those two failure
+    modes.  When both exist and differ, containment must be proven for both.
+    The source labels are used only to make the two answers distinguishable.
+    """
+    if ref.startswith("refs/remotes/origin/"):
+        return [(ref, "origin")]
+    if ref.startswith("origin/"):
+        return [("refs/remotes/" + ref, "origin")]
+    if ref.startswith("refs/heads/"):
+        name = ref[len("refs/heads/"):]
+    elif ref.startswith("refs/"):
+        return [(ref, None)]
+    else:
+        name = ref
+
+    local_ref = "refs/heads/" + name
+    remote_ref = "refs/remotes/origin/" + name
+    local_rc, local_oid = _git("rev-parse", "--verify", "--quiet",
+                               local_ref + "^{commit}")
+    remote_rc, remote_oid = _git("rev-parse", "--verify", "--quiet",
+                                 remote_ref + "^{commit}")
+    if local_rc == 0 and remote_rc == 0 and local_oid != remote_oid:
+        return [(local_ref, "local"), (remote_ref, "origin")]
+    if remote_rc == 0:
+        return [(remote_ref, "origin")]
+    if local_rc == 0:
+        return [(local_ref, "local")]
+    return [(ref, None)]
+
+
 def contained(branch, base):
     """(is_contained, commits_ahead, note_or_error).
 
@@ -352,6 +386,15 @@ def selftest():
             case("e2e-unknown-flag", rc, RC_CANNOT_RUN,
                  "an unrecognised flag is refused, never read as a branch")
 
+            rc, out = run(["--no-fetch", "--base", "base", "--base",
+                           "work", "work"])
+            case("e2e-duplicate-base", rc, RC_CANNOT_RUN,
+                 "a repeated base option is refused")
+
+            rc, out = run(["--no-fetch", "--merged-prs", "1", "work"])
+            case("e2e-sweep-operand", rc, RC_CANNOT_RUN,
+                 "a merged sweep cannot silently ignore a branch operand")
+
             # Fetch updates origin/work but not the checked-out local work
             # branch.  The default path must assess the fetched tip, or the
             # exact incident this command guards becomes a quiet rc 0.
@@ -391,6 +434,29 @@ def selftest():
                          "...and assesses origin/work instead")
                 finally:
                     globals()["merged_pr_heads"] = saved_merged_pr_heads
+
+                # The opposite divergence matters too: a local commit that is
+                # not pushed must not disappear merely because origin is
+                # refreshed and already contained.
+                _git("checkout", "-qb", "local-ahead", "base")
+                _git("push", "-q", "origin", "local-ahead")
+                open("local-only", "w").write("not pushed")
+                _git("add", "local-only")
+                _git("commit", "-qm", "local-only")
+                rc, local_ahead = _git(
+                    "rev-list", "--count", "origin/base..local-ahead")
+                rc2, remote_ahead = _git(
+                    "rev-list", "--count", "origin/base..origin/local-ahead")
+                case("local-ahead-fixture",
+                     (rc, local_ahead, rc2, remote_ahead),
+                     (0, "1", 0, "0"),
+                     "only the local tip carries the unpushed commit")
+                rc, out = run(["--base", "base", "local-ahead"])
+                case("local-ahead-rc", rc, RC_FINDING,
+                     "a fetched remote cannot hide unpushed local work")
+                case("local-ahead-word",
+                     "local-ahead (local)" in out and "STRANDED" in out,
+                     True, "...and the local tip is named in the finding")
 
             # A multi-commit squash remains contained after unrelated work
             # advances the base, because only branch-touched paths matter.
@@ -487,8 +553,6 @@ KNOWN_FLAGS = {"--selftest", "--base", "--merged-prs", "--no-fetch"}
 
 def main(argv):
     args = argv[1:]
-    if "--selftest" in args:
-        return selftest()
 
     #! Reject unknown options rather than silently treating them as branches.
     #! `--bse 43a4c417 origin/foo` used to check TWO branches called
@@ -498,6 +562,17 @@ def main(argv):
         if a.startswith("-") and a not in KNOWN_FLAGS:
             sys.stderr.write(f"unknown option: {a}\n{USAGE}\n")
             return RC_CANNOT_RUN
+
+    for flag in ("--selftest", "--base", "--merged-prs"):
+        if args.count(flag) > 1:
+            sys.stderr.write(f"{flag} may be specified only once\n{USAGE}\n")
+            return RC_CANNOT_RUN
+
+    if "--selftest" in args:
+        if args != ["--selftest"]:
+            sys.stderr.write(f"--selftest accepts no other arguments\n{USAGE}\n")
+            return RC_CANNOT_RUN
+        return selftest()
 
     base = "origin/main-push"
     if "--base" in args:
@@ -532,6 +607,10 @@ def main(argv):
             limit = int(args[i + 1])
             del args[i + 1]
         del args[i]
+        if args:
+            sys.stderr.write(
+                f"--merged-prs does not accept branch operands\n{USAGE}\n")
+            return RC_CANNOT_RUN
         prs, err = merged_pr_heads(limit, base)
         if err:
             sys.stderr.write(err + "\n")
@@ -555,8 +634,13 @@ def main(argv):
                 sys.stderr.write(USAGE + "\n")
                 return RC_CANNOT_RUN
             branches = [cur]
-        targets = [(b, refreshed_origin_ref(b) if do_fetch else b)
-                   for b in branches]
+        targets = []
+        for branch in branches:
+            refs = (fetched_branch_refs(branch) if do_fetch
+                    else [(branch, None)])
+            for ref, source in refs:
+                label = (f"{branch} ({source})" if len(refs) > 1 else branch)
+                targets.append((label, ref))
 
     stranded = 0
     unknown = 0
@@ -574,7 +658,7 @@ def main(argv):
 
     if stranded:
         print()
-        print(f"{stranded} branch(es) have work that {base} does not.")
+        print(f"{stranded} branch tip(s) have work that {base} does not.")
         print("  A merge that landed before the branch stopped moving leaves")
         print("  the rest behind, and nothing else reports it. Open a")
         print("  follow-up PR for the remainder -- see CONTRIBUTING.md 2.1")

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -38,6 +38,20 @@ THREE WAYS TO GET THE WRONG ANSWER, ALL OF WHICH THIS HAS DONE
    Anything this tool cannot measure is an UNKNOWN and fails, the same rule
    ``scripts/suite_tally.py`` enforces on the sweep.
 
+THE ONE CASE IT STILL GETS WRONG, AND IN WHICH DIRECTION
+--------------------------------------------------------
+A branch squash-merged as **two or more** commits, whose paths were then edited
+again on the base, reads ``STRANDED`` although nothing is missing: the squash
+left no matching patch-id, and the later edit means the paths no longer agree,
+so neither equivalence test can prove the work landed.
+
+That is a false **alarm**, not a false pass -- the direction that costs a
+reader a minute rather than costing them a regression -- and the verdict names
+the differing paths so it can be settled by looking.  It cannot be fixed by
+comparing harder: once the base has moved on, "these changes were applied and
+then superseded" and "these changes were never applied" are the same tree.
+Deciding it needs the merge commit, which only the sweep has.
+
 WHY EXIT CODES AND BARE NUMBERS
 -------------------------------
 ``git rev-list --count`` prints one integer and ``git merge-base
@@ -128,7 +142,20 @@ def contained(branch, base):
                 f"every commit has an equivalent in {base} ({ahead} not "
                 f"ancestors -- rebase merge)")
 
-    return (False, ahead, None)
+    #! NAME THE PATHS. "3 commits not in base" does not tell anyone whether
+    #! this is real, and there is one case that reads STRANDED without being
+    #! so: a multi-commit squash whose paths were later edited on base. No
+    #! patch-id matches (the squash collapsed them) and the paths no longer
+    #! agree (the later edit), so neither arm above can prove it landed. That
+    #! is a false ALARM rather than a false pass -- the safe direction -- and
+    #! naming the paths is what lets a reader settle it in one look instead of
+    #! learning to ignore the check.
+    differing = []
+    if rc == 0 and mb:
+        rc2, names = _git("diff", "--name-only", base, branch)
+        differing = [n for n in names.splitlines() if n][:6]
+    return (False, ahead, ("paths differing: " + ", ".join(differing))
+            if differing else None)
 
 
 def merged_pr_heads(limit, base):
@@ -363,7 +390,8 @@ def main(argv):
         elif ok:
             print(f"  contained  {label}" + (f"  [{note}]" if note else ""))
         else:
-            print(f"  STRANDED   {label}: {ahead} commit(s) not in {base}")
+            print(f"  STRANDED   {label}: {ahead} commit(s) not in {base}"
+                  + (f"  [{note}]" if note else ""))
             stranded += 1
 
     if stranded:

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -162,6 +162,9 @@ def contained(branch, base):
     rc, _ = _git("merge-base", "--is-ancestor", branch, base)
     if rc == 0:
         return (True, 0, None)
+    if rc != 1:
+        return (None, None,
+                f"merge-base could not compare {branch} with {base}")
 
     rc, out = _git("rev-list", "--count", f"{base}..{branch}")
     if rc != 0:
@@ -184,6 +187,10 @@ def contained(branch, base):
     #! branch reads stranded again. A review demonstrated exactly that: five
     #! sequential squash merges, only the newest passing.
     mb_rc, mb = _git("merge-base", base, branch)
+    if mb_rc not in (0, 1):
+        return (None, None,
+                f"merge-base could not find a common history for "
+                f"{base} and {branch}")
     if mb_rc == 0 and mb:
         #! Disable rename folding so a move contributes both the deleted and
         #! added path.  Comparing only the destination can certify a base that
@@ -193,7 +200,11 @@ def contained(branch, base):
                          mb, branch)
         paths = [n for n in names.split("\0") if n]
         if rc == 0 and paths:
-            rc, _ = _git("diff", "--quiet", base, branch, "--", *paths)
+            #! Names came from git, not from a pathspec language.  A real file
+            #! beginning with `:(exclude)` must not turn itself into an exclude
+            #! rule and make a missing change compare equal.
+            rc, _ = _git("--literal-pathspecs", "diff", "--quiet",
+                         base, branch, "--", *paths)
             if rc == 0:
                 return (True, ahead,
                         f"every path this branch touched is identical in "
@@ -212,6 +223,9 @@ def contained(branch, base):
                 f"could not determine whether {branch} contains merge commits")
     if int(merge_count) == 0:
         rc, cherry = _git("cherry", base, branch)
+        if rc != 0:
+            return (None, None,
+                    f"git cherry could not compare {branch} with {base}")
         if (rc == 0 and cherry
                 and all(l.startswith("-") for l in cherry.splitlines())):
             return (True, ahead,
@@ -308,6 +322,17 @@ def selftest():
     ok, ahead, note = contained(head, head)
     case("self-containment", (ok, ahead), (True, 0),
          "a commit is contained in itself")
+
+    saved_git = globals()["_git"]
+    globals()["_git"] = lambda *args: (
+        (128, "") if args[:2] == ("merge-base", "--is-ancestor")
+        else saved_git(*args))
+    try:
+        ok, ahead, note = contained(head, head)
+        case("ancestor-plumbing-error", (ok, ahead), (None, None),
+             "a failed ancestry command is UNKNOWN, never not-ancestor")
+    finally:
+        globals()["_git"] = saved_git
 
     ok, ahead, note = contained("refs/heads/definitely-not-a-branch", head)
     case("missing-ref", (ok, ahead), (None, None),
@@ -461,6 +486,26 @@ def selftest():
                      "local-ahead (local)" in out and "STRANDED" in out,
                      True, "...and the local tip is named in the finding")
 
+                # An incomplete history cannot prove ancestry or patch
+                # equivalence.  Offline mode must refuse it, while normal mode
+                # deepens the clone before answering.
+                _git("--git-dir", remote, "symbolic-ref", "HEAD",
+                     "refs/heads/work")
+                with tempfile.TemporaryDirectory() as shallow_parent:
+                    shallow_repo = os.path.join(shallow_parent, "repo")
+                    _git("clone", "-q", "--depth", "1",
+                         "--no-single-branch", "file://" + remote,
+                         shallow_repo)
+                    os.chdir(shallow_repo)
+                    rc, out = run(["--no-fetch", "--base", "origin/base",
+                                   "origin/work"])
+                    case("shallow-offline-rc", rc, RC_CANNOT_RUN,
+                         "offline mode refuses incomplete history")
+                    rc, out = run(["--base", "origin/base", "origin/work"])
+                    case("shallow-deepened-rc", rc, RC_FINDING,
+                         "normal mode deepens before measuring containment")
+                    os.chdir(td)
+
             # A multi-commit squash remains contained after unrelated work
             # advances the base, because only branch-touched paths matter.
             _git("checkout", "-qb", "squash-feature", "base")
@@ -493,6 +538,18 @@ def selftest():
                            "rename-feature"])
             case("rename-source-remains", rc, RC_FINDING,
                  "a copied destination cannot hide a missing deletion")
+
+            # A filename is data, not a Git pathspec.  Without literal mode an
+            # exclude-shaped name removes itself from the comparison.
+            magic_name = ":(exclude)magic"
+            _git("checkout", "-qb", "pathspec-feature", "base")
+            open(magic_name, "w").write("stranded")
+            _git("--literal-pathspecs", "add", "--", magic_name)
+            _git("commit", "-qm", "pathspec")
+            rc, out = run(["--no-fetch", "--base", "base",
+                           "pathspec-feature"])
+            case("literal-pathspec-name", rc, RC_FINDING,
+                 "an exclude-shaped filename remains part of the comparison")
 
             # Patch-id equivalence is valid for a linear rebased history even
             # when the base later edits the same path.
@@ -591,10 +648,28 @@ def main(argv):
 
     do_fetch = "--no-fetch" not in args
     args = [a for a in args if a != "--no-fetch"]
+    rc, shallow = _git("rev-parse", "--is-shallow-repository")
+    if rc != 0 or shallow not in ("true", "false"):
+        sys.stderr.write(
+            "could not determine whether the repository history is complete\n")
+        return RC_CANNOT_RUN
+    if shallow == "true" and not do_fetch:
+        sys.stderr.write(
+            "--no-fetch cannot answer from a shallow repository: history is "
+            "incomplete\n")
+        return RC_CANNOT_RUN
     if do_fetch:
         #! Answering from a stale remote-tracking ref is how this tool once
         #! reported `contained` for a branch that had work stranded on it.
-        rc, _ = _git("fetch", "--prune", "--quiet", "origin")
+        fetch_args = ["fetch", "--prune", "--quiet"]
+        if shallow == "true":
+            fetch_args.append("--unshallow")
+        #! Do not trust a narrowed remote.origin.fetch configuration.  The
+        #! command accepts any origin branch and must refresh every branch it
+        #! may later resolve.
+        fetch_args.extend(("origin",
+                           "+refs/heads/*:refs/remotes/origin/*"))
+        rc, _ = _git(*fetch_args)
         if rc != 0:
             sys.stderr.write(
                 "could not fetch origin. Re-run with --no-fetch only if you "

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -236,26 +236,40 @@ def refreshed_origin_ref(ref):
     return remote_ref
 
 
+def configured_remote_name(ref):
+    """Return the longest configured remote prefix in a shorthand ref."""
+    if "/" not in ref:
+        return (None, None)
+    rc, configured = _git("remote")
+    if rc != 0:
+        return (None, "could not identify configured remotes")
+    matches = [name for name in configured.splitlines()
+               if ref.startswith(name + "/")]
+    if len(matches) > 1:
+        matches.sort(key=len, reverse=True)
+        return (None, f"{ref!r} matches multiple configured remotes: "
+                + ", ".join(matches))
+    return (matches[0] if matches else None, None)
+
+
 def offline_ref(ref):
     """Resolve a local-only branch spelling without falling through to tags."""
     if is_full_oid(ref) or ref.startswith("refs/"):
         return (ref, None)
-    if ref.startswith("origin/"):
-        return ("refs/remotes/" + ref, None)
 
     local_ref = "refs/heads/" + ref
     remote_ref = "refs/remotes/" + ref
-    remote_name, separator, _branch_name = ref.partition("/")
-    if separator:
-        rc, configured = _git("remote")
-        if rc != 0:
-            return (None, "could not identify configured remotes for "
-                    f"{ref!r}")
-        if remote_name in configured.splitlines():
-            #! --no-fetch is the deliberate route for another remote.  Its
-            #! shorthand keeps that remote identity even when a slash-named
-            #! local branch also exists or the tracking ref is missing.
-            return (remote_ref, None)
+    remote_name, remote_error = configured_remote_name(ref)
+    if remote_error:
+        return (None, remote_error + f" for {ref!r}")
+    if remote_name:
+        #! --no-fetch is the deliberate route for another remote.  Its
+        #! shorthand keeps that remote identity even when a slash-named local
+        #! branch also exists or the tracking ref is missing.  Remote names
+        #! may themselves contain slashes, so match the full configured name.
+        return (remote_ref, None)
+    if ref.startswith("origin/"):
+        return (remote_ref, None)
     local_rc, _ = _git("rev-parse", "--verify", "--quiet",
                        local_ref + "^{commit}")
     remote_rc, _ = _git("rev-parse", "--verify", "--quiet",
@@ -321,21 +335,25 @@ def non_origin_remote_ref(ref):
     """Name an unrefreshable remote-tracking ref, or return None."""
     if is_full_oid(ref):
         return None
-    if ref.startswith("refs/remotes/origin/") or ref.startswith("origin/"):
+    if ref.startswith("refs/"):
+        if not ref.startswith("refs/remotes/"):
+            return None
+        shorthand = ref[len("refs/remotes/"):]
+    else:
+        shorthand = ref
+    remote_name, remote_error = configured_remote_name(shorthand)
+    if remote_error:
+        #! We cannot prove that a remote-like shorthand is refreshable by the
+        #! origin-only fetch, so refuse it instead of changing type.
+        return ref
+    if remote_name and remote_name != "origin":
+        return (ref if ref.startswith("refs/remotes/")
+                else "refs/remotes/" + ref)
+    if (ref.startswith("refs/remotes/origin/")
+            or ref.startswith("origin/")):
         return None
     if ref.startswith("refs/remotes/"):
         return ref
-    if ref.startswith("refs/"):
-        return None
-    remote_name, separator, _branch_name = ref.partition("/")
-    if separator:
-        rc, configured = _git("remote")
-        if rc != 0:
-            #! We cannot prove that a remote-like shorthand is refreshable by
-            #! the origin-only fetch, so refuse it instead of changing type.
-            return ref
-        if remote_name != "origin" and remote_name in configured.splitlines():
-            return "refs/remotes/" + ref
     #! Resolve the remote namespace directly before asking Git to resolve the
     #! caller's shorthand.  When refs/heads/upstream/work and
     #! refs/remotes/upstream/work both exist, symbolic-full-name rejects the
@@ -891,6 +909,43 @@ def selftest():
                      "offline mode keeps a missing remote base typed")
                 case("missing-remote-base-offline-word", "UNKNOWN" in out,
                      True, "...rather than using a slash-named local base")
+
+                _git("remote", "add", "corp/upstream", remote)
+                _git("update-ref", "refs/remotes/corp/upstream/work",
+                     "refs/remotes/origin/work")
+                _git("branch", "corp/upstream/work", "base")
+                _git("update-ref", "-d",
+                     "refs/remotes/corp/upstream/work")
+                _git("--git-dir", remote, "update-ref",
+                     "refs/heads/corp/upstream/work", "refs/heads/base")
+                rc, out = run(["--base", "base", "corp/upstream/work"])
+                case("slash-remote-normal-rc", rc, RC_CANNOT_RUN,
+                     "a slash-bearing configured remote stays non-origin")
+                rc, out = run(["--no-fetch", "--base", "base",
+                               "corp/upstream/work"])
+                case("slash-remote-offline-rc", rc, RC_FINDING,
+                     "offline slash-bearing remote shorthand stays typed")
+                case("slash-remote-offline-word", "UNKNOWN" in out, True,
+                     "...instead of using a same-spelled local branch")
+                rc, out = run(["--base", "corp/upstream/work", "base"])
+                case("slash-remote-base-rc", rc, RC_CANNOT_RUN,
+                     "a slash-bearing remote base is refused before fetch")
+                rc, out = run(["--no-fetch", "--base",
+                               "corp/upstream/work", "base"])
+                case("slash-remote-base-offline-rc", rc, RC_FINDING,
+                     "offline slash-bearing remote base stays typed")
+                case("slash-remote-base-offline-word", "UNKNOWN" in out, True,
+                     "...instead of using a same-spelled local base")
+                # git remote add rejects overlapping names, but a repository
+                # config can still contain them.  Such a ref has no unique
+                # remote provenance and must be refused.
+                _git("config", "remote.corp.url", remote)
+                _git("config", "remote.corp.fetch",
+                     "+refs/heads/*:refs/remotes/corp/*")
+                rc, out = run(["--no-fetch", "--base", "base",
+                               "corp/upstream/work"])
+                case("overlapping-remote-prefix-rc", rc, RC_CANNOT_RUN,
+                     "overlapping configured remote prefixes are ambiguous")
 
                 # A merged PR's head OID is frozen at merge time.  The live
                 # branch tip is the only ref that can expose later pushes.

--- a/scripts/run_all_suites.sh
+++ b/scripts/run_all_suites.sh
@@ -144,6 +144,19 @@ if ! selftest_out=$(python3 "$ROOT/scripts/suite_tally.py" --selftest 2>&1); the
   exit 2
 fi
 
+# Same argument, different gate: check_merge_containment.py decides whether a
+# merge left work behind, and a review pointed out it was wired into nothing at
+# all -- its only caller was a sentence in CONTRIBUTING.md telling a human to
+# run it. The CHECK itself is a post-merge act nobody can schedule from here,
+# but its self-test can be gated exactly like the tally's, so the tool cannot
+# rot into a green that means nothing between merges.
+if ! selftest_out=$(python3 "$ROOT/scripts/check_merge_containment.py" --selftest 2>&1); then
+  echo "$selftest_out" >&2
+  echo "ABORTING: scripts/check_merge_containment.py fails its own self-test," >&2
+  echo "so its 'contained' verdicts cannot be trusted either." >&2
+  exit 2
+fi
+
 mkdir -p "$OUT"
 rm -f "$OUT"/*.log            # a stale log from a previous sweep is not evidence
 

--- a/scripts/run_all_suites.sh
+++ b/scripts/run_all_suites.sh
@@ -150,7 +150,8 @@ fi
 # run it. The CHECK itself is a post-merge act nobody can schedule from here,
 # but its self-test can be gated exactly like the tally's, so the tool cannot
 # rot into a green that means nothing between merges.
-if ! selftest_out=$(python3 "$ROOT/scripts/check_merge_containment.py" --selftest 2>&1); then
+if ! selftest_out=$(cd "$ROOT" && \
+        python3 "$ROOT/scripts/check_merge_containment.py" --selftest 2>&1); then
   echo "$selftest_out" >&2
   echo "ABORTING: scripts/check_merge_containment.py fails its own self-test," >&2
   echo "so its 'contained' verdicts cannot be trusted either." >&2


### PR DESCRIPTION
Closes #88.

## Status

In review at `ee43ff2ba432a9148d6aabec18eb1c72f337b84e`.

## Description

Adds a post-merge containment command and makes the issue-to-merge lane explicit:

- Do not merge while any review round remains outstanding.
- Run the containment check when the branch stops moving.
- Re-run verification on the merge result.
- Check that every observable branch tip is contained in `main-push`.
- Treat a missing measurement or unresolved ref as UNKNOWN, never as success.
- Gate the containment self-test from `scripts/run_all_suites.sh`.
- Treat GitHub `verilator-suites` and `yosys-portability` as optional signals while requiring both equivalent commands locally.

## Correctness properties

- After fetch, divergent local and `origin/<branch>` tips are both checked, including when the caller spells the remote ref explicitly.
- Fetch refreshes every origin branch even when the configured refspec is narrow.
- Shallow history is deepened before evaluation; `--no-fetch` refuses a shallow repository.
- `--merged-prs` checks a same-repository live tip only when its first-parent history continues the frozen merge-time head OID and no post-merge GitHub ref event broke continuity.
- `--merged-prs` requests a bounded complete candidate set, refuses possible truncation, sorts by merge time, and only then selects the requested count.
- Fork heads, deleted or recreated branch names, post-merge force pushes, and discontinuous live tips become UNKNOWN.
- Patch-id equivalence is used only for linear histories because merge patch IDs omit unique resolution content.
- Linear replay evidence uses whitespace-preserving verbatim patch IDs plus exact touched-path postimages, never `git cherry` alone.
- Proof-producing Git comparisons disable external diff drivers, text conversion, and submodule-ignore configuration.
- Git replacement objects are disabled and active legacy graft files are refused.
- Branch and base operands must be exact ref names or full object IDs, never revision expressions; full object IDs remain immutable through fetch normalization.
- Full object IDs remain immutable when same-named local branches and tags exist.
- Explicit `refs/remotes/origin/` operands remain in the namespace refreshed by the origin fetch even when configured remote names overlap that prefix.
- The implicit current branch keeps its `refs/heads/` identity even when its legal name is 40 hexadecimal characters.
- A missing fetched branch or base remains fully qualified, so a same-named tag cannot replace it.
- Offline short names retain branch identity and cannot fall through to same-named tags.
- Configured remote shorthand retains remote identity even when the remote name contains slashes, its tracking ref is missing, or a slash-named local branch collides with it.
- Normal mode keeps an explicit local base origin-qualified after fetch, including when the origin base disappeared.
- Normal mode rejects non-origin remote-tracking refs that its origin-only fetch cannot refresh, including ambiguous shorthand and missing tracking refs.
- Squash detection compares every touched path with rename folding disabled and literal path handling enabled.
- A multi-commit branch with no net tree change is recognized as contained.
- Path enumeration and comparison failures become UNKNOWN.
- A fetched branch whose origin ref disappeared remains UNKNOWN even when a stale local branch exists.
- Repeated or conflicting command-line options are rejected.
- The suite runner invokes the containment self-test from the repository root regardless of caller directory.
- Self-test count relationships use controlled linear history, so the required post-merge run passes when the caller HEAD is a merge commit.

The documented conservative case remains: a multi-commit squash whose touched paths are later edited on the base can report STRANDED. This is a false alarm, not a false pass, and the differing paths are printed.

## Validation

- Candidate base `39d059b4d79ad227ce22b41f6ea081eb629b66a7` is an ancestor of the reviewed head; candidate merge tree `5b1934a0d9e8c6d9cc51c8b6458f042a9a9c72b3` equals the reviewed head tree.
- `python3 scripts/check_merge_containment.py --selftest`: 127 assertions, PASS.
- The same self-test from a synthetic two-parent merge HEAD: PASS.
- `python3 scripts/check_merge_containment.py --merged-prs 20`: 6 live branches contained, rc 0.
- Final-head local `scripts/run_all_suites.sh`: 50 of 50 suites, 2,113,140 checks, 0 failures, 0 timeouts.
- `tsn_fuzz` declared one zero-count field-campaign skip because `tsn-gen` is absent; the suite still reported an accountable result.
- Final-head local `syn/yosys/run.sh`: 44 of 44 tops passed.
- Yosys tied-input gate: PASS, 0 unjustified ties.
- Yosys observer-purity gate: PASS, 0 violations.
- Two independent cleared-context reviews of the exact head: VALIDATED.
- Python bytecode compilation: PASS.
- `bash -n scripts/run_all_suites.sh`: PASS.
- Documentation check: 0 findings across 204 files.
- Documentation paths: 1,086 cited paths resolve.
- Archive gate: PASS.
- TOC gate: PASS.
- Anchor verification: PASS.
- Added documentation contains no em dash.

## Regression coverage

The self-test executes these cases end to end:

- stale local branch behind its fetched remote;
- local branch carrying an unpushed commit beyond its contained remote, including explicit `origin/<branch>` spelling;
- merged PR with a frozen merge-time head OID;
- fork PR, recreated same-name branch, and post-merge ref-event refusal;
- full object IDs colliding with hex-named origin branches, local branches, and tags;
- an implicit 40-hex current branch and deleted branches colliding with tags;
- offline short branch and base names colliding with tags;
- merged PR results returned out of merge-time order and possible candidate truncation;
- revision suffixes on branch and base operands;
- shallow offline refusal and automatic deepening;
- failed ancestry plumbing;
- replacement refs and legacy grafts attempting to rewrite containment ancestry;
- ambiguous short names shared by a branch and tag;
- non-origin remote-tracking branch and base refs that normal mode cannot refresh, including slash-bearing remote names, ambiguous prefixes, and missing tracking refs;
- explicit origin refs colliding with configured slash-bearing remote prefixes;
- failed path enumeration and comparison plumbing;
- multi-commit squash followed by unrelated base advancement;
- multi-commit history with no net tree change;
- rename versus copy with the source path left behind;
- pathspec-shaped filename treated literally;
- linear patch-equivalent rebase followed by a same-path edit;
- whitespace-different patches that `git cherry` incorrectly equates;
- equal verbatim patch IDs applied to different repeated locations;
- textconv and external diff configuration hiding changed blobs;
- submodule-ignore configuration hiding a missing gitlink update;
- deleted remote branch with a stale contained local tip;
- deleted origin base with a stale explicit local base;
- merge commit carrying unique resolution content that `git cherry` omits;
- duplicate and conflicting command-line operands, including repeated `--no-fetch`;
- one-commit count checks isolated from a merge-result caller.

## Definition of done

- [x] The lane states when a PR may be merged.
- [x] The lane contains an exact post-merge command.
- [x] A live branch that advances after merge is detected without reading the review thread.
- [x] The containment self-test is part of the repository sweep.
- [x] Every reproduced false-success path has a committed regression.
- [x] The self-test passes from an ordinary commit and a merge result.
- [x] Fresh review is complete.
- [ ] Merge approval requirements are met.
