### PR TITLE
[A0] Shard GitHub Verilator CI

### DIFF
--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# A newer commit makes an older run irrelevant. Free its four hosted runners
+# immediately instead of making the useful run queue behind stale evidence.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Pinned to the version the harnesses are developed and gated against.
   # Distro Verilator is NOT usable here - see docs/testing/TESTING.md §7:
@@ -22,9 +28,14 @@ env:
 jobs:
   # The full Verilator suite sweep needs verilog-axis and protocol-processor.
   # Both use anonymous HTTPS so a fork can fetch them too.
-  verilator-suites:
+  verilator-shards:
+    name: Verilator shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v4
       - name: Fetch the RTL submodules
@@ -113,15 +124,63 @@ jobs:
           test -x "$RUNNER_TEMP/tsn-gen/build/traffic-gen/packet_gen"
           echo "TSN_GEN_ROOT=$RUNNER_TEMP/tsn-gen" >> "$GITHUB_ENV"
 
-      - name: Run every suite
-        run: scripts/run_all_suites.sh "$RUNNER_TEMP/suite-logs"
+      - name: Run this suite shard
+        run: scripts/run_all_suites.sh "$RUNNER_TEMP/suite-logs" --shard "${{ matrix.shard }}/4"
 
-      - name: Upload suite logs on failure
-        if: failure()
+      # Always upload: the final required check proves that the four artifacts
+      # are an exhaustive, disjoint copy of the serial suite inventory.
+      - name: Upload this shard's suite logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: suite-logs
+          name: suite-logs-${{ matrix.shard }}
           path: ${{ runner.temp }}/suite-logs
+          if-no-files-found: error
+          retention-days: 3
+
+  # Preserve the public required-check name while moving the expensive work to
+  # four isolated workers. This job fails if any worker failed OR if their logs
+  # omit, duplicate, or invent a suite relative to tb/verilator/.
+  verilator-suites:
+    name: verilator-suites
+    # Still aggregate ordinary worker failures, but let concurrency cancellation
+    # stop the obsolete run instead of keeping it alive for this bookkeeping.
+    if: ${{ !cancelled() }}
+    needs: verilator-shards
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download every shard's logs
+        id: download-logs
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: suite-logs-*
+          path: ${{ runner.temp }}/all-suite-logs
+
+      - name: Prove exhaustive ownership and tally every log
+        if: always()
+        run: |
+          shopt -s nullglob
+          roots=("$RUNNER_TEMP"/all-suite-logs/suite-logs-*)
+          if [ "${#roots[@]}" -eq 0 ]; then
+            mkdir -p "$RUNNER_TEMP/all-suite-logs/none"
+            roots=("$RUNNER_TEMP/all-suite-logs/none")
+          fi
+          python3 scripts/suite_tally.py "${roots[@]}" --quiet \
+            --expect-suite-root tb/verilator
+
+      - name: Require every shard worker to pass
+        if: always()
+        env:
+          SHARD_RESULT: ${{ needs.verilator-shards.result }}
+        run: |
+          if [ "$SHARD_RESULT" != success ]; then
+            echo "one or more Verilator shard workers ended: $SHARD_RESULT" >&2
+            exit 1
+          fi
 
   # BDD conformance suite (Gherkin, tests/features). Offline by default - the
   # Python models in tests/steps mirror the RTL, so it needs no DUT binary and

--- a/docs/testing/RUNNING_TESTS.md
+++ b/docs/testing/RUNNING_TESTS.md
@@ -190,8 +190,19 @@ cd tb/verilator/adp_tx && make     # builds + runs; self-checking, prints PASS/c
 > the mandatory commands and root dynamic-state connections that remain open.
 
 No Xilinx dependencies (the RTL is XPM-free). Run the affected module's harness after
