### PR TITLE
Adopt dev as development branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,10 @@ flowchart LR
    validated, with the gate results. The findings, the mutation tables and the
    clause arguments belong in the review itself and in the commit messages —
    a PR thread that reprints them is a PR thread nobody reads to the end.
+
+   **Prefix every PR message with the role.** Start every PR body and comment
+   with `[A]` when writing as the PR author, or `[R]` when writing as a
+   reviewer. The prefix states which responsibility the message represents.
 6. **Merge back into `dev`** only once the findings are answered, and
    **not while a review round is in flight.** A round that has not reported is
    a round outstanding; merging past it is merging unreviewed code with a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,10 @@ lane-per-worktree, every change grows the test suite, and nothing merges on
 
 ## Contents
 
-- **[1. HDL house style (Cemal Dogan / Oguz Kahraman school)](#1-hdl-house-style-cemal-dogan--oguz-kahraman-school)** — The naming, reset and banner conventions a new `.sv` file must follow, ending in the CDC rule that cost us the 07-24 link-guard deadlock: clock-liveness observers must be `reset_less`.
-- **[2. Workflow](#2-workflow)** — The issue-to-merge lane: an issue moves to *In progress*, a branch is cut **from the issue**, the work lands on it, a PR opens, review runs as **multiple agents with cleared context**, and only then does it merge back to `main-push`. Plus one lane = one worktree, one-line commits, and two traps with history: `cp -r` (never symlink) `third_party/` into a worktree, and rebuild `LAYOUTS` merges semantically rather than by marker-union.
-- **[3. Verification bar](#3-verification-bar)** — What a change owes before it merges: a self-checking Verilator harness under `tb/verilator/<name>/`, a ratcheted `scripts/lint_rtl.py --check` that fails on any new lint violation, a justification for every `lint_off`, a matrix row that only turns ✅ with a runnable test, and timing claims quoted with the full cell recipe rather than a bare WNS.
-- **[4. Bench discipline (the expensive lessons)](#4-bench-discipline-the-expensive-lessons)** — Four rules paid for on hardware: ≥ 8 min AX boot probes, never resume a frozen PCM ring, dump a QSPI slot before overwriting it, and regenerate the DTB from `csr.csv` on any gateware block-set change.
+- **[1. HDL house style (Cemal Dogan / Oguz Kahraman school)](#1-hdl-house-style-cemal-dogan--oguz-kahraman-school)** -- The naming, reset and banner conventions a new `.sv` file must follow, ending in the CDC rule that cost us the 07-24 link-guard deadlock: clock-liveness observers must be `reset_less`.
+- **[2. Workflow](#2-workflow)** -- The issue-to-merge lane: an issue moves to *In progress*, a branch is cut **from the issue**, the work lands on it, a PR opens, review runs as **multiple agents with cleared context**, and only then does it merge back to `dev`. Plus one lane = one worktree, one-line commits, and two traps with history: `cp -r` (never symlink) `third_party/` into a worktree, and rebuild `LAYOUTS` merges semantically rather than by marker-union.
+- **[3. Verification bar](#3-verification-bar)** -- What a change owes before it merges: a self-checking Verilator harness under `tb/verilator/<name>/`, a ratcheted `scripts/lint_rtl.py --check` that fails on any new lint violation, a justification for every `lint_off`, a matrix row that only turns ✅ with a runnable test, and timing claims quoted with the full cell recipe rather than a bare WNS.
+- **[4. Bench discipline (the expensive lessons)](#4-bench-discipline-the-expensive-lessons)** -- Four rules paid for on hardware: ≥ 8 min AX boot probes, never resume a frozen PCM ring, dump a QSPI slot before overwriting it, and regenerate the DTB from `csr.csv` on any gateware block-set change.
 
 ## 1. HDL house style (Cemal Dogan / Oguz Kahraman school)
 
@@ -50,7 +50,7 @@ flowchart LR
     W -->|fixed| RV
     RV -->|2 positive:<br/>1 own + 1 EXTERNAL| G[validate candidate merge result<br/>with the FULL local bar]
     G -->|regression| W
-    G -->|clean| M[merge to main-push]
+    G -->|clean| M[merge to dev]
     M --> C[branch stops moving<br/>run containment]
     C -->|finding| F[follow-up issue + PR]
     C -->|clean| D[close issue manually<br/>Done]
@@ -61,13 +61,13 @@ flowchart LR
    how two lanes collide — which has happened: the dynamic-state store was
    built twice on 2026-08-16 because the issue was filed after the work
    started.
-2. **Cut the branch from the issue**: `gh issue develop <N> --base main-push`.
-   This links the branch and issue on GitHub. Because `main-push` is not the
+2. **Cut the branch from the issue**: `gh issue develop <N> --base dev`.
+   This links the branch and issue on GitHub. Because `dev` is not the
    repository's default branch, merging its PR does not auto-close the issue.
    Close the issue manually only after the post-merge containment check passes.
 3. **Do the work on that branch**, with the §3 verification bar met *on the
    branch* — a PR is not the place to discover the sweep is red.
-4. **Open the PR** against `main-push`, with the template below and the
+4. **Open the PR** against `dev`, with the template below and the
    self-test results as a **comment** (a comment is evidence, not approval).
 5. **Review with multiple agents, each with CLEARED context.** Not forks of
    the authoring session: agents that have never seen the reasoning that
@@ -90,7 +90,7 @@ flowchart LR
    validated, with the gate results. The findings, the mutation tables and the
    clause arguments belong in the review itself and in the commit messages —
    a PR thread that reprints them is a PR thread nobody reads to the end.
-6. **Merge back into `main-push`** only once the findings are answered, and
+6. **Merge back into `dev`** only once the findings are answered, and
    **not while a review round is in flight.** A round that has not reported is
    a round outstanding; merging past it is merging unreviewed code with a
    review thread attached.
@@ -114,7 +114,7 @@ flowchart LR
 7. **Validate the candidate merge result, then prove containment.** A merge is
    a change nobody wrote and nobody reviewed, and *"Merge made by the 'ort'
    strategy"* is not evidence of anything. Before pressing merge, construct a
-   candidate from the latest `origin/main-push` and the reviewed PR head, then
+   candidate from the latest `origin/dev` and the reviewed PR head, then
    gate that tree exactly as §3 gates a hand-written one: full Verilator sweep,
    both repos' suites, behave, the lint ratchet, and Yosys. If the reviewed head
    directly descends from the unchanged base, its tree is the candidate merge
@@ -156,9 +156,9 @@ flowchart LR
    Its `--selftest` runs inside `scripts/run_all_suites.sh` next to
    `suite_tally.py`'s, so the tool cannot rot into a green that means nothing
    between merges. The check *itself* is still a thing a person runs: nothing
-   here can schedule a post-merge action, and CI does not run on `main-push`
+   here can schedule a post-merge action, and CI does not run on `dev`
    at all (both workflows are `on: push: branches: [main]`). That gap is worth
-   closing separately. A `push: [main-push]` trigger would run the bar and the
+   closing separately. A `push: [dev]` trigger would run the bar and the
    containment self-test on the merge result. It would still need an explicit
    `check_merge_containment.py --merged-prs` step to render a live containment
    verdict.

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -749,6 +749,15 @@ def selftest():
             case("e2e-stranded-word", "STRANDED" in out, True,
                  "...and says STRANDED")
 
+            #! Exercise main() without --base. origin/dev contains work while
+            #! the retired name stops at base, so changing the production
+            #! default path back to that name makes this case fail.
+            _git("update-ref", "refs/remotes/origin/dev", "work")
+            _git("update-ref", "refs/remotes/origin/main-push", "base")
+            rc, out = run(["--no-fetch", "work"])
+            case("default-base-e2e", rc, RC_OK,
+                 "the implicit CLI base is origin/dev")
+
             rc, base_oid = _git("rev-parse", "base")
             _git("checkout", "-qb", base_oid, "work")
             rc2, out = run(["--no-fetch", "--base", "base"])

--- a/scripts/check_merge_containment.py
+++ b/scripts/check_merge_containment.py
@@ -69,6 +69,7 @@ USAGE = __doc__.split("WHY THIS EXISTS")[0].strip()
 
 #! rc 0 contained · rc 1 something is stranded or unknown · rc 2 cannot run
 RC_OK, RC_FINDING, RC_CANNOT_RUN = 0, 1, 2
+DEFAULT_BASE = "origin/dev"
 RAW_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv",
                   "--ignore-submodules=none")
 
@@ -578,7 +579,7 @@ def merged_pr_heads(limit, base):
     """
     import json
     #! gh wants a branch NAME; `base` is a git ref and usually carries the
-    #! remote. Passing "origin/main-push" here silently matched nothing, so the
+    #! remote. Passing "origin/dev" here silently matched nothing, so the
     #! sweep printed an empty list and exited 0 -- a pass by vacancy.
     if base.startswith("refs/remotes/origin/"):
         base_name = base[len("refs/remotes/origin/"):]
@@ -658,6 +659,9 @@ def selftest():
         if not ok:
             bad += 1
             print(f"       got {got!r}, expected {want!r}")
+
+    case("default-development-base", DEFAULT_BASE, "origin/dev",
+         "the retired development branch name cannot return silently")
 
     rc, head = _git("rev-parse", "HEAD")
     if rc != 0:
@@ -1628,7 +1632,7 @@ def main(argv):
             return RC_CANNOT_RUN
         return selftest()
 
-    base = "origin/main-push"
+    base = DEFAULT_BASE
     if "--base" in args:
         i = args.index("--base")
         if i + 1 >= len(args) or args[i + 1].startswith("-"):


### PR DESCRIPTION
[A0]

## Summary

- updates active contribution workflow references from `main-push` to `dev`
- makes `origin/dev` the merge-containment checker's default base
- adds a self-test assertion for the development branch default
- preserves historical and explicitly obsolete records unchanged
- documents the [A] author and [R] reviewer message prefixes
- updates open issue #97 to reference `dev`

## Validation

- merge-containment self-test: pass
- PR #95 reviewed head containment in `origin/dev`: pass
- documentation check: 0 findings across 204 Markdown files
- path, archive, anchor, and TOC gates: pass
- Python compilation and `git diff --check`: pass
- added documentation lines containing em dashes: 0
- remote `dev`: `687b25be3e6ecf8a7172851f3502c1c0f6f32ea3`
- retired remote branch ref: absent

Closes #99
