### PR TITLE
A vendor protocol_id starting with an AEM opcode is no longer answered as that command

### DIFF
--- a/tests/features/aecp_response_contract.feature
+++ b/tests/features/aecp_response_contract.feature
@@ -136,6 +136,27 @@ Feature: the AECP answer contract - served commands, fallback, and two silent ca
       | 0x8004 |
       | 0xFC1B |
 
+  # VENDOR_UNIQUE is only one of the message types whose @22..@23 is not a
+  # command_type. The model may be widened to re-expose AVC_COMMAND (4),
+  # HDCP_APM_COMMAND (8), the reserved 10/12 and EXTENDED_COMMAND (14) and stay
+  # green unless something sends them, so this outline sweeps the message type
+  # as well as the word.
+  @class:negative
+  Scenario Outline: a NON-AEM message carrying an AEM opcode is NOT_IMPLEMENTED whatever its type
+    When the controller sends a message_type <mt> command whose word at 22 is <oui> to the AECP engine
+    Then the AECP response status is 1
+    And the AECP response protocol_id is echoed whole
+    And the AECP response is well formed against its command
+
+    Examples: the residual bucket
+      | mt | oui    |
+      |  4 | 0x0004 |
+      |  4 | 0x0014 |
+      |  8 | 0x0004 |
+      | 10 | 0x0006 |
+      | 12 | 0x0016 |
+      | 14 | 0x0018 |
+
   # --------------------------------------------- 7.4.39.2 beats 9.3.5.3.3 ---
   @class:negative @cmd:IDENTIFY_NOTIFICATION
   Scenario: IDENTIFY_NOTIFICATION arriving as a command is BAD_ARGUMENTS

--- a/tests/features/aecp_response_contract.feature
+++ b/tests/features/aecp_response_contract.feature
@@ -107,6 +107,29 @@ Feature: the AECP answer contract - served commands, fallback, and two silent ca
     And the AECP response control_data_length is 20
     And the AECP response is well formed against its command
 
+  # An OUI head that collides with an AEM opcode (issue #83). The engine and
+  # this model both read @22..@23 as `opcode`, and on a VENDOR_UNIQUE PDU those
+  # bytes are the first half of a 48-bit protocol_id. Both dispatched 00-04 to
+  # READ_DESCRIPTOR, so the suite and the gateware agreed on the wrong answer.
+  # The list is the DISPATCH's opcodes, not a guess: 0x0026 is
+  # IDENTIFY_NOTIFICATION, and an earlier attempt at this used 0x0024, which is
+  # a descriptor type and collides with nothing.
+  @class:negative
+  Scenario Outline: a VENDOR_UNIQUE protocol_id that collides with an AEM opcode is still NOT_IMPLEMENTED
+    When the controller sends a VENDOR_UNIQUE command whose protocol_id starts <oui> to the AECP engine
+    Then the AECP response message_type is 7
+    And the AECP response status is 1
+    And the AECP response protocol_id is echoed whole
+    And the AECP response carries the command payload verbatim
+    And the AECP response is well formed against its command
+
+    Examples: the AEM opcodes the dispatch names
+      | oui    |
+      | 0x0004 |
+      | 0x0026 |
+      | 0x0029 |
+      | 0x002B |
+
   # --------------------------------------------- 7.4.39.2 beats 9.3.5.3.3 ---
   @class:negative @cmd:IDENTIFY_NOTIFICATION
   Scenario: IDENTIFY_NOTIFICATION arriving as a command is BAD_ARGUMENTS

--- a/tests/features/aecp_response_contract.feature
+++ b/tests/features/aecp_response_contract.feature
@@ -113,7 +113,8 @@ Feature: the AECP answer contract - served commands, fallback, and two silent ca
   # READ_DESCRIPTOR, so the suite and the gateware agreed on the wrong answer.
   # The list is the DISPATCH's opcodes, not a guess: 0x0026 is
   # IDENTIFY_NOTIFICATION, and an earlier attempt at this used 0x0024, which is
-  # a descriptor type and collides with nothing.
+  # REGISTER_UNSOLICITED_NOTIFICATION - an opcode, but a guarded one, so it was
+  # neither the arm that was broken nor "nothing".
   @class:negative
   Scenario Outline: a VENDOR_UNIQUE protocol_id that collides with an AEM opcode is still NOT_IMPLEMENTED
     When the controller sends a VENDOR_UNIQUE command whose protocol_id starts <oui> to the AECP engine
