### PR TITLE
grade_tx: grade masks and fail closed on unknown constraint kinds

### DIFF
--- a/tb/verilator/tsn_fuzz/Makefile
+++ b/tb/verilator/tsn_fuzz/Makefile
@@ -70,7 +70,7 @@ AAF_SRCS = $(RTL)/common/ethernet_packet_pkg.sv \
 AAF_FLAGS = --top-module avtp_rxmon_wrap -GCLK_FREQ_HZ_P=10000 \
             +incdir+$(RTL)/common +incdir+$(RTL)/ieee1722/avtp --Mdir obj_aaf
 
-.PHONY: all build run aaf ptp matrix matrix-check clean
+.PHONY: all build run graderself aaf ptp matrix matrix-check clean
 
 all: run
 
@@ -85,8 +85,15 @@ gptp_ucode.hex: $(GPTP_DIR)/hdl/ucode/gen_gptp_ucode.py
 obj_ptp/Vptp_cosim: cosim_ptp.cpp cosim_axis.h $(PTP_SRCS) gptp_ucode.hex
 	$(VERILATOR) $(VCOMMON) $(PTP_FLAGS) $(PTP_SRCS) cosim_ptp.cpp -o Vptp_cosim
 
-run: build aaf ptp matrix-check
+run: graderself build aaf ptp matrix-check
 	@echo "== tsn_fuzz: all campaigns passed =="
+
+# The field grader's own self-test. Deliberately FIRST and deliberately free of
+# Verilator and tsn-gen: it guards a defect the campaigns cannot see, because a
+# constraint kind grade_tx does not know produces no check to fail. It therefore
+# has to run even where the campaigns skip.
+graderself:
+	@$(PY) test_grade_tx.py
 
 # regenerate the module<->spec<->test traceability matrix from the tree
 matrix:

--- a/tb/verilator/tsn_fuzz/fuzz_ptp.py
+++ b/tb/verilator/tsn_fuzz/fuzz_ptp.py
@@ -261,6 +261,11 @@ class Campaign:
         for name, _bits, con in model.fields:
             if name in skip or name not in got or not con:
                 continue
