### PR TITLE
Make the host PCM capture-ring an elaboration option (SNDCARD_P), #120 datapath lever

### DIFF
--- a/docs/design/AREA_BUDGET.md
+++ b/docs/design/AREA_BUDGET.md
@@ -199,6 +199,7 @@ enforces that on all three shipped configs.
 | RX address filter | `RXFILT_P` | `--no-rx-mac-filter` | `rx_mac_filter` | the port is promiscuous, or filtering is done in software |
 | PCM low-pass | `LPF_P` | `--no-render-lpf` | `render_lpf` | render path only, and every digital acceptance measurement is taken upstream of it |
 | datapath probe groups | `DPROBES_P` | `--no-datapath-probes` | `datapath_probes` | the APRB (0x8B4–0x8C4) and PBK (0x8C8–0x8D0) groups are closed-finding diagnostics (fabric-listener blocker + item-7 chain, both TB-pinned since); the range reads 0 on a pruned build — the LTAP precedent (added 2026-07-29 to unlock AreaOptimized_medium on the AX, whose AreaOptimized_high timing was congestion-systemic) |
+| sound card | `SNDCARD_P` | `--no-sound-card` | `sound_card` | there is no Linux ALSA consumer for the host PCM capture ring (issue #120: the baremetal shape). This lever gates only the datapath `m_axis_pcm` OUTPUT surface (KL_pcm_route's DMA leg); the AAF/TDM/I2S datapath and the DAC render leg are separate and stay. The BULK of the sound card is the SoC-layer ring (`KL_pcm_ring_bram` + the DMA writer + the host CSR bank), removed and re-measured in the SoC-side follow-up — the figure below is the datapath surface only (added 2026-08-19) |
 
 #### What each one is worth — MEASURED, and every figure a yosys ESTIMATE
 

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -268,6 +268,20 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! diagnostics whose counters/latches die with the parameter; the CSR
   //! range reads 0 on a pruned build (the LTAP precedent).
   parameter int DPROBES_P = 1,
+  //! Host-facing PCM capture-ring surface (the "sound card": issue #120).
+  //! The m_axis_pcm output port is the datapath's contribution to the ring
+  //! the SoC layer binds to feed the board's Linux ALSA driver. With every
+  //! control plane and time sync in fabric, a baremetal (no-Linux) shape has
+  //! no ALSA consumer, so this becomes an elaboration option. 0 prunes the
+  //! output surface: the port is tied inert (its documented ring-disabled
+  //! value -- exactly what a build with no ring writer bound produces), the
+  //! KL_pcm_route DMA leg feeding it goes dead and is optimised away, and the
+  //! audio DATAPATH (the render leg, the LPF/I2S DAC, the crossbar) is
+  //! untouched -- render backpressure is left on m_axis_pcm_tready, which the
+  //! SoC still drives. Defaults 1 = PRESENT (the no-regression axiom); the
+  //! SoC-side ring removal and the default-removed flip follow with the
+  //! baremetal shipping shape.
+  parameter int SNDCARD_P = 1,
   //! Protocol-processor timer compression for SIMULATION only (the
   //! CLKV_QTICK_CYC_P precedent). Defaults are REAL time and are what silicon
   //! builds use: at 100 MHz, 100 clk = 1 us and 1000 us = 1 ms. A harness
@@ -5397,7 +5411,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     //! NXN §1.1 tuser tag: the shared monitor's per-stream accept index
     .pdu_accept_idx_i (avtprx_accept_idx_w),
     .m_axis_tdata (dpkt_pcm_tdata_w),
-    .m_axis_tkeep (m_axis_pcm_tkeep),
+    .m_axis_tkeep (snd_pcm_tkeep_w),
     .m_axis_tvalid(dpkt_pcm_tvalid_w),
     .m_axis_tlast (dpkt_pcm_tlast_w),
     .m_axis_tuser (dpkt_pcm_tuser_w),
@@ -5454,13 +5468,39 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     //! P12: route field <- the window CTRL[2:1] commit (glue above)
     .route_wr_en_i (wing_route_we_r), .route_wr_idx_i (wing_idx_r),
     .route_wr_val_i (wing_route_r),
-    .m_axis_tdata (m_axis_pcm_tdata), .m_axis_tvalid (m_axis_pcm_tvalid),
-    .m_axis_tlast (m_axis_pcm_tlast), .m_axis_tuser (m_axis_pcm_tuser),
+    .m_axis_tdata (snd_pcm_tdata_w), .m_axis_tvalid (snd_pcm_tvalid_w),
+    .m_axis_tlast (snd_pcm_tlast_w), .m_axis_tuser (snd_pcm_tuser_w),
     .m_axis_tready (m_axis_pcm_tready),
     .render_tvalid_o (rend_pcm_tvalid_w), .render_tdata_o (rend_pcm_tdata_w),
     .render_tlast_o (rend_pcm_tlast_w),
     .render_sel_o (route_render_sel_w), .render_active_o ()
   );