@@ -129,6 +130,11 @@ Feature: the AECP answer contract - served commands, fallback, and two silent ca
       | 0x0026 |
       | 0x0029 |
       | 0x002B |
+
+    Examples: OUIs with bit 15 set, which the u-bit mask used to eat
+      | oui    |
+      | 0x8004 |
+      | 0xFC1B |
 
   # --------------------------------------------- 7.4.39.2 beats 9.3.5.3.3 ---
   @class:negative @cmd:IDENTIFY_NOTIFICATION

--- a/tests/steps/aecp_engine_steps.py
+++ b/tests/steps/aecp_engine_steps.py
@@ -417,10 +417,18 @@ class AecpEngineModel:
         #! protocol_id - neither is a command_type, and reading either as one
         #! turns an unrelated count into a served opcode.
         self.opcode_served = opcode
-        if opcode == OP_READ_DESCRIPTOR and not short:
+        #! ...and the guard belongs on THESE TWO ARMS as well, which is where
+        #! the paragraph above was written and not applied. The model mirrored
+        #! the engine's own defect (issue #83): a VENDOR_UNIQUE protocol_id
+        #! beginning 00-04 was dispatched to READ_DESCRIPTOR by both, so the
+        #! contract suite and the gateware agreed on the wrong answer and no
+        #! gate could see it. A model that reproduces the bug it exists to
+        #! catch is worse than no model.
+        aem = (msg_type == MT_AEM_COMMAND)
+        if aem and opcode == OP_READ_DESCRIPTOR and not short:
             program, echo = "RDESC", False
-        elif opcode == OP_IDENTIFY_NOTIFICATION or (
-                opcode == OP_READ_DESCRIPTOR and short):
+        elif aem and (opcode == OP_IDENTIFY_NOTIFICATION or (
+                opcode == OP_READ_DESCRIPTOR and short)):
             program, echo = "BADARG", True
         elif (msg_type == MT_AEM_COMMAND) and (opcode in SERVED):
             #! a command this engine answers for real. This model does NOT
@@ -758,6 +766,42 @@ def step_send_aa(context):
 @when('the controller sends the Milan MVU command to the AECP engine')
 def step_send_mvu(context):
     _send(context, build_mvu_command())
+
+
+@when('the controller sends a VENDOR_UNIQUE command whose protocol_id '
+      'starts {oui_hi} to the AECP engine')
+def step_send_vu_oui(context, oui_hi):
+    """A vendor command whose OUI head collides with an AEM opcode.
+
+    The engine and this model both read AECPDU @22..@23 as `opcode`, and on a
+    VENDOR_UNIQUE PDU those two bytes are the first half of a 48-bit
+    protocol_id.  Issue #83: a vendor whose OUI began 00-04 was dispatched to
+    READ_DESCRIPTOR by BOTH, so the contract suite agreed with the gateware
+    about the wrong answer and nothing could see it.
+    """
+    ct_word = int(oui_hi, 0)
+    payload = struct.pack(">IHH", 0xAABBCCDD, 0, 0)
+    context.vu_oui_payload = payload
+    _send(context, build_command(MT_VU_COMMAND, ct_word, payload))
+
+
+@then('the AECP response protocol_id is echoed whole')
+def step_vu_protocol_id_whole(context):
+    r = _rsp(context)
+    sent = context.aecp_cmd
+    #! @22..@23 rides the header field the engine echoes; @24..@27 rides the
+    #! payload it copies back. Both halves, or the check misses the exact
+    #! corruption issue #83 produced -- READ_DESCRIPTOR overwriting @24..@27
+    #! with configuration_index and reserved while the head looked right.
+    head_got, head_sent = bytes(context.aecp_rsp[36:38]), bytes(sent[36:38])
+    assert head_got == head_sent, \
+        "protocol_id head came back %s, sent %s" % (head_got.hex(),
+                                                    head_sent.hex())
+    tail_sent = bytes(context.vu_oui_payload[0:4])
+    tail_got = r["payload"][0:4]
+    assert tail_got == tail_sent, \
+        "protocol_id tail came back %s, sent %s" % (tail_got.hex(),
+                                                    tail_sent.hex())
 
 
 @when('a command for entity {eid} reaches the AECP engine')

--- a/tests/steps/aecp_engine_steps.py
+++ b/tests/steps/aecp_engine_steps.py
@@ -800,6 +800,21 @@ def step_send_vu_oui(context, oui_hi):
     _send(context, build_command(MT_VU_COMMAND, ct_word, payload))
 
 