+            # Dispatch order matches tsn_model.legal()/illegal() exactly:
+            # value, values, range, mask. No field declares two kinds today,
+            # but a grader that resolved a combination differently from the
+            # generator that produced the stimulus would be judging by one
+            # rule what was built by another.
             if "value" in con:
                 if name in gaps:
                     self.eq_or_gap("%s.%s" % (label, name), got[name],
@@ -268,14 +273,14 @@ class Campaign:
                 else:
                     self.rep.eq("%s.%s" % (label, name), got[name],
                                 int(con["value"]))
-            elif "range" in con:
-                lo, hi = int(con["range"][0]), int(con["range"][1])
-                self.rep.ck("%s.%s in [%d,%d]" % (label, name, lo, hi),
-                            lo <= got[name] <= hi, "got=%d" % got[name])
             elif "values" in con:
                 self.rep.ck("%s.%s legal" % (label, name),
                             got[name] in [int(v) for v in con["values"]],
                             "got=%d" % got[name])
+            elif "range" in con:
+                lo, hi = int(con["range"][0]), int(con["range"][1])
+                self.rep.ck("%s.%s in [%d,%d]" % (label, name, lo, hi),
+                            lo <= got[name] <= hi, "got=%d" % got[name])
             elif "mask" in con:
                 # A mask names the DEFINED bits; the spec claim is that no bit
                 # outside that set is set. tsn_model already reads masks this

--- a/tb/verilator/tsn_fuzz/fuzz_ptp.py
+++ b/tb/verilator/tsn_fuzz/fuzz_ptp.py
@@ -276,6 +276,26 @@ class Campaign:
                 self.rep.ck("%s.%s legal" % (label, name),
                             got[name] in [int(v) for v in con["values"]],
                             "got=%d" % got[name])
+            elif "mask" in con:
+                # A mask names the DEFINED bits; the spec claim is that no bit
+                # outside that set is set. tsn_model already reads masks this
+                # way for probe generation (legal/illegal), so grade to match.
+                m = int(con["mask"][0])
+                undef = got[name] & ~m
+                self.rep.ck("%s.%s within defined bits" % (label, name),
+                            undef == 0,
+                            "got=0x%X undefined=0x%X mask=0x%X"
+                            % (got[name], undef, m))
+            else:
+                # FAIL CLOSED. A constraint kind this grader does not know must
+                # never pass in silence: that is exactly how an Announce `mask:`
+                # pin left the campaign once already, with the tally unmoved and
+                # nothing red to notice. Anyone adding a kind has to teach the
+                # grader what it asserts before the suite will go green again.
+                self.rep.ck("%s.%s constraint is gradeable" % (label, name),
+                            False,
+                            "ungradeable constraint kind %s -- teach grade_tx"
+                            % sorted(con))
         return got
 
     def become_gm(self, budget=10 * SECOND):

--- a/tb/verilator/tsn_fuzz/test_grade_tx.py
+++ b/tb/verilator/tsn_fuzz/test_grade_tx.py
@@ -78,10 +78,50 @@ CASES = [
      8, {"mask": [0x0F]}, [0x85], 0, 1, "undefined=0x80"),
     ("mask: every defined bit set is still legal",
      8, {"mask": [0x0F]}, [0x0F], 1, 0, ""),
+
+    # REAL WIDTHS. Every mask in the live models is 16, 32 or 64 bits wide
+    # (talker/listener_capabilities 16, controller_capabilities 32,
+    # tlv_length_and_mode 16, acquire/lock_entity_flags 32, msrp_flags 64) and
+    # every undefined bit that matters sits ABOVE bit 7. An 8-bit fixture set
+    # cannot see a grader that truncates -- `got & ~m & 0xFF` passes all three
+    # cases above while waving an undefined bit through five of the six real
+    # fields. Each case below puts the offending bit high enough that any
+    # narrower mask arithmetic misses it.
+    ("mask 16b talker_capabilities: legal",
+     16, {"mask": [0x803F]}, [0x80, 0x3F], 1, 0, ""),
+    ("mask 16b: undefined bit 14, above the low byte",
+     16, {"mask": [0x803F]}, [0x40, 0x00], 0, 1, "undefined=0x4000"),
+    ("mask 32b acquire_entity_flags: legal",
+     32, {"mask": [0xC0000000]}, [0xC0, 0, 0, 0], 1, 0, ""),
+    ("mask 32b: undefined bit 29, above 16 bits",
+     32, {"mask": [0xC0000000]}, [0x20, 0, 0, 0], 0, 1, "undefined=0x20000000"),
+    ("mask 64b msrp_flags: legal",
+     64, {"mask": [0xF800000000000000]},
+     [0xF8, 0, 0, 0, 0, 0, 0, 0], 1, 0, ""),
+    ("mask 64b: undefined bit 58, above 32 bits",
+     64, {"mask": [0xF800000000000000]},
+     [0x04, 0, 0, 0, 0, 0, 0, 0], 0, 1, "undefined=0x400000000000000"),
+
     ("unknown kind fails closed",
      8, {"regex": ["x"]}, [0x00], 0, 1, "ungradeable constraint kind"),
     ("unknown kind names the field",
      8, {"regex": ["x"]}, [0x00], 0, 1, "t.f"),
+    # #146 asks the failure to name the field AND THE KIND. Without this the
+    # message could drop the kind and both needles above would still be met.
+    ("unknown kind names the KIND itself",
+     8, {"regex": ["x"]}, [0x00], 0, 1, "regex"),
+
+    # Dispatch precedence. No field at the pinned rev declares two kinds, so
+    # a reordering of the if/elif chain is otherwise invisible. Pin the order
+    # tsn_model.legal() uses (value, values, range, mask) so the grader and the
+    # generator cannot silently disagree about which constraint governs.
+    ("precedence: value wins over mask",
+     8, {"value": 0x03, "mask": [0x0F]}, [0x01], 0, 1, "exp=3"),
+    ("precedence: values wins over range",
+     8, {"values": [1, 2], "range": [0, 255]}, [9], 0, 1, "legal"),
+    ("precedence: range wins over mask",
+     8, {"range": [1, 9], "mask": [0xFF]}, [200], 0, 1, "in [1,9]"),
+
     ("value: matching", 8, {"value": 0x42}, [0x42], 1, 0, ""),
     ("value: mismatching", 8, {"value": 0x42}, [0x43], 0, 1, "got=67"),
     ("range: inside", 8, {"range": [1, 9]}, [5], 1, 0, ""),
@@ -91,13 +131,22 @@ CASES = [
     # An absent `expected:` block must keep SKIPPING. Failing it here would
     # redden every legitimately unconstrained field (sequence_id, clock
     # identities), so the fail-closed rule deliberately stops at non-empty
-    # constraints. The shrinking-tally problem that causes is tracked apart.
+    # constraints. The shrinking-tally problem that causes is issue #150.
     ("no constraint at all still skips",
      8, {}, [0xFF], 0, 0, ""),
 ]
 
+# A floor, for the same reason the campaigns carry one: an empty CASES list
+# would print "0 checks: 0 PASS, 0 FAIL" and exit 0, which reads as success.
+MIN_CASES = 22
+
+
 
 def main():
+    if len(CASES) < MIN_CASES:
+        print("grade_tx self-test: FAIL, only %d cases, expected at least %d"
+              % (len(CASES), MIN_CASES))
+        return 1
     bad = 0
     for name, bits, con, pdu, want_p, want_f, needle in CASES:
         npass, nfail, msg = grade(bits, con, pdu)

--- a/tb/verilator/tsn_fuzz/test_grade_tx.py
+++ b/tb/verilator/tsn_fuzz/test_grade_tx.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""
+Self-test for the campaign's field grader (`Campaign.grade_tx`).
+
+This does NOT touch the DUT, Verilator or tsn-gen: it drives grade_tx with
+synthetic one-field models and hand-built frames, so it runs everywhere the
+campaigns themselves skip. That matters, because the defect it guards is
+invisible to the campaigns by construction.
+
+WHAT IT GUARDS. grade_tx dispatches on the constraint kind a tsn-gen model
+declares. Before issue #146 the chain ended after `values`, so a field
+constrained any other way was simply not graded -- no failure, no skip line,
+no movement in the tally. The check did not exist. That is not hypothetical:
+an Announce `flags` pin was once replaced with `mask: [0x003F]` on the claim
+that the harness would catch a regression, and it would not have.
+
+So the two properties below are the point of this file:
+  1. `mask:` is graded, and it grades what a mask actually asserts.
+  2. Any kind grade_tx does NOT know fails CLOSED, naming the field and kind.
+
+A grader that silently ignores what it does not understand cannot be trusted
+to mean anything, so (2) is the durable half: it holds for constraint kinds
+nobody has invented yet, while (1) only covers the one we know about.
+"""
+
+import contextlib
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cosim import Report                                    # noqa: E402
+import fuzz_ptp                                             # noqa: E402
+
+
+class OneFieldModel:
+    """The whole surface grade_tx and extract_fields touch: `.fields`."""
+
+    def __init__(self, fields):
+        self._fields = fields
+
+    @property
+    def fields(self):
+        return self._fields
+
+
+def grade(field_bits, constraint, pdu):
+    """Grade one synthetic field and return (npass, nfail, first message).
+
+    The inner Report prints a banner and a `[FAIL]` line for every case that
+    is SUPPOSED to fail. Those are this file's expected results, not its
+    verdict, so stdout is swallowed while the grader runs -- otherwise the log
+    reads as a wall of failures and `suite_tally.py` would be scanning our
+    fixtures. Only the per-case verdict below is printed.
+    """
+    with contextlib.redirect_stdout(io.StringIO()):
+        rep = Report("grade_tx self-test", verbose=False)
+        camp = fuzz_ptp.Campaign.__new__(fuzz_ptp.Campaign)  # no cosim socket
+        camp.rep = rep
+        frame = bytes(14) + bytes(pdu)      # extract_fields reads from byte 14
+        camp.grade_tx(OneFieldModel([("f", field_bits, constraint)]),
+                      frame, "t")
+    msg = ""
+    if rep.failures:
+        _sec, what, detail = rep.failures[0]
+        msg = "%s | %s" % (what, detail)
+    return rep.npass, rep.nfail, msg
+
+
+CASES = [
+    # (name, bits, constraint, pdu, want_pass, want_fail, msg_must_contain)
+    ("mask: no undefined bit set",
+     8, {"mask": [0x0F]}, [0x05], 1, 0, ""),
+    ("mask: an undefined bit IS set",
+     8, {"mask": [0x0F]}, [0x85], 0, 1, "undefined=0x80"),
+    ("mask: every defined bit set is still legal",
+     8, {"mask": [0x0F]}, [0x0F], 1, 0, ""),
+    ("unknown kind fails closed",
+     8, {"regex": ["x"]}, [0x00], 0, 1, "ungradeable constraint kind"),
+    ("unknown kind names the field",
+     8, {"regex": ["x"]}, [0x00], 0, 1, "t.f"),
+    ("value: matching", 8, {"value": 0x42}, [0x42], 1, 0, ""),
+    ("value: mismatching", 8, {"value": 0x42}, [0x43], 0, 1, "got=67"),
+    ("range: inside", 8, {"range": [1, 9]}, [5], 1, 0, ""),
+    ("range: outside", 8, {"range": [1, 9]}, [200], 0, 1, "got=200"),
+    ("values: legal", 8, {"values": [1, 2]}, [2], 1, 0, ""),
+    ("values: illegal", 8, {"values": [1, 2]}, [3], 0, 1, "got=3"),
+    # An absent `expected:` block must keep SKIPPING. Failing it here would
+    # redden every legitimately unconstrained field (sequence_id, clock
+    # identities), so the fail-closed rule deliberately stops at non-empty
+    # constraints. The shrinking-tally problem that causes is tracked apart.
+    ("no constraint at all still skips",
+     8, {}, [0xFF], 0, 0, ""),
+]
+
+
+def main():
+    bad = 0
+    for name, bits, con, pdu, want_p, want_f, needle in CASES:
+        npass, nfail, msg = grade(bits, con, pdu)
+        ok = (npass == want_p and nfail == want_f
+              and (not needle or needle in msg))
+        if not ok:
+            bad += 1
+        print("  [%s] %-46s pass=%d/%d fail=%d/%d%s"
+              % ("ok  " if ok else "FAIL", name, npass, want_p, nfail, want_f,
+                 "" if not needle else
+                 ("  needle=%r %s" % (needle, "found" if needle in msg
+                                      else "MISSING in %r" % msg))))
+
+    print("\ngrade_tx self-test: %d checks: %d PASS, %d FAIL"
+          % (len(CASES), len(CASES) - bad, bad))
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #146.

`grade_tx()` (`tb/verilator/tsn_fuzz/fuzz_ptp.py:253`) is the campaign's only field grader, and its dispatch chain ended after `values` with no `else`. A field constrained any other way fell off the end and was **not graded at all**: no failure, no skip line, no movement in the tally. The check simply did not exist.

This is the defect that let my Announce `mask: [0x003F]` pin pass review-by-inspection while asserting nothing. It was caught by a reader, not by any gate, which is the part worth fixing.

## What changed

1. **A `mask` branch.** It grades what a mask actually asserts: no bit outside the defined set is set. `tsn_model.py` already reads masks this way for probe generation (`legal()` at :119, `illegal()` at :144), so the grader now agrees with the generator instead of ignoring it.
2. **Fail closed on an unrecognised kind.** This is the durable half. A kind nobody has invented yet now turns the suite RED and names the field and the kind, forcing whoever adds it to teach the grader what it asserts. Point 1 only covers the one kind we know about; point 2 covers the rest.

3. **The dispatch order now matches `tsn_model`** exactly (value, values, range, mask). Pinning precedence surfaced a real disagreement: `grade_tx` tried `range` before `values` while `tsn_model.legal()`/`illegal()` do the reverse. Nothing was misgraded, because no field at the pinned rev declares two kinds, but a grader that resolved a combination differently from the generator that built the stimulus would be judging by one rule what was made by another.

An absent `expected:` block still SKIPS rather than failing, deliberately: failing it would redden every legitimately unconstrained field (`sequence_id`, the clock identities). The related problem, that deleting a pin silently shrinks the campaign, is a different shape and is now tracked as **#150** with its measured evidence.

## The gate

New `tb/verilator/tsn_fuzz/test_grade_tx.py`, wired into the Makefile as `graderself` and run FIRST in `run`. It drives `grade_tx` with synthetic one-field models and hand-built frames, so it needs neither Verilator nor tsn-gen. That is the point: it guards a defect the campaigns cannot see, so it has to run where the campaigns skip.

**22 checks, 22 PASS.** Each negative case also asserts the failure MESSAGE contains the right needle, so a check that reddens for an unrelated reason does not read as a catch. The mask fixtures run at the widths that actually occur - 16, 32 and 64 bits - with the undefined bit placed above any narrower arithmetic, because an all-8-bit fixture set cannot see a grader that truncates. `MIN_CASES` refuses to report success on an emptied case list.

## Mutation proof

Reverting `grade_tx` to its pre-#146 shape (drop the `mask` branch and the `else`) takes the self-test red. Three further mutants, all found by review rather than by me, are also caught: truncating the mask arithmetic to 8 bits fails 3 of 22 (one per width); dropping the constraint kind from the failure message fails 1 of 22; emptying `CASES` exits 1, and `make graderself` exits 2.

The original revert produces:

```
[FAIL] mask: no undefined bit set                 pass=0/1 fail=0/0
[FAIL] mask: an undefined bit IS set              pass=0/0 fail=0/1  needle MISSING
[FAIL] mask: every defined bit set is still legal pass=0/1 fail=0/0
[FAIL] unknown kind fails closed                  pass=0/0 fail=0/1  needle MISSING
[FAIL] unknown kind names the field               pass=0/0 fail=0/1  needle MISSING
```

Read `pass=0/1 fail=0/0` carefully: the old grader produced **no check at all** for those fields, neither passing nor failing. That is the silent skip, visible.

`make graderself` exits **2** with the reverted grader and **0** with it restored, so the failure genuinely propagates rather than being printed and swallowed.

## Blast radius

None to the existing tally. No 802.1AS model uses `mask` or any kind outside `value` / `values` / `range`, verified across all seven `protocols/data_link/ptp/*.yaml` at the CI-pinned tsn-gen rev, so the campaign adds no checks and removes none. `mask:` is live in 7 fields of the 1722.1 models (`1722_1_adp.yaml`, `aecp_address_access.yaml`, `aecp_aem_acquire_entity.yaml`, `aecp_aem_lock_entity.yaml`, `aecp_aem_set_stream_info.yaml`), which `fuzz_ptp` does not grade today; the hole was latent for the PTP tier and reopened the moment anyone added one.

`python3 scripts/docs_check.py` clean, 0 findings across 211 md files. No RTL touched.
