### PR TITLE
Split review findings by target and bound the review loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ This file tells AI agents how to work efficiently in that system. It supplements
 - **[3. Agent identities and roles](#3-agent-identities-and-roles)** — Session prefixes, the executor/reviewer split, and the requirement that an executor never approves its own work.
 - **[4. Public task contract](#4-public-task-contract)** — What an Issue must contain before work starts, why settled scope rather than size decides readiness, and that new findings become new Issues.
 - **[5. Executor procedure](#5-executor-procedure)** — The steps before the first edit, what to do during implementation, and the two public comments an executor owes.
-- **[6. Reviewer procedure](#6-reviewer-procedure)** — Reviewing from public state alone, the lenses to cover, and the severity classification every finding carries.
-- **[7. Completion and merge](#7-completion-and-merge)** — The full bar a task must clear, and the rule that an agent does not merge without explicit maintainer authorization.
+- **[6. Reviewer procedure](#6-reviewer-procedure)** — Reviewing from public state alone, the lenses to cover, the severity every finding carries, and the split between findings against the deliverable and findings against the instruments that measure it.
+- **[7. Completion and merge](#7-completion-and-merge)** — The full bar a task must clear, when to stop reviewing and ask for authorization, and the rule that an agent does not merge without explicit maintainer authorization.
 - **[8. Non-negotiable rules](#8-non-negotiable-rules)** — The short list that overrides convenience, including never letting two agents edit one branch concurrently, and never weakening a test to obtain a pass.
 
 ## 1. Repository model
@@ -204,7 +204,10 @@ Review at least these lenses.
 - Obsolete requirements or documents were not accidentally restored.
 - The PR and Issue contain enough evidence for another cold reviewer.
 
-Classify every finding:
+Classify every finding twice: by severity, and by what it is a finding
+*against*.
+
+Severity:
 
 - `BLOCKER` — incorrect, unsafe, or non-compliant; must fix before merge.
 - `MAJOR` — substantial correctness, design, or test weakness; normally blocking.
@@ -212,11 +215,46 @@ Classify every finding:
 - `SUGGESTION` — optional improvement.
 - `PASS` — no blocking finding for the assigned review lens.
 
+Target, which is `deliverable` or `instrument`:
+
+- `deliverable` — the work the Issue asked for. A finding is against the
+  deliverable when fixing it changes whether one of the Issue's frozen
+  acceptance criteria (section 4) holds.
+- `instrument` — the gates, harnesses, fixtures, scripts and published figures
+  built to demonstrate the deliverable. A finding is against an instrument when
+  fixing it leaves every acceptance criterion exactly as true or false as it
+  was.
+
+The test is that question and not the reviewer's sense of importance. An
+instrument finding can be severe, and severity is recorded independently. What
+the target decides is not how much the finding matters but which lane owns it.
+
+The two are decided per Issue, not per artifact type. When the Issue asked for a
+gate, that gate IS the deliverable and a defect in it is a `deliverable`
+finding; the instruments are then whatever was built to demonstrate the gate
+works, such as its mutation table or its self-test fixtures. The same file can
+be the deliverable in one lane and an instrument in the next. Apply the
+acceptance-criteria test rather than reading the label off the path.
+
+**An instrument finding does not block the merge it was found on.** File it as
+its own Issue, link it from the PR, and continue. It is not waived, dismissed,
+or downgraded; it is moved to a lane where it can be fixed without holding the
+deliverable hostage.
+
+This exists because verification scaffolding has no natural end. Every gate can
+carry a gate, and a reviewer who keeps looking will keep finding real defects in
+the instruments long after the deliverable has stopped changing. Without this
+split the loop's only exit is a reviewer finding nothing, which is not a bound.
+Issue #166 records the case that produced this rule: a suite that was correct
+and unchanged for seven commits, and six further review rounds, every one of
+them a genuine finding, none of them against the suite.
+
 Use this concise format:
 
 ```text
-[R<n>] <SEVERITY> — <path:line or artifact> — <title>
+[R<n>] <SEVERITY> <deliverable|instrument> — <path:line or artifact> — <title>
 Requirement/evidence: <why this is a finding>
+Target rationale: <which acceptance criterion changes truth, or why none does>
 Impact: <failure mode>
 Required change: <what must be true, without prescribing unnecessary design>
 Verification: <how the fix will be checked>
@@ -224,6 +262,11 @@ Verification: <how the fix will be checked>
 
 A review round that discovers defects is not approval of later fixes. Re-review
 the corrected commit and publish a new verdict.
+
+**A round that produces no `deliverable` finding is a positive result, and it
+must be published as one.** State plainly that the deliverable is ready, listing
+the instrument findings and the Issues they became. That sentence is what ends
+the round; it is not a silence for the executor to read past.
 
 ## 7. Completion and merge
 
@@ -233,7 +276,9 @@ A task is complete only when:
 - required tests and local verification gates pass;
 - no undocumented requirement/interface change remains;
 - the full review bar in [CONTRIBUTING.md](CONTRIBUTING.md) is met;
-- blocking and major findings are fixed and re-reviewed;
+- blocking and major findings **against the deliverable** are fixed and
+  re-reviewed, and instrument findings are filed as their own Issues;
+- the most recent review round produced no `deliverable` finding;
 - no review round remains in flight;
 - the candidate merge result is validated;
 - the change lands in `dev`;
@@ -244,12 +289,21 @@ A task is complete only when:
 Green CI alone is not proof of correctness. A PR must not be merged by an agent
 unless a maintainer explicitly authorizes that merge.
 
+Once the bar above is met, the executor's next act is to request that
+authorization. Requesting another review round instead is a decision, not a
+default, and it needs a stated reason: naming a specific untested property of
+the deliverable, not the general possibility that an instrument could be
+sharper. An executor is the worst-placed party to judge when to stop, because
+the incentive always points at one more round while findings keep arriving.
+
 ## 8. Non-negotiable rules
 
 - Never let two agents edit the same branch/worktree concurrently.
 - Never change another active lane's branch.
 - Never hide a material assumption or specification conflict in code.
 - Never weaken a test or acceptance criterion solely to obtain a pass.
+- Never hold a finished deliverable open on instrument findings alone, and
+  never let an instrument finding be dropped instead of filed.
 - Never treat generated prose or an agent summary as more authoritative than the
   linked requirement and executable evidence.
 - Never publish private chain-of-thought; publish concise conclusions and evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,8 +256,14 @@ A task is complete only when:
 - no undocumented requirement/interface change remains;
 - the full review bar in [CONTRIBUTING.md](CONTRIBUTING.md) is met;
 - blocking and major findings are fixed and re-reviewed;
-- **every lens in section 6 has been covered by a round that produced no
-  `BLOCKER` or `MAJOR` under it**, and the covering round is named for each;
+- **every lens in section 6 has been covered clean**, and the covering round is
+  named for each. A lens is covered clean by a round that applied it and
+  produced no `BLOCKER` or `MAJOR` **under that lens**. Coverage is judged per
+  lens, not per round: a round that finds a blocker in one lens still covers
+  any other lens it applied cleanly, and findings elsewhere do not un-cover a
+  lens already covered. Reading this per round would mean a clean lens never
+  counts while any other lens is dirty, which is the unbounded loop again
+  wearing a different collar;
 - no review round remains in flight;
 - the candidate merge result is validated;
 - the change lands in `dev`;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,13 @@ reviewer** before implementation starts. Roles should rotate across tasks:
 
 An executor never approves its own work.
 
+**The reviewer assigns a finding's lens, and the executor may not re-label it.**
+The label decides which lens banks coverage under section 7, so leaving it
+unowned puts the completion test in the hands of the party the test is about. An
+executor that believes a finding is filed under the wrong lens says so in the
+thread and the reviewer re-files it; where the two disagree, both lenses are
+recorded and neither is covered clean.
+
 [CONTRIBUTING.md](CONTRIBUTING.md) currently requires two positive reviews, including one external
 to the implementation lane. With two AI systems, use a separate cleared-context
 review session for the lane's internal review and the other AI system for the
@@ -164,9 +171,26 @@ Read, in order:
 
 Review at least these lenses. They are named and countable, and section 7
 measures completion against them, so record which lens each finding came from
-and which lenses a round covered.
+and which lenses a round covered. Each carries a short token, given below its
+heading, because the full names run to thirty-six characters and a line already
+carrying a severity, a path and a title cannot also carry that. Use the token.
+
+**This list is the normative one.** [CONTRIBUTING.md](CONTRIBUTING.md) also
+names review angles, in different words and a different number of them; those
+are guidance for what to look at, and these five are what section 7 counts.
+
+**The lenses overlap on purpose and are not a partition.** A timeout rule is
+named under `Conformance`, under `RTL` and under `Robustness`, and a real
+missing timeout is honestly all three. So a finding attributable to more than
+one lens is recorded under **each** of them, and none of those lenses is
+covered clean by the round that found it. Recording it under the closest-looking
+single name is what makes mislabelling profitable: the other lenses bank a clean
+result they did not earn, and no reader can tell an honest mislabel from a
+deliberate one.
 
 ### Requirement and protocol conformance
+
+Token: `Conformance`
 
 - Every acceptance criterion is actually satisfied.
 - Cited IEEE 1722/1722.1/Milan behavior is interpreted correctly.
@@ -174,6 +198,8 @@ and which lenses a round covered.
   rules are correct.
 
 ### RTL and architecture
+
+Token: `RTL`
 
 - Clock and reset assumptions are valid.
 - CDC uses only approved primitives and patterns.
@@ -183,6 +209,8 @@ and which lenses a round covered.
 - Existing module/interface contracts remain valid.
 
 ### Robustness
+
+Token: `Robustness`
 
 - malformed and truncated input;
 - minimum/maximum values;
@@ -194,6 +222,8 @@ and which lenses a round covered.
 
 ### Tests
 
+Token: `Tests`
+
 - Each new test can fail for the defect it claims to detect.
 - Positive, negative, and boundary behavior is covered.
 - Real integration wiring is tested where practical.
@@ -201,6 +231,8 @@ and which lenses a round covered.
 - Tests do not merely reproduce implementation assumptions.
 
 ### Documentation
+
+Token: `Docs`
 
 - Changed contracts are reflected in authoritative docs.
 - Obsolete requirements or documents were not accidentally restored.
@@ -232,20 +264,51 @@ nothing.** A lens is covered when it was applied, not when it was listed. "I
 read the RTL against the clause and found nothing" is a result section 7 needs;
 silence about a lens is not.
 
+**A clean lens is reported in the same format as a finding, and carries the
+same evidence.** Every finding must name a `path:line or artifact`; the clean
+result must too, because that is the claim section 7 reads to release a merge.
+Requiring evidence for the statements that do not unlock a merge and none for
+the one that does is the asymmetry that lets a round bank a lens on its word:
+
+```text
+[R<n>] PASS <lens> — <path:line or artifact> — <what was checked and against what>
+```
+
+The artifact field names what was actually examined, at the head under review.
+"Reviewed the RTL" is not an artifact and neither is a module name on its own;
+a second reviewer must be able to open what is named and disagree. A lens whose
+scope has no matching file in the diff is still covered by naming the artifact
+that made it inapplicable. One line per clean lens, or an equivalent table with
+the same three fields.
+
 **Prefer the lens covered least.** A reviewer who keeps applying the lens that
 keeps producing findings is doing the most productive-feeling and least
 informative thing available: the yield stays high because that artifact is deep,
 not because it is the right place to look. Depth in one lens is not coverage,
 and a high finding rate is not evidence of good targeting.
 
-The case in Issue #166 is the argument. On protocol-processor #13, twelve
-consecutive rounds asked whether the harness proved what it claimed. Every round
-found something real and every fix was correct. None asked whether the DUT was
-right. When a different angle was finally run it found defects in the RTL itself
-that no amount of further harness review would have reached, including a latch
-held in every state and a missing timeout that lets a silent device wedge the
-port forever. The failure was not that review continued too long. It was that
-twenty-one rounds bought depth in one lens and left others untouched.
+The case in Issue #166 is the argument, and it is worth stating exactly, since
+an approximation of it would be the same defect the rule is about. On
+protocol-processor #13, thirteen consecutive rounds asked whether the harness
+proved what it claimed and whether the document describing it was true. The
+round that ended that run opens "Thirteen rounds, and this is the first"
+positive one. Every round found something real and every fix was correct. Those
+rounds ran two lenses, `Tests` and `Docs`, and the later ones say so in their
+own first line: seven consecutive answers are headed "Doc-only".
+
+Three lenses went unapplied for all thirteen. When `RTL` was finally run, as a
+separate round on the same head, it found two defects in the shipped RTL that no
+further harness review would have reached: `done_seen_r` latched in every state
+with no outstanding command, and no timeout or abort, so a silent device wedges
+the port forever.
+
+That round published `POSITIVE` and moved both defects to new Issues. The PR
+merged. At the merged head `5121dce`, `hdl/packet_engine/KL_pp_nvm_port.sv:153`
+still reads `if (dev_done_i) done_seen_r <= 1'b1;`, and both Issues are open.
+So the failure was not that review continued too long, and it was not that the
+missing lens was never run. It was that thirteen rounds bought depth in two
+lenses, and that the round which finally widened was allowed to bank the lens it
+widened into while leaving what it found in the tree.
 
 ## 7. Completion and merge
 
@@ -257,9 +320,30 @@ A task is complete only when:
 - the full review bar in [CONTRIBUTING.md](CONTRIBUTING.md) is met;
 - blocking and major findings are fixed and re-reviewed;
 - **every lens in section 6 has been covered clean**, and the covering round is
-  named for each. A lens is covered clean by a round that applied it and left no
-  `BLOCKER`, `MAJOR` or `MINOR` **open under that lens**. `SUGGESTION` is
-  optional by definition and does not affect coverage.
+  named for each **with the exact head it covered**. A lens is covered clean by
+  a round that applied it and left no `BLOCKER`, `MAJOR` or `MINOR` **open under
+  that lens**. `SUGGESTION` is optional by definition and does not affect
+  coverage.
+
+  **Coverage is banked against a commit, not against a round.** A later commit
+  that changes any artifact within a lens's scope un-covers that lens, and it
+  must be covered again at a head that includes the change. Otherwise the bar is
+  satisfiable by covering lenses early and then rewriting what they covered,
+  which is the ordinary shape of a lane answering findings across many commits
+  rather than an exotic abuse of the rule. On protocol-processor #13 the round
+  that covered the harness ran at `c47ef19b`; twelve commits later the merge head
+  carried a new 886-line figure gate and a modified `sim_main.cpp`, so the round
+  nameable for `Tests` had never seen the tests that merged.
+
+  So the completion ledger is three columns, not two: **lens, covering round,
+  head**. A ledger whose heads are not the merge candidate, or an ancestor of it
+  that nothing in that lens's scope has touched since, does not clear this bullet.
+
+  **The ledger is published by a reviewer, or explicitly accepted by one.** Every
+  other bullet here is an executor's claim about its own work, which is why
+  section 3 says an executor never approves its own work. This one decides
+  whether review is finished, so it is the one bullet the party under review
+  cannot assemble alone.
 
   Open, not merely un-blocking. **A finding moved to another Issue is not
   resolved**: the defect is still in the tree, and moving the paperwork does not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,9 +175,11 @@ and which lenses a round covered. Each carries a short token, given below its
 heading, because the full names run to thirty-six characters and a line already
 carrying a severity, a path and a title cannot also carry that. Use the token.
 
-**This list is the normative one.** [CONTRIBUTING.md](CONTRIBUTING.md) also
-names review angles, in different words and a different number of them; those
-are guidance for what to look at, and these five are what section 7 counts.
+**These five names are the ones a completion ledger counts**, and
+[CONTRIBUTING.md](CONTRIBUTING.md) says so where it assigns lenses, so the
+precedence rule at the top of this file has nothing to resolve. The angles named
+there are examples of what to look at within a lens, not a second list to report
+against.
 
 **The lenses overlap on purpose and are not a partition.** A timeout rule is
 named under `Conformance`, under `RTL` and under `Robustness`, and a real

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ This file tells AI agents how to work efficiently in that system. It supplements
 - **[3. Agent identities and roles](#3-agent-identities-and-roles)** — Session prefixes, the executor/reviewer split, and the requirement that an executor never approves its own work.
 - **[4. Public task contract](#4-public-task-contract)** — What an Issue must contain before work starts, why settled scope rather than size decides readiness, and that new findings become new Issues.
 - **[5. Executor procedure](#5-executor-procedure)** — The steps before the first edit, what to do during implementation, and the two public comments an executor owes.
-- **[6. Reviewer procedure](#6-reviewer-procedure)** — Reviewing from public state alone, the lenses to cover, the severity every finding carries, and the split between findings against the deliverable and findings against the instruments that measure it.
-- **[7. Completion and merge](#7-completion-and-merge)** — The full bar a task must clear, when to stop reviewing and ask for authorization, and the rule that an agent does not merge without explicit maintainer authorization.
+- **[6. Reviewer procedure](#6-reviewer-procedure)** — Reviewing from public state alone, the lenses to cover, and the severity every finding carries, and the requirement that every lens be covered before a task is complete.
+- **[7. Completion and merge](#7-completion-and-merge)** — The full bar a task must clear, why lens coverage rather than round count decides when review is done, and the rule that an agent does not merge without explicit maintainer authorization.
 - **[8. Non-negotiable rules](#8-non-negotiable-rules)** — The short list that overrides convenience, including never letting two agents edit one branch concurrently, and never weakening a test to obtain a pass.
 
 ## 1. Repository model
@@ -162,7 +162,9 @@ Read, in order:
 4. PR diff and commit history.
 5. Tests, logs, and validation evidence.
 
-Review at least these lenses.
+Review at least these lenses. They are named and countable, and section 7
+measures completion against them, so record which lens each finding came from
+and which lenses a round covered.
 
 ### Requirement and protocol conformance
 
@@ -204,10 +206,7 @@ Review at least these lenses.
 - Obsolete requirements or documents were not accidentally restored.
 - The PR and Issue contain enough evidence for another cold reviewer.
 
-Classify every finding twice: by severity, and by what it is a finding
-*against*.
-
-Severity:
+Classify every finding:
 
 - `BLOCKER` — incorrect, unsafe, or non-compliant; must fix before merge.
 - `MAJOR` — substantial correctness, design, or test weakness; normally blocking.
@@ -215,46 +214,11 @@ Severity:
 - `SUGGESTION` — optional improvement.
 - `PASS` — no blocking finding for the assigned review lens.
 
-Target, which is `deliverable` or `instrument`:
-
-- `deliverable` — the work the Issue asked for. A finding is against the
-  deliverable when fixing it changes whether one of the Issue's frozen
-  acceptance criteria (section 4) holds.
-- `instrument` — the gates, harnesses, fixtures, scripts and published figures
-  built to demonstrate the deliverable. A finding is against an instrument when
-  fixing it leaves every acceptance criterion exactly as true or false as it
-  was.
-
-The test is that question and not the reviewer's sense of importance. An
-instrument finding can be severe, and severity is recorded independently. What
-the target decides is not how much the finding matters but which lane owns it.
-
-The two are decided per Issue, not per artifact type. When the Issue asked for a
-gate, that gate IS the deliverable and a defect in it is a `deliverable`
-finding; the instruments are then whatever was built to demonstrate the gate
-works, such as its mutation table or its self-test fixtures. The same file can
-be the deliverable in one lane and an instrument in the next. Apply the
-acceptance-criteria test rather than reading the label off the path.
-
-**An instrument finding does not block the merge it was found on.** File it as
-its own Issue, link it from the PR, and continue. It is not waived, dismissed,
-or downgraded; it is moved to a lane where it can be fixed without holding the
-deliverable hostage.
-
-This exists because verification scaffolding has no natural end. Every gate can
-carry a gate, and a reviewer who keeps looking will keep finding real defects in
-the instruments long after the deliverable has stopped changing. Without this
-split the loop's only exit is a reviewer finding nothing, which is not a bound.
-Issue #166 records the case that produced this rule: a suite that was correct
-and unchanged for seven commits, and six further review rounds, every one of
-them a genuine finding, none of them against the suite.
-
 Use this concise format:
 
 ```text
-[R<n>] <SEVERITY> <deliverable|instrument> — <path:line or artifact> — <title>
+[R<n>] <SEVERITY> <lens> — <path:line or artifact> — <title>
 Requirement/evidence: <why this is a finding>
-Target rationale: <which acceptance criterion changes truth, or why none does>
 Impact: <failure mode>
 Required change: <what must be true, without prescribing unnecessary design>
 Verification: <how the fix will be checked>
@@ -263,10 +227,25 @@ Verification: <how the fix will be checked>
 A review round that discovers defects is not approval of later fixes. Re-review
 the corrected commit and publish a new verdict.
 
-**A round that produces no `deliverable` finding is a positive result, and it
-must be published as one.** State plainly that the deliverable is ready, listing
-the instrument findings and the Issues they became. That sentence is what ends
-the round; it is not a silence for the executor to read past.
+**Every round states which lenses it covered, including those that found
+nothing.** A lens is covered when it was applied, not when it was listed. "I
+read the RTL against the clause and found nothing" is a result section 7 needs;
+silence about a lens is not.
+
+**Prefer the lens covered least.** A reviewer who keeps applying the lens that
+keeps producing findings is doing the most productive-feeling and least
+informative thing available: the yield stays high because that artifact is deep,
+not because it is the right place to look. Depth in one lens is not coverage,
+and a high finding rate is not evidence of good targeting.
+
+The case in Issue #166 is the argument. On protocol-processor #13, twelve
+consecutive rounds asked whether the harness proved what it claimed. Every round
+found something real and every fix was correct. None asked whether the DUT was
+right. When a different angle was finally run it found defects in the RTL itself
+that no amount of further harness review would have reached, including a latch
+held in every state and a missing timeout that lets a silent device wedge the
+port forever. The failure was not that review continued too long. It was that
+twenty-one rounds bought depth in one lens and left others untouched.
 
 ## 7. Completion and merge
 
@@ -276,9 +255,9 @@ A task is complete only when:
 - required tests and local verification gates pass;
 - no undocumented requirement/interface change remains;
 - the full review bar in [CONTRIBUTING.md](CONTRIBUTING.md) is met;
-- blocking and major findings **against the deliverable** are fixed and
-  re-reviewed, and instrument findings are filed as their own Issues;
-- the most recent review round produced no `deliverable` finding;
+- blocking and major findings are fixed and re-reviewed;
+- **every lens in section 6 has been covered by a round that produced no
+  `BLOCKER` or `MAJOR` under it**, and the covering round is named for each;
 - no review round remains in flight;
 - the candidate merge result is validated;
 - the change lands in `dev`;
@@ -289,12 +268,17 @@ A task is complete only when:
 Green CI alone is not proof of correctness. A PR must not be merged by an agent
 unless a maintainer explicitly authorizes that merge.
 
-Once the bar above is met, the executor's next act is to request that
-authorization. Requesting another review round instead is a decision, not a
-default, and it needs a stated reason: naming a specific untested property of
-the deliverable, not the general possibility that an instrument could be
-sharper. An executor is the worst-placed party to judge when to stop, because
-the incentive always points at one more round while findings keep arriving.
+Lens coverage is the bar because it is the one property the motivating failure
+lacked. It is enumerable rather than a threshold: the lenses are the list in
+section 6, so the bar is read off the contract and no number is chosen. It
+cannot be met by repetition, since a thirteenth round of one lens covers
+nothing new. And it does not end review early, because a lens that keeps
+producing findings keeps the task open.
+
+What it does end is the other failure, which is subtler and was the real one:
+review that continues indefinitely while never widening. When the bar is
+unstated, the reviewer with the highest finding rate looks the most diligent,
+and the lens already yielding findings is always the cheapest to run again.
 
 ## 8. Non-negotiable rules
 
@@ -302,8 +286,8 @@ the incentive always points at one more round while findings keep arriving.
 - Never change another active lane's branch.
 - Never hide a material assumption or specification conflict in code.
 - Never weaken a test or acceptance criterion solely to obtain a pass.
-- Never hold a finished deliverable open on instrument findings alone, and
-  never let an instrument finding be dropped instead of filed.
+- Never re-run a covered lens in place of an uncovered one, and never report a
+  lens as covered without having applied it.
 - Never treat generated prose or an agent summary as more authoritative than the
   linked requirement and executable evidence.
 - Never publish private chain-of-thought; publish concise conclusions and evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,11 +290,11 @@ and a high finding rate is not evidence of good targeting.
 The case in Issue #166 is the argument, and it is worth stating exactly, since
 an approximation of it would be the same defect the rule is about. On
 protocol-processor #13, thirteen consecutive rounds asked whether the harness
-proved what it claimed and whether the document describing it was true. The
-round that ended that run opens "Thirteen rounds, and this is the first"
-positive one. Every round found something real and every fix was correct. Those
-rounds ran two lenses, `Tests` and `Docs`, and the later ones say so in their
-own first line: seven consecutive answers are headed "Doc-only".
+proved what it claimed and whether the document describing it was true. Twelve
+found something real, every fix was correct, and the thirteenth opens "Thirteen
+rounds, and this is the first" positive one. Those rounds ran two lenses,
+`Tests` and `Docs`, and the later ones say so in their own first line: seven
+consecutive answers are headed "Doc-only".
 
 Three lenses went unapplied for all thirteen. When `RTL` was finally run, as a
 separate round on the same head, it found two defects in the shipped RTL that no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,8 +257,21 @@ A task is complete only when:
 - the full review bar in [CONTRIBUTING.md](CONTRIBUTING.md) is met;
 - blocking and major findings are fixed and re-reviewed;
 - **every lens in section 6 has been covered clean**, and the covering round is
-  named for each. A lens is covered clean by a round that applied it and
-  produced no `BLOCKER` or `MAJOR` **under that lens**. Coverage is judged per
+  named for each. A lens is covered clean by a round that applied it and left no
+  `BLOCKER`, `MAJOR` or `MINOR` **open under that lens**. `SUGGESTION` is
+  optional by definition and does not affect coverage.
+
+  Open, not merely un-blocking. **A finding moved to another Issue is not
+  resolved**: the defect is still in the tree, and moving the paperwork does not
+  move the code. This is the case the rule exists for and it is not
+  hypothetical. On protocol-processor #13 a round applied the RTL lens, found a
+  latch held in every state and a missing timeout that lets a silent device
+  wedge the port, published **POSITIVE**, and deferred both to new Issues. That
+  PR merged, those Issues are still open, and the RTL is unchanged. Under a
+  severity test that round covers the lens; under this one it does not.
+
+  Severity therefore cannot be the coverage test on its own, or downgrading a
+  finding becomes the cheapest way to bank a lens. Coverage is judged per
   lens, not per round: a round that finds a blocker in one lens still covers
   any other lens it applied cleanly, and findings elsewhere do not un-cover a
   lens already covered. Reading this per round would mean a clean lens never
@@ -292,8 +305,10 @@ and the lens already yielding findings is always the cheapest to run again.
 - Never change another active lane's branch.
 - Never hide a material assumption or specification conflict in code.
 - Never weaken a test or acceptance criterion solely to obtain a pass.
-- Never re-run a covered lens in place of an uncovered one, and never report a
-  lens as covered without having applied it.
+- Never re-run a lens already covered CLEAN in place of one never applied, and
+  never report a lens as covered without having applied it. Re-running a lens
+  to check a fix is required, not discouraged: a lens is not covered clean
+  while a finding under it is open.
 - Never treat generated prose or an agent summary as more authoritative than the
   linked requirement and executable evidence.
 - Never publish private chain-of-thought; publish concise conclusions and evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,15 @@ flowchart LR
 5. **Review with multiple agents, each with CLEARED context.** Not forks of
    the author's session: agents that have never seen the reasoning that
    produced the diff. An agent that helped write a change will re-derive the
-   same blind spot when asked to check it. Give each one a different lens —
-   clause conformance, wire format and response sizing, test adequacy and
-   whether the tests can actually fail — and let them read the diff cold.
+   same blind spot when asked to check it. Give each one a different lens and
+   let them read the diff cold. **The lens list is
+   [`AGENTS.md` reviewer procedure](AGENTS.md#6-reviewer-procedure)** —
+   `Conformance`, `RTL`, `Robustness`,
+   `Tests`, `Docs` — and those five names are the ones a completion ledger
+   counts, so report coverage in them. The angles this file used to list here
+   (clause conformance, wire format and response sizing, test adequacy, whether
+   the tests can actually fail) are examples of what to look at within them,
+   not a second list to report against.
 
    **Two positive reviews are the merge bar, and one of them must be
    EXTERNAL.** One from this lane's own review agents, at least one from an


### PR DESCRIPTION
Closes #166.

## The defect, corrected

**This PR was first written on a false premise and has been rewritten.** The original claim was that protocol-processor #13's deliverable was finished and unchanged while further review rounds found only defects in the instruments around it. The record says otherwise: **25 `[R1]` comments, 21 NEGATIVE**, and rounds after the ones originally tabulated found defects in the RTL itself, including a latch held in every state and a missing timeout that lets a silent device wedge the port forever. An `[A1]` comment on that PR states it directly:

> twelve rounds of harness review could not have found any of this, because every one of them asked whether the checks prove what they claim, and none asked whether the DUT is right.

So review was not unbounded and useless. It was **stuck on one lens**, and became productive the moment the lens changed. The failure was never that review continued too long. It was that twenty-one rounds bought depth in one lens and left others untouched.

The Issue title still says "no stopping rule". That framing is wrong and the correction is recorded on #166; the real defect is **no coverage rule**.

## The change

`AGENTS.md` only.

- **Section 6** — every finding records which lens it came from, and every round states which lenses it covered including those that found nothing. A lens is covered when applied, not when listed. Reviewers should prefer the lens covered least, with the reason stated: re-running the lens that keeps yielding is the most productive-feeling and least informative thing available, because the yield is high where the artifact is deep, not where it is the right place to look.
- **Section 7** — completion requires **every section 6 lens covered by a round that produced no BLOCKER or MAJOR under it**, with the covering round named for each.
- **Section 8** — never re-run a covered lens in place of an uncovered one; never report a lens covered without applying it.

## Why lens coverage and not a round cap or a finding classification

A **round cap** is the arbitrary-threshold shape this repo has been caught on repeatedly, and it would have cut off the rounds that eventually found the RTL defects.

A **finding classification** was the first attempt in this PR and it was wrong in a way worth recording, because a reviewer had to demonstrate it rather than argue it. It split findings into `deliverable` and `instrument` by asking whether fixing one changed a frozen acceptance criterion. Under that test:

- the flagship example failed its own rule: #131's GCC-splice blocker classified `instrument` and shipped, and reached `deliverable` in the PR body only by an artifact-class reading the same amendment forbade two paragraphs earlier;
- shipping-RTL defects classified `instrument`. The latch and the missing timeout above change no #70 criterion, so a wedging port would have merged;
- blindness could never block while noise always did. "The gate does not detect X" cannot flip a criterion, so it was `instrument` by construction;
- it was gameable by writing narrow acceptance criteria, and it required criteria to exist at all, which **#70 and #166 both fail to publish**.

Lens coverage has none of those properties. It is **enumerable rather than a threshold**, since the lenses are already the list in section 6, so the bar is read off the contract and no number is chosen. It **cannot be met by repetition**, since a thirteenth round of one lens covers nothing new. It **does not end review early**, since a lens that keeps producing findings keeps the task open. And it **does not depend on what an executor wrote in an Issue**.

## What it would have done

| case | under lens coverage |
|---|---|
| #131 GCC splice defeats the census | Tests lens, BLOCKER, blocks |
| pp #13 rounds 1 to 12, all one lens | covers one lens; four remain open |
| pp #13 latch held in every state, missing timeout | RTL lens applied, but **deferred to pp #14/#15 rather than fixed**, so the lens is NOT covered clean |

**The third row was wrong in the first two versions of this table and is the reason for the current head.** I claimed those defects would block. They would not have, under the text as written: the round that found them published POSITIVE and deferred both to new Issues. That PR merged, pp #14 and pp #15 are still open, and `KL_pp_nvm_port.sv:153` is unchanged at the merge commit. A reviewer verified all four facts.

That is now fixed in the rule rather than in the table: a lens is covered clean only when nothing is left **open** under it, and a finding moved to another Issue is explicitly not resolved. Severity alone cannot bank a lens, because if it could, downgrading a finding would be the cheapest way to close one.

## Review note

This changes what reviewers are asked to report, so it needs the reviewer role's agreement rather than only a correctness check.

The thing to attack: whether "covered" is checkable, or whether a reviewer can report a lens covered after a glance. The text says a lens is covered when applied and section 8 forbids claiming otherwise, but that is an honour rule with no mechanism behind it, and this repo's whole recent history is instruments that claimed more than they closed.

## Gates

`gen_toc.py --check` OK. `docs_check.py` 0 findings across 212 files. Documentation only.