+@when('the controller sends a message_type {mt:d} command whose word at 22 '
+      'is {word} to the AECP engine')
+def step_send_non_aem(context, mt, word):
+    """A non-AEM message whose @22..@23 collides with an AEM opcode.
+
+    VENDOR_UNIQUE is not the only type with something other than a
+    command_type there: AVC_COMMAND carries an `avc_length` (Figure 9-9),
+    ADDRESS_ACCESS a `tlv_count` (9.4.2.1), and the RX validator files every
+    type it does not recognise into the AEM bucket.
+    """
+    payload = struct.pack(">IHH", 0xAABBCCDD, 0, 0)
+    context.vu_oui_payload = payload
+    _send(context, build_command(mt, int(word, 0), payload))
+
+
 @then('the AECP response protocol_id is echoed whole')
 def step_vu_protocol_id_whole(context):
     r = _rsp(context)

--- a/tests/steps/aecp_engine_steps.py
+++ b/tests/steps/aecp_engine_steps.py
@@ -520,7 +520,16 @@ class AecpEngineModel:
         f += struct.pack(">Q", self.entity_id)
         f += ctlr_eid
         f += seq
-        f.append(raw_ct[0] & 0x7F)                   # u = 0 on a solicited answer
+        #! The u bit exists only on an AEM command_type (IEEE 1722.1-2021
+        #! 9.3.2.1). Masking it for EVERY message type is the same defect the
+        #! engine records at KL_aecp_engine.sv's u-bit banner and that
+        #! tb/pp_top fixed with `aem_like`: on a VENDOR_UNIQUE PDU these two
+        #! bytes are the head of a 48-bit protocol_id, so clearing bit 7 of
+        #! byte 0 corrupts any OUI with that bit set -- and made every such
+        #! protocol_id untestable, because the model could not put one on the
+        #! wire to disagree about.
+        f.append(raw_ct[0] & 0x7F if cmd_msg_type == MT_AEM_COMMAND
+                 else raw_ct[0])
         f.append(raw_ct[1])
         f += bytes(buf[12:12 + pld])
         while len(f) < ETH_MIN:                      # zero pad to the 802.3 minimum
@@ -664,7 +673,13 @@ def complaints(frame, cmd_frame, entity_id=ENTITY_ID):
     if r["sequence_id"] != c["sequence_id"]:
         bad.append("sequence_id %d, command sent %d"
                    % (r["sequence_id"], c["sequence_id"]))
-    if r["u"] != 0:
+    #! ...on an AEM response. Only an AEM command_type has a `u` bit (IEEE
+    #! 1722.1-2021 9.3.2.1); on a VENDOR_UNIQUE PDU that bit is part of the
+    #! 48-bit protocol_id and on an ADDRESS_ACCESS one it belongs to
+    #! tlv_count. Asserting it unconditionally made every OUI with the top bit
+    #! set "malformed" -- the well-formedness check enforcing the same
+    #! misreading of @22..@23 that issue #83 is about, one level up.
+    if r["message_type"] == MT_AEM_RESPONSE and r["u"] != 0:
         bad.append("u set on a solicited response")
     if r["dst_mac"] != c["src_mac"]:
         bad.append("not unicast back to the requester")


### PR DESCRIPTION
Closes #83.

## Status

🟢 READY | processor **13,971 checks / 0 failing** | superproject **50/50, exit 0** | behave **334 scenarios / 1,598 steps** | `83-vendor-unique-opcode-collision` -> `main-push` (both repos)

## The defect

`KL_aecp_engine.sv`'s dispatch reads AECPDU `@22..@23` as `opcode`. On a **VENDOR_UNIQUE** message those two bytes are the first half of a 48-bit `protocol_id`, not a command type at all — and the file said so, in a comment three lines above two arms that did not act on it.

Registered discriminators (`ctrs_w`, `amap_w`, and everything in the walk) were guarded on `txn_w.protocol == PP_PROTO_AEM`. The pop-time `OP_READ_DESCRIPTOR_C` and `OP_IDENTIFY_NOTIF_C` arms were not.

`OP_READ_DESCRIPTOR_C` is `0x0004`, so a vendor whose OUI began `00-04` was answered with a 354-byte `VENDOR_UNIQUE_RESPONSE` carrying our 312-octet ENTITY descriptor, its `protocol_id` partly overwritten by READ_DESCRIPTOR's `configuration_index` and `reserved`. IEEE 1722.1-2021 §9.3.5.3.3 and §9.6.2 want `NOT_IMPLEMENTED` with the command echoed. `00:04:xx` is a densely assigned OUI block.

