### PR TITLE
Derive the submodule source list from the tree

### DIFF
--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -82,6 +82,17 @@ jobs:
       - name: RTL lint (whole hdl/, ratcheted)
         run: python3 scripts/lint_rtl.py --check --self-test
 
+      # Every build input derives the submodule source list rather than listing
+      # it. This gate is the backstop against a literal coming back: a new
+      # consumer, or a derivation reverted to a hand-written list. It cannot
+      # catch a stale copy that no longer exists, which is the point -- it
+      # catches the copy being re-created.
+      - name: Submodule source list is derived, not copied
+        run: |
+          python3 scripts/pp_srcs.py --check \
+            syn/yosys/run.sh syn/yosys/ooc.sh \
+            tb/verilator/milan_dp/Makefile sw/litex/milan_soc.py
+
       # The chmap_capture lane's netcheck leg synthesizes KL_chan_map_capture
       # with yosys and re-simulates the netlist, which is how the VERSION
       # 0x0030 class of hazard is pinned: RTL green while synthesized silicon

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -88,10 +88,7 @@ jobs:
       # catch a stale copy that no longer exists, which is the point -- it
       # catches the copy being re-created.
       - name: Submodule source list is derived, not copied
-        run: |
-          python3 scripts/pp_srcs.py --check \
-            syn/yosys/run.sh syn/yosys/ooc.sh \
-            tb/verilator/milan_dp/Makefile sw/litex/milan_soc.py
+        run: python3 scripts/pp_srcs.py --check --selftest
 
       # The chmap_capture lane's netcheck leg synthesizes KL_chan_map_capture
       # with yosys and re-simulates the netlist, which is how the VERSION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,26 @@ Two board rules that go with it:
   entry naming the reason **and where the reason is recorded**.
   `--pragmas` alone is instantaneous and is the useful pre-commit hook:
   `echo 'python3 scripts/lint_rtl.py --pragmas' >> .git/hooks/pre-commit`.
+- **A build input never lists the protocol-processor sources, it derives
+  them**: [`scripts/pp_srcs.py`](scripts/pp_srcs.py) reads the submodule tree
+  and emits the list, packages first (detected by reading each file for a
+  `package` declaration, not by its name). Every consumer calls it --
+  [`syn/yosys/run.sh`](syn/yosys/run.sh),
+  [`syn/yosys/ooc.sh`](syn/yosys/ooc.sh),
+  [`tb/verilator/milan_dp/Makefile`](tb/verilator/milan_dp/Makefile),
+  [`sw/litex/milan_soc.py`](sw/litex/milan_soc.py),
+  [`syn/ooc/pp_shadow_ooc.tcl`](syn/ooc/pp_shadow_ooc.tcl) and
+  [`syn/ooc/dp_srcs.py`](syn/ooc/dp_srcs.py) -- and each takes the exit status
+  rather than discarding it, because the script refuses to emit an empty list
+  and an empty list builds cleanly while proving nothing. `--check` fails if
+  any tracked file outside the script's `PROSE_OK` table names a submodule
+  source literally, so a new build input is caught the first time it names one
+  and no consumer list has to be maintained. Prose that legitimately cites a
+  source path adds the **exact literal** to `PROSE_OK` with its reason; a
+  whole-file exemption is not available, because that is how a cited path
+  becomes a hand-written list again. `--selftest` drives the check over
+  synthetic trees and runs in the same CI step, so the gate cannot rot into a
+  green that means nothing.
 - **A `// verilator lint_off X` needs a justification**, exactly like a
   tied-off input does — an unexplained suppression is the same defect class
   as an unexplained tie. Put the reason next to the code AND a

