### PR TITLE
Apply and verify the toolchain patch series instead of trusting it

### DIFF
--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -1,0 +1,127 @@
+name: elaborate
+
+# WHY THIS WORKFLOW EXISTS (issues #154, #156).
+#
+# Every argv-to-RTL-parameter chain in this repository used to be proven by
+# source-text greps against sw/litex/milan_soc.py, because NO CI JOB
+# ELABORATED THE SOC. Three separate blockers in three lanes on one day were
+# that gap: a flag parsed, threaded part of the way, and never reaching the
+# parameter it names. In one of them a reviewer severed the chain at two
+# independent hops and read ALL GATES PASS both times.
+#
+# The behavioural proof existed - gate 23f patches `Instance` in the executed
+# module's namespace and reads the live p_* keyword arguments - and it skipped
+# in CI, because docs.yml installs pyyaml and rtl.yml installs behave and
+# neither has LiteX. That is the whole crux: the proof existed and CI could
+# not run it.
+#
+# So this job installs LiteX and runs it. It is separate from docs.yml because
+# it is the only job in the tree that needs a JVM and a Scala build, and a
+# documentation PR should not pay for that.
+#
+# NOT ENABLED YET, AND THIS FILE IS HERE SO THE REASON IS READABLE. Measured
+# 2026-08-21: NO config in this tree elaborates on a stock toolchain. The
+# shipping AX shape asks for a `baremetal` VexiiRiscv variant upstream LiteX
+# does not have; the four Linux shapes pass --scala-args the pinned VexiiRiscv
+# does not accept. Both come from about 184 lines of uncommitted patch across
+# four third-party trees under ~/litex-milan, which #185 measures and whose
+# fix is a maintainer decision. Until that decision is made this job would
+# install correctly and then fail on every config, so its triggers are
+# withheld and it runs only on manual dispatch.
+#
+# Gates 23f and 23g run today on any interpreter that has a working LiteX,
+# which is how they were validated. Everywhere else they SKIP, the verdict
+# says `ALL GATES PASS EXCEPT n NOT RUN` and names them, and
+# --require-elaboration turns a missing interpreter into a failure rather
+# than a skip. That is what stops the absence of the proof from reading as
+# the presence of one while this job is off.
+
+on:
+  # Manual only until #185 is decided. The push/pull_request triggers below
+  # are the intended ones and are commented rather than deleted, so enabling
+  # this job is one edit and not a rediscovery.
+  workflow_dispatch:
+  # push:
+  #   branches: [main, dev]
+  # pull_request:
+
+concurrency:
+  group: elaborate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  elaborate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The elaboration reads the protocol-processor and gptp-processor source
+      # lists through scripts/pp_srcs.py, which REFUSES to emit an empty list.
+      # Without the submodules it fails before the datapath is reached.
+      - name: Fetch the processor sources the elaboration reads
+        run: git submodule update --init protocol-processor gptp-processor
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # LiteX ships from git, not PyPI: the PyPI releases lag by more than a
+      # year and their VexiiRiscv wrapper does not carry the pinned-revision
+      # setup this job depends on. The revisions are in sw/litex/litex_pins.txt
+      # with the reason they are pinned; master of 2026-08-21 cannot elaborate
+      # this SoC at all, so an unpinned install would redden PRs that changed
+      # nothing.
+      - name: Install LiteX at the pinned revisions
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 -m pip install --quiet -r sw/litex/litex_pins.txt
+
+      # The VexiiRiscv wrapper turns its CPU arguments into a small generated
+      # Python file, once per distinct argument set, by running Scala. That is
+      # the only reason this job needs a JVM at all, and the result caches: a
+      # cold run pays about 90 s for it, a warm one nothing.
+      - name: Cache the CPU netlist arguments and the Scala toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.sbt
+            ~/.ivy2
+            ~/vexii-netlist-args
+          key: elaborate-vexii-${{ hashFiles('configs/*.yaml', 'sw/litex/milan_soc.py', 'sw/litex/build.sh', 'sw/litex/sweep.sh') }}
+          restore-keys: elaborate-vexii-
+
+      - name: Install sbt
+        run: |
+          sbt --version >/dev/null 2>&1 && exit 0
+          curl -fsSL --retry 3 -o /tmp/sbt.tgz \
+            https://github.com/sbt/sbt/releases/download/v1.10.7/sbt-1.10.7.tgz
+          sudo tar xzf /tmp/sbt.tgz -C /opt
+          echo /opt/sbt/bin >> "$GITHUB_PATH"
+
+      # LiteX's own git_setup returns immediately unless --update-repo asks it
+      # to clone, and milan_soc.py never passes that, so the Scala source has
+      # to be placed here. The revision is DERIVED from LiteX rather than
+      # restated: a pin copied to a second place goes stale in silence, and
+      # the symptom is a netlist from the wrong CPU source, not a red build.
+      - name: Place the VexiiRiscv source at the revision LiteX pins
+        run: |
+          python3 scripts/ci_litex_env.py
+          mkdir -p ~/vexii-netlist-args
+          cp -n ~/vexii-netlist-args/*.py \
+            "$(python3 -c 'import pythondata_cpu_vexiiriscv as p; print(p.data_location)')/" \
+            2>/dev/null || true
+
+      # The gate that could not run in CI, running in CI. Gates 23f/23g
+      # observe what elaboration hands Instance("milan_datapath"); their
+      # mutation arms sever the chain hop by hop and require the gate to go
+      # red. --require-elaboration turns a missing interpreter into a failure
+      # rather than a skip.
+      - name: Elaboration gates
+        run: python3 sw/builder/test_builder.py --require-elaboration
+
+      - name: Keep the generated CPU netlist arguments for the next run
+        if: always()
+        run: |
+          cp -n "$(python3 -c 'import pythondata_cpu_vexiiriscv as p; print(p.data_location)')"/*.py \
+            ~/vexii-netlist-args/ 2>/dev/null || true

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -23,11 +23,11 @@ name: elaborate
 # 2026-08-21: NO config in this tree elaborates on a stock toolchain. The
 # shipping AX shape asks for a `baremetal` VexiiRiscv variant upstream LiteX
 # does not have; the four Linux shapes pass --scala-args the pinned VexiiRiscv
-# does not accept. Both come from about 184 lines of uncommitted patch across
-# four third-party trees under ~/litex-milan, which #185 measures and whose
-# fix is a maintainer decision. Until that decision is made this job would
-# install correctly and then fail on every config, so its triggers are
-# withheld and it runs only on manual dispatch.
+# does not accept. sw/litex/patches carries the series that closes both, and
+# apply.sh applies it, but nothing in CI runs that script and no gate compares
+# its result - so it had stopped applying, which #185 measures. Until that is
+# fixed this job would install correctly and then fail on every config, so its
+# triggers are withheld and it runs only on manual dispatch.
 #
 # Gates 23f and 23g run today on any interpreter that has a working LiteX,
 # which is how they were validated. Everywhere else they SKIP, the verdict
@@ -65,12 +65,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      # LiteX ships from git, not PyPI: the PyPI releases lag by more than a
-      # year and their VexiiRiscv wrapper does not carry the pinned-revision
-      # setup this job depends on. The revisions are in sw/litex/litex_pins.txt
-      # with the reason they are pinned; master of 2026-08-21 cannot elaborate
-      # this SoC at all, so an unpinned install would redden PRs that changed
-      # nothing.
+      # LiteX ships from git, not PyPI, and so does migen: the PyPI migen wheel
+      # and the m-labs git tree share the version number 0.9.2 and are
+      # different code, and only the git one can walk Python 3.11+ bytecode in
+      # its CSR-name tracer. Installed from PyPI the SoC dies at csr.py:64,
+      # measured 2026-08-21. pythondata-cpu-vexiiriscv is not on PyPI at all.
+      # The revisions are pinned in sw/litex/litex_pins.txt so that an
+      # upstream commit cannot redden a PR that changed nothing.
       - name: Install LiteX at the pinned revisions
         run: |
           python3 -m pip install --quiet pyyaml

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -118,7 +118,19 @@ jobs:
       # Python file, once per distinct argument set, by running Scala. That is
       # the only reason this job needs a JVM at all, and the result caches: a
       # cold run pays about 90 s for it, a warm one nothing.
-      - name: Cache the CPU netlist arguments and the Scala toolchain
+      # TWO CACHES, NOT ONE, and the split is the correctness fix rather than a
+      # tidy-up. The Scala toolchain is content-addressed by coursier and safe
+      # to share across every revision, so it keeps a broad fallback. The
+      # GENERATED CPU METADATA is not: LiteX names those .py files from
+      # `interface-metadata-v1 + metadata_args` - the CPU ARGUMENTS - and
+      # skips PythonArgsGen entirely when the file already exists
+      # (litex/soc/cores/cpu/vexiiriscv/core.py). Nothing in that name
+      # covers the Scala source. So a cache entry made before a pin or patch
+      # changed still satisfies the lookup, and the job elaborates metadata
+      # built by the OLD generator while reporting green - the one component
+      # this workflow exists to prove would stop being from-scratch ([R0] on
+      # PR #189).
+      - name: Cache the Scala toolchain
         if: ${{ steps.scope.outputs.rtl == 'true' }}
         uses: actions/cache@v4
         with:
@@ -126,9 +138,20 @@ jobs:
             ~/.cache/coursier
             ~/.sbt
             ~/.ivy2
-            ~/vexii-netlist-args
-          key: elaborate-vexii-${{ hashFiles('configs/*.yaml', 'sw/litex/milan_soc.py', 'sw/litex/build.sh', 'sw/litex/sweep.sh') }}
-          restore-keys: elaborate-vexii-
+          key: elaborate-sbt-${{ runner.os }}
+          restore-keys: elaborate-sbt-
+
+      # NO restore-keys HERE, deliberately. A prefix fallback is exactly the
+      # mechanism that hands over .py metadata from another toolchain head; a
+      # miss must cost one ~90 s Scala run, never a silent wrong answer. The
+      # key covers every input that can change what the generator emits: the
+      # argv sources, the pinned revisions, and the patch series itself.
+      - name: Cache the generated CPU metadata
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/vexii-netlist-args
+          key: elaborate-vexii-${{ hashFiles('configs/*.yaml', 'sw/litex/milan_soc.py', 'sw/litex/build.sh', 'sw/litex/sweep.sh', 'sw/litex/litex_pins.txt', 'sw/litex/patches/**') }}
 
       - name: Install sbt
         if: ${{ steps.scope.outputs.rtl == 'true' }}
@@ -162,6 +185,7 @@ jobs:
       # `baremetal` variant and the --l2-* arguments exist; gate 23h proves
       # the result is upstream plus exactly these patches.
       - name: Apply the toolchain patch series
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: sw/litex/patches/apply.sh
 
       # The gates that could not run in CI, running in CI. 23f/23g observe

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -32,10 +32,13 @@ name: elaborate
 # is about three minutes, most of it one Scala run per distinct CPU argument
 # set; warm it is under one.
 #
-# --require-elaboration fails the job when no LiteX interpreter is found,
-# rather than skipping the gates and reporting the green this workflow exists
-# to end. Everywhere else those gates SKIP and the verdict says
-# `ALL GATES PASS EXCEPT n NOT RUN` and names them.
+# --require-elaboration fails the job when no LiteX interpreter is found, and
+# when the one found carries a VexiiRiscv that rejects the --l2-* arguments
+# the series adds (the generator prints scopt's `Unknown option`), rather
+# than skipping the gates and reporting the green this workflow exists to
+# end. A row a gate declines for a RECORDED reason (#184's Arty leg) is named
+# in the verdict, not absorbed. Everywhere else those gates SKIP and the
+# verdict says `ALL GATES PASS EXCEPT n NOT RUN` and names them.
 
 on:
   push:
@@ -179,8 +182,10 @@ jobs:
       # The gate that could not run in CI, running in CI. Gates 23f/23g
       # observe what elaboration hands Instance("milan_datapath"); their
       # mutation arms sever the chain hop by hop and require the gate to go
-      # red. --require-elaboration turns a missing interpreter into a failure
-      # rather than a skip.
+      # red. --require-elaboration turns a missing interpreter, and an
+      # interpreter whose VexiiRiscv is unpatched, into a failure rather
+      # than a skip; only a row with a recorded, exactly matching failure
+      # may skip.
       # Upstream cannot build this design. The series is what makes the
       # `baremetal` variant and the --l2-* arguments exist; gate 23h proves
       # the result is upstream plus exactly these patches.

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -165,8 +165,7 @@ jobs:
         run: python3 sw/builder/test_builder.py --require-elaboration
 
       - name: Keep the generated CPU netlist arguments for the next run
-        if: ${{ steps.scope.outputs.rtl == 'true' }}
-        if: always()
+        if: ${{ always() && steps.scope.outputs.rtl == 'true' }}
         run: |
           cp -n "$(python3 -c 'import pythondata_cpu_vexiiriscv as p; print(p.data_location)')"/*.py \
             ~/vexii-netlist-args/ 2>/dev/null || true

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -19,31 +19,29 @@ name: elaborate
 # it is the only job in the tree that needs a JVM and a Scala build, and a
 # documentation PR should not pay for that.
 #
-# NOT ENABLED YET, AND THIS FILE IS HERE SO THE REASON IS READABLE. Measured
-# 2026-08-21: NO config in this tree elaborates on a stock toolchain. The
-# shipping AX shape asks for a `baremetal` VexiiRiscv variant upstream LiteX
-# does not have; the four Linux shapes pass --scala-args the pinned VexiiRiscv
-# does not accept. sw/litex/patches carries the series that closes both, and
-# apply.sh applies it, but nothing in CI runs that script and no gate compares
-# its result - so it had stopped applying, which #185 measures. Until that is
-# fixed this job would install correctly and then fail on every config, so its
-# triggers are withheld and it runs only on manual dispatch.
+# NO CONFIG IN THIS TREE ELABORATES ON A STOCK TOOLCHAIN (#185), so this job
+# does not install one. Upstream LiteX has no `baremetal` VexiiRiscv variant,
+# which is the whole shipping AX profile, and the VexiiRiscv revision it pins
+# rejects the --l2-* arguments four of the five configs pass.
+# sw/litex/patches/ carries the six patches that close both, and apply.sh
+# applies them. Until 2026-08-21 nothing ran that script end to end and the
+# series had stopped applying; gate 23h now reconstructs it and compares.
 #
-# Gates 23f and 23g run today on any interpreter that has a working LiteX,
-# which is how they were validated. Everywhere else they SKIP, the verdict
-# says `ALL GATES PASS EXCEPT n NOT RUN` and names them, and
-# --require-elaboration turns a missing interpreter into a failure rather
-# than a skip. That is what stops the absence of the proof from reading as
-# the presence of one while this job is off.
+# The whole job is therefore: pinned revisions, the VexiiRiscv checkout at the
+# revision LiteX itself names, the patch series, and then the gates. Cold it
+# is about three minutes, most of it one Scala run per distinct CPU argument
+# set; warm it is under one.
+#
+# --require-elaboration fails the job when no LiteX interpreter is found,
+# rather than skipping the gates and reporting the green this workflow exists
+# to end. Everywhere else those gates SKIP and the verdict says
+# `ALL GATES PASS EXCEPT n NOT RUN` and names them.
 
 on:
-  # Manual only until #185 is decided. The push/pull_request triggers below
-  # are the intended ones and are commented rather than deleted, so enabling
-  # this job is one edit and not a rediscovery.
+  push:
+    branches: [main, dev]
+  pull_request:
   workflow_dispatch:
-  # push:
-  #   branches: [main, dev]
-  # pull_request:
 
 concurrency:
   group: elaborate-${{ github.workflow }}-${{ github.ref }}
@@ -160,6 +158,15 @@ jobs:
       # mutation arms sever the chain hop by hop and require the gate to go
       # red. --require-elaboration turns a missing interpreter into a failure
       # rather than a skip.
+      # Upstream cannot build this design. The series is what makes the
+      # `baremetal` variant and the --l2-* arguments exist; gate 23h proves
+      # the result is upstream plus exactly these patches.
+      - name: Apply the toolchain patch series
+        run: sw/litex/patches/apply.sh
+
+      # The gates that could not run in CI, running in CI. 23f/23g observe
+      # what elaboration hands Instance("milan_datapath"); their mutation arms
+      # sever the chain hop by hop and require the gate to go red.
       - name: Elaboration gates
         if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: python3 sw/builder/test_builder.py --require-elaboration

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -54,14 +54,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # A documentation-only pull request must not pay a LiteX install, a
+      # VexiiRiscv checkout and a Scala run. scripts/ci_scope.py is the
+      # repository's one answer to "does this change need the RTL toolchain",
+      # and it fails safe: an empty diff and an unresolvable base both come
+      # back `true`. Raised against this workflow by [R1] while reviewing
+      # PR #176, which introduces that classifier.
+      - name: Decide whether this head needs an elaboration
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # ci_scope.py arrives with PR #176. Until that lands this file may
+          # not exist, and the safe answer to "is this change RTL relevant"
+          # when the classifier is absent is yes.
+          if [ ! -f scripts/ci_scope.py ]; then
+            echo "rtl=true" >> "$GITHUB_OUTPUT"
+            echo "no scripts/ci_scope.py yet: elaborating unconditionally"
+            exit 0
+          fi
+          python3 scripts/ci_scope.py --selftest
+          if [ "$EVENT_NAME" != pull_request ]; then
+            echo "rtl=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$PR_BASE_SHA" ] \
+             && git cat-file -e "$PR_BASE_SHA^{commit}" 2>/dev/null; then
+            git diff --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > "$RUNNER_TEMP/changed"
+          else
+            git ls-files > "$RUNNER_TEMP/changed"
+          fi
+          echo "rtl=$(python3 scripts/ci_scope.py < "$RUNNER_TEMP/changed")" >> "$GITHUB_OUTPUT"
 
       # The elaboration reads the protocol-processor and gptp-processor source
       # lists through scripts/pp_srcs.py, which REFUSES to emit an empty list.
       # Without the submodules it fails before the datapath is reached.
       - name: Fetch the processor sources the elaboration reads
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: git submodule update --init protocol-processor gptp-processor
 
       - uses: actions/setup-python@v5
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         with:
           python-version: '3.12'
 
@@ -73,6 +111,7 @@ jobs:
       # The revisions are pinned in sw/litex/litex_pins.txt so that an
       # upstream commit cannot redden a PR that changed nothing.
       - name: Install LiteX at the pinned revisions
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: |
           python3 -m pip install --quiet pyyaml
           python3 -m pip install --quiet -r sw/litex/litex_pins.txt
@@ -82,6 +121,7 @@ jobs:
       # the only reason this job needs a JVM at all, and the result caches: a
       # cold run pays about 90 s for it, a warm one nothing.
       - name: Cache the CPU netlist arguments and the Scala toolchain
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -93,6 +133,7 @@ jobs:
           restore-keys: elaborate-vexii-
 
       - name: Install sbt
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: |
           sbt --version >/dev/null 2>&1 && exit 0
           curl -fsSL --retry 3 -o /tmp/sbt.tgz \
@@ -106,6 +147,7 @@ jobs:
       # restated: a pin copied to a second place goes stale in silence, and
       # the symptom is a netlist from the wrong CPU source, not a red build.
       - name: Place the VexiiRiscv source at the revision LiteX pins
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: |
           python3 scripts/ci_litex_env.py
           mkdir -p ~/vexii-netlist-args
@@ -119,9 +161,11 @@ jobs:
       # red. --require-elaboration turns a missing interpreter into a failure
       # rather than a skip.
       - name: Elaboration gates
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         run: python3 sw/builder/test_builder.py --require-elaboration
 
       - name: Keep the generated CPU netlist arguments for the next run
+        if: ${{ steps.scope.outputs.rtl == 'true' }}
         if: always()
         run: |
           cp -n "$(python3 -c 'import pythondata_cpu_vexiiriscv as p; print(p.data_location)')"/*.py \

--- a/docs/litex/LITEX_SOC.md
+++ b/docs/litex/LITEX_SOC.md
@@ -19,7 +19,7 @@ build/boot recipe stays in [`sw/README.md`](../../sw/README.md) and
 - **[3. Building](#3-building)** — The ship-shape command line to copy, and the useful distinction: without `--build` you get elaboration and Verilog export with **no vendor tools at all**. Vivado is currently the only P&R backend wired for this board.
 - **[4. The flags that are not optional](#4-the-flags-that-are-not-optional)** — Four flags and the exact failure each one prevents. `--coherent-dma` is not implied by `--all-blocks` and its absence looks like all-zero skbs and a garbage destination MAC; `--gtx-tx-invert` is the difference between 25–40 % corrupt frames and none.
 - **[5. Simulation (milan_sim.py)](#5-simulation-milan_simpy)** — A single non-interactive command that boots the BIOS on a softcore and reads `"MILN"` back through the real datapath — the SoC-level rung between the RTL harnesses and silicon.
-- **[6. Patches (patches/)](#6-patches-patches)** — Three patches applied in place to your LiteX/LiteEth trees, re-run after every LiteX update. Note that the VexiiRiscv L2-geometry one is **not** applied by `apply.sh` — apply it by hand for non-default L2.
+- **[6. Patches (patches/)](#6-patches-patches)** — The six patches applied in place to your LiteX/LiteEth/VexiiRiscv trees. Upstream cannot build any shape of this design without them, so this is a required install step and not a tuning one, and a gate now proves the result.
 - **[7. Reproducibility - versions](#7-reproducibility---versions)** — There is no pinned requirements file; this is the list of known-good anchors instead (LiteX `a1e1c36`, openFPGALoader ≥ v1.1.1, the `verilog-axis` gitlink) and what to do when `apply.sh` fails after an upgrade.
 - **[8. The Migen DMA sims and on-target tools](#8-the-migen-dma-sims-and-on-target-tools)** — The six commands to run after touching ring or BD logic, straight from the interpreter with no pytest. Also flags that the `tools_*.c` benchmarks are board-side research instruments, not part of any build.
 
@@ -273,24 +273,53 @@ NaxRiscv and the same `add_milan_datapath()` as the board build.
 
 ## 6. Patches (`patches/`)
 
-Applied **in place** to the active Python env's LiteX/LiteEth trees by
-`patches/apply.sh` (idempotent; **re-run after every LiteX update**):
+Applied **in place** to the active Python env's LiteX/LiteEth/VexiiRiscv
+trees by `patches/apply.sh` (idempotent; **re-run after every LiteX update**).
+
+**This is a required step, not a tuning one.** Upstream LiteX cannot build any
+shape of this design: it has no `baremetal` VexiiRiscv variant, and the
+VexiiRiscv revision it pins rejects the `--l2-*` arguments four of the five
+configs pass. Measured over all five configs on 2026-08-21, a stock install
+elaborates none of them.
+
+`apply.sh` normalises before it applies, so it converges from a partially
+applied tree instead of refusing. It has to: `0003` is diffed on top of
+`0001` and both rewrite the same `boot.c` hunks, and the older per-patch
+check called that state broken. Nothing ran the script end to end, so the
+series had stopped applying for an unknown length of time and two patches had
+drifted from the tree the boards are built from. `test_builder.py` gate 23h
+now reverses the series off the installed trees, re-applies it and requires
+the result to be byte-identical, with a control that removes one patch at a
+time and requires the gate to fail.
 
 | Patch | What it does |
 |---|---|
 | `0001-milan-linux-flashboot.patch` | Adds the `linux_flashboot` BIOS boot method (runs before serialboot; inert without the `MILAN_FLASHBOOT_*` constants that `--with-spiflash` emits) |
 | `0002-liteeth-gmii-tx-clk-invert.patch` | Adds `tx_clk_invert` to `LiteEthPHYGMII` → the `--gtx-tx-invert` flag |
-| `0002-vexiiriscv-l2-depth-args.patch` | Exposes VexiiRiscv L2 depth/geometry args used by the perf campaign's L2 experiments. **Not applied by `apply.sh`** - apply manually when building VexiiRiscv with non-default L2 |
+| `0002-vexiiriscv-l2-depth-args.patch` | Exposes the VexiiRiscv `--l2-down-pending` / `--l2-general-slots` args. **Applied by `apply.sh` since 2026-08-21**: four of the five end-station configs pass them, so without it those four cannot elaborate at all (#185) |
+| `0003-milan-flashboot-xz-kernel.patch` | xz-compressed kernel support in `linux_flashboot`. Diffed **on top of 0001**, which is why apply order is not alphabetical |
+| `0004-vexiiriscv-baremetal-variant.patch` | The LiteX `baremetal` VexiiRiscv variant. Upstream has no such variant, and it is the shipping AX profile |
+| `0005-vexiiriscv-cacheless-litex.patch` | The cacheless iBus/dBus fabric and direct DMA path the bare-metal shape needs at netlist time |
 
 Details and re-diff instructions: [`patches/README.md`](../../sw/litex/patches/README.md).
 
 ## 7. Reproducibility - versions
 
-There is currently **no pinned requirements file**; patches are diffed
-against LiteX `master`. Known-good anchors, recorded from working builds:
+Revisions are pinned in
+[`sw/litex/litex_pins.txt`](../../sw/litex/litex_pins.txt), which also records
+why each one is a git revision rather than a PyPI release. The full install is
+three steps, in this order:
+
+```sh
+python3 -m pip install -r sw/litex/litex_pins.txt
+python3 scripts/ci_litex_env.py    # the VexiiRiscv checkout at the revision LiteX pins
+sw/litex/patches/apply.sh          # the six patches
+```
+
+Known-good anchors, recorded from working builds:
 
 * LiteX git `a1e1c36` (from `evidence/hw_naxriscv_reads_MILN.log` - the
-  on-silicon M-A2 run).
+  on-silicon M-A2 run), which is what `litex_pins.txt` pins.
 * openFPGALoader ≥ v1.1.1; Vivado with Artix-7 support for `--build`.
 * `verilog-axis` submodule pinned by the gitlink
   (`git submodule update --init third_party/verilog-axis` - required for any

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -8,6 +8,7 @@ reduce the local verification bar in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 - **[Fast feedback](#fast-feedback)** — What runs on every pull-request update and why docs-only changes avoid RTL tool setup.
 - **[Exhaustive validation](#exhaustive-validation)** — When the full Verilator and Yosys inventories run and how exact-head evidence is preserved.
+- **[Elaboration](#elaboration)** — The one job that installs LiteX and observes what elaboration hands the datapath Instance, and what makes it red.
 - **[Pull-request state](#pull-request-state)** — How draft and ready states control hosted long jobs without changing local responsibilities.
 - **[Local commands](#local-commands)** — The serial commands that remain the authoritative developer-side gates.
 - **[Failure and cancellation semantics](#failure-and-cancellation-semantics)** — How missing artifacts, superseded commits, and resumed work are handled.
@@ -72,6 +73,41 @@ top. The `yosys-portability` aggregate rejects:
 The tap-purity report remains informational in the combined Yosys script, which
 preserves the existing local policy. Its result is still recorded exactly once.
 
+## Elaboration
+
+[The elaboration workflow](../../.github/workflows/elaborate.yml) runs on every
+pull-request update, on every push to `dev` and `main`, and on manual dispatch.
+It is the one job that installs LiteX. It exists because no other job can
+observe what elaboration hands `Instance("milan_datapath")` (#154): every
+argv-to-parameter chain used to be proven by source-text greps against
+`sw/litex/milan_soc.py`, and a flag severed on its way to the parameter it
+names read green at two independent hops.
+
+It uses the same change classification as the fast workflow. A docs-only
+change skips every step after the classification and the `elaborate` check
+still completes. A relevant change installs the pinned LiteX of
+[`sw/litex/litex_pins.txt`](../../sw/litex/litex_pins.txt), places the
+VexiiRiscv source at the revision LiteX itself pins, applies the patch series
+in [`sw/litex/patches/`](../../sw/litex/patches/) with its `apply.sh`, and runs
+`sw/builder/test_builder.py --require-elaboration`: gates 23f, 23g and 23h and
+their mutation arms. Upstream LiteX elaborates no configuration in this tree
+(#185), so the series is a required install step and gate 23h proves the
+installed trees are upstream plus exactly that series.
+
+Two caches, deliberately split. The Scala toolchain is content-addressed and
+keeps a broad fallback. The generated CPU metadata does not: its key hashes the
+configs, `milan_soc.py`, `build.sh`, `sweep.sh`, the pins and the patch series,
+with no prefix fallback, because LiteX names those files from the CPU
+arguments alone and skips the generator whenever the file exists, so a stale
+entry would elaborate metadata built by the previous toolchain while reporting
+green.
+
+The `elaborate` check fails when no interpreter can import LiteX, when the
+interpreter's VexiiRiscv rejects the `--l2-*` arguments the series adds, and
+when any gate fails. A recipe recorded as unrunnable (#184's Arty leg) skips
+only when it fails with exactly the recorded diagnostic, and the verdict names
+every arm that did not run rather than claiming every arm ran.
+
 ## Pull-request state
 
 Open implementation PRs as drafts while work is changing. The fast workflow
@@ -110,6 +146,14 @@ Useful read-only inspection commands are:
 scripts/run_all_suites.sh --shard 0/4 --list
 syn/yosys/run.sh --list
 syn/yosys/run.sh --shard 0/4 --list
+```
+
+The elaboration gates run locally against any interpreter that imports
+LiteX; without one they skip and the verdict says so:
+
+```sh
+MILAN_LITEX_PYTHON=$HOME/litex-milan/venv/bin/python3 \
+  python3 sw/builder/test_builder.py --require-elaboration
 ```
 
 The fast Yosys mode is diagnostic only:

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -766,6 +766,38 @@ host-only.
   `verilog-axis` and `protocol-processor`. The docs workflow also initializes
   `protocol-processor` before running the builder gate. Local commands:
   [Section 2 of `../../QUICKSTART.md`](../../QUICKSTART.md#2-track-1--simulate-no-fpga-no-vendor-tools).
+* **The SoC is elaborated, and by whom is the open question** (2026-08-21,
+  issues #154, #156 and #185). Every argv-to-RTL-parameter chain in this
+  repository used to be proven by source-text greps against
+  `sw/litex/milan_soc.py`, and three separate blockers in three lanes on one
+  day were that one gap: a flag parsed, threaded part of the way, and never
+  reaching the parameter it names. In one of them a reviewer severed the
+  chain at two independent hops and got `ALL GATES PASS` both times.
+
+  Two gates in [`sw/builder/test_builder.py`](../../sw/builder/test_builder.py)
+  close that class. Gate 23f patches `Instance` in the executed module's
+  namespace and reads the live `p_*` keyword arguments, so what is graded is
+  what elaboration would hand Vivado; eleven negative controls sever the
+  chain hop by hop and require it to go red. Gate 23g asserts every
+  `build.sh` recipe and every `sweep.sh` leg reaches that same `Instance`
+  with the flow tail its own launcher appends, `--build` included, which is
+  the flag every shape gate in the tree excludes.
+
+  Both need a LiteX interpreter, and **CI has none yet**.
+  [`.github/workflows/elaborate.yml`](../../.github/workflows/elaborate.yml)
+  is written and is `workflow_dispatch` only, because no config in this tree
+  elaborates on a stock toolchain: about 184 lines of uncommitted patch
+  across four third-party trees supply the `baremetal` CPU variant the
+  shipping AX shape is built on and the `--scala-args` the Linux shapes
+  pass. #185 carries that measurement and the decision.
+
+  What holds meanwhile is that the gap is **visible instead of silent**:
+
+  | property | why |
+  |---|---|
+  | the verdict **names every arm that did not run** | `ALL GATES PASS EXCEPT n NOT RUN`, with the reason, is the honest line when a gate declines. A gate that prints its own SKIP and lets the verdict print a green is how the absence of a proof comes to read as the presence of one |
+  | `--require-elaboration` **fails** rather than skips | so the day the job is enabled, a broken install cannot quietly return it to the state it was written to end |
+  | LiteX is **pinned** in [`sw/litex/litex_pins.txt`](../../sw/litex/litex_pins.txt) | an install from master turns an upstream commit into a red on a pull request that changed nothing, and `migen` on PyPI is stale code sharing a version number with the git tree, which fails at `csr.py:64` on any interpreter newer than 3.10 |
 * **The Verilator version matters, and distro packages are not enough.**
   Measured 2026-07-26 by running the suites under each version in a container:
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -815,7 +815,7 @@ host-only.
   | property | why |
   |---|---|
   | the verdict **names every arm that did not run** | `ALL GATES PASS EXCEPT n NOT RUN`, with the reason, is the honest line when a gate declines. A gate that prints its own SKIP and lets the verdict print a green is how the absence of a proof comes to read as the presence of one |
-  | `--require-elaboration` **fails** rather than skips | so the day the job is enabled, a broken install cannot quietly return it to the state it was written to end |
+  | `--require-elaboration` **fails** rather than skips | so the day the job is enabled, a broken install cannot quietly return it to the state it was written to end. Two things fail it: no interpreter, and an interpreter whose VexiiRiscv rejects the `--l2-*` arguments the series adds. A recipe recorded as unrunnable (#184's Arty leg) skips only when it fails with exactly the recorded diagnostic; any other failure on that row, and any other generator failure, is red. The verdict line says which arms did not run instead of claiming every arm ran |
   | LiteX is **pinned** in [`sw/litex/litex_pins.txt`](../../sw/litex/litex_pins.txt) | an install from master turns an upstream commit into a red on a pull request that changed nothing, and `migen` on PyPI is stale code sharing a version number with the git tree, which fails at `csr.py:64` on any interpreter newer than 3.10 |
 * **The Verilator version matters, and distro packages are not enough.**
   Measured 2026-07-26 by running the suites under each version in a container:

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -800,15 +800,13 @@ host-only.
   `apply.sh` and no gate compared its result, so it had silently stopped
   applying. Gate 23h now reconstructs it. #185 carries that measurement.
 
-  A documentation-only pull request is meant to pay for none of it: every
-  heavy step is gated on `scripts/ci_scope.py`, the classifier PR #176 adds,
-  and that classifier fails safe - an empty diff or an unresolvable base both
-  come back RTL-relevant. **That script is not on this branch yet**, because
-  this work is stacked on a base predating #176; while it is absent the
-  workflow says so in its log and elaborates unconditionally rather than
-  guessing. The skip becomes real when this stack retargets to `dev`, and
-  #176's scheduling-policy page - which also exists only on `dev` - gains
-  this workflow's row in the same move.
+  A documentation-only pull request pays for none of it: every heavy step is
+  gated on `scripts/ci_scope.py`, the classifier PR #176 added, and that
+  classifier fails safe - an empty diff or an unresolvable base both come
+  back RTL-relevant. Were the script ever absent the workflow would say so in
+  its log and elaborate unconditionally rather than guess. The workflow's
+  scheduling policy, what makes its check red and what only skips, is the
+  `Elaboration` section of [`CI_WORKFLOWS.md`](CI_WORKFLOWS.md).
 
   What the workflow does **not** prove is stated in its own output:
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -786,10 +786,13 @@ host-only.
   Both need a LiteX interpreter, and **CI has none yet**.
   [`.github/workflows/elaborate.yml`](../../.github/workflows/elaborate.yml)
   is written and is `workflow_dispatch` only, because no config in this tree
-  elaborates on a stock toolchain: about 184 lines of uncommitted patch
-  across four third-party trees supply the `baremetal` CPU variant the
-  shipping AX shape is built on and the `--scala-args` the Linux shapes
-  pass. #185 carries that measurement and the decision.
+  elaborates on a stock toolchain. Upstream LiteX has no `baremetal`
+  VexiiRiscv variant, which is the shipping AX profile, and the revision it
+  pins rejects the `--scala-args` four of the five configs pass.
+  [`sw/litex/patches`](../../sw/litex/patches) carries the series that closes
+  both and `apply.sh` applies it, but nothing in CI runs that script and no
+  gate compares its result, so it had stopped applying. #185 carries the
+  measurement.
 
   What holds meanwhile is that the gap is **visible instead of silent**:
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -783,18 +783,34 @@ host-only.
   with the flow tail its own launcher appends, `--build` included, which is
   the flag every shape gate in the tree excludes.
 
-  Both need a LiteX interpreter, and **CI has none yet**.
+  Both need a LiteX interpreter, and **CI now installs one**.
   [`.github/workflows/elaborate.yml`](../../.github/workflows/elaborate.yml)
-  is written and is `workflow_dispatch` only, because no config in this tree
-  elaborates on a stock toolchain. Upstream LiteX has no `baremetal`
-  VexiiRiscv variant, which is the shipping AX profile, and the revision it
-  pins rejects the `--scala-args` four of the five configs pass.
-  [`sw/litex/patches`](../../sw/litex/patches) carries the series that closes
-  both and `apply.sh` applies it, but nothing in CI runs that script and no
-  gate compares its result, so it had stopped applying. #185 carries the
-  measurement.
+  runs on pushes to `dev`/`main`, on pull requests, and on manual dispatch.
+  It installs the revisions pinned in
+  [`sw/litex/litex_pins.txt`](../../sw/litex/litex_pins.txt), places the
+  VexiiRiscv checkout at the revision LiteX itself names, runs
+  [`sw/litex/patches/apply.sh`](../../sw/litex/patches/apply.sh), and then
+  runs `sw/builder/test_builder.py --require-elaboration`.
 
-  What holds meanwhile is that the gap is **visible instead of silent**:
+  The patch series is the reason that install is three steps and not one.
+  Upstream LiteX has no `baremetal` VexiiRiscv variant, which is the shipping
+  AX profile, and the revision it pins rejects the `--scala-args` four of the
+  five configs pass. [`sw/litex/patches`](../../sw/litex/patches) has always
+  carried the series that closes both, but until 2026-08-21 nothing in CI ran
+  `apply.sh` and no gate compared its result, so it had silently stopped
+  applying. Gate 23h now reconstructs it. #185 carries that measurement.
+
+  A documentation-only pull request is meant to pay for none of it: every
+  heavy step is gated on `scripts/ci_scope.py`, the classifier PR #176 adds,
+  and that classifier fails safe - an empty diff or an unresolvable base both
+  come back RTL-relevant. **That script is not on this branch yet**, because
+  this work is stacked on a base predating #176; while it is absent the
+  workflow says so in its log and elaborates unconditionally rather than
+  guessing. The skip becomes real when this stack retargets to `dev`, and
+  #176's scheduling-policy page - which also exists only on `dev` - gains
+  this workflow's row in the same move.
+
+  What the workflow does **not** prove is stated in its own output:
 
   | property | why |
   |---|---|

--- a/scripts/check_doc_paths.py
+++ b/scripts/check_doc_paths.py
@@ -62,6 +62,15 @@ LEDGER_MARKER = "docs-check: allow-dead-refs"
 #: prose - so they are recorded here rather than deleted. The gate refuses
 #: SILENT additions: a new dangling path fails until someone writes the reason.
 ALLOW = {
+    # STACKED-BRANCH ABSENCE, not a dead reference. The elaboration workflow
+    # gates its heavy steps on this classifier and TESTING.md says so; the
+    # script itself arrives with PR #176, which is on `dev`, while this work
+    # is stacked on a base predating it. The workflow falls back to
+    # elaborating unconditionally while the file is absent, and the entry
+    # goes away when the stack retargets to `dev` and the path resolves.
+    "scripts/ci_scope.py":
+        "arrives with PR #176 on dev; this stack predates it and the "
+        "workflow falls back to unconditional elaboration until retarget",
     "tb/utests/802_1q_traffic_shaper/tb_credit_based_shaper.sv":
         "removed bench, named by REQUIREMENTS/TODO to record that "
         "tb/verilator/cbs supersedes it",

--- a/scripts/ci_litex_env.py
+++ b/scripts/ci_litex_env.py
@@ -28,10 +28,13 @@ WHAT IT DOES. Two things a `pip install` cannot:
      the wrong CPU source. If the call cannot be found the script REFUSES,
      because guessing a revision is the thing it exists to prevent.
 
-WHAT IT DOES NOT DO. It does not make every recipe elaborable. The Linux 8x8
-and Arty shapes pass --scala-args the pinned VexiiRiscv does not accept and
-build here only against an uncommitted local patch (#185); gate 23g names each
-one it could not run rather than passing over it.
+WHAT IT DOES NOT DO. It places the VexiiRiscv SOURCE and nothing else. The
+patches that make this tree elaborable at all are carried in
+sw/litex/patches/ and applied by that directory's apply.sh, which is a
+separate step and must run after this one - upstream LiteX has no `baremetal`
+VexiiRiscv variant and the revision it pins rejects the --scala-args four of
+the five configs pass (#185). Gate 23g names any recipe it could not run
+rather than passing over it.
 
 Run: python3 scripts/ci_litex_env.py [--check]
      --check reports what it would do and changes nothing.

--- a/scripts/ci_litex_env.py
+++ b/scripts/ci_litex_env.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""
+ci_litex_env.py - put a CI runner in a state where the SoC can be elaborated.
+
+WHY THIS EXISTS. Every argv-to-RTL-parameter chain in this repository used to
+be proven by source-text greps against sw/litex/milan_soc.py, because no CI
+job elaborated the SoC (#154). Three separate blockers in three lanes were
+the same defect underneath: a flag parsed, threaded part of the way, and never
+reaching the parameter it names. Gate 23f observes what elaboration really
+hands Instance("milan_datapath"), which closes the class - but it needs LiteX,
+and CI had none.
+
+WHAT IT DOES. Two things a `pip install` cannot:
+
+  1. Clones the VexiiRiscv Scala source into the pythondata package, because
+     LiteX's own `git_setup` returns immediately unless --update-repo asks it
+     to, and milan_soc.py never passes that. Without it the CPU wrapper's
+     netlist-argument generator has nothing to run and elaboration dies before
+     the datapath is reached.
+
+  2. DERIVES the revision from LiteX rather than restating it. The pin lives
+     in litex/soc/cores/cpu/vexiiriscv/core.py as the argument of the
+     git_setup call; this script reads that call. A pin copied to a second
+     place is a pin that goes stale in silence (the derive-never-mirror rule),
+     and the failure mode is not a red build: it is a netlist generated from
+     the wrong CPU source. If the call cannot be found the script REFUSES,
+     because guessing a revision is the thing it exists to prevent.
+
+WHAT IT DOES NOT DO. It does not make every recipe elaborable. The Linux 8x8
+and Arty shapes pass --scala-args the pinned VexiiRiscv does not accept and
+build here only against an uncommitted local patch (#185); gate 23g names each
+one it could not run rather than passing over it.
+
+Run: python3 scripts/ci_litex_env.py [--check]
+     --check reports what it would do and changes nothing.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+#: The call this script reads its pin out of, in LiteX's own source.
+#: Deliberately anchored on the repository name as well as the function, so a
+#: refactor that moves the call still matches and one that renames the CPU
+#: does not silently match the NaxRiscv line two screens below it.
+GIT_SETUP = re.compile(
+    r'git_setup\(\s*"VexiiRiscv"\s*,\s*\w+\s*,\s*"([^"]+)"\s*,'
+    r'\s*"([^"]+)"\s*,\s*"([0-9a-f]{7,40})"')
+
+
+def _pin():
+    """(url, branch, sha) LiteX pins VexiiRiscv to, read out of LiteX."""
+    from litex.soc.cores.cpu.vexiiriscv import core
+    src = open(core.__file__, encoding="utf-8").read()
+    m = GIT_SETUP.search(src)
+    if not m:
+        sys.exit(f"{core.__file__}: no git_setup(\"VexiiRiscv\", ...) call "
+                 "with a pinned revision. This script refuses to guess one: "
+                 "a wrong revision does not fail the build, it generates a "
+                 "netlist from the wrong CPU source.")
+    return m.groups()
+
+
+def _run(cmd, cwd=None):
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="report the pin and the target path, change nothing")
+    args = ap.parse_args()
+
+    from pythondata_cpu_vexiiriscv import data_location
+    url, branch, sha = _pin()
+    ext = os.path.join(data_location, "ext", "VexiiRiscv")
+    print(f"VexiiRiscv pin (read from LiteX): {sha} on {branch} of {url}")
+    print(f"target: {ext}")
+    if args.check:
+        print("--check: nothing done")
+        return 0
+
+    if not os.path.isdir(os.path.join(ext, ".git")):
+        os.makedirs(os.path.dirname(ext), exist_ok=True)
+        # A blobless clone rather than --depth 1: the pin is not the branch
+        # tip, so a shallow clone cannot check it out, and blobless keeps the
+        # transfer to the same order as a shallow one.
+        _run(["git", "clone", "--filter=blob:none", "--no-checkout",
+              url, ext])
+    _run(["git", "checkout", "--detach", sha], cwd=ext)
+    _run(["git", "submodule", "update", "--init", "--recursive",
+          "--filter=blob:none"], cwd=ext)
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ext,
+                          capture_output=True, text=True).stdout.strip()
+    assert head == sha or sha.startswith(head[:len(sha)]) or \
+        head.startswith(sha), f"{ext}: HEAD is {head}, want {sha}"
+    print(f"VexiiRiscv ready at {head}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -4054,6 +4054,11 @@ with open(spec["result"], "w", encoding="utf-8") as fh:
 #: directory as a namespace package and the import fails.
 SOC_DIR = os.path.join(ROOT, "sw/litex")
 
+#: Placeholder an argv uses for "the launcher's --output-dir".  _instance_params
+#: substitutes its own scratch directory and then proves that directory is
+#: still empty, which is how the spy's cheapness stops being an assumption.
+BUILD_OUT_TOKEN = "@BUILD_OUT@"
+
 #: The config whose argv drives gate 23f: the SHIPPING AX shape (USER
 #: 2026-08-05, 1x1x8 TDM8), and it is the shipping one that matters here for
 #: two independent reasons.
@@ -4137,7 +4142,19 @@ def _instance_params(python, runs, mutations=()):
     env = dict(os.environ, PYTHONHASHSEED="0")
     out, seen = {}, {}
     with tempfile.TemporaryDirectory() as tmp:
+        # THE SPY MUST STOP THE ELABORATION, not merely witness it, and the
+        # empty directory below is what proves it.  Every recipe run carries
+        # `--build`; if the spy ever raised too LATE - after Builder() was
+        # constructed - LiteX would write its gateware and software trees in
+        # here and invoke Vivado, and every assertion in these gates would
+        # still pass because the parameters were still read correctly.  A
+        # harness whose own cheapness is assumed rather than checked is the
+        # thing these gates exist to stop.  Borrowed from gate 1e on the #116
+        # lane (PR #135), which had this and this file did not.
+        build_out = os.path.join(tmp, "build-out")
+        os.makedirs(build_out)
         for label, argv in runs:
+            argv = [build_out if a == BUILD_OUT_TOKEN else a for a in argv]
             # Several labels share one command line on purpose - the shipping
             # argv is simultaneously the prune baseline, the sound card's
             # ABSENT side and the gPTP plane's PRESENT side - and elaborating
@@ -4163,6 +4180,12 @@ def _instance_params(python, runs, mutations=()):
                 f"\n{proc.stderr[-2000:]}")
             with open(result) as fh:
                 out[label] = seen[key] = json.load(fh)
+        left = os.listdir(build_out)
+        assert not left, (
+            "the Instance spy no longer stops the elaboration: a run carrying "
+            f"--build wrote {left} into its output directory, so these runs "
+            "are not the sub-second read-back they are documented to be and "
+            "a real Vivado build was reached")
     return out
 
 
@@ -4528,9 +4551,10 @@ def _recipe_cases():
 
 
 #: Stand-in for the launcher's own `$out`/`$W/build_...` directory.  Replaced
-#: with a real temp path per run: milan_soc.py must be refused for its own
-#: reasons, never for an output directory that does not exist.
-OUT_DIR_TOKEN = "@OUTDIR@"
+#: with the probe runner's own scratch path: milan_soc.py must be refused for
+#: its own reasons, never for an output directory that does not exist, and
+#: that directory has to be one _instance_params can afterwards prove empty.
+OUT_DIR_TOKEN = BUILD_OUT_TOKEN
 
 
 def _is_unpatched_vexii(argv, err):
@@ -4560,10 +4584,11 @@ def test_every_recipe_elaborates():
         eb.build(CONFIGS[name], OUT)
     cases = _recipe_cases()
     t0 = time.time()
-    with tempfile.TemporaryDirectory() as tmp:
-        runs = [(label, [tmp if a == OUT_DIR_TOKEN else a for a in argv])
-                for label, argv in cases]
-        got = _instance_params(python, runs)
+    # The --output-dir token is left FOR _instance_params to substitute, so
+    # the directory these `--build` runs are pointed at is the one it can
+    # afterwards prove empty. Substituting a local temp here would put the
+    # proof out of its reach, which is the point of the token.
+    got = _instance_params(python, cases)
     bad, stale, ran = [], [], 0
     for label, argv in cases:
         err = got[label].get("error")
@@ -4611,12 +4636,9 @@ def test_recipe_smoke_gate_bites():
     if python is None:
         return
     cases = [c for c in _recipe_cases() if c[0] not in KNOWN_UNRUNNABLE]
-    with tempfile.TemporaryDirectory() as tmp:
-        controls = []
-        for label, argv in cases[:1] + cases[-1:]:
-            argv = [tmp if a == OUT_DIR_TOKEN else a for a in argv]
-            controls.append((label, _drop_flag(argv, "--entity-gen-dir", 1)))
-        got = _instance_params(python, controls)
+    controls = [(label, _drop_flag(argv, "--entity-gen-dir", 1))
+                for label, argv in cases[:1] + cases[-1:]]
+    got = _instance_params(python, controls)
     for label, _argv in controls:
         assert got[label].get("error") is not None, (
             f"gate 23g accepted `{label}` with --entity-gen-dir stripped - "

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -190,8 +190,30 @@ Gates (gaps item 4, generator round):
       no AAF (5.3.3.4 exclusivity), every advertised Base rate is one the
       AUDIO_UNIT reports (5.3.3.3), and no descriptor outgrows the store's
       576-octet line buffer (1722.1-2021 Table 7-8: 138 + 8*N + 2*R).
+  30. THE ARGV REALLY REACHES THE RTL PARAMETER, observed rather than read
+      (gate 23f, issue #154): the shipping AX argv goes through the REAL
+      milan_soc.py main() once per optional block, and what is graded is the
+      p_* keyword arguments Instance("milan_datapath", ...) is handed.  Eleven
+      negative controls sever the chain hop by hop and require the gate to go
+      red, two of them the exact hops a reviewer severed on #135 while reading
+      ALL GATES PASS.  Gate 23d holds the same chain by the SPELLING of the
+      statements it walks and cannot see any of them.
+  31. EVERY SHIPPED RECIPE CAN ACTUALLY RUN (gate 23g, issue #156): every
+      build.sh recipe and every sweep.sh leg reaches that same Instance, with
+      the flow tail its own launcher appends and `--build` included, because
+      a guard that reads args.build is invisible to every shape gate in the
+      tree.  Two recipes could not launch at all until this gate ran.
+
+BOTH NEED LiteX, which is why they were worth the trouble: no CI job in this
+repository elaborated the SoC, so a behavioural proof of these chains existed
+on two branches and ran nowhere.  `.github/workflows/elaborate.yml` installs
+the pinned LiteX of sw/litex/litex_pins.txt and runs this file with
+--require-elaboration, which FAILS rather than skips when no interpreter can
+import migen + litex.  Everywhere else they SKIP, and skip() puts them in the
+verdict so the absence of the proof cannot read as the presence of one.
 
 Run: python3 sw/builder/test_builder.py   (or pytest sw/builder/test_builder.py)
+     python3 sw/builder/test_builder.py --require-elaboration   (the CI job)
 """
 
 import ast
@@ -204,6 +226,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
@@ -229,6 +252,33 @@ CONFIGS = {
 }
 OUT = os.path.join(HERE, "out")
 SWEEP = os.path.join(ROOT, "sw/litex/sweep.sh")
+BUILD_SH = os.path.join(ROOT, "sw/litex/build.sh")
+
+#: Every gate arm that could not run, in the order it declined.  A gate that
+#: prints its SKIP and then lets `main()` print ALL GATES PASS with exit 0
+#: turns the ABSENCE of a proof into the presence of one, which is the whole
+#: subject of #154: gate 23f was written, reviewed and merged into a lane, and
+#: the reason it protected nothing is that it skipped where it mattered and
+#: the verdict never said so.  Record instead, and let the verdict name them.
+SKIPPED = []
+
+#: The skip kind `--require-elaboration` refuses.  A row a gate could not run
+#: for a RECORDED reason is a normal skip; "there is no LiteX on this box" is
+#: not, in the one job that exists to elaborate.  Without this, a broken
+#: install in the elaboration job degrades to the exact green #154 is about.
+NO_LITEX = "no-litex"
+
+
+def skip(gate, why, kind="row"):
+    """Record one gate arm that could not run, and say so on stdout.
+
+    `gate` is the bracketed name the gate prints under, `why` the condition
+    that has to change for it to run.  Both end up in main()'s verdict, so
+    "why" is read by somebody deciding whether the green they are looking at
+    covers the thing they are about to merge - write it for that reader.
+    """
+    SKIPPED.append((gate, why, kind))
+    print(f"  [{gate}] SKIP: {why}")
 #: The TRACKED entity definition - now ONE file, the shape include a gateware
 #: `include-s.  Path comes from the builder that writes it, so there is one
 #: spelling of it.  Its old partner hdl/ieee17221/aecp/gen/aecp_aem_rom.svh is
@@ -1128,8 +1178,8 @@ def _real_totals(path):
 
 def test_resource_calibration():
     if not os.path.exists(REAL_RPT):
-        print(f"  [gate 11] SKIP: real report not on disk ({REAL_RPT}) - "
-              "calibration gate needs the mf48 build tree")
+        skip("gate 11", f"real report not on disk ({REAL_RPT}) - the "
+                        "calibration gate needs the mf48 build tree")
         return
     real = _real_totals(REAL_RPT)
     est = eb.build(CONFIGS["arty_current"], OUT)["resource_estimate"]
@@ -2375,7 +2425,7 @@ def test_platform_dt_and_driver_shape():
         print(f"  [gate 19b] {cfg_name}: {len(pairs)} window bases "
               f"BYTE-MATCH the real LiteX csr.csv ({os.path.basename(os.path.dirname(csv))})")
     if not checked:
-        print("  [gate 19b] SKIP csr.csv cross-check: no build tree on disk")
+        skip("gate 19b", "csr.csv cross-check: no build tree on disk")
     checked = 0
     for cfg_name, board in (("arty_current", "arty"), ("ax7101_8x8", "ax7101")):
         dts = DEPLOYED_DTS[board]
@@ -2418,8 +2468,8 @@ def test_platform_dt_and_driver_shape():
               f"base + kl,rsc-clk-mhz + the station MAC MATCH the deployed "
               f"{os.path.basename(dts)}")
     if not checked:
-        print("  [gate 19b] SKIP deployed-.dts cross-check: sibling repo "
-              "milan-tests-avb not on disk")
+        skip("gate 19b", "deployed-.dts cross-check: sibling repo "
+                         "milan-tests-avb not on disk")
 
 
 def test_platform_rejects():
@@ -3875,6 +3925,707 @@ def test_optional_block_consumption_gate_bites():
           "that would prune an UNFLAGGED build included")
 
 
+# ========================================================== gates 23f/23g ====
+#  THE BEHAVIOURAL ELABORATION PROOF (issues #154 and #156).
+#
+#  Gate 23d is a SPELLING proof.  It parses main() and asserts that every
+#  `--no-<block>` argparse value is handed to the MilanSoC(...) call, which
+#  closes the defect that shipped - a block declared in OPTIONAL_BLOCKS, in
+#  argparse, in the RTL and in AREA_BUDGET, and threaded nowhere - and nothing
+#  further.  THREE MORE HOPS stand between that call and the parameter the RTL
+#  reads, and every one of them is the same defect class:
+#
+#      main()               -> MilanSoC(optional_blocks=..., render_lpf=...)
+#      MilanSoC.__init__    -> MilanNIC(optional_blocks=..., render_lpf=...)
+#      MilanNIC.__init__    -> add_milan_datapath(optional_blocks=...)
+#      add_milan_datapath   -> dp_params[f"p_{param}"] = 0
+#                           -> Instance("milan_datapath", **dp_params)
+#
+#  A value that reaches the constructor and is then dropped, renamed or
+#  inverted on any of those hops is INVISIBLE to gate 23d, and its symptom is
+#  the #130 symptom exactly: the config declares the prune, the build plan
+#  tabulates it, the resource estimate books the saving, and the bitstream
+#  ships WITH the block.  #154 counts three incidents of it across two flags,
+#  and in the `--fabric-gptp` case a reviewer severed the chain at TWO
+#  independent hops and read `ALL GATES PASS` both times.
+#
+#  So these gates do what #130 asked for in as many words: "build a config
+#  with the block pruned and assert p_<PARAM>=0 appears in the emitted
+#  Instance parameters".  They run the REAL argv through the REAL
+#  milan_soc.py main() and READ THE PARAMETERS THAT REACH
+#  Instance("milan_datapath", ...).  Nothing is re-implemented and nothing is
+#  pattern-matched: `Instance` itself is the observation point, so what is
+#  graded is what the elaboration would hand Vivado.  Vivado never runs - the
+#  spy raises the moment the Instance is constructed, about 0.9 s after the
+#  process starts.
+#
+#  BOTH POLARITIES, because the flags have both.  The seven OPTIONAL_BLOCKS
+#  rows default PRESENT and pass their parameter ONLY when pruned (a default
+#  build emits a byte-identical top .v, the AAF_PLAYBACK_P discipline).
+#  `sound_card` and `fabric_gptp` are the mirror image - the RTL defaults are
+#  SOUND_CARD_P=0 and GPTP_PLANE_EN_P=0 and the parameter is passed only when
+#  the block is PRESENT - so they are graded upside down rather than assumed
+#  to follow the others.
+#
+#  WHAT THESE GATES DO NOT PROVE, stated here and in their own output because
+#  #154 asks the mechanism to say so:
+#    * not that the RTL parameter DOES anything - that a `parameter int X`
+#      exists and guards a generate with an else arm is gate 23d's, and what
+#      the guarded logic costs is the OOC area work's;
+#    * not that the bitstream places, times or boots;
+#    * not that a recipe builds the SoC its config describes - gate 1e and
+#      scripts/check_sweep_shape.py compare recipe argv against config, and
+#      #155 carries the ten flags where they currently disagree;
+#    * nothing at all, on a machine with no LiteX interpreter.  There the arms
+#      SKIP, and `skip()` puts them in main()'s verdict so the absence of the
+#      proof cannot read as the presence of one.
+
+#: The child program.  It runs under the LiteX interpreter, execs
+#: milan_soc.py's SOURCE (optionally mutated) as a module whose __file__ is
+#: the real path - so REPO_ROOT, the platforms/ search path and every
+#: generated-image lookup resolve exactly as they do in a build - patches that
+#: module's own `Instance` to a spy, and calls main().  The result goes to a
+#: FILE, never to stdout: add_milan_datapath spawns the ACMP/AECP image
+#: generators as SUBPROCESSES and their output reaches fd 1 whatever this
+#: process redirects.
+_INSTANCE_PROBE = r'''
+import contextlib, io, json, logging, os, sys, types
+
+spec = json.load(open(sys.argv[1], encoding="utf-8"))
+soc_path = spec["soc_path"]
+source = open(soc_path, encoding="utf-8").read()
+for old, new, want in spec["mutations"]:
+    got = source.count(old)
+    if got != want:
+        raise SystemExit("mutation %r matched %d times, want %d"
+                         % (old, got, want))
+    source = source.replace(old, new)
+
+logging.disable(logging.CRITICAL)
+sys.path.insert(0, os.path.dirname(soc_path))
+
+
+class _Reached(Exception):
+    """Carries the parameters Instance("milan_datapath", ...) was given."""
+
+    def __init__(self, params):
+        Exception.__init__(self)
+        self.params = params
+
+
+mod = types.ModuleType("milan_soc_probe")
+mod.__file__ = soc_path
+sys.modules[mod.__name__] = mod
+exec(compile(source, soc_path, "exec"), mod.__dict__)
+_real_instance = mod.Instance
+
+
+def _spy(*args, **kwargs):
+    if args and args[0] == "milan_datapath":
+        raise _Reached({k: v for k, v in kwargs.items() if k.startswith("p_")})
+    return _real_instance(*args, **kwargs)
+
+
+mod.Instance = _spy
+sys.argv = ["milan_soc.py"] + spec["argv"]
+sink = io.StringIO()
+try:
+    with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+        mod.main()
+    out = {"error": 'no Instance("milan_datapath") was constructed'}
+except _Reached as reached:
+    out = {"params": reached.params}
+except BaseException as exc:            # reported to the gate, not raised
+    # The captured output goes WITH the error, because LiteX reports through
+    # a logger rather than through the exception: SoCError carries an empty
+    # str() and everything a reader needs is in the stream this process
+    # redirected. Without the tail, a CI failure here says "SoCError:" and
+    # nothing else, which is a gate nobody can act on.
+    tail = sink.getvalue().strip().splitlines()[-12:]
+    out = {"error": "%s: %s" % (type(exc).__name__, exc),
+           "output": "\n".join(tail)}
+
+with open(spec["result"], "w", encoding="utf-8") as fh:
+    json.dump(out, fh)
+'''
+
+#: sw/litex, the directory every real build runs milan_soc.py from.  NOT the
+#: LiteX repo parent: `import litex` from there resolves to the checkout
+#: directory as a namespace package and the import fails.
+SOC_DIR = os.path.join(ROOT, "sw/litex")
+
+#: The config whose argv drives gate 23f: the SHIPPING AX shape (USER
+#: 2026-08-05, 1x1x8 TDM8), and it is the shipping one that matters here for
+#: two independent reasons.
+#:
+#: It is the only config that carries `--fabric-gptp`, which is #135's
+#: incident - nothing tied the parsed flag to p_GPTP_PLANE_EN_P, and on THIS
+#: profile (bare-metal, no ptp4l, no phc2sys) that is a bitstream with no
+#: time source and no signal.
+#:
+#: And it is the only shape that ELABORATES ANYWHERE BUT THIS BENCH.  The
+#: Linux 8x8 and Arty profiles pass `--scala-args=--l2-down-pending` and
+#: `--scala-args=--l2-general-slots`, which the VexiiRiscv revision LiteX
+#: pins does not accept; they work here because the checkout under
+#: ~/litex-milan carries an UNCOMMITTED 40-line patch to
+#: VexiiRiscv/src/main/scala/vexiiriscv/soc/litex/Soc.scala that adds those
+#: two options (measured 2026-08-21; that patch also carries the cacheless
+#: `unified` bus area the bare-metal shape needs at netlist time).  Choosing
+#: the 8x8 shape here would make this gate SKIP in the CI it was written for.
+#: The dependency itself is issue #185.
+BEHAVIOURAL_CFG = "ax7101_1x1_tdm8"
+
+
+def _litex_python():
+    """An interpreter that can import migen + litex + litex_boards, or None.
+
+    Search order: $MILAN_LITEX_PYTHON (a path), this interpreter, then the
+    venv sweep.sh puts on PATH for every real build - READ OUT OF sweep.sh,
+    never restated here, because a second spelling of the build interpreter
+    is a second thing that has to stay true.
+    """
+    cands = [os.environ.get("MILAN_LITEX_PYTHON"), sys.executable]
+    m = re.search(r'export PATH="?\$HOME/([^/"\s:]+)/venv/bin',
+                  open(SWEEP).read())
+    if m:
+        cands.append(os.path.join(os.path.expanduser("~"), m.group(1),
+                                  "venv", "bin", "python3"))
+    for cand in cands:
+        if not cand or not os.path.exists(cand):
+            continue
+        if subprocess.run([cand, "-c", "import migen, litex, litex_boards"],
+                          cwd=SOC_DIR, capture_output=True).returncode == 0:
+            return cand
+    return None
+
+
+#: The one place that decides "no LiteX here".  Both gates and both mutation
+#: arms ask it, so a box where the interpreter appears half-way through a run
+#: cannot have one arm skip and the next one grade.
+_LITEX_PY = []
+
+
+def _litex_or_skip(gate):
+    """The LiteX interpreter, or None with the skip already recorded."""
+    if not _LITEX_PY:
+        _LITEX_PY.append(_litex_python())
+    if _LITEX_PY[0] is None:
+        skip(gate, "no interpreter here can import migen + litex + "
+                   "litex_boards, so NO argv -> Instance parameter chain was "
+                   "observed in this run (point MILAN_LITEX_PYTHON at one, or "
+                   "run scripts/ci_litex_env.py). Gate 23d holds the argv -> "
+                   "MilanSoC half structurally, by the SPELLING of the "
+                   "statements it walks", NO_LITEX)
+    return _LITEX_PY[0]
+
+
+def _instance_params(python, runs, mutations=()):
+    """{label: {"params": ...} or {"error": ...}} for each (label, argv) run.
+
+    ONE CHILD PROCESS PER RUN, deliberately.  migen/LiteX accumulate enough
+    per-elaboration state that a second SoC built in the same interpreter
+    costs ~40 percent more than the first and a sixteenth costs seven times
+    as much (measured: 0.88 s -> 6.28 s, and clearing the tracebacks and
+    collecting does not touch it).  A fresh process is flat at ~0.9 s.
+
+    PYTHONHASHSEED is pinned for the same reason the sweep staggers its
+    launches: the CPU wrapper builds its argument string from a SET, so an
+    unpinned hash seed spells those arguments differently in every process,
+    misses the pinned core's netlist cache, and pays a ~90 s cold `sbt` run
+    EACH TIME.
+    """
+    env = dict(os.environ, PYTHONHASHSEED="0")
+    out, seen = {}, {}
+    with tempfile.TemporaryDirectory() as tmp:
+        for label, argv in runs:
+            # Several labels share one command line on purpose - the shipping
+            # argv is simultaneously the prune baseline, the sound card's
+            # ABSENT side and the gPTP plane's PRESENT side - and elaborating
+            # the same thing three times buys nothing.
+            key = tuple(argv)
+            if key in seen:
+                out[label] = seen[key]
+                continue
+            spec = os.path.join(tmp, "spec.json")
+            result = os.path.join(tmp, "result.json")
+            if os.path.exists(result):
+                os.unlink(result)
+            with open(spec, "w") as fh:
+                json.dump({"soc_path": os.path.join(SOC_DIR, "milan_soc.py"),
+                           "result": result, "argv": argv,
+                           "mutations": [list(m) for m in mutations]}, fh)
+            proc = subprocess.run([python, "-", spec], input=_INSTANCE_PROBE,
+                                  text=True, cwd=SOC_DIR, env=env,
+                                  capture_output=True)
+            assert os.path.exists(result), (
+                f"{label}: the milan_soc.py probe wrote no result "
+                f"(rc={proc.returncode})\n{proc.stdout[-2000:]}"
+                f"\n{proc.stderr[-2000:]}")
+            with open(result) as fh:
+                out[label] = seen[key] = json.load(fh)
+    return out
+
+
+#: The two inverted rows, and they are inverted for DIFFERENT reasons: the
+#: sound card is a Linux-only surface the shipping bare-metal profile drops,
+#: the fabric gPTP plane is an area-funded option the Linux profile does not
+#: take.  (flag, {parameter: the value a PRESENT build must pass}).
+#:
+#: `None` means "must appear, value unconstrained" - the ONE case is the gPTP
+#: microcode image, whose path is a build-tree location and not a constant.
+#: It is graded rather than ignored because the ROM is half of what the flag
+#: buys: a plane parameter of 1 with no image is #135's symptom with an extra
+#: step, an enabled plane that never leaves reset.  A row lists EVERY
+#: parameter its flag moves, so "changed nothing else" stays an exact test
+#: instead of a set difference nobody reads.
+PRESENT_ONLY_BLOCKS = {
+    "sound_card": ("--sound-card", {"p_SOUND_CARD_P": 1}),
+    "fabric_gptp": ("--fabric-gptp", {"p_GPTP_PLANE_EN_P": 1,
+                                      "p_GPTP_UCODE_HEX_P": None}),
+}
+
+
+def _why_failed(row):
+    """One probe failure as text, with the captured output when there is any.
+
+    LiteX reports through a logger, so several of its refusals arrive as an
+    exception whose str() is empty; the reason is in the stream the probe
+    redirected.  Both halves are printed or the gate is unactionable.
+    """
+    err = row.get("error", "no result")
+    out = (row.get("output") or "").strip()
+    return f"{err}\n      " + out.replace("\n", "\n      ") if out else err
+
+
+def _prune_contract(got, rows, inverted=()):
+    """Every prune-contract violation in one probe result set, as text.
+
+    ONE grader, shared by the gates and by their negative controls, so a
+    mutation is proved to turn THE GATE red rather than some weaker
+    restatement of it.  `rows` are the OPTIONAL_BLOCKS names to grade against
+    the "present" baseline; `inverted` names PRESENT_ONLY_BLOCKS rows, each
+    graded against its OWN `<name>_present`/`<name>` pair.
+    """
+    bad = []
+
+    def params(label):
+        row = got.get(label) or {"error": "case not run"}
+        if "params" not in row:
+            bad.append(f"{label}: {_why_failed(row)}")
+            return None
+        return row["params"]
+
+    base = params("present") if rows else None
+    for name in rows:
+        flag, param, _why = eb.OPTIONAL_BLOCKS[name]
+        key = f"p_{param}"
+        pruned = params(name)
+        if base is not None and key in base:
+            bad.append(f"{name}: a build that prunes NOTHING already passes "
+                       f"{key}={base[key]!r} - the default Instance is no "
+                       "longer the shipping one")
+        if base is None or pruned is None:
+            continue
+        if pruned.get(key) != 0:
+            bad.append(
+                f"{name}: `{flag}` reached argparse but "
+                f'Instance("milan_datapath") got {key}='
+                f"{pruned.get(key, '<absent>')!r}, want 0 - the config "
+                "declares the prune, the plan tabulates it, the estimate "
+                "books it, and the bitstream ships WITH the block (#130)")
+        rest = {k: v for k, v in pruned.items() if k != key}
+        if rest != base:
+            bad.append(f"{name}: `{flag}` changed Instance parameters other "
+                       f"than {key}: "
+                       f"{sorted(set(rest) ^ set(base)) or 'a value'}")
+    for name in inverted:
+        flag, wants = PRESENT_ONLY_BLOCKS[name]
+        on, off = params(f"{name}_present"), params(name)
+        for key, want in wants.items():
+            if on is not None and (on.get(key, KeyError) == KeyError
+                                   or (want is not None
+                                       and on.get(key) != want)):
+                bad.append(
+                    f"{name}: a build WITH `{flag}` got {key}="
+                    f"{on.get(key, '<absent>')!r}, want "
+                    f"{'any value' if want is None else repr(want)} - the "
+                    "RTL default is 0, so this is a row whose parameters are "
+                    "passed when the block is PRESENT")
+            if off is not None and key in off:
+                bad.append(f"{name}: a build WITHOUT `{flag}` still passes "
+                           f"{key}={off[key]!r}")
+        if on is not None and off is not None:
+            rest = {k: v for k, v in on.items() if k not in wants}
+            if rest != off:
+                bad.append(f"{name}: dropping `{flag}` changed parameters "
+                           f"other than {sorted(wants)}: "
+                           f"{sorted(set(rest) ^ set(off)) or 'a value'}")
+    return bad
+
+
+def _config_argv(name):
+    """(cfg, the config's OWN emitted argv, with --entity-gen-dir attached).
+
+    eb.build() is what writes both the generated include dir the argv points
+    at and the platform_shape.json milan_soc.py reads, so it runs first.
+    """
+    cfg = eb.load_config(CONFIGS[name])
+    eb.build(CONFIGS[name], OUT)
+    gen = os.path.join(ROOT, "configs/generated", cfg["name"])
+    assert os.path.isdir(gen), \
+        f"{gen}: this config has no generated include dir"
+    return cfg, eb.emit_soc_argv(cfg) + ["--entity-gen-dir", gen]
+
+
+def _behavioural_runs():
+    """(cfg, [(label, argv)]) for the full 23f case set.
+
+    The baseline is the config's OWN emitted argv with the prune flags taken
+    out, so every case differs from a real shipping command line by exactly
+    the token under test.  The shipping shape declares the gPTP plane and no
+    sound card, so it IS the gPTP row's present side and the sound card's
+    absent side; _instance_params elaborates that command line once.
+    """
+    cfg, argv = _config_argv(BEHAVIOURAL_CFG)
+    flags = {f for f, _p, _w in eb.OPTIONAL_BLOCKS.values()}
+    present = [a for a in argv if a not in flags]
+    assert "--sound-card" not in present and "--fabric-gptp" in present, \
+        f"{cfg['name']} no longer has the polarities this gate grades " \
+        "against - it must ship the gPTP plane and no sound card"
+    runs = [("present", present)]
+    runs += [(name, present + [flag])
+             for name, (flag, _p, _w) in eb.OPTIONAL_BLOCKS.items()]
+    runs += [("sound_card_present", present + ["--sound-card"]),
+             ("sound_card", present),
+             ("fabric_gptp_present", present),
+             ("fabric_gptp", _drop_flag(present, "--fabric-gptp", 0))]
+    return cfg, runs
+
+
+def _drop_flag(argv, flag, nargs):
+    """argv without `flag` and its nargs values.  Asserts it was there."""
+    assert flag in argv, f"{flag} is not on this argv: {' '.join(argv)}"
+    i = argv.index(flag)
+    return argv[:i] + argv[i + 1 + nargs:]
+
+
+def test_optional_blocks_reach_the_instance():
+    """gate 23f - THE BEHAVIOURAL PRUNE PROOF (issues #130, #154).
+
+    Every OPTIONAL_BLOCKS row plus the two PRESENT_ONLY_BLOCKS rows, both
+    directions, graded on the parameters that actually reach
+    Instance("milan_datapath", ...) in a real elaboration of the shipping
+    configs.  A prune must land as `p_<PARAM>=0` AND MUST CHANGE NOTHING ELSE
+    - a flag that prunes the wrong block is the same silent lie as a flag
+    that prunes nothing."""
+    python = _litex_or_skip("gate 23f")
+    if python is None:
+        return
+    cfg, runs = _behavioural_runs()
+    t0 = time.time()
+    got = _instance_params(python, runs)
+    bad = _prune_contract(got, list(eb.OPTIONAL_BLOCKS),
+                          list(PRESENT_ONLY_BLOCKS))
+    assert not bad, "gate 23f:\n  " + "\n  ".join(bad)
+    base = got["present"]["params"]
+    print(f"  [gate 23f] {len({tuple(a) for _l, a in runs})} real "
+          f"milan_soc.py elaborations of {cfg['name']}, the shipping AX "
+          f"shape, in {time.time() - t0:.0f} s: each of the "
+          f"{len(eb.OPTIONAL_BLOCKS)} --no-* flags lands as p_<PARAM>=0 in "
+          f'the Instance("milan_datapath") parameters and moves NOTHING '
+          f"else, a build that prunes nothing passes none of them "
+          f"({len(base)} parameters, byte-identical top .v), and both "
+          f"inverted rows land the other way up: p_SOUND_CARD_P=1 with "
+          f"--sound-card, and p_GPTP_PLANE_EN_P=1 WITH its microcode image "
+          f"with --fabric-gptp, both absent without them. This grades what "
+          f"elaboration HANDS the module, not "
+          f"what the module DOES with it (gate 23d) and not that the "
+          f"bitstream places or boots")
+
+
+def test_optional_block_instance_gate_bites():
+    """Gate 23f negative controls - the hops a spelling gate cannot see.
+
+    Each row deletes, renames or inverts ONE link of the argv -> Instance
+    chain in milan_soc.py's source and re-runs the gate's OWN grader over the
+    same real elaborations, so what is proved is that THE GATE goes red, not
+    that some weaker restatement of it does.
+
+    Eight of the eleven leave every OTHER gate in this file green, which is
+    the whole reason this gate exists.  The three that do NOT are gate 23d's
+    own: the dropped `not args.no_maap` handoff is exactly what 23d was
+    written for, and the renamed parameter trips its `p_<PARAM>=0` grep.
+    They are kept here so the two gates' division of labour is stated rather
+    than assumed - and so a later relaxation of 23d cannot quietly reopen
+    them."""
+    python = _litex_or_skip("gate 23f mutation")
+    if python is None:
+        return
+    _cfg, runs = _behavioural_runs()
+    cases = {label: argv for label, argv in runs}
+    # (why it is the #130 class, the source edit, which rows it must redden)
+    controls = [
+        ("main() drops ONE --no-* handoff",
+         [("not args.no_maap", "True", 1)], ["maap"], []),
+        ("MilanSoC never forwards optional_blocks to MilanNIC",
+         [("optional_blocks=optional_blocks,\n                              "
+           "    cbs_queues_mask=cbs_queues_mask,",
+           "cbs_queues_mask=cbs_queues_mask,", 1)], ["latency_taps"], []),
+        ("MilanSoC never forwards render_lpf to MilanNIC",
+         [("render_lpf=bool(render_lpf),\n", "", 1)], ["render_lpf"], []),
+        ("MilanNIC never forwards optional_blocks to add_milan_datapath",
+         [("render_lpf=render_lpf, optional_blocks=optional_blocks,",
+           "render_lpf=render_lpf,", 1)], ["maap"], []),
+        ("the pruned keyword is dropped inside add_milan_datapath",
+         [("blocks[k] = blocks[k] and bool(v)", "blocks[k] = True", 1)],
+         ["media_clock_servo"], []),
+        ("no parameter is ever emitted for a pruned block",
+         [("        if not blocks[k]:", "        if False:", 1)],
+         ["i2s_playback"], []),
+        ("the emitted parameter is renamed on its way to the Instance",
+         [('dp_params[f"p_{param}"] = 0', 'dp_params[f"p_{param}_X"] = 0', 1)],
+         ["rx_mac_filter"], []),
+        ("the prune predicate is INVERTED",
+         [("        if not blocks[k]:", "        if blocks[k]:", 1)],
+         ["datapath_probes"], []),
+        ("the sound-card row's own predicate is inverted",
+         [('    if sound_card:\n        dp_params["p_SOUND_CARD_P"] = 1',
+           '    if not sound_card:\n        dp_params["p_SOUND_CARD_P"] = 1',
+           1)], [], ["sound_card"]),
+        # The two #135 hops, verbatim: a reviewer severed the --fabric-gptp
+        # chain at each of them and read ALL GATES PASS both times.
+        ("main() never hands --fabric-gptp to MilanSoC (#135, hop 1)",
+         [("gptp_plane=args.fabric_gptp,", "gptp_plane=False,", 1)],
+         [], ["fabric_gptp"]),
+        ("the gPTP plane parameter is never emitted (#135, hop 2)",
+         [('        dp_params["p_GPTP_PLANE_EN_P"] = 1',
+           "        pass", 1)], [], ["fabric_gptp"]),
+    ]
+    t0 = time.time()
+    for why, mutations, rows, inverted in controls:
+        labels = ["present"] + rows if rows else []
+        labels += [f"{n}_present" for n in inverted] + list(inverted)
+        got = _instance_params(python, [(lbl, cases[lbl]) for lbl in labels],
+                               mutations)
+        bad = _prune_contract(got, rows, inverted)
+        assert bad, (f"gate 23f accepted a milan_soc.py in which {why} "
+                     f"({mutations[0][0]!r} -> {mutations[0][1]!r})")
+        want = (rows or inverted)[0]
+        assert any(line.startswith(f"{want}:") for line in bad), \
+            f"{why}: gate 23f went red for the wrong row: {bad}"
+    print(f"  [gate 23f mutation] {len(controls)}/{len(controls)} broken "
+          f"links of the argv -> Instance chain rejected in "
+          f"{time.time() - t0:.0f} s: a dropped CLI handoff, two dropped "
+          "constructor keywords, a dropped keyword inside "
+          "add_milan_datapath, a suppressed parameter, a renamed parameter, "
+          "both prune polarities inverted, and BOTH #135 hops - severed "
+          "independently, each one a bitstream with no time source")
+
+
+#  gate 23g (issue #156) - EVERY SHIPPED RECIPE CAN ACTUALLY RUN.
+#
+#  Every shape gate this repo has compares a recipe's argv against the config
+#  it claims to build.  NOTHING RAN THE ARGV.  A recipe can agree with its
+#  config flag for flag and still be unable to elaborate, and #156 records
+#  three findings that turned out to be that one gap - two build.sh recipes
+#  that could not launch at all for want of `--entity-gen-dir`, a flow-flag
+#  blind spot that let a late `and not args.build` leave the whole suite
+#  green while the real launcher line built the wrong SoC, and a sweep leg
+#  that cannot elaborate at all.
+#
+#  THE FLOW TAIL IS PART OF THE RECIPE HERE, and that is the load-bearing
+#  difference from gate 1e and scripts/check_sweep_shape.py.  Both of those
+#  exclude FLOW_FLAGS from the comparison, for the good reason that Vivado
+#  directives are not part of the end-station definition - but that makes
+#  `--build` invisible to every gate in the tree, and `--build` is on every
+#  real launcher line.  This gate appends the tail each launcher appends.
+#
+#  It asserts ONLY that the recipe reaches Instance("milan_datapath").  It is
+#  a smoke gate, not a shape gate: the shape comparison already exists and is
+#  sound.
+
+#: Recipes that are known NOT to elaborate, with the ticket that owns each.
+#: An entry here is a RECORDED failure, not a waiver: the gate still runs the
+#: recipe, still reports the error, and goes RED if a listed recipe starts
+#: working - because then the note is stale and the ticket is done.  Keeping
+#: the list this way is what stops "expected to fail" from becoming "nobody
+#: looks".
+KNOWN_UNRUNNABLE = {
+    "sweep.sh arty": "#184: milan_soc.py binds o_media_lrclk_o to "
+                     "tdm_pads.lrclk, a subsignal only the AX7101 platform "
+                     "declares, so this TDM-master leg dies with "
+                     "AttributeError before the Instance. Recorded rather "
+                     "than fixed here - the fix is a per-board binding "
+                     "decision and the Arty is a retired DUT (USER "
+                     "2026-08-01: AX7101 is the sole DUT)",
+}
+
+
+def _shell_recipes(path, pattern, flags=0):
+    """{name: argv} from a shell file, one entry per `pattern` match.
+
+    `pattern` must capture (name, body).  The body is the raw shell word
+    salad a recipe echoes; `$SOC_DIR` is the only variable a recipe uses and
+    it resolves to sw/litex in every launcher, so it is the only one expanded
+    - anything else left unexpanded is an assertion failure rather than a
+    token silently handed to argparse with a `$` in it.
+    """
+    text = open(path, encoding="utf-8").read()
+    out = {}
+    for name, body in re.findall(pattern, text, flags):
+        body = body.replace("\\\n", " ").replace("$SOC_DIR", SOC_DIR)
+        argv = shlex.split(body)
+        assert not [a for a in argv if "$" in a], \
+            f"{os.path.basename(path)} {name}: unexpanded shell variable in " \
+            f"{[a for a in argv if '$' in a]} - this gate would hand it to " \
+            "argparse verbatim"
+        out[name] = argv
+    assert out, f"{path}: no recipe matched {pattern!r} - the launcher was " \
+                "reshaped and this gate stopped testing anything"
+    return out
+
+
+def _recipe_cases():
+    """(label, argv) for every build.sh recipe and every sweep.sh board leg.
+
+    The flow tail each launcher appends is appended here too, `--build`
+    included, because a guard that reads args.build is invisible to every
+    other gate in the tree (#156 item 2).  --output-dir gets a real path so
+    the recipe is refused for its own reasons and not for a missing one.
+    """
+    out = []
+    # build.sh: `cfg_<name>() { ... echo "<argv>" }`, tail from its own exec
+    # line, read out of build.sh rather than restated.
+    tail = re.search(r"exec python3 milan_soc\.py \$args \$\{EXTRA\[\*\]:-\}"
+                     r'(.*?)"\s*$', open(BUILD_SH, encoding="utf-8").read(),
+                     re.M)
+    assert tail, "build.sh no longer execs milan_soc.py the way this gate reads"
+    build_tail = shlex.split(tail.group(1).replace("$out", OUT_DIR_TOKEN))
+    for name, argv in _shell_recipes(
+            BUILD_SH, r'^cfg_(\w+)\(\)[^\n]*\n(?:[^\n]*\n)*?\s*echo "(.*?)"\n',
+            re.M | re.S).items():
+        out.append((f"build.sh cfg_{name}", argv + build_tail))
+    # sweep.sh: OPTS per board from its own case table, plus the BASE tail and
+    # the per-directive launch tail.
+    sweep = open(SWEEP, encoding="utf-8").read()
+    base = re.search(r'BASE="python3 \$R/sw/litex/milan_soc\.py \$OPTS(.*?)"',
+                     sweep, re.S)
+    assert base, "sweep.sh no longer composes BASE the way this gate reads"
+    sweep_tail = shlex.split(base.group(1).replace("\\\n", " ")
+                             .replace("$CFG_GEN", "$CFG_GEN"))
+    for board, argv in _shell_recipes(
+            SWEEP, r'^\s{2}(\w+)\)\s+OPTS="(.*?)";\s*L2=', re.M | re.S).items():
+        cfg = re.search(r'^\s{2}%s\)\s+NS=\d+;\s*CFG=\$\{SWEEP_CFG:-([^}]+)\}'
+                        % board, sweep, re.M)
+        assert cfg, f"sweep.sh names no default config for the {board} leg"
+        gen = os.path.join(ROOT, "configs/generated",
+                           os.path.basename(cfg.group(1))[:-len(".yaml")])
+        tail = [gen if a == "$CFG_GEN" else a for a in sweep_tail]
+        out.append((f"sweep.sh {board}", argv + tail +
+                    ["--place-directive", "AltSpreadLogic_high",
+                     "--output-dir", OUT_DIR_TOKEN]))
+    return out
+
+
+#: Stand-in for the launcher's own `$out`/`$W/build_...` directory.  Replaced
+#: with a real temp path per run: milan_soc.py must be refused for its own
+#: reasons, never for an output directory that does not exist.
+OUT_DIR_TOKEN = "@OUTDIR@"
+
+
+def _is_unpatched_vexii(argv, err):
+    """True when this failure is #185's, and not the recipe's own.
+
+    BOTH halves are required, so a real failure cannot borrow the excuse: the
+    recipe must actually pass one of the two `--scala-args` the stock
+    upstream VexiiRiscv rejects, AND the failure must be the CPU wrapper's
+    own generator call rather than anything downstream of it.
+    """
+    return (any(a.startswith("--scala-args=--l2-down-pending")
+                or a.startswith("--scala-args=--l2-general-slots")
+                for a in argv)
+            and "PythonArgsGen" in err)
+
+
+def test_every_recipe_elaborates():
+    """gate 23g - every build.sh recipe and sweep.sh leg REACHES the Instance.
+
+    #156: nothing in this tree ever ran a recipe.  Two of them could not
+    launch at all, for the better part of a year, and every shape gate was
+    green throughout."""
+    python = _litex_or_skip("gate 23g")
+    if python is None:
+        return
+    for name in CONFIGS:                # every --entity-gen-dir a recipe names
+        eb.build(CONFIGS[name], OUT)
+    cases = _recipe_cases()
+    t0 = time.time()
+    with tempfile.TemporaryDirectory() as tmp:
+        runs = [(label, [tmp if a == OUT_DIR_TOKEN else a for a in argv])
+                for label, argv in cases]
+        got = _instance_params(python, runs)
+    bad, stale, ran = [], [], 0
+    for label, argv in cases:
+        err = got[label].get("error")
+        if label in KNOWN_UNRUNNABLE:
+            if err is None:
+                stale.append(f"{label}: RECORDED as unrunnable "
+                             f"({KNOWN_UNRUNNABLE[label]}) but it elaborated "
+                             "- delete the entry and close the ticket")
+            else:
+                skip("gate 23g", f"{label} is RECORDED as unrunnable and was "
+                                 f"not proved: {KNOWN_UNRUNNABLE[label]}")
+            continue
+        if err is not None and _is_unpatched_vexii(argv, err):
+            # NOT a defect in the recipe, and not something this gate can
+            # decide: on a stock upstream VexiiRiscv these recipes cannot
+            # elaborate at all, because two of their --scala-args exist only
+            # in the patch #185 is about.  Naming it is the whole value here
+            # - silently passing would say CI proved a recipe it never ran.
+            skip("gate 23g", f"{label} needs the VexiiRiscv patch of #185 "
+                             "(--l2-down-pending / --l2-general-slots), which "
+                             "this interpreter's checkout does not carry, so "
+                             "it was NOT proved to reach the Instance")
+            continue
+        if err is not None:
+            bad.append(f"{label}: never reached "
+                       f'Instance("milan_datapath"): {err}')
+            continue
+        ran += 1
+    assert not bad + stale, "gate 23g:\n  " + "\n  ".join(bad + stale)
+    print(f"  [gate 23g] {ran}/{len(cases)} shipped recipes reach "
+          f'Instance("milan_datapath") in {time.time() - t0:.0f} s, each with '
+          "the flow tail its own launcher appends (--build included, the "
+          "flag every shape gate excludes). This proves a recipe RUNS, not "
+          "that it builds the SoC its config describes - that comparison is "
+          "gate 1e's and #155 carries where the two disagree")
+
+
+def test_recipe_smoke_gate_bites():
+    """Gate 23g negative control - a recipe that cannot launch must redden it.
+
+    The mutation is the REAL #156 item 1, replayed: strip `--entity-gen-dir`
+    from a recipe and milan_soc.py refuses with "this build needs its
+    end-station config". Two recipes shipped exactly that way."""
+    python = _litex_or_skip("gate 23g mutation")
+    if python is None:
+        return
+    cases = [c for c in _recipe_cases() if c[0] not in KNOWN_UNRUNNABLE]
+    with tempfile.TemporaryDirectory() as tmp:
+        controls = []
+        for label, argv in cases[:1] + cases[-1:]:
+            argv = [tmp if a == OUT_DIR_TOKEN else a for a in argv]
+            controls.append((label, _drop_flag(argv, "--entity-gen-dir", 1)))
+        got = _instance_params(python, controls)
+    for label, _argv in controls:
+        assert got[label].get("error") is not None, (
+            f"gate 23g accepted `{label}` with --entity-gen-dir stripped - "
+            "the exact shape #156 item 1 shipped")
+    print(f"  [gate 23g mutation] {len(controls)}/{len(controls)} recipes "
+          "stripped of --entity-gen-dir refused to elaborate, which is #156 "
+          "item 1 replayed on the recipes that shipped it")
+
+
 # ======================================================== gates 24c / 24d ====
 #  PER-BOARD AUDIO FRONT-END ROUTING - the L1 binding, one board at a time.
 #
@@ -4848,8 +5599,8 @@ def test_entity_identity_is_derived_not_mirrored():
          builds (sweep_config(), READ from sweep.sh - never restated here, the
          gate-9 rule). A stale file cannot survive."""
     if not os.path.exists(S50MILAN):
-        print("  [gate 25] SKIP identity-derivation cross-check: sibling repo "
-              "milan-tests-avb not on disk")
+        skip("gate 25", "identity-derivation cross-check: sibling repo "
+                        "milan-tests-avb not on disk")
         return
     code = _sh_code(S50MILAN)
     seen = set()
@@ -5769,6 +6520,10 @@ if __name__ == "__main__":
                test_optional_block_prune_accounting,
                test_optional_block_names_reach_the_rtl,
                test_optional_block_consumption_gate_bites,
+               test_optional_blocks_reach_the_instance,
+               test_optional_block_instance_gate_bites,
+               test_every_recipe_elaborates,
+               test_recipe_smoke_gate_bites,
                test_tdm_master_binding_reaches_the_pins,
                test_tdm_master_binding_gate_bites,
                test_front_end_routing_per_board,
@@ -5787,4 +6542,27 @@ if __name__ == "__main__":
                test_per_row_format_facts_are_per_row):
         print(f"{fn.__name__}:")
         fn()
-    print("ALL GATES PASS")
+    # The verdict names what did not run.  Printing SKIP inside a gate and
+    # then printing ALL GATES PASS here is how a reviewer severed the
+    # --fabric-gptp chain at two hops and read a green both times (#154).
+    if SKIPPED:
+        print(f"\n{len(SKIPPED)} GATE ARM(S) DID NOT RUN - this verdict does "
+              "not cover them:")
+        for gate, why, _kind in SKIPPED:
+            print(f"  - [{gate}] {why}")
+        print(f"ALL GATES PASS EXCEPT {len(SKIPPED)} NOT RUN")
+    else:
+        print("ALL GATES PASS")
+    # --require-elaboration is what stops the ONE job that exists to
+    # elaborate from reporting a green when its LiteX install broke.  Rows a
+    # gate declined for a recorded reason still pass; "there is no LiteX
+    # here" does not.
+    if "--require-elaboration" in sys.argv:
+        missing = [(g, w) for g, w, k in SKIPPED if k == NO_LITEX]
+        if missing:
+            print("\n--require-elaboration: this run was asked to observe "
+                  "the argv -> Instance chain and could not:")
+            for gate, why in missing:
+                print(f"  - [{gate}] {why}")
+            sys.exit(1)
+        print("--require-elaboration: every elaboration arm ran")

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -222,6 +222,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import struct
 import subprocess
 import sys
@@ -253,6 +254,8 @@ CONFIGS = {
 OUT = os.path.join(HERE, "out")
 SWEEP = os.path.join(ROOT, "sw/litex/sweep.sh")
 BUILD_SH = os.path.join(ROOT, "sw/litex/build.sh")
+PATCH_DIR = os.path.join(ROOT, "sw/litex/patches")
+APPLY_SH = os.path.join(PATCH_DIR, "apply.sh")
 
 #: Every gate arm that could not run, in the order it declined.  A gate that
 #: prints its SKIP and then lets `main()` print ALL GATES PASS with exit 0
@@ -4648,6 +4651,205 @@ def test_recipe_smoke_gate_bites():
           "item 1 replayed on the recipes that shipped it")
 
 
+#  gate 23h (issue #185) - THE TOOLCHAIN THIS SOC IS BUILT WITH IS THE ONE
+#  THIS REPOSITORY DESCRIBES.
+#
+#  Upstream LiteX cannot build any shape of this design. It has no `baremetal`
+#  VexiiRiscv variant, which is the whole #120/#125 downgrade and the shipping
+#  AX profile, and the VexiiRiscv revision it pins does not accept the
+#  `--l2-down-pending` / `--l2-general-slots` four of the five configs pass.
+#  sw/litex/patches/ carries the six patches that close that, and apply.sh
+#  applies them.
+#
+#  NOTHING RAN IT. Measured 2026-08-21: the series had not applied cleanly for
+#  an unknown length of time, and there was no way to notice, because the only
+#  reader was a person following a document. Two failures had accumulated:
+#
+#    * 0003 was diffed against pristine upstream while 0001 rewrites the same
+#      boot.c hunks, so apply.sh died on the third patch and never reached the
+#      two that follow it;
+#    * 0002-liteeth had fallen 25 lines behind the tree the boards are built
+#      from - the ext_reset input KL_link_guard drives was only ever in the
+#      bench's working copy.
+#
+#  A third was by design and had outlived it: the L2 patch was documented as
+#  "apply it by hand for non-default L2" from a time when it WAS optional, and
+#  four configs now pass those arguments, so `apply.sh` completing successfully
+#  still left a tree that could not elaborate them.
+#
+#  So this gate asks the two questions that would have caught all three:
+#  is every patch in the directory actually in the series apply.sh applies, and
+#  is every patch in that series actually applied to the trees this interpreter
+#  imports. Both are answered against the live install, not against text.
+#
+#  WHAT IT DOES NOT PROVE: that the patches are CORRECT, that upstream still
+#  wants them, or that the built bitstream works. It proves the tree you are
+#  elaborating with is the tree this repository says you should be elaborating
+#  with, which is the property that was silently untrue.
+
+#: The tree keys apply.sh resolves, and how to resolve each from a LiteX
+#: interpreter. Read here rather than restated: `vexiiriscv` is the Scala
+#: checkout INSIDE the pythondata package, which is why it cannot be found the
+#: way a Python package is.
+_TREE_EXPR = {
+    "vexiiriscv": "import pythondata_cpu_vexiiriscv as p, os; "
+                  "print(os.path.join(p.data_location, 'ext', 'VexiiRiscv'))",
+}
+
+
+def _patch_series():
+    """[(tree key, patch filename)] read out of apply.sh's own SERIES array.
+
+    The list is READ, never restated, for the reason the gate exists: a patch
+    that is in the directory and not in the series is exactly the shape the
+    L2 one had, and a second copy of the list here could hold it while
+    apply.sh dropped it.
+    """
+    src = open(APPLY_SH, encoding="utf-8").read()
+    block = re.search(r"^SERIES=\((.*?)^\)", src, re.M | re.S)
+    assert block, "apply.sh no longer declares a SERIES array this gate can read"
+    rows = re.findall(r'"\s*(\S+)\s+(\S+\.patch)\s*"', block.group(1))
+    assert rows, "apply.sh's SERIES array is empty or reshaped"
+    return rows
+
+
+def _tree_root(python, key):
+    """The directory apply.sh's patch paths are relative to, for one tree key."""
+    expr = _TREE_EXPR.get(
+        key, f"import {key}, os; "
+             f"print(os.path.dirname(os.path.dirname({key}.__file__)))")
+    got = subprocess.run([python, "-c", expr], capture_output=True, text=True)
+    assert got.returncode == 0, \
+        f"{key}: this interpreter cannot locate the tree ({got.stderr.strip()})"
+    return got.stdout.strip()
+
+
+def _patch_targets(patch):
+    """The paths one patch rewrites, relative to its tree root."""
+    got = re.findall(r"^\+\+\+ b/(\S+)", open(patch, encoding="utf-8").read(),
+                     re.M)
+    assert got, f"{patch}: no target files - is it a valid diff?"
+    return got
+
+
+def _reconstruct(python, series, break_patch=None):
+    """Problems with "the live trees are pristine upstream plus this series".
+
+    THE SERIES IS STACKED, so no patch can be graded on its own: 0003 is
+    diffed on top of 0001 and both rewrite the same boot.c hunks, so asking
+    "does 0001 reverse-apply?" against a correctly patched tree answers no.
+    That is the same mistake apply.sh used to make in the other direction.
+
+    So the whole series is reversed, in reverse order, on a COPY of just the
+    files it touches - which lands on pristine upstream without downloading
+    one - and then applied forward again. Every step must succeed and the
+    result must equal the live files byte for byte. `break_patch` reverses one
+    extra patch at the end, which is how the control proves this can fail.
+    """
+    problems = []
+    with tempfile.TemporaryDirectory() as tmp:
+        live = {}
+        for key, patch in series:
+            root = _tree_root(python, key)
+            for rel in _patch_targets(os.path.join(PATCH_DIR, patch)):
+                src = os.path.join(root, rel)
+                if not os.path.exists(src):
+                    problems.append(f"{patch}: {key} has no {rel} at all")
+                    continue
+                dst = os.path.join(tmp, key, rel)
+                if (key, rel) not in live:
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    shutil.copy2(src, dst)
+                    live[(key, rel)] = src
+        if problems:
+            return problems
+        order = list(series)
+        if break_patch:
+            order = order + [break_patch]
+        for key, patch in reversed(order):
+            rc = subprocess.run(
+                ["git", "-C", os.path.join(tmp, key), "apply", "--reverse",
+                 os.path.join(PATCH_DIR, patch)], capture_output=True)
+            if rc.returncode != 0:
+                problems.append(
+                    f"{patch}: does not reverse out of the live {key}, so "
+                    "that tree is not upstream plus this series. Either the "
+                    "patch was never applied (run sw/litex/patches/apply.sh) "
+                    "or the file drifted (re-diff per "
+                    "sw/litex/patches/README.md)")
+                return problems
+        for key, patch in series:
+            rc = subprocess.run(
+                ["git", "-C", os.path.join(tmp, key), "apply",
+                 os.path.join(PATCH_DIR, patch)], capture_output=True)
+            if rc.returncode != 0:
+                problems.append(
+                    f"{patch}: does not re-apply to the pristine {key} the "
+                    "reversal produced, so the series is not self-consistent "
+                    "in its own order")
+                return problems
+        for (key, rel), src in sorted(live.items()):
+            if open(os.path.join(tmp, key, rel), "rb").read() != \
+                    open(src, "rb").read():
+                problems.append(
+                    f"{key}/{rel}: upstream plus the series does not "
+                    "reproduce the installed file, so the tree carries a "
+                    "change no patch here records")
+    return problems
+
+
+def test_toolchain_patches_are_applied():
+    """gate 23h - the LiteX being elaborated with is the one this repo describes.
+
+    Reconstruction, not inspection: the series is reversed off a copy of the
+    live files and applied again, and the result must be the live files."""
+    python = _litex_or_skip("gate 23h")
+    if python is None:
+        return
+    series = _patch_series()
+    on_disk = {f for f in os.listdir(PATCH_DIR) if f.endswith(".patch")}
+    listed = {f for _k, f in series}
+    assert listed == on_disk, (
+        "sw/litex/patches and apply.sh's SERIES disagree, which is how "
+        "0002-vexiiriscv-l2-depth-args sat unapplied while four configs "
+        f"needed it: only in the directory {sorted(on_disk - listed)}, only "
+        f"in SERIES {sorted(listed - on_disk)}")
+    problems = _reconstruct(python, series)
+    assert not problems, "gate 23h:\n  " + "\n  ".join(problems)
+    files = {(k, r) for k, p in series
+             for r in _patch_targets(os.path.join(PATCH_DIR, p))}
+    print(f"  [gate 23h] the {len(series)} patches in sw/litex/patches are the "
+          f"{len(on_disk)} apply.sh applies, and reversing them off this "
+          f"interpreter's trees and re-applying them reproduces all "
+          f"{len(files)} installed files byte for byte. Upstream LiteX has no "
+          "`baremetal` VexiiRiscv variant and the revision it pins rejects "
+          "the --l2-* arguments four configs pass, so this is what lets gates "
+          "23f/23g elaborate at all. It says nothing about whether the "
+          "patches are CORRECT, only that the tree is the one described here")
+
+
+def test_toolchain_patch_gate_bites():
+    """Gate 23h negative control - a tree missing one patch must redden it.
+
+    Run against the same scratch copy the gate uses, never the live install:
+    a gate that proves itself by breaking the tree the rest of the run
+    depends on is worse than no gate. One extra reversal per case is exactly
+    the state apply.sh left behind for an unknown length of time."""
+    python = _litex_or_skip("gate 23h mutation")
+    if python is None:
+        return
+    series = _patch_series()
+    for case in series:
+        problems = _reconstruct(python, series, break_patch=case)
+        assert problems, (
+            f"gate 23h would NOT have noticed {case[1]} missing from the "
+            f"installed {case[0]}")
+    print(f"  [gate 23h mutation] {len(series)}/{len(series)} patches removed "
+          "one at a time from the reconstructed tree were each rejected, so "
+          "the gate above fails for the state it exists to catch rather than "
+          "passing on the strength of a directory listing")
+
+
 # ======================================================== gates 24c / 24d ====
 #  PER-BOARD AUDIO FRONT-END ROUTING - the L1 binding, one board at a time.
 #
@@ -6546,6 +6748,8 @@ if __name__ == "__main__":
                test_optional_block_instance_gate_bites,
                test_every_recipe_elaborates,
                test_recipe_smoke_gate_bites,
+               test_toolchain_patches_are_applied,
+               test_toolchain_patch_gate_bites,
                test_tdm_master_binding_reaches_the_pins,
                test_tdm_master_binding_gate_bites,
                test_front_end_routing_per_board,

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -209,15 +209,19 @@ repository elaborated the SoC, so a behavioural proof of these chains existed
 on two branches and ran nowhere.  `.github/workflows/elaborate.yml` installs
 the pinned LiteX of sw/litex/litex_pins.txt and runs this file with
 --require-elaboration, which FAILS rather than skips when no interpreter can
-import migen + litex.  Everywhere else they SKIP, and skip() puts them in the
-verdict so the absence of the proof cannot read as the presence of one.
+import migen + litex, or when the one it finds carries a VexiiRiscv that
+rejects the --l2-* arguments the patch series adds.  Everywhere else they
+SKIP, and skip() puts them in the verdict so the absence of the proof cannot
+read as the presence of one.
 
 Run: python3 sw/builder/test_builder.py   (or pytest sw/builder/test_builder.py)
      python3 sw/builder/test_builder.py --require-elaboration   (the CI job)
 """
 
 import ast
+import contextlib
 import copy
+import io
 import json
 import os
 import re
@@ -270,6 +274,14 @@ SKIPPED = []
 #: not, in the one job that exists to elaborate.  Without this, a broken
 #: install in the elaboration job degrades to the exact green #154 is about.
 NO_LITEX = "no-litex"
+
+#: The other kind it refuses: an interpreter was found, and its VexiiRiscv
+#: rejects an --l2-* argument that only the series in sw/litex/patches
+#: teaches it.  On a bench that is a recorded gap; in the one job that
+#: installs the series (elaborate.yml) it is a setup failure, and a row skip
+#: must not absorb a setup failure in the job that exists to prove the
+#: toolchain ([R0] on PR #188).
+TOOLCHAIN = "toolchain"
 
 
 def skip(gate, why, kind="row"):
@@ -4071,16 +4083,15 @@ BUILD_OUT_TOKEN = "@BUILD_OUT@"
 #: profile (bare-metal, no ptp4l, no phc2sys) that is a bitstream with no
 #: time source and no signal.
 #:
-#: And it is the only shape that ELABORATES ANYWHERE BUT THIS BENCH.  The
-#: Linux 8x8 and Arty profiles pass `--scala-args=--l2-down-pending` and
+#: And it was once thought to be the only shape that elaborates anywhere
+#: but this bench, which was wrong in both directions (#185): on a stock
+#: toolchain NO shape elaborates - this one needs the `baremetal` CPU
+#: variant, the four Linux shapes pass `--scala-args=--l2-down-pending` and
 #: `--scala-args=--l2-general-slots`, which the VexiiRiscv revision LiteX
-#: pins does not accept; they work here because the checkout under
-#: ~/litex-milan carries an UNCOMMITTED 40-line patch to
-#: VexiiRiscv/src/main/scala/vexiiriscv/soc/litex/Soc.scala that adds those
-#: two options (measured 2026-08-21; that patch also carries the cacheless
-#: `unified` bus area the bare-metal shape needs at netlist time).  Choosing
-#: the 8x8 shape here would make this gate SKIP in the CI it was written for.
-#: The dependency itself is issue #185.
+#: pins rejects - and with the series in sw/litex/patches applied, which
+#: apply.sh does and gate 23h proves, every shape but #184's Arty leg does.
+#: The series is carried in this repository; nothing about it is a local
+#: modification.
 BEHAVIOURAL_CFG = "ax7101_1x1_tdm8"
 
 
@@ -4182,7 +4193,19 @@ def _instance_params(python, runs, mutations=()):
                 f"(rc={proc.returncode})\n{proc.stdout[-2000:]}"
                 f"\n{proc.stderr[-2000:]}")
             with open(result) as fh:
-                out[label] = seen[key] = json.load(fh)
+                row = json.load(fh)
+            if "error" in row:
+                # The CPU wrapper runs its Scala generator as a CHILD of the
+                # probe, on the process's own file descriptors, so the
+                # probe's Python-level redirect never sees it, and the only
+                # place scopt's refusal of an --l2-* argument is spelled out
+                # is this stream.  Keep its tail next to the error for
+                # _classify_recipe.  A dozen lines would not do: measured
+                # 2026-08-21, the refusal sits 17 lines above the end of a
+                # stack trace.
+                row["child_output"] = "\n".join(
+                    (proc.stdout + "\n" + proc.stderr).splitlines()[-200:])
+            out[label] = seen[key] = row
         left = os.listdir(build_out)
         assert not left, (
             "the Instance spy no longer stops the elaboration: a run carrying "
@@ -4470,20 +4493,25 @@ def test_optional_block_instance_gate_bites():
 #  a smoke gate, not a shape gate: the shape comparison already exists and is
 #  sound.
 
-#: Recipes that are known NOT to elaborate, with the ticket that owns each.
+#: Recipes that are known NOT to elaborate, with the ticket that owns each
+#: and the EXACT diagnostic the ticket records, as a regular expression the
+#: probe's `<ExceptionType>: <message>` line must match in full.
 #: An entry here is a RECORDED failure, not a waiver: the gate still runs the
-#: recipe, still reports the error, and goes RED if a listed recipe starts
-#: working - because then the note is stale and the ticket is done.  Keeping
-#: the list this way is what stops "expected to fail" from becoming "nobody
-#: looks".
+#: recipe, still reports the error, goes RED if a listed recipe starts
+#: working - because then the note is stale and the ticket is done - and
+#: goes RED if it fails for ANY OTHER reason than the one recorded, because
+#: a row that skips on any error is a row nobody looks at ([R0] on PR #188:
+#: the first version accepted every error here, so a new parser, a broken
+#: tool install or a regression in this very recipe would have been reported
+#: as #184 and left the verdict green).
 KNOWN_UNRUNNABLE = {
-    "sweep.sh arty": "#184: milan_soc.py binds o_media_lrclk_o to "
-                     "tdm_pads.lrclk, a subsignal only the AX7101 platform "
-                     "declares, so this TDM-master leg dies with "
-                     "AttributeError before the Instance. Recorded rather "
-                     "than fixed here - the fix is a per-board binding "
-                     "decision and the Arty is a retired DUT (USER "
-                     "2026-08-01: AX7101 is the sole DUT)",
+    "sweep.sh arty": (
+        "#184: milan_soc.py binds o_media_lrclk_o to tdm_pads.lrclk, a "
+        "subsignal only the AX7101 platform declares, so this TDM-master leg "
+        "dies with AttributeError before the Instance. Recorded rather than "
+        "fixed here - the fix is a per-board binding decision and the Arty "
+        "is a retired DUT (USER 2026-08-01: AX7101 is the sole DUT)",
+        r"AttributeError: 'Record' object has no attribute 'lrclk'"),
 }
 
 
@@ -4560,18 +4588,74 @@ def _recipe_cases():
 OUT_DIR_TOKEN = BUILD_OUT_TOKEN
 
 
-def _is_unpatched_vexii(argv, err):
-    """True when this failure is #185's, and not the recipe's own.
+#: What a STOCK VexiiRiscv says to an --l2-* argument that only the series
+#: in sw/litex/patches teaches it.  The generator is a Scala program whose
+#: options scopt parses; handed one it does not know, it prints
+#:     [error] Error: Unknown option --l2-down-pending=4
+#:     [error] Try --help for more information.
+#: and sbt fails the runMain, which LiteX surfaces as a CalledProcessError
+#: whose message is the sbt command line, PythonArgsGen included.  Observed
+#: 2026-08-21 by handing the bench's generator `--l2-bogus-option=1`; the
+#: two option names below are the ones the pinned revision rejects (#185).
+UNPATCHED_VEXII_RE = re.compile(
+    r"Unknown option --l2-(down-pending|general-slots)")
+L2_SCALA_ARGS = ("--scala-args=--l2-down-pending",
+                 "--scala-args=--l2-general-slots")
 
-    BOTH halves are required, so a real failure cannot borrow the excuse: the
-    recipe must actually pass one of the two `--scala-args` the stock
-    upstream VexiiRiscv rejects, AND the failure must be the CPU wrapper's
-    own generator call rather than anything downstream of it.
+#: The five things one gate-23g recipe result can be.
+RECIPE_RAN, RECIPE_RECORDED, RECIPE_TOOLCHAIN, RECIPE_STALE, RECIPE_FAILED = (
+    "ran", "recorded", "toolchain", "stale", "failed")
+
+
+def _classify_recipe(label, argv, row):
+    """(verdict, detail) for one recipe's probe result.
+
+    EVERY SKIP IS PINNED TO ITS EXACT DIAGNOSTIC.  The first version of this
+    gate skipped a recorded row on ANY error, and skipped any failure whose
+    text mentioned PythonArgsGen as "#185's": a new parser bug, a Scala
+    compile error, a missing sbt or a regression in the recipe itself would
+    all have been reported as the old, known, harmless reason and left the
+    verdict green ([R0] on PR #188).  Now a recorded row must fail with the
+    error its ticket records, and the toolchain skip needs all three of: the
+    recipe passes one of the two --l2-* arguments, the failure is the CPU
+    generator's own sbt run, and that run's output carries scopt's refusal
+    of an --l2-* argument.  Anything else is a failure of the recipe.
     """
-    return (any(a.startswith("--scala-args=--l2-down-pending")
-                or a.startswith("--scala-args=--l2-general-slots")
-                for a in argv)
-            and "PythonArgsGen" in err)
+    err = row.get("error")
+    if label in KNOWN_UNRUNNABLE:
+        why, signature = KNOWN_UNRUNNABLE[label]
+        if err is None:
+            return RECIPE_STALE, (
+                f"{label}: RECORDED as unrunnable ({why}) but it elaborated "
+                "- delete the entry and close the ticket")
+        if re.fullmatch(signature, err):
+            return RECIPE_RECORDED, (
+                f"{label} is RECORDED as unrunnable and was not proved: {why}")
+        return RECIPE_FAILED, (
+            f"{label}: RECORDED as unrunnable for `{signature}` but failed "
+            f"DIFFERENTLY, which the record does not cover: {_why_failed(row)}")
+    if err is None:
+        return RECIPE_RAN, ""
+    generator_text = "\n".join(
+        t for t in (row.get("output"), row.get("child_output")) if t)
+    if (any(a.startswith(L2_SCALA_ARGS) for a in argv)
+            and err.startswith("CalledProcessError:")
+            and "PythonArgsGen" in err
+            and UNPATCHED_VEXII_RE.search(generator_text)):
+        # NOT a defect in the recipe, and not something this gate can
+        # decide: on a stock upstream VexiiRiscv these recipes cannot
+        # elaborate at all, because two of their --scala-args exist only
+        # in the patch #185 is about.  Naming it is the whole value here
+        # - silently passing would say CI proved a recipe it never ran.
+        return RECIPE_TOOLCHAIN, (
+            f"{label} needs the VexiiRiscv patch of #185 (--l2-down-pending "
+            "/ --l2-general-slots), which this interpreter's checkout does "
+            "not carry - its generator printed scopt's `Unknown option` - so "
+            "it was NOT proved to reach the Instance; run "
+            "sw/litex/patches/apply.sh")
+    return RECIPE_FAILED, (
+        f'{label}: never reached Instance("milan_datapath"): '
+        f"{_why_failed(row)}")
 
 
 def test_every_recipe_elaborates():
@@ -4594,32 +4678,19 @@ def test_every_recipe_elaborates():
     got = _instance_params(python, cases)
     bad, stale, ran = [], [], 0
     for label, argv in cases:
-        err = got[label].get("error")
-        if label in KNOWN_UNRUNNABLE:
-            if err is None:
-                stale.append(f"{label}: RECORDED as unrunnable "
-                             f"({KNOWN_UNRUNNABLE[label]}) but it elaborated "
-                             "- delete the entry and close the ticket")
-            else:
-                skip("gate 23g", f"{label} is RECORDED as unrunnable and was "
-                                 f"not proved: {KNOWN_UNRUNNABLE[label]}")
-            continue
-        if err is not None and _is_unpatched_vexii(argv, err):
-            # NOT a defect in the recipe, and not something this gate can
-            # decide: on a stock upstream VexiiRiscv these recipes cannot
-            # elaborate at all, because two of their --scala-args exist only
-            # in the patch #185 is about.  Naming it is the whole value here
-            # - silently passing would say CI proved a recipe it never ran.
-            skip("gate 23g", f"{label} needs the VexiiRiscv patch of #185 "
-                             "(--l2-down-pending / --l2-general-slots), which "
-                             "this interpreter's checkout does not carry, so "
-                             "it was NOT proved to reach the Instance")
-            continue
-        if err is not None:
-            bad.append(f"{label}: never reached "
-                       f'Instance("milan_datapath"): {err}')
-            continue
-        ran += 1
+        verdict, detail = _classify_recipe(label, argv, got[label])
+        if verdict == RECIPE_RAN:
+            ran += 1
+        elif verdict == RECIPE_RECORDED:
+            skip("gate 23g", detail)
+        elif verdict == RECIPE_TOOLCHAIN:
+            # A row skip on a bench; in the job that installs the series it
+            # is a setup failure, and --require-elaboration refuses it.
+            skip("gate 23g", detail, TOOLCHAIN)
+        elif verdict == RECIPE_STALE:
+            stale.append(detail)
+        else:
+            bad.append(detail)
     assert not bad + stale, "gate 23g:\n  " + "\n  ".join(bad + stale)
     print(f"  [gate 23g] {ran}/{len(cases)} shipped recipes reach "
           f'Instance("milan_datapath") in {time.time() - t0:.0f} s, each with '
@@ -4649,6 +4720,86 @@ def test_recipe_smoke_gate_bites():
     print(f"  [gate 23g mutation] {len(controls)}/{len(controls)} recipes "
           "stripped of --entity-gen-dir refused to elaborate, which is #156 "
           "item 1 replayed on the recipes that shipped it")
+
+
+def test_recipe_skip_classifier_bites():
+    """Gate 23g negative controls for the SKIP classifier; they need no LiteX.
+
+    The skips are the part of gate 23g that can turn a failure into a green,
+    so they are graded on every box, interpreter or not.  Each arm hands the
+    production classifier a result shaped like a real one - the recorded
+    Arty error and scopt's refusal are the texts observed on 2026-08-21,
+    verbatim - and requires the verdict [R0] asked for on PR #188: a
+    recorded row failing for a different reason FAILS, a generator failure
+    without scopt's refusal FAILS, the refusal on a recipe that passes no
+    --l2-* argument FAILS, and only the two exact shapes skip.  The
+    --require-elaboration verdict is graded the same way: a toolchain skip
+    fails it, a recorded row does not, and the line it prints says which.
+    """
+    arty = "sweep.sh arty"
+    assert arty in KNOWN_UNRUNNABLE, "these controls replay the recorded Arty row"
+    l2 = ["--scala-args=--l2-down-pending=4",
+          "--scala-args=--l2-general-slots=8"]
+    gen = ("CalledProcessError: Command 'cd /v/ext/VexiiRiscv && sbt "
+           "\"runMain vexiiriscv.soc.litex.PythonArgsGen --xlen=32 "
+           "--l2-down-pending=4 --python-file=/v/x.py\"' returned non-zero "
+           "exit status 1.")
+    refusal = ("[error] Error: Unknown option --l2-down-pending=4\n"
+               "[error] Try --help for more information.")
+    trace = "\n".join(f"[error] \tat scala.App.main(App.scala:{n})"
+                      for n in range(40))
+    arms = [
+        ("recorded row failing as recorded", arty, [],
+         {"error": "AttributeError: 'Record' object has no attribute 'lrclk'"},
+         RECIPE_RECORDED),
+        ("recorded row failing DIFFERENTLY", arty, [],
+         {"error": "SoCError: ", "output": "a refusal #184 never recorded"},
+         RECIPE_FAILED),
+        ("recorded row that elaborated", arty, [], {"params": {}},
+         RECIPE_STALE),
+        ("--l2 recipe on a stock VexiiRiscv", "build.sh cfg_ax8x8", l2,
+         {"error": gen, "child_output": refusal + "\n" + trace},
+         RECIPE_TOOLCHAIN),
+        ("--l2 recipe whose generator failed for ANOTHER reason",
+         "build.sh cfg_ax8x8", l2,
+         {"error": gen, "child_output": "[error] Soc.scala:12: not found: "
+                                        "value l2DownPending\n" + trace},
+         RECIPE_FAILED),
+        ("the refusal on a recipe passing NO --l2 argument",
+         "build.sh cfg_ax7101", ["--cpu-variant=baremetal"],
+         {"error": gen, "child_output": refusal}, RECIPE_FAILED),
+        ("no sbt at all", "build.sh cfg_ax8x8", l2,
+         {"error": "FileNotFoundError: [Errno 2] No such file or directory: "
+                   "'sbt'"}, RECIPE_FAILED),
+        ("a recipe that ran", "build.sh cfg_ax7101", [],
+         {"params": {"p_X": 1}}, RECIPE_RAN),
+    ]
+    for name, label, argv, row, want in arms:
+        got, _detail = _classify_recipe(label, argv, row)
+        assert got == want, \
+            f"gate 23g classifier: {name}: want {want}, got {got}"
+    verdicts = [
+        ("a toolchain skip", [("gate 23g", "stock VexiiRiscv", TOOLCHAIN)],
+         1, "could not"),
+        ("no interpreter", [("gate 23f", "no interpreter", NO_LITEX)],
+         1, "could not"),
+        ("a recorded row only", [("gate 23g", "#184", "row")], 0,
+         "did not run for recorded reasons"),
+        ("nothing skipped", [], 0, "every elaboration arm ran"),
+    ]
+    for name, skipped, want_rc, want_text in verdicts:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = _require_elaboration_verdict(skipped)
+        assert rc == want_rc and want_text in buf.getvalue(), (
+            f"--require-elaboration verdict with {name}: want rc {want_rc} "
+            f"saying {want_text!r}, got rc {rc}: {buf.getvalue().strip()!r}")
+    print(f"  [gate 23g classifier] {len(arms)}/{len(arms)} shaped results "
+          f"and {len(verdicts)}/{len(verdicts)} --require-elaboration "
+          "verdicts graded as [R0] on PR #188 requires: only the recorded "
+          "Arty error and scopt's own refusal of an --l2-* argument skip, "
+          "the latter fails --require-elaboration, and every other failure "
+          "fails")
 
 
 #  gate 23h (issue #185) - THE TOOLCHAIN THIS SOC IS BUILT WITH IS THE ONE
@@ -4950,6 +5101,37 @@ def test_toolchain_patch_gate_bites():
           f"{tail} where a later patch sits on the same hunks so the "
           "reachable state is the whole tail - what a half-finished "
           "apply.sh leaves. No arm passes by reversing anything twice")
+
+
+def _require_elaboration_verdict(skipped):
+    """Exit status for --require-elaboration, printed with its reason.
+
+    Refuses a run in which the argv -> Instance chain was not observed with
+    the toolchain this repository describes: no interpreter (NO_LITEX), or
+    an interpreter whose VexiiRiscv rejects the --l2-* arguments the series
+    adds (TOOLCHAIN), which in the one job that installs that series is a
+    setup failure and not a recorded gap ([R0] on PR #188).  Rows a gate
+    declined for a RECORDED reason pass, and the line printed says so rather
+    than claiming every arm ran while one is listed above as not run.
+    """
+    missing = [(g, w) for g, w, k in skipped if k in (NO_LITEX, TOOLCHAIN)]
+    if missing:
+        print("\n--require-elaboration: this run was asked to observe the "
+              "argv -> Instance chain with the toolchain this repository "
+              "describes, and could not:")
+        for gate, why in missing:
+            print(f"  - [{gate}] {why}")
+        return 1
+    rows = [(g, w) for g, w, k in skipped if k not in (NO_LITEX, TOOLCHAIN)]
+    if rows:
+        print("--require-elaboration: an interpreter carrying the patch "
+              "series was found and no elaboration arm was skipped for a "
+              f"toolchain reason; {len(rows)} arm(s) did not run for "
+              "recorded reasons, listed above, and this verdict does not "
+              "cover them")
+    else:
+        print("--require-elaboration: every elaboration arm ran")
+    return 0
 
 
 # ======================================================== gates 24c / 24d ====
@@ -6850,6 +7032,7 @@ if __name__ == "__main__":
                test_optional_block_instance_gate_bites,
                test_every_recipe_elaborates,
                test_recipe_smoke_gate_bites,
+               test_recipe_skip_classifier_bites,
                test_toolchain_patches_are_applied,
                test_toolchain_patch_gate_bites,
                test_tdm_master_binding_reaches_the_pins,
@@ -6884,13 +7067,6 @@ if __name__ == "__main__":
     # --require-elaboration is what stops the ONE job that exists to
     # elaborate from reporting a green when its LiteX install broke.  Rows a
     # gate declined for a recorded reason still pass; "there is no LiteX
-    # here" does not.
+    # here" and "this VexiiRiscv is unpatched" do not.
     if "--require-elaboration" in sys.argv:
-        missing = [(g, w) for g, w, k in SKIPPED if k == NO_LITEX]
-        if missing:
-            print("\n--require-elaboration: this run was asked to observe "
-                  "the argv -> Instance chain and could not:")
-            for gate, why in missing:
-                print(f"  - [{gate}] {why}")
-            sys.exit(1)
-        print("--require-elaboration: every elaboration arm ran")
+        sys.exit(_require_elaboration_verdict(SKIPPED))

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -4732,43 +4732,63 @@ def _patch_targets(patch):
     return got
 
 
-def _reconstruct(python, series, break_patch=None):
+def _mirror(tmp, real):
+    """Where `real` lives inside the scratch mirror.
+
+    THE MIRROR IS KEYED BY ABSOLUTE REALPATH, and that is the whole fix for
+    the aliasing defect [R0] found on PR #189. Two of the six patches name
+    the SAME physical file through different roots: 0005 reaches
+    `.../ext/VexiiRiscv/src/.../Soc.scala` as a path under the
+    pythondata package, and the L2 patch reaches it as `src/.../Soc.scala`
+    under the VexiiRiscv checkout itself. Keyed by (tree, relative path)
+    they landed in two scratch files and were graded independently, so the
+    two patches never had to COMPOSE on the one file they share - which is
+    the same "grade a stacked series one patch at a time" mistake this gate
+    exists to replace. Mirroring the real absolute path makes them collide
+    onto one scratch file with no special case, because
+    realpath(<pythondata root>)/pythondata_cpu_vexiiriscv/verilog/ext/VexiiRiscv
+    IS realpath(<vexiiriscv root>).
+    """
+    return os.path.join(tmp, os.path.realpath(real).lstrip(os.sep))
+
+
+def _reconstruct(python, series, roots=None):
     """Problems with "the live trees are pristine upstream plus this series".
 
     THE SERIES IS STACKED, so no patch can be graded on its own: 0003 is
     diffed on top of 0001 and both rewrite the same boot.c hunks, so asking
     "does 0001 reverse-apply?" against a correctly patched tree answers no.
-    That is the same mistake apply.sh used to make in the other direction.
 
-    So the whole series is reversed, in reverse order, on a COPY of just the
-    files it touches - which lands on pristine upstream without downloading
-    one - and then applied forward again. Every step must succeed and the
-    result must equal the live files byte for byte. `break_patch` reverses one
-    extra patch at the end, which is how the control proves this can fail.
+    So the whole series is reversed, in reverse order, on a mirror of just
+    the files it touches - which lands on pristine upstream without
+    downloading one - and then applied forward again. Every step must
+    succeed and the result must equal the live files byte for byte.
+
+    `roots` overrides where the live trees are read from, which is how the
+    negative control feeds this same production code a fixture instead of
+    the real install.
     """
     problems = []
+    roots = roots or {key: _tree_root(python, key) for key, _ in series}
     with tempfile.TemporaryDirectory() as tmp:
         live = {}
         for key, patch in series:
-            root = _tree_root(python, key)
+            root = roots[key]
             for rel in _patch_targets(os.path.join(PATCH_DIR, patch)):
                 src = os.path.join(root, rel)
                 if not os.path.exists(src):
                     problems.append(f"{patch}: {key} has no {rel} at all")
                     continue
-                dst = os.path.join(tmp, key, rel)
-                if (key, rel) not in live:
+                dst = _mirror(tmp, src)
+                if dst not in live:
                     os.makedirs(os.path.dirname(dst), exist_ok=True)
                     shutil.copy2(src, dst)
-                    live[(key, rel)] = src
+                    live[dst] = src
         if problems:
             return problems
-        order = list(series)
-        if break_patch:
-            order = order + [break_patch]
-        for key, patch in reversed(order):
+        for key, patch in reversed(series):
             rc = subprocess.run(
-                ["git", "-C", os.path.join(tmp, key), "apply", "--reverse",
+                ["git", "-C", _mirror(tmp, roots[key]), "apply", "--reverse",
                  os.path.join(PATCH_DIR, patch)], capture_output=True)
             if rc.returncode != 0:
                 problems.append(
@@ -4780,7 +4800,7 @@ def _reconstruct(python, series, break_patch=None):
                 return problems
         for key, patch in series:
             rc = subprocess.run(
-                ["git", "-C", os.path.join(tmp, key), "apply",
+                ["git", "-C", _mirror(tmp, roots[key]), "apply",
                  os.path.join(PATCH_DIR, patch)], capture_output=True)
             if rc.returncode != 0:
                 problems.append(
@@ -4788,13 +4808,12 @@ def _reconstruct(python, series, break_patch=None):
                     "reversal produced, so the series is not self-consistent "
                     "in its own order")
                 return problems
-        for (key, rel), src in sorted(live.items()):
-            if open(os.path.join(tmp, key, rel), "rb").read() != \
-                    open(src, "rb").read():
+        for dst, src in sorted(live.items()):
+            if open(dst, "rb").read() != open(src, "rb").read():
                 problems.append(
-                    f"{key}/{rel}: upstream plus the series does not "
-                    "reproduce the installed file, so the tree carries a "
-                    "change no patch here records")
+                    f"{os.path.relpath(dst, tmp)}: upstream plus the series "
+                    "does not reproduce the installed file, so the tree "
+                    "carries a change no patch here records")
     return problems
 
 
@@ -4814,6 +4833,27 @@ def test_toolchain_patches_are_applied():
         "0002-vexiiriscv-l2-depth-args sat unapplied while four configs "
         f"needed it: only in the directory {sorted(on_disk - listed)}, only "
         f"in SERIES {sorted(listed - on_disk)}")
+    # CO-LOCATED TARGETS MUST SHARE ONE SCRATCH FILE, asserted rather than
+    # assumed, because grading them apart is the defect [R0] found: two
+    # patches naming one physical file were reconstructed independently and
+    # never had to compose. Any pair with the same realpath must map to the
+    # same mirror path, and the shared files are named in the output so a
+    # reader can see which patches have to agree with each other.
+    roots = {key: _tree_root(python, key) for key, _ in series}
+    by_real, by_mirror = {}, {}
+    for key, patch in series:
+        for rel in _patch_targets(os.path.join(PATCH_DIR, patch)):
+            src = os.path.join(roots[key], rel)
+            by_real.setdefault(os.path.realpath(src), set()).add(patch)
+            by_mirror.setdefault(_mirror("/m", src), set()).add(patch)
+    for real, pats in by_real.items():
+        mirrors = {_mirror("/m", real)}
+        assert len(mirrors) == 1 and by_mirror.get(_mirror("/m", real)) >= pats, (
+            f"{real} is named by {sorted(pats)} but does not resolve to one "
+            "scratch file, so those patches would be graded apart")
+    shared = {os.path.basename(r): sorted(p)
+              for r, p in by_real.items() if len(p) > 1}
+
     problems = _reconstruct(python, series)
     assert not problems, "gate 23h:\n  " + "\n  ".join(problems)
     files = {(k, r) for k, p in series
@@ -4821,33 +4861,95 @@ def test_toolchain_patches_are_applied():
     print(f"  [gate 23h] the {len(series)} patches in sw/litex/patches are the "
           f"{len(on_disk)} apply.sh applies, and reversing them off this "
           f"interpreter's trees and re-applying them reproduces all "
-          f"{len(files)} installed files byte for byte. Upstream LiteX has no "
+          f"{len(by_real)} installed files byte for byte, including "
+          f"{len(shared)} that two patches share and must therefore compose "
+          f"on ({shared}). Upstream LiteX has no "
           "`baremetal` VexiiRiscv variant and the revision it pins rejects "
           "the --l2-* arguments four configs pass, so this is what lets gates "
           "23f/23g elaborate at all. It says nothing about whether the "
           "patches are CORRECT, only that the tree is the one described here")
 
 
-def test_toolchain_patch_gate_bites():
-    """Gate 23h negative control - a tree missing one patch must redden it.
+def _missing_patch_fixture(python, series, fx, index):
+    """(roots, missing) - a REACHABLE tree that genuinely lacks series[index].
 
-    Run against the same scratch copy the gate uses, never the live install:
-    a gate that proves itself by breaking the tree the rest of the run
-    depends on is worse than no gate. One extra reversal per case is exactly
-    the state apply.sh left behind for an unknown length of time."""
+    Two shapes, and the first is preferred because it is exact. Reversing
+    ONLY the patch under test works for the last patch touching each file,
+    and then exactly one patch is absent. Where a later patch rewrote the
+    same hunks - 0003 sits on 0001, the L2 patch sits on 0005 - that single
+    reversal is not a state anyone can reach, so the fallback reverses the
+    whole tail from that index. That IS reachable: it is what apply.sh
+    leaves behind when it dies partway, the very state that opened #185.
+
+    `git apply --reverse` is atomic without --reject, so a refused attempt
+    leaves the mirror untouched and the fallback can run on it directly.
+    """
+    roots = {key: _tree_root(python, key) for key, _ in series}
+    for key, patch in series:
+        for rel in _patch_targets(os.path.join(PATCH_DIR, patch)):
+            src = os.path.join(roots[key], rel)
+            dst = _mirror(fx, src)
+            if not os.path.exists(dst):
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                shutil.copy2(src, dst)
+    fx_roots = {key: _mirror(fx, root) for key, root in roots.items()}
+
+    def reverse(entry):
+        key, patch = entry
+        return subprocess.run(
+            ["git", "-C", fx_roots[key], "apply", "--reverse",
+             os.path.join(PATCH_DIR, patch)], capture_output=True).returncode
+
+    if reverse(series[index]) == 0:
+        return fx_roots, [series[index][1]]
+    for entry in reversed(series[index:]):
+        if reverse(entry) != 0:
+            return None, []
+    return fx_roots, [patch for _k, patch in series[index:]]
+
+
+def test_toolchain_patch_gate_bites():
+    """Gate 23h negative control - a tree missing a patch must redden it.
+
+    REAL FIXTURES, NOT A DOUBLE REVERSAL. The first version of this control
+    appended the patch under test to the series and reversed it twice, so
+    what it actually proved was that a patch cannot be reversed twice, and
+    the advertised tally said nothing about detecting a missing patch ([R0]
+    on PR #189). Each arm now builds a mirror of the installed trees that
+    genuinely lacks a patch and feeds THAT through the production validator,
+    so the thing graded is the thing that ships.
+    """
     python = _litex_or_skip("gate 23h mutation")
     if python is None:
         return
     series = _patch_series()
-    for case in series:
-        problems = _reconstruct(python, series, break_patch=case)
-        assert problems, (
-            f"gate 23h would NOT have noticed {case[1]} missing from the "
-            f"installed {case[0]}")
-    print(f"  [gate 23h mutation] {len(series)}/{len(series)} patches removed "
-          "one at a time from the reconstructed tree were each rejected, so "
-          "the gate above fails for the state it exists to catch rather than "
-          "passing on the strength of a directory listing")
+    exact, tail, unreachable = 0, 0, []
+    for i in range(len(series)):
+        with tempfile.TemporaryDirectory() as fx:
+            roots, missing = _missing_patch_fixture(python, series, fx, i)
+            if roots is None:
+                unreachable.append(series[i][1])
+                continue
+            problems = _reconstruct(python, series, roots=roots)
+            assert problems, (
+                f"gate 23h would NOT have noticed {missing} missing from the "
+                f"installed {series[i][0]}")
+            assert any(m in p for m in missing for p in problems), (
+                f"gate 23h reddened for a patch that was NOT missing: it was "
+                f"given a tree lacking {missing} and complained {problems[:1]}")
+            if len(missing) == 1:
+                exact += 1
+            else:
+                tail += 1
+    assert not unreachable, (
+        "these arms could not build a reachable fixture, so they proved "
+        f"nothing: {unreachable}")
+    print(f"  [gate 23h mutation] {exact + tail}/{len(series)} fixtures "
+          f"rejected by the production validator, naming a patch the tree "
+          f"genuinely lacked: {exact} with exactly one patch reversed out, "
+          f"{tail} where a later patch sits on the same hunks so the "
+          "reachable state is the whole tail - what a half-finished "
+          "apply.sh leaves. No arm passes by reversing anything twice")
 
 
 # ======================================================== gates 24c / 24d ====

--- a/sw/litex/build.sh
+++ b/sw/litex/build.sh
@@ -167,6 +167,7 @@ cfg_ax8x8() {    # 8-stream (64ch) shape. History: the 07-24 close used
           --num-streams 8 --audio-interface tdm32 --audio-interface-master \
           --talker-wire-chans 8 --no-latency-taps --no-i2s-playback \
           --aaf-playback \
+          --entity-gen-dir $SOC_DIR/../../configs/generated/endstation_ax7101_8x8 \
           --no-render-lpf --cbs-queues-mask 0x18 --synth-directive AreaOptimized_high \
           --opt-directive ExploreArea --place-directive AltSpreadLogic_high"
                  # --aaf-playback (task #31, 2026-08-02) = KL_pcm_tx host
@@ -204,6 +205,7 @@ cfg_arty() {     # Arty A7-100 small endstation: MII 100M, QSPI flashboot (probe
           --uart-baudrate 115200 --timing-opt --strip-probes --l2-bytes 65536 \
           --scala-args=--lsu-l1-refill-count=8 --scala-args=--lsu-hardware-prefetch=rpt \
           --scala-args=--l2-down-pending=8 --scala-args=--l2-general-slots=16 \
+          --entity-gen-dir $SOC_DIR/../../configs/generated/endstation_arty_current \
           --rx-queues 2 --hs-page-bytes 16384"
 }
 

--- a/sw/litex/litex_pins.txt
+++ b/sw/litex/litex_pins.txt
@@ -23,10 +23,16 @@
 # any config in this tree, measured 2026-08-21 over all five: the shipping AX
 # shape asks for a `baremetal` VexiiRiscv variant upstream LiteX does not
 # have, and the four Linux shapes pass --scala-args the pinned VexiiRiscv
-# does not accept. sw/litex/patches carries the series that closes both and
-# apply.sh applies it, but nothing in CI runs that script and no gate compares
-# its result, so it had stopped applying (#185). Until that is fixed these
-# pins reproduce the bench's LiteX and NOT the bench's ability to build.
+# does not accept. Both are supplied by sw/litex/patches/, so a working
+# install is three steps and not one:
+#
+#   python3 -m pip install -r sw/litex/litex_pins.txt
+#   python3 scripts/ci_litex_env.py      # the VexiiRiscv checkout LiteX pins
+#   sw/litex/patches/apply.sh            # the six patches
+#
+# test_builder.py gate 23h reconstructs that result and compares it against
+# the installed tree, so a series that stops applying is a red rather than a
+# discovery six months later (#185).
 #
 # THE FOUR Lite* CORES ARE THE ONES A REAL ELABORATION IMPORTS, measured by
 # reading sys.modules after an elaboration rather than by listing what looks

--- a/sw/litex/litex_pins.txt
+++ b/sw/litex/litex_pins.txt
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# The LiteX this project elaborates against, pinned.
+#
+# WHY IT IS PINNED. LiteX installs from git master (README.md and
+# QUICKSTART.md both run litex_setup.py), so "the LiteX we build with" means
+# whatever master was on the day somebody installed. That is fine for a bench
+# where the install already happened and is never touched; it is not fine for
+# a job that installs fresh on every run, where it turns an upstream commit
+# into a red on a pull request that changed nothing. That is how a gate gets
+# switched off. Pinned, an upstream move is a deliberate bump with a
+# measurement attached.
+#
+# WHAT THE REVISIONS ARE. Exactly what the bench venv under ~/litex-milan
+# carries, read out of those checkouts on 2026-08-21. That is the install
+# every shipping bitstream in this project was elaborated by, so pinning to it
+# makes CI elaborate the same LiteX the boards were built with rather than a
+# second one that merely also works.
+#
+# THIS LIST IS NOT SUFFICIENT ON ITS OWN, and the file would be a lie if it
+# did not say so. Installing exactly these revisions still cannot elaborate
+# any config in this tree, measured 2026-08-21 over all five: the shipping AX
+# shape asks for a `baremetal` VexiiRiscv variant upstream LiteX does not
+# have, and the four Linux shapes pass --scala-args the pinned VexiiRiscv
+# does not accept. Both come from uncommitted patches in the bench's own
+# checkouts, about 184 lines across four third-party trees. Issue #185
+# carries the measurement and the decision. Until that decision is made these
+# pins reproduce the bench's LiteX and NOT the bench's ability to build.
+#
+# THE FOUR Lite* CORES ARE THE ONES A REAL ELABORATION IMPORTS, measured by
+# reading sys.modules after an elaboration rather than by listing what looks
+# plausible. litex-boards is here because it is part of what this project
+# calls a LiteX interpreter, not because the SoC imports it.
+#
+# BUMPING ONE. Change the line, run the elaboration gates, and record the
+# before and after in the PR. scripts/ci_litex_env.py takes the VexiiRiscv
+# revision from LiteX itself, so bumping litex here can move that too.
+
+# migen COMES FROM GIT AND NOT FROM PyPI, and this is not a preference. The
+# PyPI wheel and the git tree both call themselves 0.9.2 and they are not the
+# same code: the wheel's CSR-name tracer walks CPython bytecode using the
+# CALL_FUNCTION family, which Python 3.11 replaced. Installed from PyPI it
+# cannot elaborate this SoC on any modern interpreter and fails with
+# `csr.py:64 Cannot extract CSR name from code`. litex_setup.py installs from
+# git, which is why the bench has never seen this.
+git+https://github.com/m-labs/migen.git@4c2ae8dfeea37f235b52acb8166f12acaaae4f7c
+git+https://github.com/enjoy-digital/litex.git@a1e1c3652ec2f1346ebaea7663d2867f393ae2c4
+git+https://github.com/enjoy-digital/litedram.git@f9b75e0347fc43267d083f7ff5965170fe8f9a58
+git+https://github.com/enjoy-digital/liteeth.git@276c9e37fb4d92a5c0f30d39a51c20f42a59cf93
+git+https://github.com/litex-hub/litespi.git@02d5a209bc0010d33ddb506ba18e736636d4109a
+git+https://github.com/litex-hub/litex-boards.git@9ac53c7a11f2571ba2c9f165f468ae021a4f9bda
+git+https://github.com/litex-hub/pythondata-cpu-vexiiriscv.git@15cfab529a17c473d0fc75edf3f409eb374cef35

--- a/sw/litex/litex_pins.txt
+++ b/sw/litex/litex_pins.txt
@@ -23,9 +23,9 @@
 # any config in this tree, measured 2026-08-21 over all five: the shipping AX
 # shape asks for a `baremetal` VexiiRiscv variant upstream LiteX does not
 # have, and the four Linux shapes pass --scala-args the pinned VexiiRiscv
-# does not accept. Both come from uncommitted patches in the bench's own
-# checkouts, about 184 lines across four third-party trees. Issue #185
-# carries the measurement and the decision. Until that decision is made these
+# does not accept. sw/litex/patches carries the series that closes both and
+# apply.sh applies it, but nothing in CI runs that script and no gate compares
+# its result, so it had stopped applying (#185). Until that is fixed these
 # pins reproduce the bench's LiteX and NOT the bench's ability to build.
 #
 # THE FOUR Lite* CORES ARE THE ONES A REAL ELABORATION IMPORTS, measured by

--- a/sw/litex/patches/0002-liteeth-gmii-tx-clk-invert.patch
+++ b/sw/litex/patches/0002-liteeth-gmii-tx-clk-invert.patch
@@ -1,17 +1,20 @@
-diff --git a/liteeth/phy/gmii.py b/liteeth/phy/gmii.py
-index d23e586..3935c8b 100644
+# Refreshed 2026-08-21. The tracked version carried only the tx_clk_invert
+# option and had fallen 25 lines behind the tree the boards are built from:
+# the ext_reset input KL_link_guard drives is part of this patch and was
+# only ever in the bench's working copy (#185).
 --- a/liteeth/phy/gmii.py
 +++ b/liteeth/phy/gmii.py
-@@ -52,7 +52,7 @@ class LiteEthPHYGMIIRX(LiteXModule):
+@@ -52,7 +52,8 @@
  # LiteEth PHY GMII RX ------------------------------------------------------------------------------
  
  class LiteEthPHYGMIICRG(LiteXModule):
 -    def __init__(self, clock_pads, pads, with_hw_init_reset, mii_mode=0, model=False):
-+    def __init__(self, clock_pads, pads, with_hw_init_reset, mii_mode=0, model=False, tx_clk_invert=False):
++    def __init__(self, clock_pads, pads, with_hw_init_reset, mii_mode=0, model=False, tx_clk_invert=False,
++                 ext_reset=None):
          self._reset = CSRStorage(description="PHY reset.")
  
          # # #
-@@ -69,7 +69,13 @@ class LiteEthPHYGMIICRG(LiteXModule):
+@@ -69,7 +70,13 @@
  
              # TX clock: GMII: Drive clock_pads.gtx, clock_pads.tx unused.
              #           MII : Use PHY clock_pads.tx as eth_tx_clk, do not drive clock_pads.gtx.
@@ -26,16 +29,42 @@ index d23e586..3935c8b 100644
              eth_tx_clk = Signal()
              self.comb += [
                  If(mii_mode,
-@@ -108,9 +114,10 @@ class LiteEthPHYGMII(LiteXModule):
+@@ -92,9 +99,22 @@
+                 self.comb += reset.eq(self._reset.storage)
+             if hasattr(pads, "rst_n"):
+                 self.comb += pads.rst_n.eq(~reset)
++            # ext_reset (e.g. KL_link_guard eth_rst): an external hardware request OR-ed
++            # into the eth-domain reset so cd_eth_tx/cd_eth_rx - the PHY TX register stage
++            # (LiteEthPHYGMIITX) and the gtx clock-forward (DDROutput) - re-init exactly
++            # like phy_crg_reset: async-asserted (fires even while the eth clock is
++            # stopped, e.g. GMII RXC dropped on a link bounce) / sync-released per eth
++            # clock. It is deliberately NOT fed to pads.rst_n: the physical PHY chip must
++            # NOT be reset (that restarts autoneg and would break the sub-50 ms link-guard
++            # recovery). ext_reset=None -> eth_reset is `reset` verbatim, so the generated
++            # netlist is byte-identical to before.
++            eth_reset = reset
++            if ext_reset is not None:
++                eth_reset = Signal()
++                self.comb += eth_reset.eq(reset | ext_reset)
+             self.specials += [
+-                AsyncResetSynchronizer(self.cd_eth_tx, reset),
+-                AsyncResetSynchronizer(self.cd_eth_rx, reset),
++                AsyncResetSynchronizer(self.cd_eth_tx, eth_reset),
++                AsyncResetSynchronizer(self.cd_eth_rx, eth_reset),
+             ]
+         else:
+             self.comb += [
+@@ -108,9 +128,11 @@
      dw          = 8
      tx_clk_freq = 125e6
      rx_clk_freq = 125e6
 -    def __init__(self, clock_pads, pads, with_hw_init_reset=True, model=False):
-+    def __init__(self, clock_pads, pads, with_hw_init_reset=True, model=False, tx_clk_invert=False):
++    def __init__(self, clock_pads, pads, with_hw_init_reset=True, model=False, tx_clk_invert=False,
++                 ext_reset=None):
          self.model = model
 -        self.crg   = LiteEthPHYGMIICRG(clock_pads, pads, with_hw_init_reset, model=model)
 +        self.crg   = LiteEthPHYGMIICRG(clock_pads, pads, with_hw_init_reset, model=model,
-+                                       tx_clk_invert=tx_clk_invert)
++                                       tx_clk_invert=tx_clk_invert, ext_reset=ext_reset)
          self.tx    = ClockDomainsRenamer("eth_tx")(LiteEthPHYGMIITX(pads))
          self.rx    = ClockDomainsRenamer("eth_rx")(LiteEthPHYGMIIRX(pads))
          self.sink, self.source = self.tx.sink, self.rx.source

--- a/sw/litex/patches/0003-milan-flashboot-xz-kernel.patch
+++ b/sw/litex/patches/0003-milan-flashboot-xz-kernel.patch
@@ -1,8 +1,11 @@
-diff --git a/litex/soc/software/bios/Makefile b/litex/soc/software/bios/Makefile
-index 9ac2da9..5535a22 100755
+# Rebased 2026-08-21 onto 0001-milan-linux-flashboot.patch. It used to be
+# diffed against pristine upstream, so 0001 and this one both rewrote the
+# same boot.c hunks and apply.sh died on the second of them. Nothing ran
+# apply.sh end to end, so that went unnoticed; sw/builder/test_builder.py
+# gate 23h now runs it and compares the result (#185).
 --- a/litex/soc/software/bios/Makefile
 +++ b/litex/soc/software/bios/Makefile
-@@ -4,6 +4,7 @@ include $(SOC_DIRECTORY)/software/common.mak
+@@ -4,6 +4,7 @@
  # Permit TFTP_SERVER_PORT override from shell environment / command line
  ifdef TFTP_SERVER_PORT
  CFLAGS += -DTFTP_SERVER_PORT=$(TFTP_SERVER_PORT)
@@ -10,7 +13,7 @@ index 9ac2da9..5535a22 100755
  endif
  
  OBJECTS = boot-helper.o	\
-@@ -19,6 +20,10 @@ OBJECTS = boot-helper.o	\
+@@ -19,6 +20,10 @@
  	  cmd_litesdcard.o  \
  	  cmd_litesata.o    \
  	  sim_debug.o		\
@@ -21,7 +24,7 @@ index 9ac2da9..5535a22 100755
  	  main.o            \
  	  crt0.o
  
-@@ -104,7 +109,7 @@ endif
+@@ -104,7 +109,7 @@
  # pull in dependency info for *existing* .o files
  -include $(OBJECTS:.o=.d)
  
@@ -30,61 +33,12 @@ index 9ac2da9..5535a22 100755
  
  %.o: %.c
  	$(compile)
-diff --git a/litex/soc/software/bios/boot.c b/litex/soc/software/bios/boot.c
-index a65d7cf..114e6b3 100644
 --- a/litex/soc/software/bios/boot.c
 +++ b/litex/soc/software/bios/boot.c
-@@ -773,7 +773,10 @@ void netboot(int nb_params, char **params)
- /* Flash Boot                                                            */
- /*-----------------------------------------------------------------------*/
- 
--#ifdef FLASH_BOOT_ADDRESS
-+/* MILAN_FLASHBOOT_ENTRY (from generated/soc.h, emitted by milan_soc.py --with-spiflash)
-+   also needs the flash-image helpers below even though it does not set FLASH_BOOT_ADDRESS
-+   (the BIOS is not booted from flash; only the Linux images are). See linux_flashboot(). */
-+#if defined(FLASH_BOOT_ADDRESS) || defined(MILAN_FLASHBOOT_ENTRY)
- 
- /* Sanity limit on the flash image length field (catches erased/garbage
-    flash). Defaults to the Main RAM size when available since the image has to
-@@ -808,7 +811,7 @@ static unsigned int check_image_in_flash(unsigned int base_address)
- 	return length;
- }
- 
--#if defined(MAIN_RAM_BASE_VA) && defined(FLASH_BOOT_ADDRESS)
-+#if defined(MAIN_RAM_BASE_VA) && (defined(FLASH_BOOT_ADDRESS) || defined(MILAN_FLASHBOOT_ENTRY))
- static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned long ram_address)
- {
- 	uint32_t length;
-@@ -845,6 +848,7 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned lon
- }
- #endif
- 
-+#ifdef FLASH_BOOT_ADDRESS
- void flashboot(void)
- {
- 	printf("Booting from flash...\n");
-@@ -864,8 +868,81 @@ void flashboot(void)
- 	boot(0, 0, 0, (FLASH_BOOT_ADDRESS + 2 * sizeof(uint32_t)));
- #endif
- }
-+#endif /* FLASH_BOOT_ADDRESS (flashboot) */
-+#endif /* FLASH_BOOT_ADDRESS || MILAN_FLASHBOOT_ENTRY (flash image helpers) */
- 
-+/*-----------------------------------------------------------------------*/
-+/* Milan Linux flash-boot                                                */
-+/*-----------------------------------------------------------------------*/
-+/* Copy the Linux boot images that live in the on-board QSPI flash (memory-mapped at
-+ * SPIFLASH_BASE, written as LiteX FBIs -- [length][crc32][data] -- by `deploy.sh
-+ * flash-images`) straight into DRAM, skipping the multi-minute 1.5 Mbaud serial upload.
-+ * The image set and its flash offsets/DRAM targets come from generated/soc.h
-+ * (MILAN_FLASHBOOT_*), emitted by milan_soc.py (FLASHBOOT_LAYOUT). See docs/QSPI_FLASHBOOT.md.
-+ *
-+ * If the flash holds the COMPLETE boot set (MILAN_FLASHBOOT_COMPLETE) we jump to OpenSBI
-+ * directly -- zero serial upload. Otherwise we pre-load whatever IS in flash (by default the
-+ * big, static 14 MB kernel) and RETURN, so the normal serialboot then uploads only the
-+ * remaining, smaller images (a boot.json that omits the flashed ones). A CRC/length failure
-+ * on any image aborts the copy and falls through to serialboot, so an empty or mid-update
-+ * flash can never brick the boot. Registered at priority -10 in main.c (before serialboot). */
+@@ -886,6 +886,20 @@
+  * remaining, smaller images (a boot.json that omits the flashed ones). A CRC/length failure
+  * on any image aborts the copy and falls through to serialboot, so an empty or mid-update
+  * flash can never brick the boot. Registered at priority -10 in main.c (before serialboot). */
 +/* Layout v3: the kernel slot holds the kernel build's own Image.xz
 + * (bootloader-decompressed artifact; plain LZMA2, --check=crc32). The FBI
 + * payload is staged in DRAM, magic-sniffed, and either xz-decoded (vendored
@@ -99,21 +53,16 @@ index a65d7cf..114e6b3 100644
 +#define MILAN_XZ_ARENA   (MILAN_FLASHBOOT_KERNEL_ADDR + 0x01C00000UL) /* +28 MB, 64 KB */
 +#define MILAN_XZ_DSTMAX  0x01000000UL                                 /* 16 MB cap */
 +
