### PR TITLE
The gPTP pin advances to v6 and the blind spot closes (issue #115)

### DIFF
--- a/tb/verilator/gptp_plane/README.md
+++ b/tb/verilator/gptp_plane/README.md
@@ -20,13 +20,12 @@ What it proves:
 | 2 | a live auto-answering peer raises asCapable at the second exchange |
 | 3 | a better announce is adopted; the publish bank carries the GM identity and role flags |
 | 4 | closed loop vs a +100 ppm master 1 ms ahead in counter time: ONE adjtime re-base near +1 ms (the correction negates the offset), the latched adjfine level lands at the +100 ppm ideal (13,421 Q8.24 units, within 15%), the measured offset locks under 150 ns, and the REAL counter's advance tracks the master's within 100 ns over the last four sync intervals |
+| 5 | announce silence rides to grandmaster and the transmitted Sync's originTimestamp is the live counter value -- phc_ns_i observed on the wire (a constant-tied mis-wire fails) |
 
-Known blind spot, on purpose: `phc_ns_i` (the engine's live-clock
-snapshot input) is dispatch metadata in the current µcode -- no handler
-consumes it yet -- so a mis-wire of that one input is invisible to these
-checks. The loop closes through the ingress/egress timestamps. Its first
-functional consumer is a donor-side µcode revision; the splice round
-carries the observing check.
+The `phc_ns_i` blind spot from PR #113's review is CLOSED: the
+submodule's v6 ucode consumes the live-clock input for the Sync
+originTimestamp, and phase 5 observes it on the wire -- tying
+`phc_ns_i` to a constant now fails the run.
 
 Timescale note: the bench clock is 2 MHz while the counter keeps its
 8.0 ns/tick shape, so counter time runs 62.5x slower than the bench

--- a/tb/verilator/gptp_plane/sim_main.cpp
+++ b/tb/verilator/gptp_plane/sim_main.cpp
@@ -337,7 +337,8 @@ int main(int argc, char **argv) {
            wait_flags(FL_AMGM, FL_AMGM, 10000000ull), 1);
     tx_seen = txf.size();
     std::vector<uint8_t> sy = wait_tx(0x0, 800000);
-    if (!sy.empty()) {
+    expect("sync long enough to parse", sy.size() >= 58, 1);
+    if (sy.size() >= 58) {
       uint64_t origin = fld48(sy, 48) * 1000000000ull + fld32(sy, 54);
       uint64_t now = phc();
       int64_t d = (int64_t)(now - origin);

--- a/tb/verilator/gptp_plane/sim_main.cpp
+++ b/tb/verilator/gptp_plane/sim_main.cpp
@@ -190,6 +190,15 @@ static bool wait_flags(uint32_t mask, uint32_t want, uint64_t max_ticks) {
   return false;
 }
 
+static uint64_t fld48(const std::vector<uint8_t> &f, size_t o) {
+  uint64_t v = 0; for (int i = 0; i < 6; i++) v = (v << 8) | f[o + i];
+  return v;
+}
+static uint32_t fld32(const std::vector<uint8_t> &f, size_t o) {
+  return ((uint32_t)f[o] << 24) | ((uint32_t)f[o + 1] << 16) |
+         ((uint32_t)f[o + 2] << 8) | f[o + 3];
+}
+
 static size_t tx_seen = 0;
 static std::vector<uint8_t> wait_tx(int mtype, uint64_t max_cycles) {
   for (uint64_t n = 0; n < max_cycles; n++) {
@@ -315,6 +324,25 @@ int main(int argc, char **argv) {
            rate_err > -100 && rate_err < 100, 1);
     expect("sync-ok held through lock",
            dut->pub_flags_o & FL_SYNCOK, FL_SYNCOK);
+  }
+
+  // ---- 5: as master, the Sync origin carries the REAL counter -----------
+  // announce silence rides out the receipt timeout (pdelay keeps
+  // asCapable alive), the plane becomes grandmaster, and its Sync's
+  // originTimestamp must be the live timestamp_counter value -- the
+  // phc_ns_i observing check PR #113's review filed as its blind spot
+  // (the submodule's v6 gather consumer makes it observable)
+  {
+    expect("quiet ride to grandmaster",
+           wait_flags(FL_AMGM, FL_AMGM, 10000000ull), 1);
+    tx_seen = txf.size();
+    std::vector<uint8_t> sy = wait_tx(0x0, 800000);
+    if (!sy.empty()) {
+      uint64_t origin = fld48(sy, 48) * 1000000000ull + fld32(sy, 54);
+      uint64_t now = phc();
+      int64_t d = (int64_t)(now - origin);
+      expect("origin is the real counter", d >= 0 && d < 300000, 1);
+    }
   }
 
   printf("%d checks: %d PASS, %d FAIL\n", checks, checks - fails, fails);


### PR DESCRIPTION
[A1] The parent-side companion of the #115 donor rounds: the gptp-processor pin advances to 71ee8de -- the v6 full-compare tip merged through review (donor PR #3: full BTCA against a stored best-vector record with parent updates and immediate takeover on degradation, Sync/Follow_Up sequence-and-source pairing, the asCapable consumption gate, the dispatch-identity guard against the single-bank race, and the Sync originTimestamp carrying the live PHC).

**The payoff this bump unlocks**: PR #113's review filed phc_ns_i as an F2 blind spot -- tying the engine's live-clock input to a constant survived every check because no ucode consumed it. v6's gather consumer makes it observable, and tb/verilator/gptp_plane grows phase 5: announce silence rides the receipt timeout to grandmaster (pdelay keeps asCapable alive), and the transmitted Sync's originTimestamp must be the live timestamp_counter value. The formerly-surviving mutation now fails the run (verified both ways in this branch); the suite goes 13 to 15 checks.

**Deliberately NOT in this PR**: the donor's in-review engine v2 (the second message bank + the cease rule, donor PR #4) -- that pin advance ships with round 3b (#114), whose area verdict prices against the re-measured 3,046 LUT engine.

Gates here: the suite 15/15 with the mutation red-then-restored, docs_check 0/206, matrix no-drift 2/2, doc paths OK, zero added em dashes. No hdl/ changes; the remote sweep covers the battery per the long-gate policy.