--- a/scripts/pp_srcs.py
+++ b/scripts/pp_srcs.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Emit the protocol-processor source list, derived from the tree.
+
+WHY THIS EXISTS. Four build inputs carried the same hand-written list of
+submodule filenames: ``syn/yosys/run.sh``, ``syn/yosys/ooc.sh``,
+``tb/verilator/milan_dp/Makefile`` and ``sw/litex/milan_soc.py``. Nothing
+compared any of them against the tree, and each copy names the other as
+authoritative, so the authority was circular.
+
+The failure mode is not that a copy is wrong. All four are correct against the
+pin they were written for, and they stay correct until the submodule moves.
+When it moves, a module added on the submodule side is in every tree and in no
+list, and the first symptom is an elaboration error naming the missing module
+rather than the stale list::
+
+    [FAIL] KL_pp_shadow   yosys: ERROR: Module `\\KL_aecp_ca_originator'
+                          referenced in module `\\protocol_processor_top' ...
+                          is not part of the design.
+
+That is the loud case. The silent case is worse: a module that no current top
+instantiates is simply never built, and the portability sweep reports PASS over
+a design that does not contain it. The gate's claim is that every top
+elaborates off-vendor, and that claim was only ever as wide as the list.
+
+ORDERING. Packages first, because a package must be declared before the modules
+that import it; everything else sorted, because the tools do not care and a
+stable order keeps diffs readable. That is the only ordering constraint the old
+lists encoded, and ``tb/verilator/milan_dp/Makefile`` says so in as many words.
+
+EXCLUSIONS are explicit and carry a reason, printed on a clean ``--check`` run.
+There are none today: every ``.sv`` under the submodule's ``hdl/`` is a design
+file, and the submodule keeps no testbench or simulation sources there. An
+exclusion added later must say why, so that a file dropped on purpose cannot be
+confused with one dropped by accident.
+"""
+
+import argparse
+import pathlib
+import re
+import sys
+
+#: Repository root, from this file's location.
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PP_HDL = ROOT / "protocol-processor" / "hdl"
+
+#: {stem: reason}. Empty on purpose; see the module docstring.
+EXCLUDE: dict[str, str] = {}
+
+
+def pp_sources(prefix="protocol-processor/hdl"):
+    """Every submodule design source, packages first, then sorted."""
+    if not PP_HDL.is_dir():
+        raise SystemExit(
+            f"{PP_HDL} not found. The protocol-processor submodule is not "
+            "checked out; run `git submodule update --init protocol-processor`. "
+            "This script refuses to emit an empty list, because an empty list "
+            "builds cleanly and proves nothing.")
+    files = [p for p in PP_HDL.rglob("*.sv") if p.stem not in EXCLUDE]
+    if not files:
+        raise SystemExit(f"{PP_HDL} contains no .sv files")
+    pkgs = sorted(p for p in files if p.name.endswith("_pkg.sv"))
+    rest = sorted(p for p in files if not p.name.endswith("_pkg.sv"))
+    return [f"{prefix}/{p.relative_to(PP_HDL)}" for p in pkgs + rest]
+
+
+def check(paths):
+    """Report any listed file that names a stale set. Returns (problems, derived).
+
+    A file that invokes this script has no literal to check and cannot go
+    stale, so it is reported as derived rather than scanned. Scanning it would
+    report every source as missing, which is true of the text and false of the
+    build.
+    """
+    have = {pathlib.Path(s).stem for s in pp_sources()}
+    bad, derived = [], []
+    for f in paths:
+        p = ROOT / f
+        if not p.is_file():
+            bad.append(f"{f}: not found")
+            continue
+        text = p.read_text()
+        if "pp_srcs.py" in text:
+            derived.append(f)
+            continue
+        listed = set(re.findall(r"(\w+)\.sv", text)) & (
+            have | set(EXCLUDE))
+        missing = sorted(have - listed)
+        excluded = sorted(set(EXCLUDE) & listed)
+        if missing:
+            bad.append(f"{f}: {len(missing)} submodule source(s) absent from "
+                       f"this list: {', '.join(missing)}")
+        if excluded:
+            bad.append(f"{f}: names deliberately excluded source(s): "
+                       f"{', '.join(excluded)}")
+    return bad, derived
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--prefix", default="protocol-processor/hdl",
+                    help="path prefix for each emitted entry")
+    ap.add_argument("--sep", default=" ", help="separator (default: a space)")
+    ap.add_argument("--python-list", action="store_true",
+                    help="emit as a Python list literal")
+    ap.add_argument("--check", nargs="*", metavar="FILE",
+                    help="verify these files name every submodule source")
+    args = ap.parse_args()
+
+    if args.check is not None:
+        bad, derived = check(args.check)
+        for b in bad:
+            print("  -", b)
+        if bad:
+            print("\nA build input names a stale set of submodule sources. This "
+                  "is what a\nsubmodule bump breaks and what nothing used to "
+                  "catch: the copies are\ncorrect against the pin they were "
+                  "written for and go stale the moment it\nmoves. Derive the "
+                  "list with this script rather than editing the copy.")
+            return 1
+        n = len(pp_sources())
+        literal = len(args.check) - len(derived)
+        print(f"pp source list: {n} file(s); {len(derived)} consumer(s) derive it, "
+              f"{literal} carry a literal and agree")
+        for d in derived:
+            print(f"  derived  {d}")
+        for stem, why in EXCLUDE.items():
+            print(f"  excluded {stem}: {why}")
+        return 0
+
+    srcs = pp_sources(args.prefix)
+    if args.python_list:
+        print("[\n" + "".join(f'    "{s}",\n' for s in srcs) + "]")
+    else:
+        print(args.sep.join(srcs))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pp_srcs.py
+++ b/scripts/pp_srcs.py
@@ -39,6 +39,7 @@ confused with one dropped by accident.
 import argparse
 import pathlib
 import re
+import subprocess
 import sys
 
 #: Repository root, from this file's location.
@@ -57,44 +58,199 @@ def pp_sources(prefix="protocol-processor/hdl"):
             "checked out; run `git submodule update --init protocol-processor`. "
             "This script refuses to emit an empty list, because an empty list "
             "builds cleanly and proves nothing.")
-    files = [p for p in PP_HDL.rglob("*.sv") if p.stem not in EXCLUDE]
+    # Tracked files only. Reading the working tree compiles an untracked stray
+    # `.sv` that no other checkout has, which is a build that cannot be
+    # reproduced and a defect that appears only on one machine.
+    out = subprocess.run(["git", "ls-files", "*.sv"], cwd=PP_HDL,
+                         capture_output=True, text=True)
+    if out.returncode:
+        raise SystemExit(f"git ls-files failed in {PP_HDL}: {out.stderr.strip()}")
+    files = [PP_HDL / f for f in out.stdout.split()
+             if pathlib.Path(f).stem not in EXCLUDE]
     if not files:
-        raise SystemExit(f"{PP_HDL} contains no .sv files")
-    pkgs = sorted(p for p in files if p.name.endswith("_pkg.sv"))
-    rest = sorted(p for p in files if not p.name.endswith("_pkg.sv"))
+        raise SystemExit(f"{PP_HDL} contains no tracked .sv files")
+    # A package is a file that DECLARES one, read from the source. Keying on
+    # the `_pkg.sv` suffix is a naming convention, and a package in a file
+    # named otherwise would sort after its importers and fail to elaborate.
+    pkg_re = re.compile(r"^\s*package\s+\w+\s*;", re.M)
+    pkgs = sorted(p for p in files if pkg_re.search(p.read_text()))
+    rest = sorted(p for p in files if not pkg_re.search(p.read_text()))
     return [f"{prefix}/{p.relative_to(PP_HDL)}" for p in pkgs + rest]
 
 
-def check(paths):
-    """Report any listed file that names a stale set. Returns (problems, derived).
+#: Files allowed to name a submodule source literally, mapped to the EXACT
+#: literals permitted and why. Not a per-file exemption: exempting a whole file
+#: let a reviewer revert `sw/litex/milan_soc.py` to a hand-written list and pass,
+#: because the file was already on the list for an unrelated comment. Any
+#: literal not named here fails, in every file.
+PROSE_OK = {
+    "hdl/milan/KL_pp_shadow.sv": (
+        {"protocol-processor/hdl/aecp/KL_aecp_engine.sv"},
+        "an RTL comment citing the submodule module it wraps"),
+    "sw/builder/test_builder.py": (
+        {"protocol-processor/hdl/adp/KL_adp_engine.sv",
+         "protocol-processor/hdl/adp/pp_adp_pkg.sv"},
+        "a gate citing submodule paths in its findings"),
+    "sw/litex/milan_soc.py": (
+        {"protocol-processor/hdl/top/protocol_processor_top.sv"},
+        "a comment citing a submodule line number, not a source entry"),
+    "tests/steps/aecp_engine_steps.py": (
+        {"protocol-processor/hdl/aecp/KL_aecp_desc_store.sv",
+         "protocol-processor/hdl/aecp/KL_aecp_engine.sv",
+         "protocol-processor/hdl/aecp/KL_aecp_ucpu.sv"},
+        "BDD steps citing the RTL they mirror"),
+}
 
-    A file that invokes this script has no literal to check and cannot go
-    stale, so it is reported as derived rather than scanned. Scanning it would
-    report every source as missing, which is true of the text and false of the
-    build.
+#: This file's own entry is DERIVED from the table above, because the table is
+#: made of the literals it permits and hardcoding them here would mean editing
+#: two lists to add one -- which is the defect this whole script is about.
+PROSE_OK["scripts/pp_srcs.py"] = (
+    {lit for lits, _ in PROSE_OK.values() for lit in lits}
+    | {"$PP/common/pp_pkg.sv"},
+    "this generator: the table above quotes every literal it permits, and the "
+    "docstring and self-test quote a source path")
+
+#: A literal submodule source reference, in any of the spellings the build
+#: inputs use for the submodule root.
+LITERAL_RE = re.compile(
+    r"(?:protocol-processor/hdl|\$PP\b|\$\(PP_DIR\)|\$\{PP\})/\w+/\w+\.sv")
+
+
+def check(files=None, read=None):
+    """Find any build input carrying a literal copy of the source list.
+
+    DISCOVERED, not listed. The first version of this check took a list of
+    consumers and exempted any file containing the substring `pp_srcs.py`, so
+    it had two holes at once and a reviewer walked through both: reverting a
+    consumer to a hand-written literal passed as long as the comment above the
+    edit still mentioned the script, and a fifth consumer was invisible because
+    the consumer list was itself hand-written -- the same defect the script
+    exists to fix, one level up.
+
+    So the property is inverted and widened. No tracked file outside PROSE_OK
+    may name a submodule source literally. That cannot be satisfied by a
+    comment, it needs no consumer list, and a build input added tomorrow is
+    caught the first time it names a source.
+
+    `files` and `read` inject the universe under test. They default to the
+    tracked tree, and `selftest()` supplies synthetic ones so that proving this
+    function bites does not mean editing the repository to do it.
     """
