### PR TITLE
Index PR author and reviewer roles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,11 +91,11 @@ flowchart LR
    clause arguments belong in the review itself and in the commit messages —
    a PR thread that reprints them is a PR thread nobody reads to the end.
 
-   **Prefix every PR message with the role.** Start every PR body and comment
-   with `[A0]` when writing as the primary PR author, or `[R0]` when writing as
-   the primary reviewer. Additional participants increment the number within
-   their role in order of first participation, such as `[A1]` or `[R1]`. The
-   prefix states which responsibility and participant the message represents.
+   **Prefix every PR message with the role.** Session 0 starts every PR body
+   and comment with `[A0]` when authoring, or `[R0]` when reviewing. Every other
+   session replaces `0` with its assigned session number and keeps that number
+   when its role changes. The prefix states which responsibility and session
+   the message represents.
 6. **Merge back into `dev`** only once the findings are answered, and
    **not while a review round is in flight.** A round that has not reported is
    a round outstanding; merging past it is merging unreviewed code with a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,10 @@ flowchart LR
    a PR thread that reprints them is a PR thread nobody reads to the end.
 
    **Prefix every PR message with the role.** Start every PR body and comment
-   with `[A]` when writing as the PR author, or `[R]` when writing as a
-   reviewer. The prefix states which responsibility the message represents.
+   with `[A0]` when writing as the primary PR author, or `[R0]` when writing as
+   the primary reviewer. Additional participants increment the number within
+   their role in order of first participation, such as `[A1]` or `[R1]`. The
+   prefix states which responsibility and participant the message represents.
 6. **Merge back into `dev`** only once the findings are answered, and
    **not while a review round is in flight.** A round that has not reported is
    a round outstanding; merging past it is merging unreviewed code with a


### PR DESCRIPTION
[A0]

## Summary

- defines `[A0]` as session 0 author prefix
- defines `[R0]` as session 0 reviewer prefix
- keeps the assigned session number stable across role changes
- corrects PR #100's body and author validation comment to `[A0]`

## Validation

- documentation check: 0 findings across 204 Markdown files
- path, archive, anchor, and TOC gates: pass
- `git diff --check`: pass
- added documentation lines containing em dashes: 0
- no unindexed `[A]` or `[R]` prefix remains in active contribution guidance

Closes #101