-touching its SV; run the full [tb/verilator/](../../tb/verilator) sweep before a release-ish commit (`for d in tb/verilator/*/;
-do make -C "$d" || break; done`).
+touching its SV; run the full [tb/verilator/](../../tb/verilator) sweep before a
+release-ish commit:
+
+```sh
+suite_logs=$(mktemp -d)
+scripts/run_all_suites.sh "$suite_logs"
+```
+
+The no-option form is the complete serial local gate. GitHub schedules the
+same inventory as four isolated `--shard INDEX/4` workers and then rejects any
+missing, duplicate, or unexpected log in the aggregate `verilator-suites`
+check. To inspect that deterministic assignment without compiling, use
+`scripts/run_all_suites.sh --shard 0/4 --list`.
 
 ## 4. Yosys device-portability check (syn/yosys)
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -255,6 +255,15 @@ emits five summary shapes, and 29 of 57 suite logs matched none of them and
 contributed a silent zero — shown by adding 66 assertions to a suite and
 watching the printed total not move). Rerun the sweep for both figures.
 
+With no options the script remains the mandatory serial local sweep. GitHub
+uses four isolated `--shard INDEX/4` workers to reduce wall time, then keeps
+`verilator-suites` as a small aggregate required check. That aggregate compares
+the uploaded log names with the live `tb/verilator/*/Makefile` inventory and
+fails on a missing, unexpected, or multiply-owned suite before trusting the
+combined tally. `scripts/run_all_suites.sh --shard 0/4 --list` shows a worker's
+deterministic selection without building it; sharding is a scheduling detail,
+not permission to validate only one quarter locally.
+
 > **This table SHRANK on 2026-08-13, and that is the first time it ever has.**
 > The standing rule was that every round grows it. Thirteen suites — `aecp`,
 > `aempatch`, `acmp`, `acmp_lstn`, `persist`, `adp`, `adp_advertise`,

--- a/scripts/run_all_suites.sh
+++ b/scripts/run_all_suites.sh
@@ -5,7 +5,8 @@
 #
 # Run every Verilator testbench suite under tb/verilator/ and summarise.
 #
-#   scripts/run_all_suites.sh [outdir] [--wait]
+#   scripts/run_all_suites.sh [outdir] [--wait] [--shard INDEX/TOTAL]
+#   scripts/run_all_suites.sh [--shard INDEX/TOTAL] --list
 #
 # Each suite is a directory with its own Makefile; the default target builds
 # and runs every shape that suite owns (several own more than one - milan_dp
@@ -78,14 +79,42 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WAIT=0
 OUT=""
-for arg in "$@"; do
-  case "$arg" in
-    --wait) WAIT=1 ;;
-    -*)     echo "unknown option: $arg" >&2; exit 2 ;;
-    *)      OUT="$arg" ;;
+SHARD="0/1"
+LIST=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --wait) WAIT=1; shift ;;
+    --list) LIST=1; shift ;;
+    --shard)
+      [ "$#" -ge 2 ] || { echo "--shard needs INDEX/TOTAL" >&2; exit 2; }
+      SHARD="$2"; shift 2 ;;
+    --shard=*) SHARD="${1#--shard=}"; shift ;;
+    -*)        echo "unknown option: $1" >&2; exit 2 ;;
+    *)
+      [ -z "$OUT" ] || { echo "more than one output directory" >&2; exit 2; }
+      OUT="$1"; shift ;;
   esac
 done
 OUT="${OUT:-$ROOT/.suite-logs}"
+
+# Selection is delegated to a self-tested helper. Its default 0/1 result is
+# exactly the old lexical glob order, so local callers remain an unsharded
+# full sweep. --list is intentionally read-only and takes no sweep lock.
+if [ "$LIST" = 1 ]; then
+  exec python3 "$ROOT/scripts/suite_shards.py" \
+    --suite-root "$ROOT/tb/verilator" --shard "$SHARD"
+fi
+
+if ! selected_out=$(python3 "$ROOT/scripts/suite_shards.py" \
+      --suite-root "$ROOT/tb/verilator" --shard "$SHARD" 2>&1); then
+  echo "$selected_out" >&2
+  exit 2
+fi
+mapfile -t suites < <(printf '%s' "$selected_out")
+if [ "${#suites[@]}" -eq 0 ]; then
+  echo "shard $SHARD owns no suites; choose fewer workers" >&2
+  exit 2
+fi
 
 # --- concurrency guard -------------------------------------------------------
 # Scope is the repo root, which is exactly the collision domain: the obj_* dirs