-    have = {pathlib.Path(s).stem for s in pp_sources()}
-    bad, derived = [], []
-    for f in paths:
-        p = ROOT / f
-        if not p.is_file():
-            bad.append(f"{f}: not found")
+    if files is None:
+        out = subprocess.run(["git", "ls-files"], cwd=ROOT,
+                             capture_output=True, text=True)
+        if out.returncode:
+            return [f"git ls-files failed: {out.stderr.strip()}"], []
+        files = out.stdout.split()
+    if read is None:
+        def read(f):
+            return (ROOT / f).read_text()
+    tracked = set(files)
+    bad, ok = [], []
+    for f in files:
+        # The submodule names its own sources in its own build inputs; this
+        # gate is about THIS repository keeping a copy of them. Markdown is
+        # skipped because a document is not a build input: docs cite paths to
+        # say where something lives, and a stale citation in prose does not
+        # silently drop a module from a netlist.
+        if f.startswith("protocol-processor/") or f.endswith(".md"):
             continue
-        text = p.read_text()
-        if "pp_srcs.py" in text:
-            derived.append(f)
+        try:
+            text = read(f)
+        except (OSError, UnicodeDecodeError):
             continue
-        listed = set(re.findall(r"(\w+)\.sv", text)) & (
-            have | set(EXCLUDE))
-        missing = sorted(have - listed)
-        excluded = sorted(set(EXCLUDE) & listed)
-        if missing:
-            bad.append(f"{f}: {len(missing)} submodule source(s) absent from "
-                       f"this list: {', '.join(missing)}")
-        if excluded:
-            bad.append(f"{f}: names deliberately excluded source(s): "
-                       f"{', '.join(excluded)}")
-    return bad, derived
+        hits = set(LITERAL_RE.findall(text))
+        if not hits:
+            continue
+        allowed, _reason = PROSE_OK.get(f, (set(), ""))
+        extra = sorted(hits - allowed)
+        if not extra:
+            ok.append(f)
+            continue
+        bad.append(f"{f}: names submodule source(s) literally that are not "
+                   f"permitted prose: {', '.join(extra)}. A build input must "
+                   "derive the list with this script. If this really is prose, "
+                   "add the exact literal to PROSE_OK with the reason.")
+    for f in PROSE_OK:
+        if f not in tracked:
+            bad.append(f"PROSE_OK names {f}, which is not a tracked file")
+        elif f not in ok and not any(b.startswith(f + ":") for b in bad):
+            bad.append(f"PROSE_OK names {f}, which no longer contains a "
+                       "permitted literal -- the entry is dead, remove it")
+    return bad, ok
+
+
+def _world():
+    """A synthetic tree that `check()` must find clean: every PROSE_OK file,
+    holding exactly the literals its entry permits and nothing else."""
+    return {f: " ".join(sorted(lits)) for f, (lits, _) in PROSE_OK.items()}
+
+
+def selftest():
+    """Prove the check bites, on synthetic inputs, without editing the tree.
+
+    CONTRIBUTING.md:171-174 states the bar for a checker in this repository:
+    it carries a self-test that runs in a gate "so the tool cannot rot into a
+    green that means nothing". Every arm below drives the real `check()`, so
+    stubbing it to return no problems fails this.
+
+    The first version of this self-test planted a literal in `syn/yosys/run.sh`
+    and restored it afterwards. That works exactly until the process is killed
+    between the two writes, and it cannot run on a read-only checkout. Injecting
+    the universe instead exercises the same function and touches nothing.
+    """
+    def run(world):
+        return check(files=sorted(world), read=lambda f: world[f])
+
+    problems = []
+
+    def arm(name, world, want):
+        bad, _ok = run(world)
+        hit = any(want in b for b in bad)
+        if not hit:
+            problems.append(f"SELF-TEST FAILED [{name}]: expected a finding "
+                            f"naming {want}, got {bad or 'no findings'}")
+
+    # Arm 0. The clean world is clean. Without this the other arms could all be
+    # passing on a check that simply reports everything.
+    bad, ok = run(_world())
+    if bad or len(ok) != len(PROSE_OK):
+        problems.append(f"SELF-TEST FAILED [clean]: the permitted-prose world "
+                        f"must be clean, got {bad}, {len(ok)} prose file(s)")
+
+    # Arm 1. A build input reverted to a hand-written literal.
+    w = _world()
+    w["syn/yosys/run.sh"] = 'PP_SRCS="$PP/common/pp_pkg.sv"'
+    arm("revert", w, "syn/yosys/run.sh")
+
+    # Arm 2. The same revert with the comment that names this script left in
+    # place above it -- what a revert actually looks like, and what the first
+    # version of this gate passed.
+    w = _world()
+    w["syn/yosys/ooc.sh"] = ("# Derived from the submodule tree; see "
+                             'scripts/pp_srcs.py\nPP_SRCS="$PP/common/pp_pkg.sv"')
+    arm("revert-under-comment", w, "syn/yosys/ooc.sh")
+
+    # Arm 3. A consumer nobody added to any list. The gate must not need one.
+    w = _world()
+    w["syn/vendor/brand_new_flow.tcl"] = (
+        "read_verilog protocol-processor/hdl/top/protocol_processor_top.sv")
+    arm("new-consumer", w, "brand_new_flow.tcl")
+
+    # Arm 4. A permitted-prose file that grows an EXTRA literal. PROSE_OK is
+    # per-literal for this reason: a whole-file exemption would let a listed
+    # file carry a full hand-written list.
+    w = _world()
+    w["sw/litex/milan_soc.py"] += " protocol-processor/hdl/aecp/KL_aecp_engine.sv"
+    arm("prose-file-grows-a-list", w, "sw/litex/milan_soc.py")
+
+    # Arm 5. A PROSE_OK entry whose literal is gone. A dead exemption is an
+    # exemption nobody re-reads.
+    w = _world()
+    w["sw/litex/milan_soc.py"] = "# the citation this entry exists for is gone"
+    arm("dead-exemption", w, "the entry is dead")
+
+    return problems
 
 
 def main():
@@ -102,15 +258,16 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--prefix", default="protocol-processor/hdl",
                     help="path prefix for each emitted entry")
-    ap.add_argument("--sep", default=" ", help="separator (default: a space)")
-    ap.add_argument("--python-list", action="store_true",
-                    help="emit as a Python list literal")
-    ap.add_argument("--check", nargs="*", metavar="FILE",
-                    help="verify these files name every submodule source")
+    ap.add_argument("--check", action="store_true",
+                    help="fail if any build input carries a literal source list")
+    ap.add_argument("--selftest", action="store_true",
+                    help="prove the check fails on a planted literal")
     args = ap.parse_args()
 