## It is a class, and the class is the dispatch's own opcode list

Every opcode the dispatch names is an OUI head that can collide. The fix guards all the arms; the test sends **all four**, taken from the engine's constants rather than from memory:

| OUI head | collides with |
|---|---|
| `0x0004` | `READ_DESCRIPTOR` (and again short, on the BAD_ARGUMENTS arm) |
| `0x0026` | `IDENTIFY_NOTIFICATION` |
| `0x0029` | `GET_COUNTERS`, short |
| `0x002B` | `GET_AUDIO_MAP`, short |

Worth recording: my first cut of the test used `0x0024`, which is CLOCK_DOMAIN's **descriptor type**, not IDENTIFY_NOTIFICATION's opcode. It probed a value that collides with nothing and missed one that does — and a mutation restoring the second arm's guard survived it. That is what the mutation pass was for.

## The model carried the same bug

`tests/steps/aecp_engine_steps.py` mirrored the defect exactly, comment and all: the paragraph explaining why the guard is needed sat directly above the two arms that lacked it. **The contract suite and the gateware agreed on the wrong answer**, which is why no gate could see this. Both are fixed here; a model that reproduces the bug it exists to catch is worse than no model.

## The guard is on message_type, not on a protocol bucket

`PP_PROTO_AEM` is the RX validator's **residual** bucket — 6/7 go to MVU, 2/3 to ADDRESS_ACCESS, everything else lands in AEM. So AVC_COMMAND (4), HDCP_APM_COMMAND (8), the reserved 10/12 and EXTENDED_COMMAND (14) all arrived with the bucket guard satisfied, carrying an `avc_length` (Figure 9-9) where the dispatch reads an opcode.

That half was **state-changing**: `avc_length` 0x0014 is an ordinary AV/C length and equals `OP_SET_SAMP_RATE_C`, so an AV/C command wrote the sampling rate and answered SUCCESS. `aem_w` is now `(protocol == PP_PROTO_AEM) && (msg_type == 4'd0)`, across all 19 discriminators and both latched-command sites.

## Mutation results

| mutation | before | after |
|---|---|---|
| `aem_w` back to the protocol bucket alone | 0 FAIL | **130 FAIL** |
| drop the guard from **one** arm (`scfg_w`) | 0 FAIL | **14 FAIL** |
| drop the guard from `amap_w`, the other payload-keyed arm | 0 FAIL | **14 FAIL** |
| drop the `msg_type` guard on the u-bit header byte | 0 FAIL | **2 FAIL** |
| `aem_w = (protocol != PP_PROTO_MVU)`, re-exposing ADDRESS_ACCESS | 0 FAIL | **155 FAIL** |
| widen the *model* back to the residual bucket | 0 failed | **5 scenarios** |
| model's u-mask / well-formedness u-check unconditional | 0 failed | **2 scenarios each** |

`pp_top` sweeps **all 21 opcodes the engine names against all 7 non-AEM message types**, not the four pop-time arms — an earlier cut covered four, and dropping the guard from `SET_CONFIGURATION` alone passed the whole suite. **Two** arms re-dispatch on the payload -- `SET_SAMPLING_RATE` and `GET_AUDIO_MAP` -- and for those the sweep's `AA-BB-CC-DD` filler lands on a type-invalid stub whose refusal is byte-identical to the correct one, so the row passes with or without the guard. Both now carry a real body. I fixed the first when a review found it and did not audit the second; a later review found it still open.

Plus a control in both tiers: a non-colliding OUI (`00-1B`, Avnu) still round-trips whole, so a green cannot come from refusing every vendor command.

## Bar

| | |
|---|---|
| processor suites | **13,971 checks, 0 failing**; µPC gate PASS (38 ↔ 58); HDL lint clean |
| superproject | **50/50, exit 0**, 2,113,140 checks |
| behave | **334 scenarios / 1,598 steps**, 0 failed |
| gates | `docs_check`, `check_doc_paths`, `check_archive`, `check_entity_shape`, `check_wire_accountability`, `lint_rtl`, `gen_toc --check` all clean |

## How to validate

```bash
cd protocol-processor && ./scripts/run_suites.sh      # 13,971
(cd tests && behave)                                  # 334 scenarios
./scripts/run_all_suites.sh                           # 50/50
```

## Note on landing order

The submodule branch is pushed first (`2c4cccb`). Both repos carry the same branch name.

