### PR TITLE
The gPTP plane re-pins onto the real counter (issue #110, round 3a)

### DIFF
--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Fetch the RTL submodules
-        run: git submodule update --init third_party/verilog-axis protocol-processor
+        run: git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
 
       - name: Cache the pinned Verilator build
         id: cache-verilator

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/Mister-M-alt/protocol-processor-control-plane-avb-milan.git
 [submodule "gptp-processor"]
 	path = gptp-processor
-	url = git@github.com:Mister-M-alt/FPGA-gPTP.git
+	url = https://github.com/Mister-M-alt/FPGA-gPTP.git

--- a/docs/traceability/MODULE_MATRIX.md
+++ b/docs/traceability/MODULE_MATRIX.md
@@ -130,7 +130,7 @@ _gPTP timestamping / pdelay / sync_
 | ✅ `ptp_csr_sync` | `ieee8021as/ptp_timestamp/ptp_csr_sync.sv` | `hostplane` · `milan_dp` · `ptp_sync` · `ptp_ts` | — |
 | ✅ `ptp_ts_core` | `ieee8021as/ptp_timestamp/ptp_ts_core.sv` | `hostplane` · `milan_dp` · `ptp_ts` | — |
 | ✅ `ptp_ts_top` | `ieee8021as/ptp_timestamp/ptp_ts_top.sv` | `hostplane` · `milan_dp` · `ptp_ts` | — |
-| ✅ `timestamp_counter` | `ieee8021as/ptp_timestamp/timestamp_counter.sv` | `hostplane` · `milan_dp` · `ptp` · `ptp_ts` | — |
+| ✅ `timestamp_counter` | `ieee8021as/ptp_timestamp/timestamp_counter.sv` | `gptp_plane` · `hostplane` · `milan_dp` · `ptp` · `ptp_ts` | — |
 
 ## Common / integration
 

--- a/hdl/ieee8021as/ptp_timestamp/README-tests.md
+++ b/hdl/ieee8021as/ptp_timestamp/README-tests.md
@@ -14,5 +14,5 @@ hand-edit. Part of the IEEE 802.1AS family; rolled up in
 | ✅ `ptp_csr_sync` | `ptp_csr_sync.sv` | `hostplane` · `milan_dp` · `ptp_sync` · `ptp_ts` | — |
 | ✅ `ptp_ts_core` | `ptp_ts_core.sv` | `hostplane` · `milan_dp` · `ptp_ts` | — |
 | ✅ `ptp_ts_top` | `ptp_ts_top.sv` | `hostplane` · `milan_dp` · `ptp_ts` | — |
-| ✅ `timestamp_counter` | `timestamp_counter.sv` | `hostplane` · `milan_dp` · `ptp` · `ptp_ts` | — |
+| ✅ `timestamp_counter` | `timestamp_counter.sv` | `gptp_plane` · `hostplane` · `milan_dp` · `ptp` · `ptp_ts` | — |
 

--- a/tb/verilator/gptp_plane/.gitignore
+++ b/tb/verilator/gptp_plane/.gitignore
@@ -1,0 +1,2 @@
+gptp_ucode.hex
+obj_dir/

--- a/tb/verilator/gptp_plane/Makefile
+++ b/tb/verilator/gptp_plane/Makefile
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+VERILATOR ?= verilator
+RTL_DIR    = ../../../hdl
+GPTP_DIR   = ../../../gptp-processor
+TOP        = gptp_plane_wrap
+VFLAGS = --cc --exe --build -j 0 \
+         --top-module $(TOP) \
+         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL \
+         -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM \
+         -GUCODE_HEX_P='"gptp_ucode.hex"' -GCLK_HZ_P=2000000 \
+         -CFLAGS "-std=c++17 -O2 -I$(CURDIR)"
+SRCS = gptp_plane_wrap.sv \
+       $(RTL_DIR)/ieee8021as/ptp_timestamp/timestamp_counter.sv \
+       $(GPTP_DIR)/hdl/ucpu/gptp_ucpu_pkg.sv \
+       $(GPTP_DIR)/hdl/ucpu/KL_gptp_ucpu.sv \
+       $(GPTP_DIR)/hdl/wire/KL_gptp_rx_parser.sv \
+       $(GPTP_DIR)/hdl/wire/KL_gptp_tx_slot.sv \
+       $(GPTP_DIR)/hdl/common/KL_gptp_timer.sv \
+       $(GPTP_DIR)/hdl/top/KL_gptp_engine.sv
+CPP  = sim_main.cpp
+
+run: gptp_ucode.hex
+	$(VERILATOR) $(VFLAGS) $(SRCS) $(CPP) -o Vgptp_plane_sim
+	./obj_dir/Vgptp_plane_sim
+
+gptp_ucode.hex: $(GPTP_DIR)/hdl/ucode/gen_gptp_ucode.py
+	python3 $< --clk-hz 2000000 -o $@
+
+clean:
+	rm -rf obj_dir gptp_ucode.hex

--- a/tb/verilator/gptp_plane/README.md
+++ b/tb/verilator/gptp_plane/README.md
@@ -21,6 +21,13 @@ What it proves:
 | 3 | a better announce is adopted; the publish bank carries the GM identity and role flags |
 | 4 | closed loop vs a +100 ppm master 1 ms ahead in counter time: ONE adjtime re-base near +1 ms (the correction negates the offset), the latched adjfine level lands at the +100 ppm ideal (13,421 Q8.24 units, within 15%), the measured offset locks under 150 ns, and the REAL counter's advance tracks the master's within 100 ns over the last four sync intervals |
 
+Known blind spot, on purpose: `phc_ns_i` (the engine's live-clock
+snapshot input) is dispatch metadata in the current µcode -- no handler
+consumes it yet -- so a mis-wire of that one input is invisible to these
+checks. The loop closes through the ingress/egress timestamps. Its first
+functional consumer is a donor-side µcode revision; the splice round
+carries the observing check.
+
 Timescale note: the bench clock is 2 MHz while the counter keeps its
 8.0 ns/tick shape, so counter time runs 62.5x slower than the bench
 timer's millisecond. That is deliberate and self-consistent -- the

--- a/tb/verilator/gptp_plane/README.md
+++ b/tb/verilator/gptp_plane/README.md
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: CERN-OHL-W-2.0 -->
+# gptp_plane -- the time-sync plane against the real PHC
+
+Integration bench for issue #110: the `gptp-processor` submodule's
+`KL_gptp_engine` married to the PARENT's real
+`hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv` -- the exact pairing
+the datapath splice will instantiate, proven closed-loop before any
+fabric is committed. The donor repo's own engine suite proves the
+802.1AS protocol details against a MODEL of the counter; here the model
+is replaced by the counter itself (Q8.24 accumulator, 8.0 ns increment,
+the 125 MHz shape), and the wrap carries the one piece of fabric the
+splice adds beyond wires: the adjfine latch (the engine pulses an
+addend, the counter wants a level).
+
+What it proves:
+
+| phase | claim |
+|---|---|
+| 1 | the plane boots beside the ticking counter; one pdelay exchange measures 600 ns and does not raise asCapable |
+| 2 | a live auto-answering peer raises asCapable at the second exchange |
+| 3 | a better announce is adopted; the publish bank carries the GM identity and role flags |
+| 4 | closed loop vs a +100 ppm master 1 ms ahead in counter time: ONE adjtime re-base near +1 ms (the correction negates the offset), the latched adjfine level lands at the +100 ppm ideal (13,421 Q8.24 units, within 15%), the measured offset locks under 150 ns, and the REAL counter's advance tracks the master's within 100 ns over the last four sync intervals |
+
+Timescale note: the bench clock is 2 MHz while the counter keeps its
+8.0 ns/tick shape, so counter time runs 62.5x slower than the bench
+timer's millisecond. That is deliberate and self-consistent -- the
+µcode's servo gain is generated for the bench's ticks-per-sync-interval
+(`--clk-hz 2000000`, one sync per 250k ticks), and every timestamp in
+the harness is counter-time ns.
+
+```sh
+git submodule update --init gptp-processor   # once
+make        # regenerates gptp_ucode.hex from the submodule, builds, runs
+```
+
+Exit 0 = PASS; the tally line is the record.

--- a/tb/verilator/gptp_plane/gptp_plane_wrap.sv
+++ b/tb/verilator/gptp_plane/gptp_plane_wrap.sv
@@ -79,9 +79,10 @@ module gptp_plane_wrap #(
   logic [63:0] step_val_w;
 
   //! adjfine is a level at the counter: latch the engine's pulse
+  //! (sync reset, matching the counter it feeds)
   logic signed [31:0] adj_r;
-  always_ff @(posedge clk_i or negedge rst_n) begin : adj_latch
-    if (!rst_n)       adj_r <= '0;
+  always_ff @(posedge clk_i) begin : adj_latch
+    if (!rst_n)        adj_r <= '0;
     else if (adj_we_w) adj_r <= $signed(adj_val_w);
   end
 

--- a/tb/verilator/gptp_plane/gptp_plane_wrap.sv
+++ b/tb/verilator/gptp_plane/gptp_plane_wrap.sv
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Kebag Logic
+ * SPDX-License-Identifier: CERN-OHL-W-2.0
+ */
+//---------------------------------------------------------------------------//
+//  File        : gptp_plane_wrap.sv
+//  Project     : Milan AVB end-station -- gPTP plane integration bench
+//
+//  Description : Testbench wrap marrying the gptp-processor submodule's
+//                KL_gptp_engine to the PARENT's real timestamp_counter --
+//                the exact pairing the datapath splice will instantiate.
+//                The engine's PHC face maps onto the counter's knobs:
+//
+//                  phc_addend_*  ->  adj_i        (adjfine, Q8.24 ns/tick,
+//                                                  latched here: the engine
+//                                                  pulses, the counter wants
+//                                                  a level)
+//                  phc_step_*    ->  offset_i + cmd_adjust_i  (adjtime)
+//                  timestamp_out ->  phc_ns_i     (the clock it steers)
+//
+//                The addend latch is the one piece of fabric the splice
+//                adds beyond wires; it lives here until then. The counter
+//                runs its 125 MHz shape (8.0 ns Q8.24 increment) while the
+//                bench clock is CLK_HZ_P -- the engine's µcode gain is
+//                generated for the bench's ticks-per-interval, so the
+//                closed loop is exact in counter time.
+//---------------------------------------------------------------------------//
+`default_nettype none
+
+module gptp_plane_wrap #(
+    parameter string       UCODE_HEX_P = "gptp_ucode.hex",
+    parameter int unsigned CLK_HZ_P    = 2_000_000
+) (
+    input  wire         clk_i,
+    input  wire         rst_n,
+
+    //! RX byte face: pre-classified 0x88F7 frames, DA first
+    input  wire         rx_valid_i,
+    input  wire  [7:0]  rx_data_i,
+    input  wire         rx_sof_i,
+    input  wire         rx_eof_i,
+    input  wire         rx_err_i,
+    input  wire  [63:0] rx_ts_i,
+
+    //! TX byte face
+    output logic        tx_valid_o,
+    output logic [7:0]  tx_data_o,
+    output logic        tx_sof_o,
+    output logic        tx_eof_o,
+    input  wire         tx_ready_i,
+
+    //! egress timestamp return
+    input  wire         txts_valid_i,
+    input  wire  [63:0] txts_ns_i,
+    input  wire  [15:0] txts_seq_i,
+
+    //! the steered clock, observable
+    output wire  [63:0] phc_ns_o,
+
+    //! steering taps for the bench (observer only)
+    output logic        tap_adj_we_o,
+    output logic [31:0] tap_adj_o,
+    output logic        tap_step_we_o,
+    output logic [63:0] tap_step_o,
+
+    //! publish bank -- the retired software contract
+    output logic [63:0] pub_gm_id_o,
+    output logic [63:0] pub_parent_id_o,
+    output logic [31:0] pub_flags_o,
+    output logic [31:0] pub_pdelay_ns_o,
+    output logic [31:0] pub_offset_o,
+    output logic [63:0] pub_annq_o,
+    output logic        pub_commit_o
+);
+
+  logic        adj_we_w;
+  logic [31:0] adj_val_w;
+  logic        step_we_w;
+  logic [63:0] step_val_w;
+
+  //! adjfine is a level at the counter: latch the engine's pulse
+  logic signed [31:0] adj_r;
+  always_ff @(posedge clk_i or negedge rst_n) begin : adj_latch
+    if (!rst_n)       adj_r <= '0;
+    else if (adj_we_w) adj_r <= $signed(adj_val_w);
+  end
+
+  timestamp_counter #(
+      .COUNTER_WIDTH (64),
+      .INCR_WIDTH    (32),
+      .FRAC_WIDTH    (24)
+  ) u_phc (
+      .clk                  (clk_i),
+      .resetn               (rst_n),
+      .enable_i             (1'b1),
+      .incr_i               (32'h0800_0000),   // 8.0 ns, the 125 MHz shape
+      .adj_i                (adj_r),
+      .tod_wr_i             (64'd0),
+      .cmd_load_i           (1'b0),
+      .offset_i             ($signed(step_val_w)),
+      .cmd_adjust_i         (step_we_w),
+      .cmd_snapshot_i       (1'b0),
+      .timestamp_out        (phc_ns_o),
+      .tod_snapshot_o       (),
+      .tod_snapshot_valid_o ()
+  );
+
+  KL_gptp_engine #(
+      .UCODE_HEX_P (UCODE_HEX_P),
+      .CLK_HZ_P    (CLK_HZ_P)
+  ) u_engine (
+      .clk_i              (clk_i),
+      .rst_n              (rst_n),
+      .rx_valid_i         (rx_valid_i),
+      .rx_data_i          (rx_data_i),
+      .rx_sof_i           (rx_sof_i),
+      .rx_eof_i           (rx_eof_i),
+      .rx_err_i           (rx_err_i),
+      .rx_ts_i            (rx_ts_i),
+      .tx_valid_o         (tx_valid_o),
+      .tx_data_o          (tx_data_o),
+      .tx_sof_o           (tx_sof_o),
+      .tx_eof_o           (tx_eof_o),
+      .tx_ready_i         (tx_ready_i),
+      .txts_valid_i       (txts_valid_i),
+      .txts_ns_i          (txts_ns_i),
+      .txts_seq_i         (txts_seq_i),
+      .phc_ns_i           (phc_ns_o),
+      .phc_addend_we_o    (adj_we_w),
+      .phc_addend_o       (adj_val_w),
+      .phc_step_we_o      (step_we_w),
+      .phc_step_o         (step_val_w),
+      .pub_gm_id_o        (pub_gm_id_o),
+      .pub_parent_id_o    (pub_parent_id_o),
+      .pub_flags_o        (pub_flags_o),
+      .pub_pdelay_ns_o    (pub_pdelay_ns_o),
+      .pub_offset_o       (pub_offset_o),
+      .pub_annq_o         (pub_annq_o),
+      .pub_commit_o       (pub_commit_o),
+      .eff_nvm_stb_o      (),
+      .eff_nvm_mark_o     (),
+      .eff_notify_stb_o   (),
+      .eff_notify_class_o (),
+      .dbg_rx_drop_o      (),
+      .dbg_ev_drop_o      (),
+      .dbg_busy_o         (),
+      .dbg_status_o       ()
+  );
+
+  assign tap_adj_we_o  = adj_we_w;
+  assign tap_adj_o     = adj_val_w;
+  assign tap_step_we_o = step_we_w;
+  assign tap_step_o    = step_val_w;
+
+endmodule : gptp_plane_wrap
+`default_nettype wire

--- a/tb/verilator/gptp_plane/sim_main.cpp
+++ b/tb/verilator/gptp_plane/sim_main.cpp
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: 2026 Kebag Logic
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// gPTP plane integration: the submodule's KL_gptp_engine steering the
+// PARENT's real timestamp_counter -- the pairing the datapath splice
+// will instantiate, proven closed-loop before any fabric is committed.
+//
+// The donor repo's own engine suite (gptp-processor/tb/verilator/engine)
+// proves the 802.1AS protocol details against a MODEL of the counter;
+// this suite replaces the model with hdl/ieee8021as/ptp_timestamp/
+// timestamp_counter.sv itself (Q8.24 accumulator, 8.0 ns increment, the
+// 125 MHz shape) and proves:
+//
+//  1  boot -> Pdelay_Req; one good exchange (D = 600 ns); asCapable
+//     still low (Milan 4.2.6.2.4 needs two)
+//  2  a live auto-answering peer -> second exchange -> asCapable
+//  3  a better announce -> the plane adopts; publish bank carries the
+//     GM identity and flags
+//  4  closed loop: a +100 ppm master, 1 ms ahead in counter time --
+//     ONE adjtime re-base near +1 ms (the master is ahead, the
+//     correction is the offset's negation), then the PI addend slews the
+//     REAL counter into lock: measured offset under 150 ns, the
+//     latched adjfine level at the +100 ppm ideal (13,421 Q8.24 units
+//     within 15%), and the counter's advance tracking the master's
+//     over the last four intervals within 100 ns
+//
+// Timescale: the bench clock is 2 MHz while the counter keeps its
+// 8.0 ns/tick shape, so "counter time" runs 62.5x slower than the
+// bench's timer millisecond. That is deliberate and self-consistent:
+// the µcode's servo gain is generated for the bench's
+// ticks-per-sync-interval (--clk-hz 2000000, syncs every 250k ticks),
+// and every timestamp below is counter-time ns.
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+#include <verilated.h>
+#include "Vgptp_plane_wrap.h"
+
+static const uint64_t OUR_CID = 0x02A1B2FFFEC3D4E5ull;
+static const uint64_t PEER_CID = 0x0080E1FFFE112233ull;
+static const uint32_t OUR_CQ = 0xF8FE436A;
+static const uint64_t GMID = 0x00AACCFFFE010203ull;
+
+static const uint32_t FL_PRESENT = 1, FL_AMGM = 2, FL_ASCAP = 4,
+                      FL_SYNCOK = 8;
+
+static int checks = 0, fails = 0;
+static void expect(const char *what, uint64_t got, uint64_t exp) {
+  checks++;
+  if (got != exp) {
+    fails++;
+    printf("FAIL %-30s got %016llx exp %016llx\n", what,
+           (unsigned long long)got, (unsigned long long)exp);
+  }
+}
+
+struct Frame {
+  std::vector<uint8_t> b;
+  void u8(uint8_t v) { b.push_back(v); }
+  void u16(uint16_t v) { u8(v >> 8); u8(v & 0xFF); }
+  void u32(uint32_t v) { u16(v >> 16); u16(v & 0xFFFF); }
+  void u48(uint64_t v) { u16((v >> 32) & 0xFFFF); u32(v & 0xFFFFFFFF); }
+  void u64(uint64_t v) { u32(v >> 32); u32(v & 0xFFFFFFFF); }
+  void ts(uint64_t ns) { u48(ns / 1000000000ull); u32(ns % 1000000000ull); }
+};
+
+static Frame ptp(uint8_t mtype, uint16_t seq, uint64_t corr,
+                 uint16_t flags, uint16_t body_len) {
+  Frame f;
+  f.u48(0x0180C200000Eull);
+  f.u48(0x0080E1112233ull);
+  f.u16(0x88F7);
+  f.u8(0x10 | mtype); f.u8(0x02);
+  f.u16(34 + body_len);
+  f.u8(0); f.u8(0);
+  f.u16(flags);
+  f.u64(corr);
+  f.u32(0);
+  f.u64(PEER_CID); f.u16(1);
+  f.u16(seq);
+  f.u8(0x05); f.u8(0x7F);
+  return f;
+}
+
+static Vgptp_plane_wrap *dut;
+static uint64_t cyc = 0;
+static std::vector<std::vector<uint8_t>> txf;
+static std::vector<uint64_t> txns;
+static std::vector<uint8_t> cur;
+static bool in_tx = false;
+static bool auto_txts = false;
+static int auto_pend = -1;
+static std::vector<uint64_t> steps_seen;
+static std::vector<uint32_t> adj_seen;
+
+static uint64_t phc() { return dut->phc_ns_o; }
+
+static void tick() {
+  if (auto_pend >= 0 && !dut->txts_valid_i) {
+    uint64_t ns = phc() + 200;
+    dut->txts_valid_i = 1;
+    dut->txts_ns_i = ns;
+    txns[auto_pend] = ns;
+    auto_pend = -1;
+  }
+  dut->clk_i = 0; dut->eval();
+  dut->clk_i = 1; dut->eval();
+  if (dut->tap_adj_we_o) adj_seen.push_back(dut->tap_adj_o);
+  if (dut->tap_step_we_o) steps_seen.push_back(dut->tap_step_o);
+  if (dut->tx_valid_o) {
+    if (dut->tx_sof_o) { cur.clear(); in_tx = true; }
+    if (in_tx) cur.push_back(dut->tx_data_o);
+    if (dut->tx_eof_o && in_tx) {
+      txf.push_back(cur);
+      txns.push_back(0);
+      if (auto_txts) auto_pend = (int)txf.size() - 1;
+      in_tx = false;
+    }
+  }
+  dut->txts_valid_i = 0;
+  cyc++;
+}
+
+static void run(uint64_t n) { while (n--) tick(); }
+
+static void send_frame(const std::vector<uint8_t> &bytes, uint64_t rx_ts) {
+  dut->rx_ts_i = rx_ts;
+  for (size_t i = 0; i < bytes.size(); i++) {
+    dut->rx_valid_i = 1;
+    dut->rx_data_i = bytes[i];
+    dut->rx_sof_i = (i == 0);
+    dut->rx_eof_i = (i + 1 == bytes.size());
+    dut->rx_err_i = 0;
+    tick();
+  }
+  dut->rx_valid_i = 0; dut->rx_sof_i = 0; dut->rx_eof_i = 0;
+}
+
+static void txts(uint64_t ns) {
+  dut->txts_valid_i = 1; dut->txts_ns_i = ns; dut->txts_seq_i = 0;
+  tick();
+  dut->txts_valid_i = 0;
+}
+
+// ---- auto peer: answers every Pdelay_Req the plane transmits --------------
+static size_t pd_seen = 0;
+static bool pd_on = false;
+
+static uint64_t peer_ns(uint64_t ours) {
+  return 5000000ull + ours + (ours >> 13);
+}
+
+static void service_pdelay() {
+  while (pd_seen < txf.size()) {
+    size_t i = pd_seen;
+    if ((txf[i].size() <= 14) || ((txf[i][14] & 0xF) != 0x2)) {
+      pd_seen++;
+      continue;
+    }
+    if (txns[i] == 0) return;
+    pd_seen++;
+    if (!pd_on) continue;
+    uint16_t seq = (uint16_t)((txf[i][44] << 8) | txf[i][45]);
+    uint64_t t1 = txns[i];
+    uint64_t t2 = peer_ns(t1 + 300);
+    uint64_t t3 = t2 + 20000;                    // D = ~600 ns
+    uint64_t t4 = t1 + 21200;
+    Frame f = ptp(0x3, seq, 0, 0x0200, 20);
+    f.ts(t2); f.u64(OUR_CID); f.u16(1);
+    send_frame(f.b, t4);
+    run(400);
+    Frame g = ptp(0xA, seq, 0, 0x0000, 20);
+    g.ts(t3); g.u64(OUR_CID); g.u16(1);
+    send_frame(g.b, t4 + 1000);
+    run(400);
+  }
+}
+
+static void run_svc(uint64_t n) {
+  while (n--) { tick(); if ((n & 255) == 0) service_pdelay(); }
+}
+
+static bool wait_flags(uint32_t mask, uint32_t want, uint64_t max_ticks) {
+  for (uint64_t n = 0; n < max_ticks; n++) {
+    if ((dut->pub_flags_o & mask) == want) return true;
+    tick();
+    if ((n & 255) == 0) service_pdelay();
+  }
+  return false;
+}
+
+static size_t tx_seen = 0;
+static std::vector<uint8_t> wait_tx(int mtype, uint64_t max_cycles) {
+  for (uint64_t n = 0; n < max_cycles; n++) {
+    while (tx_seen < txf.size()) {
+      size_t i = tx_seen++;
+      if (mtype < 0 || (txf[i].size() > 14 && (txf[i][14] & 0xF) == mtype))
+        return txf[i];
+    }
+    tick();
+    if ((n & 255) == 0) service_pdelay();
+  }
+  printf("FAIL wait_tx type %d: timeout\n", mtype);
+  fails++; checks++;
+  return {};
+}
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  dut = new Vgptp_plane_wrap;
+
+  dut->rst_n = 0;
+  dut->rx_valid_i = 0; dut->rx_sof_i = 0; dut->rx_eof_i = 0;
+  dut->rx_err_i = 0; dut->rx_data_i = 0; dut->rx_ts_i = 0;
+  dut->tx_ready_i = 1;
+  dut->txts_valid_i = 0; dut->txts_ns_i = 0; dut->txts_seq_i = 0;
+  for (int i = 0; i < 8; i++) tick();
+  dut->rst_n = 1;
+
+  // ---- 1: boot -> Pdelay_Req; one exchange is not capable ---------------
+  std::vector<uint8_t> req = wait_tx(0x2, 3200000);
+  expect("counter is ticking", phc() > 0, 1);
+  expect("asCapable low at boot", dut->pub_flags_o & FL_ASCAP, 0);
+  uint64_t t1 = phc() + 200;
+  txts(t1);
+  run(2000);
+  {
+    uint64_t t2 = peer_ns(t1 + 300), t3 = t2 + 20000, t4 = t1 + 21200;
+    Frame f = ptp(0x3, 0, 0, 0x0200, 20);
+    f.ts(t2); f.u64(OUR_CID); f.u16(1);
+    send_frame(f.b, t4);
+    run(4000);
+    Frame g = ptp(0xA, 0, 0, 0x0000, 20);
+    g.ts(t3); g.u64(OUR_CID); g.u16(1);
+    send_frame(g.b, t4 + 1000);
+    run(6000);
+  }
+  expect("pdelay measured", dut->pub_pdelay_ns_o, 600);
+  expect("one exchange not capable", dut->pub_flags_o & FL_ASCAP, 0);
+
+  // ---- 2: the live peer raises asCapable at the second exchange ---------
+  auto_txts = true;
+  pd_seen = txf.size();
+  pd_on = true;
+  expect("second exchange -> capable",
+         wait_flags(FL_ASCAP, FL_ASCAP, 6000000ull), 1);
+
+  // ---- 3: better announce -> adopt; the publish bank is the contract ----
+  {
+    Frame f = ptp(0xB, 10, 0, 0x0008, 30);
+    for (int i = 0; i < 10; i++) f.u8(0);
+    f.u16(0xFFC4); f.u8(0);
+    f.u8(100); f.u32(OUR_CQ); f.u8(248);
+    f.u64(GMID);
+    f.u16(0); f.u8(0xA0);
+    send_frame(f.b, phc() + 150);
+    run_svc(6000);
+  }
+  expect("adopted", dut->pub_flags_o & 3, FL_PRESENT);
+  expect("pub gm id", dut->pub_gm_id_o, GMID);
+
+  // ---- 4: closed loop -- the engine steers the REAL counter -------------
+  // master: independent of the steered counter, +100 ppm in counter
+  // time (8 ns + 8/10000 per bench cycle), starting 1 ms ahead
+  {
+    size_t steps_before = steps_seen.size();
+    uint64_t mst_base =
+        phc() + 1000000ull - cyc * 8ull - cyc / 1250ull;
+    uint16_t sq = 0x0300;
+    uint64_t c_lock = 0, m_lock = 0;             // window for rate check
+    for (int k = 0; k < 24; k++) {
+      if ((k % 8) == 0) {                        // keep the GM elected
+        Frame a = ptp(0xB, (uint16_t)(20 + k), 0, 0x0008, 30);
+        for (int i = 0; i < 10; i++) a.u8(0);
+        a.u16(0xFFC4); a.u8(0);
+        a.u8(100); a.u32(OUR_CQ); a.u8(248);
+        a.u64(GMID);
+        a.u16(0); a.u8(0xA0);
+        send_frame(a.b, phc() + 150);
+        run(4000);
+      }
+      run_svc(250000);                           // one sync interval
+      if (k == 20) { c_lock = phc(); m_lock = mst_base + cyc * 8ull
+                                              + cyc / 1250ull; }
+      uint64_t origin = mst_base + cyc * 8ull + cyc / 1250ull;
+      uint64_t local_rx = phc() + 150;
+      Frame f = ptp(0x0, sq, 0, 0x0208, 10);
+      f.ts(0);
+      send_frame(f.b, local_rx);
+      run(1000);
+      Frame g = ptp(0x8, sq, 0, 0x0000, 10);
+      g.ts(origin);
+      send_frame(g.b, local_rx + 500);
+      run(4000);
+      sq++;
+    }
+    expect("one adjtime re-base", steps_seen.size(), steps_before + 1);
+    int64_t step = (int64_t)steps_seen.back();
+    expect("re-base near +1 ms",
+           step > 995000 && step < 1005000, 1);
+    int32_t final_off = (int32_t)dut->pub_offset_o;
+    expect("measured offset locked",
+           final_off > -150 && final_off < 150, 1);
+    // +100 ppm of 8 ns/tick = 0.0008 ns/tick = 13,421 Q8.24 units
+    int32_t final_adj = (int32_t)adj_seen.back();
+    expect("addend at the +100 ppm ideal",
+           final_adj > 11408 && final_adj < 15434, 1);
+    // the REAL proof: the counter's advance tracks the master's
+    uint64_t c_now = phc();
+    uint64_t m_now = mst_base + cyc * 8ull + cyc / 1250ull;
+    int64_t rate_err = (int64_t)(c_now - c_lock) -
+                       (int64_t)(m_now - m_lock);
+    expect("counter tracks the master",
+           rate_err > -100 && rate_err < 100, 1);
+    expect("sync-ok held through lock",
+           dut->pub_flags_o & FL_SYNCOK, FL_SYNCOK);
+  }
+
+  printf("%d checks: %d PASS, %d FAIL\n", checks, checks - fails, fails);
+  delete dut;
+  return fails ? 1 : 0;
+}


