### PR TITLE
Docs follow-up: the roadmap and the audit describe the gateware that shipped

### DIFF
--- a/docs/MILAN_V12_ROADMAP.md
+++ b/docs/MILAN_V12_ROADMAP.md
@@ -38,7 +38,7 @@ leaves the clause open.
 
 ### 0.1 Served for real, today
 
-**Twenty-one** AEM opcodes plus one MVU command. The authority is
+**Twenty-three** AEM opcodes plus one MVU command. The authority is
 `protocol-processor/hdl/aecp/KL_aecp_engine.sv`'s `OP_*_C` constants, and
 `tests/steps/aecp_engine_steps.py`'s `SERVED` table is gated against that list
 by a behave step that parses the RTL — so this section cannot silently rot
@@ -82,6 +82,8 @@ underneath it.
 | `0x0017` | GET_CLOCK_SOURCE | 5.4.2.16 | **0x004B** |
 | `0x0018` | SET_CONTROL (IDENTIFY) | 5.4.2.17 | **0x004C** |
 | `0x0019` | GET_CONTROL (IDENTIFY) | 5.4.2.18 | **0x004C** |
+| `0x0022` | START_STREAMING | 5.4.2.19 | 0x004F |
+| `0x0023` | STOP_STREAMING | 5.4.2.20 | 0x004F |
 | `0x0024` | REGISTER_UNSOLICITED_NOTIFICATION | 5.4.2.21 | 0x0045 |
 | `0x0025` | DEREGISTER_UNSOLICITED_NOTIFICATION | 5.4.2.22 | 0x0045 |
 | `0x0026` | IDENTIFY_NOTIFICATION as a command → `BAD_ARGUMENTS` | IEEE 7.4.39.2 | 0x0042 |
@@ -153,7 +155,7 @@ kept in §P2.1 below, because they still govern every command that has not
 landed yet.
 
 **What it does not yet do is reach its consumers.** The dynamic store holds
-eight fields. The fields served through AECP and those published to the fabric
+seven fields (selector 6, started/stopped, is retired - see below). The fields served through AECP and those published to the fabric
 are different sets:
 
 | field | a microprogram reads or writes it | it has an output port |
@@ -163,11 +165,14 @@ are different sets:
 | IDENTIFY | yes | yes |
 | `current_sampling_rate` | yes | **no** |
 | presentation-time offset | **no** | yes |
-| started or stopped | **no** (withdrawn, #78) | yes, permanently zero |
 | `current_format`, Stream Inputs | **no** | **no** |
 | `current_format`, Stream Outputs | **no** | **no** |
 
-Five fields have an output, and all five are read by nothing downstream. The
+Four fields have an output, and all four are read by nothing downstream. (A
+fifth, started/stopped, USED to sit here with an output nothing read. It is
+no longer in this store: issue #78 retired selector 6 and moved the state to
+the ACMP binding record, where `milan_datapath` gates the listener accept
+pulse on it - so that one is now both sourced and consumed.) The
 media clock still uses its compile-time select, so `SET_CLOCK_SOURCE` stores a
 value the servo does not act on. `current_sampling_rate` is the one field a
 controller can move that the fabric cannot see. Aligning the audio grid to it

--- a/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
+++ b/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
@@ -69,20 +69,27 @@ The pinned processor currently dispatches or serves `READ_DESCRIPTOR`,
 `GET_COUNTERS`, `GET_AUDIO_MAP`, the unsolicited registration pair, and Milan
 `GET_MILAN_INFO`.
 
-This inventory describes command handling, not end-to-end effect. In
-particular, B12 records that START/STOP is unimplemented, so no AECP Stream
-Input started state reaches the root wrapper or controls the media plane.
+This inventory describes command handling, not end-to-end effect. As audited on
+2026-08-16, B12 recorded that START/STOP was unimplemented, so no AECP Stream
+Input started state reached the root wrapper or controlled the media plane.
+
+> **SUPERSEDED 2026-08-18 (issue #78, VERSION `0x004F`).** `START_STREAMING`
+> (0x0022) and `STOP_STREAMING` (0x0023) are served, and the started state now
+> does control the media plane: a stopped Stream Input's frames are dropped at
+> the listener accept pulse while it goes on receiving, matching and counting.
+> The paragraph below is the 08-16 record of the withdrawal; see B12 for the
+> resolution and for the one shall of Section 5.3.8.7 that remains open.
 
 The following mandatory surface still falls through to an unimplemented echo
 or otherwise lacks the required behavior:
 
-`START_STREAMING` and `STOP_STREAMING` (Milan 5.4.2.19 / 5.4.2.20) belong in
-this list and are called out here because an earlier revision of this document
-placed them in the list above. They were implemented and then **withdrawn**
-before merge: started/stopped already has a home in the ACMP binding record,
-which clears on unbind and is persisted, and a second copy in the AECP dynamic
-store would be neither. The work is preserved on branch
-`78-start-stop-streaming` pending that decision.
+`START_STREAMING` and `STOP_STREAMING` (Milan 5.4.2.19 / 5.4.2.20) belonged in
+this list at the time of the audit, and were called out here because an earlier
+revision of this document placed them in the list above. They had been
+implemented and then **withdrawn** before merge: started/stopped already had a
+home in the ACMP binding record, which clears on unbind and is persisted, and a
+second copy in the AECP dynamic store would be neither. That decision was
+settled in favour of the record — see the SUPERSEDED note above.
 
 - `SET_STREAM_FORMAT`
 - `SET_STREAM_INFO`


### PR DESCRIPTION
Round 6 of #92's review found three live-document claims that survived the merge. #92 is already in `main-push` (`56ee1e0f`), so these land as a follow-up. Documentation only — no RTL, no tests.

1. `docs/MILAN_V12_ROADMAP.md:41` claimed **twenty-one** served AEM opcodes and named `KL_aecp_engine.sv`'s `OP_*_C` constants and the behave `SERVED` inventory as the authorities that stop it rotting. Both authorities now say **twenty-three**, and the count was verified against each. The Section 0.1 served table was also missing `0x0022`/`0x0023` while line 316 of the same file marked them LANDED.

2. Same file, the dynamic-store section still described **eight** fields including a `started or stopped` row marked "withdrawn, #78" with an output "permanently zero". Selector 6 is retired and `strm_started_o` was deleted from `KL_aecp_dyn_state.sv`, so the store holds **seven** and that row has no subject. The "five fields have an output, read by nothing downstream" sentence is now four, with the fifth called out as the one that is both sourced and consumed.

3. `docs/testing/MILAN_V12_AUDIT_2026-08-16.md` B1 contradicted B12 in the same file: B12 carries the RESOLVED annotation, B1 still listed these opcodes under "still falls through to an unimplemented echo" and pointed readers at an abandoned branch. The README sends readers to this audit for "the exact evidence and remaining gaps". B1 now carries a SUPERSEDED note and the 08-16 paragraph is preserved in past tense as the record.

A sweep of every live (non-obsolete-bannered) markdown file in both repos finds no remaining claim that these opcodes are unimplemented. The two hits that remain are the dated B1/B12 findings themselves, each with its correction directly adjacent — which is how this repo treats a dated audit.

Gates: behave 340 scenarios; docs_check, check_doc_paths, check_archive, check_entity_shape, check_wire_accountability all PASS.