-    if args.check is not None:
-        bad, derived = check(args.check)
+    if args.check or args.selftest:
+        bad = selftest() if args.selftest else []
+        problems, prose = check()
+        bad += problems
         for b in bad:
             print("  -", b)
         if bad:
@@ -121,20 +278,19 @@ def main():
                   "list with this script rather than editing the copy.")
             return 1
         n = len(pp_sources())
-        literal = len(args.check) - len(derived)
-        print(f"pp source list: {n} file(s); {len(derived)} consumer(s) derive it, "
-              f"{literal} carry a literal and agree")
-        for d in derived:
-            print(f"  derived  {d}")
+        print(f"pp source list: {n} tracked source(s) derived; no build input "
+              f"carries a literal copy"
+              + (" (self-test passed)" if args.selftest else ""))
+        for f in prose:
+            print(f"  prose    {f}: {PROSE_OK[f][1]}")
         for stem, why in EXCLUDE.items():
             print(f"  excluded {stem}: {why}")
         return 0
 
-    srcs = pp_sources(args.prefix)
-    if args.python_list:
-        print("[\n" + "".join(f'    "{s}",\n' for s in srcs) + "]")
-    else:
-        print(args.sep.join(srcs))
+    # One space-separated line. The shell consumers word-split it, the Makefile
+    # takes it as a variable and the .tcl splits it into a list; a second output
+    # format would be a second thing to keep working for no consumer.
+    print(" ".join(pp_sources(args.prefix)))
     return 0
 
 

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -540,17 +540,21 @@ class MilanNIC(LiteXModule):
                            entity_gen_dir=entity_gen_dir)
 
 
-# The milan_datapath source set (ordered: packages first). Mirrors the milan_dp
-# Verilator Makefile and the syn/yosys entry  -  the single source of truth for what
-# the §A.9 wrapper is built from.
+# The milan_datapath source set (ordered: packages first) for the §A.9 wrapper.
+# It used to say it mirrored the milan_dp Verilator Makefile and the syn/yosys
+# entry, calling those the single source of truth while each of them said the
+# same of another: nothing held the authority and every copy drifted together.
 #
 # THE PROTOCOL PROCESSOR IS PART OF THE DATAPATH NOW (scenario B, 2026-08-13).
 # milan_datapath instantiates KL_pp_shadow UNCONDITIONALLY - there is no
 # PP_PLANE_P any more - so the submodule's files are datapath files, not an
 # opt-in extra. They come FIRST because their packages must be declared before
-# the modules that import them, and the order below is copied from the
-# authoritative `PP_SRCS` in tb/verilator/milan_dp/Makefile. Paths are repo-root
-# relative like every other entry here (add_source joins them onto `base`).
+# the modules that import them, which scripts/pp_srcs.py guarantees by reading
+# each file for a `package` declaration rather than trusting a name. Paths are
+# repo-root relative like every other entry here (add_source joins them onto
+# `base`). This comment used to call tb/verilator/milan_dp/Makefile the
+# authoritative list; that file said the same of nothing, so the authority was
+# circular and the instruction to copy it is what recreated the drift.
 def _pp_sources():
     """Submodule design sources, derived from the tree by scripts/pp_srcs.py."""
     import importlib.util

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -551,52 +551,23 @@ class MilanNIC(LiteXModule):
 # the modules that import them, and the order below is copied from the
 # authoritative `PP_SRCS` in tb/verilator/milan_dp/Makefile. Paths are repo-root
 # relative like every other entry here (add_source joins them onto `base`).