### PR DESCRIPTION
[A1] The parent-side beachhead for #110. The gptp-processor submodule was already in the tree at the bench-grandmaster tip (4490637) with nothing referencing it; this PR brings the pin forward across the two donor rounds that landed since -- ucode v4 (the asCapable ladder, the Milan Table 4.2 receipt timeouts, neighborRateRatio) and v5 (the step-vs-slew PHC servo) -- and gives the parent tree its first integration proof.

**Pin e390d65** (= donor PRs #1 and #2, each merged through a cleared-context review with reviewer-authored mutations; donor battery at the pin: engine 120 checks, ucpu 768, parser 31, sixteen planted mutations red, still zero RTL change since the priced skeleton).

**New suite tb/verilator/gptp_plane** (13 checks): the submodule's KL_gptp_engine married to the PARENT's real hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv -- the exact pairing the datapath splice will instantiate. The donor's own suite proves the protocol against a MODEL of the counter; this one replaces the model with the counter itself (Q8.24, 8.0 ns increment) and proves closed-loop: boot beside the ticking counter, the asCapable ladder off two pdelay exchanges, adoption of a better announce into the publish bank, then a +100 ppm master 1 ms ahead gets ONE adjtime re-base near +1 ms and the PI addend slews the REAL counter into lock -- measured offset under 150 ns, the latched adjfine level at the +100 ppm ideal (13,421 Q8.24 units within 15%), and the counter's advance tracking the master's within 100 ns over the last four sync intervals. The wrap carries the one piece of fabric the splice will add beyond wires (the adjfine pulse-to-level latch); both integration-specific mutations (a dead latch, a dead adjtime strobe) turn the run red.

**Plumbing**: the .gitmodules URL moves from SSH to HTTPS so anonymous CI can fetch it (the protocol-processor precedent; the SSH form was uninitializable in CI), and the rtl.yml sweep job fetches gptp-processor so the new suite runs remotely. The suite's ucode hex is generated per make from the submodule (untracked: its content depends on the pin, so a tracked copy would silently diverge on the next bump).

**Gates run here**: the new suite 13/13; docs_check 0/205, TOC OK, doc paths OK, lint ratchet PASS, zero added em dashes. No hdl/ file changes, so no other suite's inputs moved and no VERSION bump is due; the remote sweep covers the full battery per the recorded long-gate policy.

**Not in this PR** (the splice round that follows, opening with the area verdict against the donor's OOC anchors since the part is LUT-bound): the 0x88F7 classifier steer, the control-cascade TX + txts return, the publish bank onto the CSR words and the tu bit, the elaboration option and default, and the rootfs retirement of ptp4l.