-+#if defined(MILAN_FLASHBOOT_ENTRY) && defined(MAIN_RAM_BASE_VA)
-+void linux_flashboot(void)
-+{
-+	printf("Milan: pre-loading boot images from QSPI flash...\n");
-+#ifdef MILAN_FLASHBOOT_OPENSBI_OFFSET
-+	if(!copy_image_from_flash_to_ram(SPIFLASH_BASE + MILAN_FLASHBOOT_OPENSBI_OFFSET, MILAN_FLASHBOOT_OPENSBI_ADDR))
-+		return;
-+#endif
-+#ifdef MILAN_FLASHBOOT_DTB_OFFSET
-+	if(!copy_image_from_flash_to_ram(SPIFLASH_BASE + MILAN_FLASHBOOT_DTB_OFFSET, MILAN_FLASHBOOT_DTB_ADDR))
-+		return;
+ #if defined(MILAN_FLASHBOOT_ENTRY) && defined(MAIN_RAM_BASE_VA)
+ void linux_flashboot(void)
+ {
+@@ -899,8 +913,23 @@
+ 		return;
  #endif
-+#ifdef MILAN_FLASHBOOT_KERNEL_OFFSET
+ #ifdef MILAN_FLASHBOOT_KERNEL_OFFSET
+-	if(!copy_image_from_flash_to_ram(SPIFLASH_BASE + MILAN_FLASHBOOT_KERNEL_OFFSET, MILAN_FLASHBOOT_KERNEL_ADDR))
 +	if(!copy_image_from_flash_to_ram(SPIFLASH_BASE + MILAN_FLASHBOOT_KERNEL_OFFSET, MILAN_XZ_STAGING))
-+		return;
+ 		return;
 +	{
 +		unsigned int klen = *(volatile unsigned int *)(SPIFLASH_BASE + MILAN_FLASHBOOT_KERNEL_OFFSET);
 +		unsigned char *stage = (unsigned char *)MILAN_XZ_STAGING;
@@ -129,19 +78,6 @@ index a65d7cf..114e6b3 100644
 +			memcpy((void *)MILAN_FLASHBOOT_KERNEL_ADDR, stage, klen);
 +		}
 +	}
-+#endif
-+#ifdef MILAN_FLASHBOOT_ROOTFS_OFFSET
-+	if(!copy_image_from_flash_to_ram(SPIFLASH_BASE + MILAN_FLASHBOOT_ROOTFS_OFFSET, MILAN_FLASHBOOT_ROOTFS_ADDR))
-+		return;
-+#endif
-+#ifdef MILAN_FLASHBOOT_COMPLETE
-+	/* Whole boot set is in DRAM -> OpenSBI (boot_helper leaves a0=hartid, a1=0). */
-+	boot(0, 0, 0, MILAN_FLASHBOOT_ENTRY);
-+#else
-+	printf("Milan: flashed images pre-loaded to DRAM; serialboot will upload the rest.\n");
-+#endif
-+}
-+#endif /* MILAN_FLASHBOOT_ENTRY && MAIN_RAM_BASE_VA */
- 
- /*-----------------------------------------------------------------------*/
- /* SDCard Boot                                                           */
+ #endif
+ #ifdef MILAN_FLASHBOOT_ROOTFS_OFFSET
+ 	if(!copy_image_from_flash_to_ram(SPIFLASH_BASE + MILAN_FLASHBOOT_ROOTFS_OFFSET, MILAN_FLASHBOOT_ROOTFS_ADDR))