@@ -144,6 +173,13 @@ if ! selftest_out=$(python3 "$ROOT/scripts/suite_tally.py" --selftest 2>&1); the
   exit 2
 fi
 
+if ! selftest_out=$(python3 "$ROOT/scripts/suite_shards.py" --selftest 2>&1); then
+  echo "$selftest_out" >&2
+  echo "ABORTING: scripts/suite_shards.py fails its own self-test, so the" >&2
+  echo "selected workers cannot be trusted to cover every suite once." >&2
+  exit 2
+fi
+
 # Same argument, different gate: check_merge_containment.py decides whether a
 # merge left work behind, and a review pointed out it was wired into nothing at
 # all -- its only caller was a sentence in CONTRIBUTING.md telling a human to
@@ -184,9 +220,9 @@ mkdir -p "$OUT"
 rm -f "$OUT"/*.log            # a stale log from a previous sweep is not evidence
 
 pass=0; fail=0; tmo=0; failed=""; timedout=""
-for d in "$ROOT"/tb/verilator/*/; do
-  suite=$(basename "$d")
-  [ -f "$d/Makefile" ] || continue
+echo "shard: $SHARD   selected suites: ${#suites[@]}"
+for suite in "${suites[@]}"; do
+  d="$ROOT/tb/verilator/$suite"
   timeout "$TMO" make -C "$d" > "$OUT/$suite.log" 2>&1
   rc=$?
   case $rc in

--- a/scripts/suite_shards.py
+++ b/scripts/suite_shards.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Select a deterministic, disjoint shard of the Verilator suite inventory.
+
+The unsharded default is the existing lexical sweep. With ``--shard I/N``, a
+stable SHA-256 digest assigns each suite to one worker. Unlike position-based
+round robin, adding or deleting one suite does not move every later suite to a
+different worker. The rule is deterministic, reviewable, and cannot silently
+omit a suite when the inventory changes.
+"""
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+
+SHARD_RE = re.compile(r"^(0|[1-9][0-9]*)/([1-9][0-9]*)$")
+
+
+def parse_shard(value):
+    """Return (zero-based index, worker count), rejecting ambiguous forms."""
+    match = SHARD_RE.fullmatch(value)
+    if not match:
+        raise ValueError("shard must be INDEX/TOTAL using non-negative integers")
+    index, total = (int(part) for part in match.groups())
+    if index >= total:
+        raise ValueError(f"shard index {index} is outside 0..{total - 1}")
+    return index, total
+
+
+def discover_suites(root):
+    """Return suite directory names in the serial sweep's lexical order."""
+    root = Path(root)
+    return sorted(
+        path.name for path in root.iterdir()
+        if path.is_dir() and (path / "Makefile").is_file()
+    )
+
+
+def select_suites(suites, index, total):
+    """Select one stable-hash shard from an already ordered inventory."""
+    return [suite for suite in suites if shard_owner(suite, total) == index]
+
+
+def shard_owner(suite, total):
+    """Return the stable zero-based owner of one suite name."""
+    digest = hashlib.sha256(suite.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % total
+
+
+def selftest():
+    suites = [f"suite-{number:02d}" for number in range(17)]
+    bad = 0
+
+    for total in (1, 2, 4, 7, 23):
+        shards = [select_suites(suites, index, total)
+                  for index in range(total)]
+        flattened = [suite for shard in shards for suite in shard]
+        complete = sorted(flattened) == suites
+        disjoint = len(flattened) == len(set(flattened))
+        deterministic = shards == [select_suites(suites, index, total)
+                                   for index in range(total)]
+        ok = complete and disjoint and deterministic
+        print(f"  {'ok  ' if ok else 'FAIL'} {total:>2} shard(s): "
+              f"complete={complete} disjoint={disjoint} "
+              f"deterministic={deterministic}")
+        bad += 0 if ok else 1
+
+    # Pin the useful four-worker geometry as well as the abstract set proof.
+    # These are the longest landmarks in a measured cache-hit GitHub sweep;
+    # putting each on a distinct worker avoids an accidental hash-rule change
+    # rebuilding the old serial critical path inside one shard.
+    landmarks = {
+        "milan_dp": 0,
+        "pp_shadow": 1,
+        "mmcm_servo": 2,
+        "hostplane": 3,
+    }
+    got = {suite: shard_owner(suite, 4) for suite in landmarks}
+    ok = got == landmarks
+    print(f"  {'ok  ' if ok else 'FAIL'} four-worker runtime landmarks: {got}")
+    bad += 0 if ok else 1
+
+    for value in ("", "1", "-1/4", "01/4", "4/4", "5/4", "0/0", "a/4"):
+        try:
+            parse_shard(value)
+            ok = False
+        except ValueError:
+            ok = True
+        print(f"  {'ok  ' if ok else 'FAIL'} reject {value!r}")
+        bad += 0 if ok else 1
+
+    print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
+    return 1 if bad else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite-root", type=Path,
+                        help="directory containing one subdirectory per suite")
+    parser.add_argument("--shard", default="0/1", metavar="INDEX/TOTAL",
+                        help="zero-based shard to print (default: 0/1)")
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv[1:])
+
+    if args.selftest:
+        return selftest()
+    if args.suite_root is None:
+        parser.error("--suite-root is required unless --selftest is used")
+
+    try:
+        index, total = parse_shard(args.shard)
+        suites = discover_suites(args.suite_root)
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+    if not suites:
+        parser.error(f"no suite Makefiles found under {args.suite_root}")
+
+    for suite in select_suites(suites, index, total):
+        print(suite)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/suite_tally.py
+++ b/scripts/suite_tally.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Tally the check counts out of a Verilator sweep's per-suite logs.
 
