### PR TITLE
check_results_fresh: cover the fail column in the freshness self-test

### DIFF
--- a/scripts/check_results_fresh.py
+++ b/scripts/check_results_fresh.py
@@ -402,6 +402,20 @@ SELFTEST = [
                      "| everything else | 330 | 0 | 8 |"),
      art(T1).replace("| everything else | 330 | 0 | 9 |",
                      "| everything else | 330 | 0 | 8 |"), UNVERIFIABLE),
+    # ...and fail is the third column, the one with the most consequence: it
+    # reads PASS at the top of an artifact while being red in the middle. The
+    # pass and gap columns each have an arm above; without this one, a mutant
+    # that compares pass+gaps and DROPS fail from the `ss != at` coherence
+    # check leaves the whole self-test green (measured: it is the one survivor
+    # of the second-order battery in #152). Both sides carry the same fail
+    # incoherence - the section rows sum to one fail the headline does not
+    # report - so a pass-only comparison reaches a clean OK over a file that
+    # disagrees with itself about whether anything failed.
+    ("only the fail column disagrees", RAN,
+     art(T1).replace("| everything else | 330 | 0 | 9 |",
+                     "| everything else | 330 | 1 | 9 |"),
+     art(T1).replace("| everything else | 330 | 0 | 9 |",
+                     "| everything else | 330 | 1 | 9 |"), UNVERIFIABLE),
     # THE SCOPING IS THE PROPERTY, so it gets arms of its own. Rows under a
     # different heading are not section rows: drop the heading scoping, or
     # match the heading by prefix instead of exactly, and the row below is


### PR DESCRIPTION
[A1]

## Status

GREEN — `check_results_fresh.py --self-test` is 18/18, and the new arm is proven to kill the target mutant and no existing arm does — `152-fresh-fail-column` -> `dev`. One file, self-test only.

## Linked Issue / roles

Closes #152.

Executor: `[A1]`
Internal cleared-context reviewer: `[R<n>]` — pending
External reviewer: `[R<n>]` — pending

## Description

`scripts/check_results_fresh.py`'s self-test covered the pass and gap columns of the `ss != at` coherence check (headline vs section-row sums) but not the **fail** column. So a mutant that compares pass+gaps and drops fail left the whole self-test green — the one genuine survivor of the #149-review second-order battery, and the literal twin of the defect that round had closed on the pass column in the same edit.

Fail is the column with the most consequence: it reads `PASS` at the top of an artifact while being red in the middle.

The fix is one arm, mirroring `only the gap column disagrees`: both the fresh and committed copies carry a section-row fail that the headline does not report (rows sum to 1 fail, headline says 0), so a pass-only comparison reaches a clean `OK` over a file that disagrees with itself about whether anything failed. The honest gate refuses it `UNVERIFIABLE` and the message names the fail column.

## Authoritative references

- #152 (the reviewer's fixture and scope), the #149 review that raised it
- `scripts/check_results_fresh.py` `verdict()` / `section_sums()` and the existing `only the gap column disagrees` arm it twins

## How to get into the same state

```sh
git fetch origin && git checkout 152-fresh-fail-column
```

## How to validate

```sh
python3 scripts/check_results_fresh.py --self-test    # 18 checks: 18 PASS, 0 FAIL
```

Expected: 18/18. Under a `drop the fail column from ss != at` mutant the self-test goes RED (the new arm catches it); under the three known non-defect mutants (empty table -> (0,0,0), case-insensitive heading, the unreachable `**FAIL**` stamp strip) it stays green, so the arm is not standing in for an existing one.

## Known limitations / out of scope

- One column of one comparison. It does not touch the live campaign path or any other gate.

## Definition of Done

- [x] A fail-column-only disagreement is refused and the message names the fail column.
- [x] The new arm kills the `drop the fail column` mutant and no other (measured: no existing arm is flipped by that mutant; the three non-defect survivors stay survivors).
- [x] Self-test green (18/18); docs gates green.
- [ ] Internal cleared-context review positive
- [ ] External review positive
- [ ] Post-merge containment checked before the Issue moves to Done