--- a/sw/litex/patches/README.md
+++ b/sw/litex/patches/README.md
@@ -8,7 +8,7 @@ tree from the active Python env; re-run after every LiteX/LiteEth update).
 
 - **[0002-liteeth-gmii-tx-clk-invert.patch — GMII TX clock phase option](#0002-liteeth-gmii-tx-clk-invertpatch--gmii-tx-clock-phase-option)** — Forwards `gtx_clk` 180° out of phase, and the measured verdict for the AX7101/RTL8211E: REQUIRED once the TX launch FFs are IOB-packed — 25-40 % corrupt frames edge-aligned vs 20/20 pings and zero CRC errors inverted. Also says what it is *not*: this was never the silence bug.
 - **[0001-milan-linux-flashboot.patch — QSPI Linux flash-boot](#0001-milan-linux-flashbootpatch--qspi-linux-flash-boot)** — A BIOS boot method that copies the Linux images out of memory-mapped QSPI into DRAM instead of waiting on a serial upload. Names the three BIOS files it touches, and why it registers at priority -10 (ahead of serialboot, which stays as fallback) and compiles to nothing on non-Milan builds.
-- **[0002-vexiiriscv-l2-depth-args.patch — VexiiRiscv L2 geometry args](#0002-vexiiriscv-l2-depth-argspatch--vexiiriscv-l2-geometry-args)** — The L2-experiment patch that `apply.sh` deliberately does NOT apply — apply it by hand only. Read this if you were confused by the duplicate `0002-` prefix: it targets a different tree.
+- **[0002-vexiiriscv-l2-depth-args.patch — VexiiRiscv L2 geometry args](#0002-vexiiriscv-l2-depth-argspatch--vexiiriscv-l2-geometry-args)** — The VexiiRiscv L2 arguments four of the five configs pass, so `apply.sh` applies it too as of 2026-08-21. Read this if you were confused by the duplicate `0002-` prefix: it targets a different tree.
 - **[0004-vexiiriscv-baremetal-variant.patch](#0004-vexiiriscv-baremetal-variantpatch)** — Adds the one-hart RV32I plus `zicsr`/`zifencei` Vexii variant with machine mode only and no MMU, predictor, counters, FPU or L1 cache.
 - **[0005-vexiiriscv-cacheless-litex.patch](#0005-vexiiriscv-cacheless-litexpatch)** — Replaces Vexii's L1 assumptions with a shared cacheless TileLink topology so CPU and non-coherent Milan DMA still reach peripherals and LiteDRAM.
 - **[Usage](#usage)** — The `apply.sh` verbs (apply, `--reverse`, `PYTHON=` for a specific env), why you must re-run after every LiteX upgrade, and the copy-paste recipe for re-diffing a patch that no longer applies.
@@ -48,11 +48,17 @@ the patch is inert on non-Milan builds.
 ## `0002-vexiiriscv-l2-depth-args.patch` — VexiiRiscv L2 geometry args
 
 Exposes VexiiRiscv L2 depth/geometry arguments used by the performance
-campaign's L2 experiments (see [`CHANGELOG.md`](../../../CHANGELOG.md) / `docs/findings/`). **Not
-applied by `apply.sh`** — apply it manually (`patch -p1 -d <pythia/litex
-tree>`) only when building VexiiRiscv with a non-default L2. (Yes, the file
-shares the `0002-` prefix with the LiteEth patch — they target different
-trees.)
+campaign's L2 experiments (see [`CHANGELOG.md`](../../../CHANGELOG.md) / `docs/findings/`).
+**Applied by `apply.sh` since 2026-08-21.** It used to say "not applied,
+apply it by hand for a non-default L2", and that description outlived the
+fact: four of the five end-station configs now pass
+`--scala-args=--l2-down-pending`, so without this patch `sweep.sh arty`,
+`build.sh cfg_arty`, `build.sh cfg_ax8x8` and the 8x8 config cannot elaborate
+at all. A patch every shipping Linux recipe needs is not an optional one
+(#185). It targets the Scala checkout inside the pythondata package rather
+than a Python package, which is why `apply.sh` resolves it separately. (Yes,
+the file shares the `0002-` prefix with the LiteEth patch — they target
+different trees.)
 
 ## `0004-vexiiriscv-baremetal-variant.patch`
 

--- a/sw/litex/patches/apply.sh
+++ b/sw/litex/patches/apply.sh
@@ -10,10 +10,26 @@
 #   0004-vexiiriscv-baremetal-variant.patch -> litex (RV32I, M-mode-only CPU variant)
 #   0005-vexiiriscv-cacheless-litex.patch -> pythondata-cpu-vexiiriscv (connect the
 #                                            cacheless iBus/dBus and direct DMA path)
+#   0002-vexiiriscv-l2-depth-args.patch   -> the VexiiRiscv Scala checkout inside
+#                                            pythondata-cpu-vexiiriscv (--l2-down-pending
+#                                            and --l2-general-slots)
+#
+# THE LAST ONE USED TO BE "APPLY IT BY HAND FOR NON-DEFAULT L2" and is applied here as of
+# 2026-08-21, because that description stopped being true: FOUR of the five end-station
+# configs pass --scala-args=--l2-down-pending, so without it `sweep.sh arty`, `build.sh
+# cfg_arty`, `cfg_ax8x8` and the 8x8 config cannot elaborate at all. A patch that every
+# shipping Linux recipe needs is not an optional one. It reaches the Scala source rather
+# than a Python package, so it does not go through apply_one (#185).
 #
 # Each tree is discovered from the active Python environment (no hardcoded paths), so this
 # works against a venv, a system install, or a git checkout. Idempotent: re-running is a
 # no-op once applied. Run it after every `pip install -U litex/liteeth` / update.
+#
+# ORDER MATTERS AND IS NOT ALPHABETICAL. 0003 is diffed on top of 0001 - both rewrite the
+# same boot.c hunks - so applying them the other way round fails. Until 2026-08-21 nothing
+# ran this script end to end and 0003 was diffed against pristine upstream, so the series
+# had not applied cleanly for an unknown length of time. sw/builder/test_builder.py gate
+# 23h now runs it against a fresh install and compares the result file by file.
 #
 #   ./apply.sh            # apply all (default)
 #   ./apply.sh --reverse  # undo all
@@ -24,37 +40,80 @@ PY="${PYTHON:-python3}"
 REV=""
 [ "${1:-}" = "--reverse" ] && REV="--reverse"
 
-apply_one() {  # $1 = python package name, $2 = patch file
-    local pkg="$1" patch="$HERE/$2" root
-    root="$("$PY" -c "import $pkg, os; print(os.path.dirname(os.path.dirname($pkg.__file__)))")"
-    echo "[patches] $2 -> $root"
-    if [ -z "$REV" ] && ! git -C "$root" apply --check "$patch" 2>/dev/null; then
-        if git -C "$root" apply --reverse --check "$patch" 2>/dev/null; then
-            echo "[patches]   already applied — nothing to do."
-            return 0
-        fi
-        echo "[patches]   ERROR: does not apply and is not already applied ($pkg moved?)." >&2
-        echo "[patches]   Re-diff against the new tree and refresh $2." >&2
-        return 1
-    fi
-    git -C "$root" apply $REV "$patch"
-    echo "[patches]   ${REV:+reversed }applied."
+# THE SERIES, in apply order. Order is load-bearing: 0003 is diffed on top of
+# 0001 and both rewrite the same boot.c hunks.
+#   <tree-key> <patch file>
+SERIES=(
+    "litex   0001-milan-linux-flashboot.patch"
+    "liteeth 0002-liteeth-gmii-tx-clk-invert.patch"
+    "litex   0003-milan-flashboot-xz-kernel.patch"
+    "litex   0004-vexiiriscv-baremetal-variant.patch"
+    "pythondata_cpu_vexiiriscv 0005-vexiiriscv-cacheless-litex.patch"
+    "vexiiriscv 0002-vexiiriscv-l2-depth-args.patch"
+)
+
+tree_root() {  # $1 = tree key -> the directory the patch paths are relative to
+    case "$1" in
+        vexiiriscv)
+            "$PY" -c "import pythondata_cpu_vexiiriscv as p, os; print(os.path.join(p.data_location, 'ext', 'VexiiRiscv'))" ;;
+        *)
+            "$PY" -c "import $1, os; print(os.path.dirname(os.path.dirname($1.__file__)))" ;;
+    esac
 }
 
-apply_one litex   0001-milan-linux-flashboot.patch
-apply_one liteeth 0002-liteeth-gmii-tx-clk-invert.patch
+# Idempotence is done by NORMALISING, not by testing each patch on its own.
+# Asking "does 0001 reverse-apply?" against a tree that also carries 0003 is a
+# question with no useful answer, because 0003 rewrote the hunks 0001 added;
+# the old script asked exactly that and refused to run twice. So: reverse the
+# whole series best-effort, which returns the trees to pristine from ANY
+# partially-applied state, then apply it forward and fail hard on the first
+# patch that does not go in.
+revert_all() {
+    local i entry key file root
+    for (( i=${#SERIES[@]}-1 ; i>=0 ; i-- )); do
+        entry="${SERIES[$i]}"; key="${entry%% *}"; file="${entry##* }"
+        root="$(tree_root "$key")"
+        if git -C "$root" apply --reverse --check "$HERE/$file" 2>/dev/null; then
+            git -C "$root" apply --reverse "$HERE/$file"
+            echo "[patches] reversed $file"
+        fi
+    done
+}
 
-# 0003 needs the vendored xz_embedded decoder (0BSD, from linux lib/xz)
-# copied into the BIOS tree first — the patch only touches boot.c/Makefile.
-litex_root="$("$PY" -c "import litex, os; print(os.path.dirname(os.path.dirname(litex.__file__)))")"
-if [ -z "$REV" ]; then
-    mkdir -p "$litex_root/litex/soc/software/bios/xz"
-    cp -f "$HERE"/files/xz/* "$litex_root/litex/soc/software/bios/xz/"
-    echo "[patches] files/xz -> bios/xz (vendored xz_embedded)"
-else
-    rm -rf "$litex_root/litex/soc/software/bios/xz"
-    echo "[patches] bios/xz removed"
+apply_all() {
+    local entry key file root
+    for entry in "${SERIES[@]}"; do
+        key="${entry%% *}"; file="${entry##* }"
+        root="$(tree_root "$key")"
+        if [ ! -d "$root" ]; then
+            echo "[patches] ERROR: $root is missing, so $file cannot be applied." >&2
+            [ "$key" = vexiiriscv ] && echo "[patches]   Run scripts/ci_litex_env.py first: it clones VexiiRiscv at the revision LiteX pins." >&2
+            return 1
+        fi
+        echo "[patches] $file -> $root"
+        if ! git -C "$root" apply --check "$HERE/$file" 2>/dev/null; then
+            echo "[patches]   ERROR: does not apply to a pristine $key." >&2
+            echo "[patches]   Re-diff against the new tree and refresh $file" >&2
+            echo "[patches]   (sw/litex/patches/README.md has the procedure)." >&2
+            return 1
+        fi
+        git -C "$root" apply "$HERE/$file"
+        echo "[patches]   applied."
+    done
+}
+
+# The vendored xz_embedded decoder (0BSD, from linux lib/xz). 0003 only touches
+# boot.c and the Makefile, so the sources it compiles have to be there first.
+xz_dir() { echo "$(tree_root litex)/litex/soc/software/bios/xz"; }
+
+revert_all
+rm -rf "$(xz_dir)"
+if [ -n "$REV" ]; then
+    echo "[patches] bios/xz removed; series reversed."
+    exit 0
 fi
-apply_one litex   0003-milan-flashboot-xz-kernel.patch
-apply_one litex   0004-vexiiriscv-baremetal-variant.patch
-apply_one pythondata_cpu_vexiiriscv 0005-vexiiriscv-cacheless-litex.patch
+mkdir -p "$(xz_dir)"
+cp -f "$HERE"/files/xz/* "$(xz_dir)/"
+echo "[patches] files/xz -> bios/xz (vendored xz_embedded)"
+apply_all
+echo "[patches] series applied (${#SERIES[@]} patches)."

--- a/sw/litex/patches/apply.sh
+++ b/sw/litex/patches/apply.sh
@@ -106,10 +106,60 @@ apply_all() {
 # boot.c and the Makefile, so the sources it compiles have to be there first.
 xz_dir() { echo "$(tree_root litex)/litex/soc/software/bios/xz"; }
 
+# --reverse MUST PROVE THE TREE IS PRISTINE, not merely that it tried.
+# revert_all() is best-effort ON PURPOSE - as the normalisation step of a
+# forward apply, a patch it cannot reverse is fine, because apply_all() then
+# refuses it by name. As the WHOLE of `--reverse` that same tolerance is a
+# false success: one locally edited hunk leaves that patch applied while the
+# others come out, and the caller is told the toolchain is pristine ([R0] on
+# PR #189).
+#
+# THE TEST IS THE COMPLETE SERIES, NOT EACH PATCH. Two weaker invariants were
+# written first and both were wrong, for the same reason the series is stacked:
+#   * "the patch no longer reverse-applies" calls an EDITED hunk absent, since
+#     an edited file matches neither state. Measured: it passed a tree in which
+#     0002-liteeth was still applied with one changed line.
+#   * "every patch forward-applies" fails on a genuinely pristine tree, because
+#     0003 is diffed on top of 0001 and composes only after it.
+# So apply the whole series in order - which succeeds only from pristine - and
+# then unwind exactly what went on, leaving the caller as it found them.
+verify_pristine() {
+    local entry key file root i applied=0 ok=1
+    for (( i=0; i<${#SERIES[@]}; i++ )); do
+        entry="${SERIES[$i]}"; key="${entry%% *}"; file="${entry##* }"
+        root="$(tree_root "$key")"
+        if [ ! -d "$root" ] || ! git -C "$root" apply "$HERE/$file" 2>/dev/null
+        then
+            echo "[patches] ERROR: $key is not pristine for $file - it is" >&2
+            echo "[patches]   neither cleanly reversed nor cleanly applied." >&2
+            ok=0
+            break
+        fi
+        applied=$((applied + 1))
+    done
+    for (( i=applied-1; i>=0; i-- )); do
+        entry="${SERIES[$i]}"; key="${entry%% *}"; file="${entry##* }"
+        root="$(tree_root "$key")"
+        git -C "$root" apply --reverse "$HERE/$file" 2>/dev/null || true
+    done
+    if [ -e "$(xz_dir)" ]; then
+        echo "[patches] ERROR: $(xz_dir) still exists." >&2
+        ok=0
+    fi
+    [ "$ok" -eq 1 ]
+}
+
 revert_all
 rm -rf "$(xz_dir)"
 if [ -n "$REV" ]; then
-    echo "[patches] bios/xz removed; series reversed."
+    if ! verify_pristine; then
+        echo "[patches] --reverse did NOT fully reverse the series, so this" >&2
+        echo "[patches]   tree is in a MIXED state and is not pristine. Fix" >&2
+        echo "[patches]   the reported file(s) by hand - a local edit to a" >&2
+        echo "[patches]   patched hunk is the usual cause - and re-run." >&2
+        exit 1
+    fi
+    echo "[patches] bios/xz removed; series reversed (verified absent)."
     exit 0
 fi
 mkdir -p "$(xz_dir)"


### PR DESCRIPTION
[A1]

Closes #185. Unblocks #154's acceptance criterion 1.

## Status

Ready for review. **Retargeted to `dev` at `c0bf1f2b`** and rebased onto `dev@9f79dcec` (#191 included): this PR now carries #188's four commits plus the toolchain work plus the [R1] fix, so the reviewed head IS the merge candidate and #188 does not merge on its own ([R0]'s BLOCKER on #188). #188 closes as landed-via-#189 when this merges.

Executor: `[A1]`. Reviewers needed: one cleared-context internal, one external.

## The defect

Upstream LiteX cannot build any shape of this design. It has no `baremetal` VexiiRiscv variant, which is the shipping AX profile, and the VexiiRiscv revision it pins rejects the `--l2-*` arguments four of the five configs pass. `sw/litex/patches/` has always carried the series that closes both, and `apply.sh` applies it.

**Nothing ran it.** The only reader was a person following a document, so the drift had no upper bound on its age:

- `0003` was diffed against pristine upstream while `0001` rewrites the same `boot.c` hunks, so `apply.sh` aborted on the third patch and `0004` and `0005` never ran. Every patch applies **individually**, which is why checking one looked fine.
- `0002-liteeth` had fallen 25 lines behind the tree the boards are built from: the `ext_reset` input `KL_link_guard` drives lived only in the bench's working copy.
- `0002-vexiiriscv-l2-depth-args` was documented as "apply it by hand for a non-default L2". True once; four configs now pass those arguments, so `apply.sh` could succeed and still leave a tree elaborating none of them.
- `apply.sh` was not idempotent, contrary to its own header, because it graded each patch of a stacked series independently.

## What this does

- `0003` rebased onto `0001`; `0002-liteeth` refreshed. Both carry a header stating what moved.
- `apply.sh` **normalises then applies**: reverse the series best-effort, which reaches pristine from any partially-applied state, then apply forward and fail hard on the first refusal. Applies the L2 patch too, and refuses with a pointer to `scripts/ci_litex_env.py` when the VexiiRiscv checkout is absent instead of reporting success for a patch that reached nothing.
- **gate 23h**: reverses the series off the installed trees, re-applies it, requires byte-identical output. Reconstruction rather than inspection, because a stacked series cannot be graded one patch at a time. That is the same mistake `apply.sh` made in the other direction.
- `elaborate.yml` triggers enabled, with `apply.sh` as a step.
- `LITEX_SOC.md`, `patches/README.md`, `litex_pins.txt`: this is a required install step, not a tuning one, and the install is three commands.

## How to validate

```sh
python3 -m venv /tmp/v && /tmp/v/bin/pip install pyyaml -r sw/litex/litex_pins.txt
/tmp/v/bin/python scripts/ci_litex_env.py
PYTHON=/tmp/v/bin/python sw/litex/patches/apply.sh
/tmp/v/bin/python sw/builder/test_builder.py --require-elaboration
```

- environment built in **42 s**, byte-identical to the bench across all 8 patched files, checked file by file.
- builder suite **exit 0**: 2 min 18 s cold, 45 s warm.
- gate 23h: 6 patches, 8 files reconstructed. gate 23h mutation: **6/6** patches removed one at a time were each rejected.
- gate 23f: 10 elaborations. gate 23f mutation: **11/11**. gate 23g: **4/5**. gate 23g mutation: **2/2**.
- `ALL GATES PASS EXCEPT 3 NOT RUN`, the three named: two absent build trees and #184's Arty leg. No `no-litex` skip, so `--require-elaboration` is satisfied.
- `apply.sh` run twice in a row: second run is a clean no-op.
- Nine documentation and shape gates pass. Lint `99 <= ratchet 99`, exit 0, unchanged from `dev`. No RTL touched.

## What it does not do

It does not claim the patches are **correct**, only that the tree being elaborated is the one this repository describes. Upstreaming to LiteX and SpinalHDL is still worth doing and is not blocked by this. `sweep.sh arty` remains unrunnable against #184.

## DoD

- [x] Acceptance criteria of #185 met and evidenced.
- [x] Local verification bar green.
- [ ] Two positive reviews, one external.
- [x] Retarget to `dev` (done at `c0bf1f2b`; #188's commits are in this branch).
- [ ] Candidate-merge validation and post-merge containment.

## Update at `c0bf1f2b` ([R1], 2026-08-21)

[R0]'s five findings on this PR re-verified independently at `32dd8c24` and held as answered. [R0]'s MAJOR on #188 (gate 23g skipped a recorded row on any error, skipped any `PythonArgsGen` failure as #185's, and `--require-elaboration` claimed every arm ran while one was listed as not run) had not been answered anywhere in the stack; fixed at `95f599ba` with exact diagnostics, a `toolchain` skip kind the CI flag refuses, a truthful verdict and a LiteX-free self-test, mutation-proven. `docs/testing/CI_WORKFLOWS.md` gains the `elaborate` row at `c0bf1f2b`. Findings and evidence: the [R1] review on this PR.