-    python3 scripts/suite_tally.py <logdir> [--quiet]
+    python3 scripts/suite_tally.py <logdir>... [--quiet]
+        [--expect-suite-root <tb/verilator>]
 
 ``<logdir>`` is the directory ``scripts/run_all_suites.sh`` writes
 ``<suite>.log`` into (default ``.suite-logs/``).  This script is the *only*
@@ -81,6 +82,7 @@ could not fail.
 
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 # --- the recognised summary shapes -------------------------------------------
@@ -439,6 +441,60 @@ def selftest():
             bad += 1
             print(f"       expected rc={want_rc}")
 
+    # --- SHARDED INVENTORY --------------------------------------------------
+    # Parallel workers are only faster if their union is still the serial
+    # sweep. These cases reach the exact multi-directory CLI the aggregate
+    # GitHub job uses and prove that omissions, additions, and double ownership
+    # all fail before a combined headline can be trusted.
+    for name, layout, want_rc, want_out, why in (
+        ("inventory-exact",
+         ({"left": {"a": "checks: 2   failures: 0\n"},
+                    "right": {"b": "checks: 3   failures: 0\n"}},
+          ("a", "b")),
+         0, "checks: 5   in-suite failures: 0",
+         "disjoint shard logs reproduce the serial tally"),
+        ("inventory-missing",
+         ({"left": {"a": "checks: 2   failures: 0\n"}}, ("a", "b")),
+         1, "MISSING     b", "one omitted serial suite fails closed"),
+        ("inventory-unexpected",
+         ({"left": {"a": "checks: 2   failures: 0\n",
+                     "c": "checks: 4   failures: 0\n"}}, ("a", "b")),
+         1, "UNEXPECTED  c", "a stale or invented suite log fails closed"),
+        ("inventory-duplicate",
+         ({"left": {"a": "checks: 2   failures: 0\n"},
+                    "right": {"a": "checks: 2   failures: 0\n",
+                              "b": "checks: 3   failures: 0\n"}},
+          ("a", "b")),
+         1, "DUPLICATE   a", "two workers owning one suite fails closed"),
+    ):
+        log_layout, expected = layout
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            suite_root = base / "suites"
+            suite_root.mkdir()
+            for suite in expected:
+                suite_dir = suite_root / suite
+                suite_dir.mkdir()
+                (suite_dir / "Makefile").write_text("all:\n\t@true\n")
+            logdirs = []
+            for dirname, logs in log_layout.items():
+                logdir = base / dirname
+                logdir.mkdir()
+                logdirs.append(logdir)
+                for stem, body in logs.items():
+                    (logdir / f"{stem}.log").write_text(body)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                rc = main([sys.argv[0], *map(str, logdirs), "--quiet",
+                           "--expect-suite-root", str(suite_root)])
+        out = buf.getvalue()
+        ok = rc == want_rc and want_out in out
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} rc={rc}  -- {why}")
+        if not ok:
+            bad += 1
+            print(f"       expected rc={want_rc} and {want_out!r} in output")
+
     # --- the CAMPAIGN GUARD --------------------------------------------------
     # The guard protects 164 checks that nothing else protects, because the
     # suite's own 2-check floor lifts it clear of NOCOUNT. A review pointed out