+
+  //! Sound-card output gate (issue #120, SNDCARD_P). The host-facing PCM
+  //! capture-ring surface: KL_pcm_route's DMA leg (tdata/tvalid/tlast/tuser)
+  //! and the depacketizer's tkeep. SNDCARD_P = 0 ties every m_axis_pcm output
+  //! to the exact value a build with no ring writer bound presents (tvalid 0,
+  //! data/keep/user 0) and leaves the DMA-leg drivers feeding dead nets, so
+  //! synthesis prunes them. The RENDER leg and m_axis_pcm_tready are NOT here:
+  //! the DAC/LPF path keeps its backpressure and is bit-identical either way.
+  wire [TDATA_WIDTH-1:0]   snd_pcm_tdata_w;
+  wire [TDATA_WIDTH/8-1:0] snd_pcm_tkeep_w;
+  wire                     snd_pcm_tvalid_w;
+  wire                     snd_pcm_tlast_w;
+  wire [3:0]               snd_pcm_tuser_w;
+  generate if (SNDCARD_P != 0) begin : g_sndcard
+    assign m_axis_pcm_tdata  = snd_pcm_tdata_w;
+    assign m_axis_pcm_tkeep  = snd_pcm_tkeep_w;
+    assign m_axis_pcm_tvalid = snd_pcm_tvalid_w;
+    assign m_axis_pcm_tlast  = snd_pcm_tlast_w;
+    assign m_axis_pcm_tuser  = snd_pcm_tuser_w;
+  end else begin : g_no_sndcard
+    assign m_axis_pcm_tdata  = {TDATA_WIDTH{1'b0}};
+    assign m_axis_pcm_tkeep  = {(TDATA_WIDTH/8){1'b0}};
+    assign m_axis_pcm_tvalid = 1'b0;
+    assign m_axis_pcm_tlast  = 1'b0;
+    assign m_axis_pcm_tuser  = 4'd0;
+  end endgenerate
 
   // ==========================================================================
   //  I2S playback (Pmod I2S2 DAC) — zero-CPU audible listener: taps the

--- a/sw/builder/endstation_builder.py
+++ b/sw/builder/endstation_builder.py
@@ -468,6 +468,11 @@ OPTIONAL_BLOCKS = {
     "datapath_probes":   ("--no-datapath-probes", "DPROBES_P",
                           "the APRB + PBK probe groups (0x8B4-0x8D0) - "
                           "closed-finding diagnostics"),
+    "sound_card":        ("--no-sound-card", "SNDCARD_P",
+                          "the host-facing PCM capture-ring output surface "
+                          "(m_axis_pcm) the SoC ring binds to feed the Linux "
+                          "ALSA driver (issue #120); the AAF/TDM/I2S datapath "
+                          "and the DAC render leg are separate and stay"),
 }
 
 #: Where the RX destination-address decision is taken. `hardware` (the
@@ -752,6 +757,22 @@ RESOURCE_COSTS = {
                               "LUT / 756 FF - the FF figures agree exactly, "
                               "the LUT figure is yosys running ~2x high",
                               "measured (yosys hierarchical ESTIMATE)"),
+    # issue #120: this PR banks ONLY the datapath output surface the
+    # SNDCARD_P gate removes (KL_pcm_route's DMA leg + the m_axis_pcm port).
+    # Measured tiny: KL_pcm_route OOC is ~4 LUT / 2 FF total (2026-08-19),
+    # so the DMA-leg share is an upper bound of that. The BULK of the sound
+    # card is the SoC-layer ring (KL_pcm_ring_bram + the DMA writer + the
+    # host CSR bank), which this datapath-only lever does not remove; that
+    # figure is banked when the SoC ring removal lands (the #120 follow-up).
+    # Deliberately NOT overstated here -- the build must not be charged for
+    # fabric its own argv still instantiates (the render-lpf lesson above).
+    "prune_sound_card": _cost(-4, -2, 0, 0,
+                              "yosys OOC KL_pcm_route ~4 LUT / 2 FF (upper "
+                              "bound of the DMA leg; ESTIMATE 2026-08-19). "
+                              "The SoC ring is the bulk and is banked with "
+                              "the follow-up that removes it",
+                              "measured (yosys OOC ESTIMATE, datapath "
+                              "surface only)"),
 }
 
 
@@ -799,7 +820,8 @@ def resource_instances(cfg, overlay):
         # feature is pruned, so a default config's row list ends exactly
         # where it did before.
         (f"prune_{name}", 0 if block_present(cfg, name) else 1)
-        for name in ("media_clock_servo", "latency_taps", "render_lpf")
+        for name in ("media_clock_servo", "latency_taps", "render_lpf",
+                     "sound_card")
     ]
 
 
@@ -4514,6 +4536,11 @@ FEATURE_REMEASURE = {
         "the APRB pre-match view (parsed/matched/last-sid) and PBK chain "
         "evidence - the 0x8B4-0x8D0 words read 0, so bench recipes that "
         "read them see the LTAP-style absent-block zero, not a measurement",
+    "sound_card":
+        "any host capture over the PCM ring (arecord / PipeWire) - with the "
+        "m_axis_pcm output tied off there is no ring for the ALSA driver to "
+        "read; the AAF listener, the DAC render leg and their audio "
+        "measurements are on a separate path and are unaffected (issue #120)",
 }
 
 

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -2942,7 +2942,8 @@ def test_optional_block_prune_accounting():
     ESTIMATE."""
     def m(c):
         _prune(c, media_clock_servo=False, latency_taps=False, maap=False,
-               i2s_playback=False, rx_mac_filter=False, render_lpf=False)
+               i2s_playback=False, rx_mac_filter=False, render_lpf=False,
+               sound_card=False)
         c["clocking"].update(media_clock_sources=["internal"],
                              default_source="internal", crf_sink=False)
         c["board"]["constraints"].update(strip_probes=True)

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -685,6 +685,7 @@ MILAN_OPTIONAL_BLOCKS = {
     "rx_mac_filter":     "RXFILT_P",    # rx_mac_filter + tcam
     "render_lpf":        "LPF_P",       # KL_pcm_lpf (banked lever, lane S)
     "datapath_probes":   "DPROBES_P",   # APRB + PBK probe groups (0x8B4-0x8D0)
+    "sound_card":        "SNDCARD_P",   # host PCM capture-ring output (m_axis_pcm)
 }
 
 
@@ -6713,6 +6714,15 @@ def main():
                          "when the port is meant to be PROMISCUOUS or filtering is done "
                          "in software. The TCAM_* CSR window still accepts writes and "
                          "nothing reads them. Default off => filter PRESENT.")
+    ap.add_argument("--no-sound-card", action="store_true",
+                    help="AREA LEVER (issue #120): prune the host-facing PCM "
+                         "capture-ring OUTPUT surface. SNDCARD_P=0 ties the "
+                         "datapath m_axis_pcm port inert (its no-ring-bound "
+                         "value), so KL_pcm_route's DMA leg is optimised away; "
+                         "the AAF/TDM/I2S datapath and the DAC render leg are "
+                         "SEPARATE and untouched. With no Linux there is no ALSA "
+                         "consumer for the ring. Default off => sound card "
+                         "PRESENT.")
     # NOTE: there is no --with-pp-plane any more. The protocol processor was a
     # shadow plane behind PP_PLANE_P for exactly one round; scenario B
     # SUBSTITUTED it for the legacy 1722.1/SRP plane, which is deleted, so

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -170,7 +170,7 @@ all: run
 # Every one defaults to 1 = PRESENT, so the two builds above are untouched;
 # this third build is the only place the 0 side is elaborated - and a prune
 # that was never elaborated is not a prune.
-PRUNE_G = -GMCSERVO_P=0 -GLTAP_P=0 -GMAAP_P=0 -GI2SPB_P=0 -GRXFILT_P=0 -GLPF_P=0
+PRUNE_G = -GMCSERVO_P=0 -GLTAP_P=0 -GMAAP_P=0 -GI2SPB_P=0 -GRXFILT_P=0 -GLPF_P=0 -GSNDCARD_P=0
 
 # THE SHIPPING ALINX SHAPE, stated ONCE. sim_main.cpp runs three different
 # elaborations now, so the geometry it asserts against can no longer be a

--- a/tb/verilator/milan_dp/sim_prune.cpp
+++ b/tb/verilator/milan_dp/sim_prune.cpp
@@ -5,7 +5,7 @@
  * PRUNED-SHAPE harness: milan_datapath elaborated with EVERY tier-1
  * optional block dropped (docs/design/AREA_BUDGET.md):
  *
- *   MCSERVO_P=0  LTAP_P=0  MAAP_P=0  I2SPB_P=0  RXFILT_P=0  LPF_P=0
+ *   MCSERVO_P=0  LTAP_P=0  MAAP_P=0  I2SPB_P=0  RXFILT_P=0  LPF_P=0  SNDCARD_P=0
  *
  * WHY THIS FILE EXISTS: a prune that was never elaborated is not a prune.
  * The default suite (sim_main / sim_nxn) proves the PRESENT shape is
@@ -116,7 +116,9 @@ static void do_reset() {
 //! single-cycle DEN strobe, so accumulate instead.
 static unsigned g_mmcm_seen = 0;     //! bit0 drp_en, 1 drp_we, 2 ps_en, 3 rst, 4 addr|di
 static unsigned g_dac_seen  = 0;     //! bit0 mclk, 1 sclk, 2 lrck, 3 sdin
+static unsigned g_pcm_seen  = 0;     //! SNDCARD_P=0: the gated host-ring output
 static void sample_pins() {
+    if (dut->m_axis_pcm_tvalid) g_pcm_seen |= 1u;
     if (dut->o_mmcm_drp_en)    g_mmcm_seen |= 1u << 0;
     if (dut->o_mmcm_drp_we)    g_mmcm_seen |= 1u << 1;
     if (dut->o_mmcm_ps_en)     g_mmcm_seen |= 1u << 2;
@@ -307,6 +309,37 @@ int main(int argc, char** argv) {
     ck("I2SPB_STAT STILL 0 after traffic", axi_read(A_I2SPB_STAT), 0);
     ck("no MMCM pin ever moved", g_mmcm_seen, 0);
     ck("no DAC pin ever moved",  g_dac_seen,  0);
+
+    // ---- sound card (SNDCARD_P=0) --------------------------------------
+    // The host-facing PCM capture-ring OUTPUT surface. The PRESENT contrast
+    // lives in sim_main, which binds the sink through the ACMP ladder and
+    // proves the same AAF PDU makes m_axis_pcm carry the payload byte-for-byte
+    // (0x6C4 advances, ring AXIS decoded). Here -- the minimal harness, no
+    // bind -- an AAF PDU is driven into the RX path and reaches the raw RX DMA
+    // (so the stimulus is real, not a dead harness), while the gated
+    // m_axis_pcm output stays at its documented inert value with tready held
+    // high: tvalid never asserts. This is the same structural-inert shape as
+    // the LTAP / MCSRV / DAC checks above; the else-branch tie is what a build
+    // with no ring writer bound presents.
+    {
+        g_pcm_seen = 0;
+        dut->m_axis_pcm_tready = 1;
+        static uint8_t af[120]; memset(af, 0, sizeof af);
+        const uint8_t dmac[6] = {0x91,0xE0,0xF0,0x00,0x2A,0x02}; memcpy(af, dmac, 6);
+        const uint8_t src[6]  = {0x02,0x00,0x00,0x00,0x00,0x02}; memcpy(af+6, src, 6);
+        af[12]=0x22; af[13]=0xF0; af[14]=0x02; af[15]=0x81; af[16]=0x05;
+        const uint8_t sid[8] = {0x02,0x00,0x00,0x00,0x00,0x02,0x00,0x00};
+        memcpy(af+18, sid, 8);
+        af[26]=0xAA; af[27]=0xBB; af[28]=0xCC; af[29]=0xDD;
+        af[30]=0x02; af[31]=(uint8_t)(0x05<<4); af[32]=2; af[33]=32;
+        af[34]=0x00; af[35]=0x30;
+        for (int i = 0; i < 48; i++) af[38+i] = (uint8_t)(0x30+i);
+        long fr = 0; inject_rx(af, 86, &fr);
+        ck("SNDCARD_P=0: an AAF PDU reaches the datapath (raw RX DMA)",
+           fr >= 1 ? 1 : 0, 1);
+        ck("SNDCARD_P=0: host PCM ring output INERT (tvalid never asserted)",
+           g_pcm_seen, 0);
+    }
 
     // ---------------------------------------------------------------- 8 ----
     // What must STILL work: the prunes touch none of the mandatory path.


### PR DESCRIPTION
[A1] First increment of issue #120 (the baremetal downgrade, subticket of #110): makes the host-facing PCM capture-ring surface — the "sound card" that exists only to feed the board's Linux ALSA driver — an **elaboration option**, following the tier-1 prune pattern.

`SNDCARD_P` (milan_datapath, DEFAULT 1 = PRESENT, the no-regression axiom) gates the datapath's `m_axis_pcm` output surface (KL_pcm_route's DMA leg + the depacketizer's tkeep). When pruned, the port is tied to the exact value a build with no ring writer bound presents, and the DMA-leg drivers feed dead nets so synthesis removes them. Deliberately **out of scope of the gate**: `m_axis_pcm_tready`, the RENDER leg, the LPF/I2S DAC, and the crossbar — the AAF/TDM/I2S audio datapath is separate and bit-identical either way. No config flips the default in this PR; the SoC-side ring removal (`KL_pcm_ring_bram` + the DMA writer + the host CSR bank — the bulk of the buy-back) and the default-removed flip land with the baremetal shipping shape, exactly the sequencing the issue states (the Linux flow stays buildable until #116).

The lever is wired end to end per the tier-1 pattern: builder `OPTIONAL_BLOCKS` + `resource_instances` + a banked `RESOURCE_COSTS` row (honestly the datapath surface only — KL_pcm_route OOC ~4 LUT/2 FF, not overstated), the `milan_soc.py` `MILAN_OPTIONAL_BLOCKS` map + `--no-sound-card` argparse, and the AREA_BUDGET tier-1 table row — so gate 23d's builder↔SoC↔datapath↔docs consistency check sees 8 blocks.

Local validation:
- `milan_dp` all shapes PASS including the pruned shape (`-GSNDCARD_P=0`): a real AAF PDU reaches the datapath and the gated `m_axis_pcm` stays inert; the present shapes are byte-identical (5570/1622/1630/1622, 0 fail).
- `test_builder` gates 23a–23e PASS (prune posture, refusals, all-pruned estimate, the 8-block decorative-ABI consistency).
- RTL lint 99≤99 (unchanged), docs-check clean, traceability no-drift, Yosys portability.

Not this PR: the SoC ring removal (LiteX) and the config flip. No RTL datapath behaviour changes for any shipping build.

Refs #120.

---
**Overlap with #125:** PR #125 ("Ship the AX7101 bare-metal gPTP profile") implements the whole of #120 in one PR, including a full sound-card removal (the same `sound_card` config key, param `SOUND_CARD`, the shipping config flipped to `false`, plus the SoC ring removal). This PR is the narrower datapath-lever subset with a different param name (`SNDCARD_P`) and no config flip. They touch the same files, so only one lands cleanly. Flagging so the maintainer can decide — if #125 is the chosen path, close this in its favour.