+def _pp_sources():
+    """Submodule design sources, derived from the tree by scripts/pp_srcs.py."""
+    import importlib.util
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    spec = importlib.util.spec_from_file_location(
+        "pp_srcs", os.path.join(root, "scripts", "pp_srcs.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.pp_sources()
+
+
 _MILAN_DATAPATH_SOURCES = [
-    "protocol-processor/hdl/common/pp_pkg.sv",
-    "protocol-processor/hdl/srp/srp_pkg.sv",
-    "protocol-processor/hdl/acmp/pp_acmp_pkg.sv",
-    "protocol-processor/hdl/adp/pp_adp_pkg.sv",
-    "protocol-processor/hdl/common/KL_pp_prng.sv",
-    "protocol-processor/hdl/common/KL_pp_timer_service.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_rx_validator.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_rx_slots.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_normalizer.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_tx_slots.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_tx_arbiter.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_scoreboard.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_event_router.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_originator.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_trace_ring.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_side_port.sv",
-    "protocol-processor/hdl/packet_engine/KL_pp_nvm_port.sv",
-    "protocol-processor/hdl/adp/KL_adp_engine.sv",
-    "protocol-processor/hdl/maap/KL_pp_maap.sv",
-    "protocol-processor/hdl/acmp/KL_pp_acmp_listener.sv",
-    "protocol-processor/hdl/acmp/KL_acmp_talker.sv",
-    "protocol-processor/hdl/acmp/KL_acmp_nvm_shadow.sv",
-    "protocol-processor/hdl/srp/KL_srp_decoder.sv",
-    "protocol-processor/hdl/srp/KL_srp_domain.sv",
-    "protocol-processor/hdl/srp/KL_srp_vlan.sv",
-    "protocol-processor/hdl/srp/KL_srp_admission.sv",
-    "protocol-processor/hdl/srp/KL_srp_talker_fsm.sv",
-    "protocol-processor/hdl/srp/KL_srp_listener_fsm.sv",
-    "protocol-processor/hdl/srp/KL_srp_encoder.sv",
-    "protocol-processor/hdl/srp/KL_srp_top.sv",
-    # the AECP engine: the uCPU, the DRAM-backed descriptor store it reads
-    # through, and the engine that binds them onto the packet engine's AECP
-    # pop face. Packages and leaves before the top that instantiates them —
-    # Vivado reported the omission as `module KL_aecp_engine not found`, not
-    # as a missing file, which is why the source list is the thing to check.
-    "protocol-processor/hdl/aecp/ucpu_pkg.sv",
-    "protocol-processor/hdl/aecp/KL_aecp_ucpu.sv",
-    "protocol-processor/hdl/aecp/KL_aecp_desc_store.sv",
-    "protocol-processor/hdl/aecp/KL_aecp_dyn_state.sv",
-    "protocol-processor/hdl/aecp/KL_aecp_resp_buf.sv",
-    "protocol-processor/hdl/aecp/KL_aecp_engine.sv",
-    "protocol-processor/hdl/aecp/KL_aecp_notify.sv",
-    "protocol-processor/hdl/top/KL_mrp_strip.sv",
-    "protocol-processor/hdl/top/protocol_processor_top.sv",
+    # The submodule half is DERIVED from the tree; see scripts/pp_srcs.py.
+    # This list used to name tb/verilator/milan_dp/Makefile as authoritative
+    # while that file named none, so the authority was circular and all four
+    # copies went stale together the moment the submodule pin moved.
+    *_pp_sources(),
     # the two consumer-side wrappers that bind it into this datapath: the
     # shadow/substitution wrapper and the block-vs-per-source MAAP adapter.
     "hdl/milan/KL_pp_shadow.sv", "hdl/milan/KL_pp_maap_shim.sv",

--- a/syn/ooc/dp_srcs.py
+++ b/syn/ooc/dp_srcs.py
@@ -3,20 +3,35 @@
 # SPDX-License-Identifier: CERN-OHL-W-2.0
 """Print the milan_datapath source list, one absolute path per line.
 
-THE POINT IS THAT THERE IS NO SECOND COPY. The authoritative list is the
-"milan_datapath|..." entry in syn/yosys/run.sh — the one the portability gate
-proves elaborates on every run. A hand-maintained duplicate in a Vivado .tcl
-would drift the first time a module lands, and the drift would show up as a
-synthesis result quietly missing a block. So the .tcl execs this instead.
+THE POINT IS THAT THERE IS NO SECOND COPY. The datapath entry is the
+"milan_datapath|..." line in syn/yosys/run.sh — the one the portability gate
+proves elaborates on every run — and its submodule half comes from
+scripts/pp_srcs.py, which derives it from the tree. A hand-maintained duplicate
+in a Vivado .tcl would drift the first time a module lands, and the drift would
+show up as a synthesis result quietly missing a block. So the .tcl execs this
+instead.
+
+This file scraped run.sh's `PP_SRCS="..."` textually until that assignment
+became a command substitution, whose inner quotes truncated the non-greedy
+capture: 104 sources became 62, exit 0, no diagnostic, and Vivado said only
+`module 'KL_pp_shadow' not found`. Scraping a build file is a recogniser;
+calling the generator resolves.
 
 Used by syn/ooc/milan_datapath_ooc.tcl.
 """
 import os
 import re
+import subprocess
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+
+#: This repository's own two wrappers, which run.sh appends to the derived
+#: submodule half. They are the parent's files, not the submodule's, so the
+#: generator does not emit them; every consumer names them. Named here so the
+#: assertion below can prove they survived the expansion.
+PARENT_WRAPPERS = ("hdl/milan/KL_pp_shadow.sv", "hdl/milan/KL_pp_maap_shim.sv")
 
 
 def main() -> int:
@@ -37,12 +52,30 @@ def main() -> int:
     # like any other source. A name listed here that run.sh no longer defines
     # is a hard error on purpose: silently dropping it would emit a source list
     # missing a whole plane, and Vivado would only say "module not found".
-    for var in ("PP_SRCS",):
-        mv = re.search(r'%s="(.*?)"' % var, s, re.S)
-        if not mv:
-            print("dp_srcs: %s not found in run.sh" % var, file=sys.stderr)
-            return 2
-        srcs = srcs.replace("$" + var, mv.group(1))
+    # PP_SRCS is DERIVED, so there is nothing in run.sh to scrape. This used to
+    # lift the literal with `PP_SRCS="(.*?)"`, and when run.sh switched to a
+    # command substitution the inner quotes truncated that capture to
+    # `$(python3 ` -- 104 sources became 62, exit 0, no diagnostic, and Vivado
+    # only said `module 'KL_pp_shadow' not found`. Calling the generator cannot
+    # fail that way: it either returns the list or exits non-zero.
+    if "$PP_SRCS" not in srcs:
+        print("dp_srcs: the milan_datapath entry in run.sh no longer references "
+              "$PP_SRCS. Expanding it now would emit a datapath without its "
+              "control plane, at exit 0.", file=sys.stderr)
+        return 2
+    pp = subprocess.run(
+        [sys.executable, os.path.join(REPO, "scripts", "pp_srcs.py"),
+         "--prefix", os.path.join(REPO, "protocol-processor", "hdl")],
+        capture_output=True, text=True)
+    if pp.returncode != 0:
+        sys.stderr.write(pp.stderr)
+        return 2
+    derived = pp.stdout.split()
+    # run.sh's PP_SRCS is the derived submodule half PLUS this repository's own
+    # two wrappers; compose it the same way or the OOC netlist loses them and
+    # Vivado reports `module 'KL_pp_shadow' not found`.
+    srcs = srcs.replace("$PP_SRCS", " ".join(
+        derived + [os.path.join(REPO, w) for w in PARENT_WRAPPERS]))
 
     env = {
         "R": REPO,
@@ -65,6 +98,29 @@ def main() -> int:
     if missing:
         print("dp_srcs: missing sources:\n  " + "\n  ".join(missing), file=sys.stderr)
         return 1
+
+    # A SHORT LIST AT EXIT 0 IS THE FAILURE THIS FILE CAUSED ONCE ALREADY, so
+    # assert what the output must contain rather than trusting the expansion.
+    # The old guards could not see it: one only checked that the variable NAME
+    # was present, the other only inspected tokens ending in .sv/.v, and the
+    # truncation residue ended in neither. Both stayed silent while the control
+    # plane vanished from the netlist.
+    emitted = set(files)
+    lost = [f for f in derived if f not in emitted]
+    lost += [w for w in PARENT_WRAPPERS
+             if os.path.join(REPO, w) not in emitted]
+    # ...and name the plane itself, not just a count. A generator that returned
+    # a truncated list would satisfy the loop above -- everything it derived
+    # survived -- while emitting a datapath with no processor in it. This is
+    # the module milan_datapath.sv instantiates through KL_pp_shadow, so its
+    # absence is not a stale list, it is a netlist that cannot elaborate.
+    if not any(os.path.basename(f) == "protocol_processor_top.sv" for f in files):
+        lost.append("protocol_processor_top.sv (the control plane itself)")
+    if lost:
+        print("dp_srcs: %d source(s) were derived but did not survive expansion "
+              "into the milan_datapath entry:\n  %s"
+              % (len(lost), "\n  ".join(lost)), file=sys.stderr)
+        return 2
 
     print("\n".join(files))
     return 0

--- a/syn/ooc/pp_shadow_ooc.tcl
+++ b/syn/ooc/pp_shadow_ooc.tcl
@@ -17,37 +17,28 @@
 #
 #   cd <workdir>
 #   python3 <pp>/hdl/acmp/rom/gen_ltn_rom.py -o ltn_rom.hex
+#   python3 <pp>/hdl/aecp/ucode/gen_ucode.py -o ucode.hex
 #   vivado -mode batch -source <repo>/syn/ooc/pp_shadow_ooc.tcl -nojournal -log ooc.log
+#
+# BOTH images, and both by RELATIVE name, because their modules $readmemh them
+# that way and Vivado resolves the name against ITS OWN working directory, not
+# against the source file. A missing one is a CRITICAL WARNING ending in
+# "ignoring", not an error, so the run completes and reports an area for a ROM
+# full of X. ucode.hex became necessary when this file stopped naming a subset
+# of the plane by hand: the AECP uCPU was one of the eight sources the old
+# literal had gone stale by. syn/yosys/run.sh generates both, for this reason.
 
 set REPO [file normalize [file dirname [info script]]/../..]
 set PP   $REPO/protocol-processor/hdl
 set AXIS $REPO/third_party/verilog-axis/rtl
 
-# packages first, then the engines, then the consumer wrapper — tb/pp_top order
-read_verilog -sv \
-  $PP/common/pp_pkg.sv $PP/srp/srp_pkg.sv $PP/acmp/pp_acmp_pkg.sv $PP/adp/pp_adp_pkg.sv \
-  $PP/common/KL_pp_prng.sv $PP/common/KL_pp_timer_service.sv \
-  $PP/packet_engine/KL_pp_rx_validator.sv \
-  $PP/packet_engine/KL_pp_rx_slots.sv \
-  $PP/packet_engine/KL_pp_normalizer.sv \
-  $PP/packet_engine/KL_pp_dispatch.sv \
-  $PP/packet_engine/KL_pp_tx_slots.sv \
-  $PP/packet_engine/KL_pp_tx_arbiter.sv \
-  $PP/packet_engine/KL_pp_scoreboard.sv \
-  $PP/packet_engine/KL_pp_event_router.sv \
-  $PP/packet_engine/KL_pp_originator.sv \
-  $PP/packet_engine/KL_pp_trace_ring.sv \
-  $PP/packet_engine/KL_pp_side_port.sv \
-  $PP/packet_engine/KL_pp_nvm_port.sv \
-  $PP/adp/KL_adp_engine.sv \
-  $PP/acmp/KL_pp_acmp_listener.sv $PP/acmp/KL_acmp_talker.sv \
-  $PP/acmp/KL_acmp_nvm_shadow.sv \
-  $PP/srp/KL_srp_decoder.sv $PP/srp/KL_srp_domain.sv \
-  $PP/srp/KL_srp_vlan.sv $PP/srp/KL_srp_admission.sv \
-  $PP/srp/KL_srp_talker_fsm.sv $PP/srp/KL_srp_listener_fsm.sv \
-  $PP/srp/KL_srp_encoder.sv $PP/srp/KL_srp_top.sv \
-  $PP/top/KL_mrp_strip.sv $PP/top/protocol_processor_top.sv \
-  $REPO/hdl/milan/KL_pp_shadow.sv
+# The submodule sources are DERIVED (scripts/pp_srcs.py), not listed here. This
+# file used to carry a sixth hand-written copy of that list and it was stale by
+# eight sources, the whole AECP engine among them, which Vivado reports only as
+# `module not found`. Packages come first because a package must be declared
+# before its importers; the generator guarantees that ordering.
+set PP_SRCS [exec python3 $REPO/scripts/pp_srcs.py --prefix $PP]
+read_verilog -sv {*}$PP_SRCS
 
 # the Forencich frame FIFO is plain Verilog-2001
 read_verilog $AXIS/axis_fifo.v

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -30,7 +30,10 @@ TMP="${OOC_TMP:-$(mktemp -d)}"; mkdir -p "$TMP"
 # sources and belong in DP_SRCS. Packages first. Order mirrors
 # syn/yosys/run.sh's PP_SRCS and tb/verilator/milan_dp/Makefile's.
 PP="$R/protocol-processor/hdl"
-PP_SRCS="$PP/common/pp_pkg.sv $PP/srp/srp_pkg.sv $PP/acmp/pp_acmp_pkg.sv $PP/adp/pp_adp_pkg.sv $PP/common/KL_pp_prng.sv $PP/common/KL_pp_timer_service.sv $PP/packet_engine/KL_pp_rx_validator.sv $PP/packet_engine/KL_pp_rx_slots.sv $PP/packet_engine/KL_pp_normalizer.sv $PP/packet_engine/KL_pp_dispatch.sv $PP/packet_engine/KL_pp_tx_slots.sv $PP/packet_engine/KL_pp_tx_arbiter.sv $PP/packet_engine/KL_pp_scoreboard.sv $PP/packet_engine/KL_pp_event_router.sv $PP/packet_engine/KL_pp_originator.sv $PP/packet_engine/KL_pp_trace_ring.sv $PP/packet_engine/KL_pp_side_port.sv $PP/packet_engine/KL_pp_nvm_port.sv $PP/adp/KL_adp_engine.sv $PP/maap/KL_pp_maap.sv $PP/acmp/KL_pp_acmp_listener.sv $PP/acmp/KL_acmp_talker.sv $PP/acmp/KL_acmp_nvm_shadow.sv $PP/srp/KL_srp_decoder.sv $PP/srp/KL_srp_domain.sv $PP/srp/KL_srp_vlan.sv $PP/srp/KL_srp_admission.sv $PP/srp/KL_srp_talker_fsm.sv $PP/srp/KL_srp_listener_fsm.sv $PP/srp/KL_srp_encoder.sv $PP/srp/KL_srp_top.sv $PP/aecp/ucpu_pkg.sv $PP/aecp/KL_aecp_ucpu.sv $PP/aecp/KL_aecp_desc_store.sv $PP/aecp/KL_aecp_dyn_state.sv $PP/aecp/KL_aecp_resp_buf.sv $PP/aecp/KL_aecp_engine.sv $PP/aecp/KL_aecp_notify.sv $PP/top/KL_mrp_strip.sv $PP/top/protocol_processor_top.sv $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
+# Derived from the submodule tree; see scripts/pp_srcs.py. The parent's own
+# two files stay explicit because they are this repository's, not the
+# submodule's.
+PP_SRCS="$(python3 "$R/scripts/pp_srcs.py" --prefix "$PP") $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
 
 # ...and with the processor comes its ROM. protocol_processor_top $readmemh's
 # the ACMP listener transition image by the RELATIVE name "ltn_rom.hex", which

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -27,13 +27,15 @@ TMP="${OOC_TMP:-$(mktemp -d)}"; mkdir -p "$TMP"
 
 # The protocol processor is the control plane (scenario B): milan_datapath
 # instantiates KL_pp_shadow unconditionally, so its sources are datapath
-# sources and belong in DP_SRCS. Packages first. Order mirrors
-# syn/yosys/run.sh's PP_SRCS and tb/verilator/milan_dp/Makefile's.
+# sources and belong in DP_SRCS. Packages first.
 PP="$R/protocol-processor/hdl"
 # Derived from the submodule tree; see scripts/pp_srcs.py. The parent's own
 # two files stay explicit because they are this repository's, not the
-# submodule's.
-PP_SRCS="$(python3 "$R/scripts/pp_srcs.py" --prefix "$PP") $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
+# submodule's. The status is taken rather than discarded: `$(...)` in an
+# assignment drops it, and the generator's refusal to emit an empty list is
+# worth nothing on this side of the process boundary if nobody reads it.
+PP_DERIVED="$(python3 "$R/scripts/pp_srcs.py" --prefix "$PP")" || exit 2
+PP_SRCS="$PP_DERIVED $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
 
 # ...and with the processor comes its ROM. protocol_processor_top $readmemh's
 # the ACMP listener transition image by the RELATIVE name "ltn_rom.hex", which

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -35,7 +35,10 @@ TMP="$(mktemp -d)"
 # top and the milan_datapath entry. Packages first: their importers follow.
 # Order mirrors tb/verilator/milan_dp/Makefile's PP_SRCS.
 PP="$R/protocol-processor/hdl"
-PP_SRCS="$PP/common/pp_pkg.sv $PP/srp/srp_pkg.sv $PP/acmp/pp_acmp_pkg.sv $PP/adp/pp_adp_pkg.sv $PP/common/KL_pp_prng.sv $PP/common/KL_pp_timer_service.sv $PP/packet_engine/KL_pp_rx_validator.sv $PP/packet_engine/KL_pp_rx_slots.sv $PP/packet_engine/KL_pp_normalizer.sv $PP/packet_engine/KL_pp_dispatch.sv $PP/packet_engine/KL_pp_tx_slots.sv $PP/packet_engine/KL_pp_tx_arbiter.sv $PP/packet_engine/KL_pp_scoreboard.sv $PP/packet_engine/KL_pp_event_router.sv $PP/packet_engine/KL_pp_originator.sv $PP/packet_engine/KL_pp_trace_ring.sv $PP/packet_engine/KL_pp_side_port.sv $PP/packet_engine/KL_pp_nvm_port.sv $PP/adp/KL_adp_engine.sv $PP/maap/KL_pp_maap.sv $PP/acmp/KL_pp_acmp_listener.sv $PP/acmp/KL_acmp_talker.sv $PP/acmp/KL_acmp_nvm_shadow.sv $PP/srp/KL_srp_decoder.sv $PP/srp/KL_srp_domain.sv $PP/srp/KL_srp_vlan.sv $PP/srp/KL_srp_admission.sv $PP/srp/KL_srp_talker_fsm.sv $PP/srp/KL_srp_listener_fsm.sv $PP/srp/KL_srp_encoder.sv $PP/srp/KL_srp_top.sv $PP/aecp/ucpu_pkg.sv $PP/aecp/KL_aecp_ucpu.sv $PP/aecp/KL_aecp_desc_store.sv $PP/aecp/KL_aecp_dyn_state.sv $PP/aecp/KL_aecp_resp_buf.sv $PP/aecp/KL_aecp_engine.sv $PP/aecp/KL_aecp_notify.sv $PP/top/KL_mrp_strip.sv $PP/top/protocol_processor_top.sv $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
+# Derived from the submodule tree, not listed here: four build inputs used to
+# carry this list by hand and each named another as authoritative. They stay
+# correct until the pin moves, and nothing compared them against the tree.
+PP_SRCS="$(python3 "$R/scripts/pp_srcs.py" --prefix "$PP") $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
 
 for t in sv2v yosys; do command -v $t >/dev/null || { echo "missing tool: $t (see syn/yosys/README.md)"; exit 2; }; done
 

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -33,14 +33,23 @@ TMP="$(mktemp -d)"
 # pp_adp_pkg/pp_acmp_pkg, and milan_datapath instantiates KL_pp_shadow
 # unconditionally - so this variable now feeds BOTH the standalone KL_pp_shadow
 # top and the milan_datapath entry. Packages first: their importers follow.
-# Order mirrors tb/verilator/milan_dp/Makefile's PP_SRCS.
 PP="$R/protocol-processor/hdl"
+
+# python3 is checked WITH the synthesis tools and BEFORE the list is built,
+# because the list is now derived by a script rather than typed out, so the
+# interpreter is a hard dependency of the variable itself.
+for t in python3 sv2v yosys; do command -v $t >/dev/null || { echo "missing tool: $t (see syn/yosys/README.md)"; exit 2; }; done
+
 # Derived from the submodule tree, not listed here: four build inputs used to
 # carry this list by hand and each named another as authoritative. They stay
 # correct until the pin moves, and nothing compared them against the tree.
-PP_SRCS="$(python3 "$R/scripts/pp_srcs.py" --prefix "$PP") $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
-
-for t in sv2v yosys; do command -v $t >/dev/null || { echo "missing tool: $t (see syn/yosys/README.md)"; exit 2; }; done
+# TAKE THE STATUS. `$(...)` inside an assignment throws the exit code away and
+# `set -u` never sees an empty-but-defined variable, so the generator's refusal
+# to emit an empty list - its whole guarantee - does not survive the process
+# boundary unless it is read here. Without this, an absent submodule synthesises
+# a KL_pp_shadow top with no plane inside it.
+PP_DERIVED="$(python3 "$R/scripts/pp_srcs.py" --prefix "$PP")" || exit 2
+PP_SRCS="$PP_DERIVED $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.sv"
 
 # protocol_processor_top $readmemh's its ACMP transition ROM by a RELATIVE
 # name, and yosys resolves that against ITS OWN working directory - not against

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -85,33 +85,11 @@ P  = $(RTL_DIR)/ieee8021as/ptp_timestamp
 # sources. They come FIRST: their packages must be declared before the modules
 # that import them. This list is exported by `print-srcs`, so tb/verilator/
 # pp_shadow gets it without keeping a second copy that could drift.
-PP_SRCS = $(PP_DIR)/common/pp_pkg.sv $(PP_DIR)/srp/srp_pkg.sv \
-       $(PP_DIR)/acmp/pp_acmp_pkg.sv $(PP_DIR)/adp/pp_adp_pkg.sv \
-       $(PP_DIR)/common/KL_pp_prng.sv $(PP_DIR)/common/KL_pp_timer_service.sv \
-       $(PP_DIR)/packet_engine/KL_pp_rx_validator.sv \
-       $(PP_DIR)/packet_engine/KL_pp_rx_slots.sv \
-       $(PP_DIR)/packet_engine/KL_pp_normalizer.sv \
-       $(PP_DIR)/packet_engine/KL_pp_dispatch.sv \
-       $(PP_DIR)/packet_engine/KL_pp_tx_slots.sv \
-       $(PP_DIR)/packet_engine/KL_pp_tx_arbiter.sv \
-       $(PP_DIR)/packet_engine/KL_pp_scoreboard.sv \
-       $(PP_DIR)/packet_engine/KL_pp_event_router.sv \
-       $(PP_DIR)/packet_engine/KL_pp_originator.sv \
-       $(PP_DIR)/packet_engine/KL_pp_trace_ring.sv \
-       $(PP_DIR)/packet_engine/KL_pp_side_port.sv \
-       $(PP_DIR)/packet_engine/KL_pp_nvm_port.sv \
-       $(PP_DIR)/adp/KL_adp_engine.sv \
-       $(PP_DIR)/maap/KL_pp_maap.sv \
-       $(PP_DIR)/acmp/KL_pp_acmp_listener.sv $(PP_DIR)/acmp/KL_acmp_talker.sv \
-       $(PP_DIR)/acmp/KL_acmp_nvm_shadow.sv \
-       $(PP_DIR)/srp/KL_srp_decoder.sv $(PP_DIR)/srp/KL_srp_domain.sv \
-       $(PP_DIR)/srp/KL_srp_vlan.sv $(PP_DIR)/srp/KL_srp_admission.sv \
-       $(PP_DIR)/srp/KL_srp_talker_fsm.sv $(PP_DIR)/srp/KL_srp_listener_fsm.sv \
-       $(PP_DIR)/srp/KL_srp_encoder.sv $(PP_DIR)/srp/KL_srp_top.sv \
-       $(PP_DIR)/aecp/ucpu_pkg.sv $(PP_DIR)/aecp/KL_aecp_ucpu.sv \
-       $(PP_DIR)/aecp/KL_aecp_desc_store.sv $(PP_DIR)/aecp/KL_aecp_dyn_state.sv $(PP_DIR)/aecp/KL_aecp_resp_buf.sv \
-       $(PP_DIR)/aecp/KL_aecp_engine.sv $(PP_DIR)/aecp/KL_aecp_notify.sv \
-       $(PP_DIR)/top/KL_mrp_strip.sv $(PP_DIR)/top/protocol_processor_top.sv \
+# The submodule half is DERIVED from the tree, not listed here. Four build
+# inputs used to carry it by hand, each naming another as authoritative, and all
+# four went stale together the moment the pin moved. The parent's own two files
+# stay explicit: they are this repository's, not the submodule's.
+PP_SRCS := $(shell python3 $(CURDIR)/../../../scripts/pp_srcs.py --prefix $(PP_DIR)) \
        $(RTL_DIR)/milan/KL_pp_shadow.sv $(RTL_DIR)/milan/KL_pp_maap_shim.sv
 
 # the gPTP plane (issue #114): parsed by every leg (the instantiation

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -89,7 +89,15 @@ P  = $(RTL_DIR)/ieee8021as/ptp_timestamp
 # inputs used to carry it by hand, each naming another as authoritative, and all
 # four went stale together the moment the pin moved. The parent's own two files
 # stay explicit: they are this repository's, not the submodule's.
-PP_SRCS := $(shell python3 $(CURDIR)/../../../scripts/pp_srcs.py --prefix $(PP_DIR)) \
+PP_DERIVED := $(shell python3 $(CURDIR)/../../../scripts/pp_srcs.py --prefix $(PP_DIR))
+# TAKE THE STATUS. $(shell) discards it, so the generator's refusal to emit an
+# empty list does not cross the process boundary on its own: without this the
+# submodule half simply vanishes from PP_SRCS and make carries on to build a
+# datapath with no control plane in it.
+ifneq ($(.SHELLSTATUS),0)
+$(error scripts/pp_srcs.py failed; the protocol-processor submodule source list could not be derived)
+endif
+PP_SRCS := $(PP_DERIVED) \
        $(RTL_DIR)/milan/KL_pp_shadow.sv $(RTL_DIR)/milan/KL_pp_maap_shim.sv
 
 # the gPTP plane (issue #114): parsed by every leg (the instantiation


### PR DESCRIPTION
Closes #170.

## The defect

Four build inputs carried the same hand-written list of submodule filenames, and each named another as authoritative while that one named none. The authority was circular:

- `syn/yosys/run.sh` (`PP_SRCS`)
- `syn/yosys/ooc.sh`
- `tb/verilator/milan_dp/Makefile`
- `sw/litex/milan_soc.py`, whose comment reads *"mirrors the authoritative `PP_SRCS` in tb/verilator/milan_dp/Makefile"*

**All four are correct against the pin they were written for.** That is what made this hard to see: nothing is wrong today. They go stale the moment the submodule pin moves, which is exactly when nobody re-reads them.

That happened yesterday. Bumping the pin in #145 pulled in two modules from another lane, and the first symptom was an elaboration error naming the missing module rather than the stale list:

```
[FAIL] KL_pp_shadow   yosys: ERROR: Module `\KL_aecp_ca_originator' referenced in
                      module `\protocol_processor_top' ... is not part of the design.
```

Each fix revealed the next, in three different places, because they were three copies of one list.

The loud case above is not the dangerous one. **The silent case is a module that no current top instantiates**: it is simply never built, and the portability sweep reports PASS over a design that does not contain it. That gate's claim is that every top elaborates off-vendor, and the claim was only ever as wide as the list.

## The change

`scripts/pp_srcs.py` derives the list from the tree. Packages first, because a package must be declared before the modules that import it; everything else sorted, because the tools do not care and a stable order keeps diffs readable. That was the only ordering constraint the old lists encoded, and `tb/verilator/milan_dp/Makefile` said so in as many words.

**All four consumers now derive.** The parent's own `KL_pp_shadow.sv` and `KL_pp_maap_shim.sv` stay explicit in each: they belong to this repository, not the submodule.

Exclusions are explicit and carry a reason, printed on a clean run. There are none today; every `.sv` under the submodule's `hdl/` is a design file.

## Evidence

**Equivalence, not plausibility.** The derived list is the same 40 files as the literal it replaces, compared as sets against `HEAD`:

```
derived: 40 first: pp_acmp_pkg.sv last: protocol_processor_top.sv
old literal: 40 | same set: True
```

**The degenerate case, which is the one that matters.** With the submodule bumped to the newer pin, the check names both missing modules in all four consumers and exits 1:

```
- syn/yosys/run.sh: 2 submodule source(s) absent: KL_aecp_ca_originator, KL_pp_release_merge
- syn/yosys/ooc.sh: 2 ...
- tb/verilator/milan_dp/Makefile: 2 ...
- sw/litex/milan_soc.py: 2 ...
EXIT=1
```

Restored to `dev`'s pin, all four report derived and exit 0.

**Builds, not just lists:**

| gate | result |
|---|---|
| Verilator sweep | **52 suites, 52 passed, 0 failed** |
| `tb/verilator/milan_dp` | PASS, built from the derived list |
| `tb/verilator/pp_shadow` | PASS, consumes milan_dp via `print-srcs`, unchanged |
| yosys `run.sh` | **46 PASS, 0 FAIL**, exit 0 |
| `lint_rtl.py --check` | exit 0 |
| `docs_check.py` | 0 findings across 212 files |

## What I did not verify

**LiteX elaboration was not run.** `migen` is not importable on this host, so `sw/litex/milan_soc.py`'s change is verified by importing `_pp_sources()` and comparing its output to the literal it replaces, not by elaborating a SoC. That is the one consumer whose full path is unexercised here, and it is the one that produces bitstreams. A reviewer with a LiteX venv should run it.

## The CI gate, and what it cannot do

`rtl.yml` runs `pp_srcs.py --check` over all four. Now that they derive, it is a backstop against a literal coming *back* -- a new consumer added with a hand-written list, or a derivation reverted. It cannot catch a stale copy that no longer exists, which is the point: it catches the copy being re-created.

## Note on the class

This is the same shape as the figure gate on protocol-processor #13 and as #166: a hand-maintained artifact standing in for a derived one, diverging in the direction nobody inspects. The difference here is that deriving was cheap, so the answer is a resolver rather than a checker. The check exists only because a checker is all you can do for a file that still carries a literal.