@@ -562,18 +618,70 @@ def main(argv):
         print("  in scripts/suite_tally.py, or a SUITE-SKIP: line saying why")
         print("  the campaign ran nothing.")
         return 1
-    args = [a for a in argv[1:] if not a.startswith("-")]
-    quiet = "--quiet" in argv[1:]
-    if len(args) != 1:
-        sys.stderr.write("usage: suite_tally.py <logdir> [--quiet]\n")
+    quiet = False
+    expected_root = None
+    logdir_args = []
+    pos = 1
+    while pos < len(argv):
+        arg = argv[pos]
+        if arg == "--quiet":
+            quiet = True
+            pos += 1
+        elif arg == "--expect-suite-root":
+            if pos + 1 >= len(argv):
+                sys.stderr.write("suite_tally: --expect-suite-root needs a path\n")
+                return 2
+            expected_root = Path(argv[pos + 1])
+            pos += 2
+        elif arg.startswith("-"):
+            sys.stderr.write(f"suite_tally: unknown option {arg}\n")
+            return 2
+        else:
+            logdir_args.append(arg)
+            pos += 1
+    if not logdir_args:
+        sys.stderr.write("usage: suite_tally.py <logdir>... [--quiet] "
+                         "[--expect-suite-root <dir>]\n")
         return 2
 
-    logdir = Path(args[0])
-    logs = sorted(logdir.glob("*.log"))
+    logdirs = [Path(arg) for arg in logdir_args]
+    logs = sorted((log for logdir in logdirs for log in logdir.glob("*.log")),
+                  key=lambda path: (path.stem, str(path)))
     if not logs:
-        sys.stderr.write(f"suite_tally: no *.log under {logdir} -- nothing to "
+        rendered = ", ".join(map(str, logdirs))
+        sys.stderr.write(f"suite_tally: no *.log under {rendered} -- nothing to "
                          f"tally, which is an unknown, not a zero\n")
         return 2
+
+    inventory_findings = []
+    counts = Counter(log.stem for log in logs)
+    for suite, count in sorted(counts.items()):
+        if count > 1:
+            inventory_findings.append(
+                ("DUPLICATE", suite, f"appears in {count} shard log directories"))
+    if expected_root is not None:
+        try:
+            expected = {
+                path.name for path in expected_root.iterdir()
+                if path.is_dir() and (path / "Makefile").is_file()
+            }
+        except OSError as exc:
+            sys.stderr.write(f"suite_tally: cannot read expected suite root "
+                             f"{expected_root}: {exc}\n")
+            return 2
+        if not expected:
+            sys.stderr.write(f"suite_tally: no suite Makefiles under expected "
+                             f"root {expected_root}\n")
+            return 2
+        actual = set(counts)
+        inventory_findings.extend(
+            ("MISSING", suite, "no shard produced its log")
+            for suite in sorted(expected - actual)
+        )
+        inventory_findings.extend(
+            ("UNEXPECTED", suite, "not present in the serial suite inventory")
+            for suite in sorted(actual - expected)
+        )
 
     total_checks = total_fails = 0
     nocount = []
@@ -613,6 +721,15 @@ def main(argv):
 
     print(f"checks: {total_checks}   in-suite failures: {total_fails}")
 
+    if inventory_findings:
+        print()
+        print("ACCOUNTING FAILURE -- shard logs do not equal the serial suite "
+              "inventory:")
+        for finding, suite, reason in inventory_findings:
+            print(f"  {finding:<11} {suite}: {reason}")
+        print("  The combined check total is not exhaustive and must not be "
+              "treated as the serial sweep.")
+
     #! Printed ALWAYS, including --quiet, and above the accounting verdicts:
     #! the total being smaller than usual is the thing a reader most needs
     #! told, and it is not a failure so nothing else would say it.
@@ -623,7 +740,7 @@ def main(argv):
         for suite, reason in skip_findings:
             print(f"  SKIPPED  {suite}: {reason}")
 
-    bad = False
+    bad = bool(inventory_findings)
     if nocount:
         bad = True
         print()


### PR DESCRIPTION
[A0]

## Contents

- **Status** — Green exact-head result and before/after timing.
- **Linked Issue / roles** — #167; A0 implementation, independent R1 and R0 reviews.
- **Description** — Stable four-way suite ownership, fail-closed aggregation, and stale-run cancellation.
- **How to validate** — Reproducible local gates and live GitHub evidence.

## Status

GREEN — 52/52 local suites and 46/46 local Yosys tops pass — `167-shard-github-verilator-ci` -> `dev`.

Exact reviewed head: `2124b4e4cc340e8afcb75e80284452d2b78f1cfe`

Serial baseline run 32401845539 took 25m10s in `verilator-suites`. Candidate run 32406467657 completed the preserved aggregate check in 13m39s: **11m31s saved, 45.8% lower wall time**. Both tallies are exactly 2,118,264 checks with zero in-suite failures.

## Linked Issue / roles

Closes: #167

Executor: `[A0]`
Internal cleared-context reviewer: `[R1]` — POSITIVE
External reviewer: `[R0]` — POSITIVE

## Description

- Schedule the 52-suite inventory across four isolated GitHub workers using stable SHA-256 ownership.
- Keep the existing local no-option sweep serial and exhaustive.
- Preserve `verilator-suites` as the final public check; reject missing, unexpected, and duplicate logs before trusting the combined tally.
- Cancel superseded runs for the same PR or branch.
- Document local versus GitHub behavior.

## Authoritative references

- #167 acceptance contract
- `CONTRIBUTING.md` sections 2 and 3
- `docs/testing/TESTING.md` and `docs/testing/RUNNING_TESTS.md`

## How to get into the same state

```sh
gh pr checkout 168
git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
```

## How to validate

```sh
python3 scripts/suite_shards.py --selftest
python3 scripts/suite_tally.py --selftest
actionlint .github/workflows/rtl.yml
python3 scripts/docs_check.py
python3 scripts/check_doc_paths.py
python3 scripts/gen_toc.py --verify-anchors
python3 scripts/gen_toc.py --check
python3 scripts/lint_rtl.py --check --self-test
cd tests && behave --no-capture -f plain
cd ..
suite_logs=$(mktemp -d)
TSN_GEN_ROOT=/path/to/pinned/tsn-gen scripts/run_all_suites.sh "$suite_logs"
syn/yosys/run.sh
```

Expected result / pass criteria:

- Shard self-test proves complete, disjoint, deterministic ownership and rejects malformed shard specifications.
- Tally self-test rejects missing, unexpected, duplicate, unreadable, and zero-count evidence.
- 52 current suites appear exactly once across the four GitHub artifacts.
- Local and aggregate totals both read 2,118,264 checks and zero failures.
- All GitHub checks and the candidate merge tree are green.

## Known limitations / out of scope

- This does not split a single suite; `milan_dp` remains the lower bound for one worker.
- No RTL, suite behavior, dependency pin, timeout, or local verification requirement changes.
- Yosys remains the GitHub critical path; urgent follow-up #171 tracks sharding its 46-top inventory after this workflow change lands.
- Donor-repository workflows remain separate lanes.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in PR comments
- [x] No undocumented requirement or interface change remains
- [x] Internal cleared-context review is positive
- [x] External review is positive
- [x] Blocking and major findings are fixed and re-reviewed
- [x] No review round remains in flight
- [x] Candidate merge result is validated per `CONTRIBUTING.md`
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done