### PR TITLE
lint_rtl: refuse rather than under-count when a resolution submodule tree is absent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,17 @@ Two board rules that go with it:
   pattern). Copy (`cp -r`), never symlink, `third_party/` into a worktree —
   a symlink escapes to the main repo and builds silently stale RTL; then
   delete the copied submodule's `.git` file.
+- **A fresh worktree inherits no submodules, and the honest local bar needs
+  three of them.** `git worktree add` does not initialise submodules, so before
+  any local gate run, in one command:
+  `git submodule update --init third_party/verilog-axis protocol-processor gptp-processor`.
+  These three are what the Verilator suites, the Yosys gate and
+  [`scripts/lint_rtl.py`](scripts/lint_rtl.py) read, and are exactly what CI
+  initialises. Lint now REFUSES (exit 2, not the ratchet-tighten exit 1) rather
+  than under-count when one is absent (#186): a count over an incomplete
+  resolution set drops findings and would invite a tighten to a number the real
+  tree cannot meet. The `external` submodule is SSH-only and no sim, lint or
+  synthesis gate reads it, so it is deliberately NOT in that command.
 - **Commits: one line, no trailers.** The private bench suite is referenced
   only as *the bench suite* (evidence token `BENCH`) in committed text —
   never by any external name.

--- a/scripts/lint_rtl.py
+++ b/scripts/lint_rtl.py
@@ -428,25 +428,50 @@ REQUIRED_TREES = [
 ]
 
 
-def missing_resolution_trees(exists=None):
-    """(label, why) for every resolution tree lint needs that is absent.
+def _tree_has_sources(rel):
+    """True only if the tree exists AND holds source files lint would read.
 
-    The COUNT lint prints depends on every tree here: without one, Verilator
-    cannot bind the modules hdl/ instantiates, the reset/logic cone it needs to
-    SEE a finding is incomplete, and the finding silently disappears. Measured
-    2026-08-21: protocol-processor absent drops two hdl/milan SYNCASYNCNET
-    findings, 99 -> 97, and a fresh `git worktree add` has NO submodules, so a
-    lane running the documented `scripts/lint_rtl.py` there reads a lower count
-    AND is invited to tighten the ratchet to a number the real tree cannot meet
-    (#186). Refusing over an incomplete resolution set is the pp_srcs.py shape:
-    a count that proves nothing must not read as a pass.
+    isdir alone is not enough: a submodule checked out to a pin with an empty
+    `hdl/`, or a partial checkout, passes isdir yet contributes no sources, so
+    the count still drops while the refusal below would not fire. So this walks
+    for a `.sv`/`.v` under the tree (skipping the non-source `doc`/`rom`/`ucode`
+    dirs, as submodule_sources does), and an empty tree is treated as absent
+    ([R0] on PR #198).
+    """
+    root = os.path.join(ROOT, rel)
+    if not os.path.isdir(root):
+        return False
+    for _base, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in ("doc", "rom", "ucode")]
+        if any(f.endswith((".sv", ".v")) for f in files):
+            return True
+    return False
+
+
+def missing_resolution_trees(present=None):
+    """(label, why) for every resolution tree lint needs that is absent or empty.
+
+    The COUNT lint prints depends on every tree here: without its sources
+    Verilator cannot bind the modules hdl/ instantiates, the reset/logic cone
+    it needs to SEE a finding is incomplete, and the finding drops out of the
+    count. Measured 2026-08-21: protocol-processor absent drops two hdl/milan
+    SYNCASYNCNET findings, 99 -> 97. A fresh `git worktree add` has NO
+    submodules, so a lane running the documented `scripts/lint_rtl.py` there
+    reads a lower count AND is invited to tighten the ratchet to a number the
+    real tree cannot meet (#186). Today an absent tree also raises a loud
+    MODMISSING that the elaboration gate turns into an exit-1 (so no lowered
+    budget is written), but that failure re-prints the misleading tighten hint
+    and would not fire for a tree whose absence dropped findings WITHOUT a
+    MODMISSING; refusing up front over an incomplete resolution set is the
+    clean and future-proof answer, the pp_srcs.py shape.
 
     external/ is deliberately NOT here: it is an SSH-only submodule lint never
-    reads. The full local-bar init set is in CONTRIBUTING 2.2. `exists`
-    overrides the directory test so the self-test drives every arm.
+    reads. The full local-bar init set is in CONTRIBUTING 2.2. `present`
+    overrides the presence test so the self-test drives every arm.
     """
-    exists = exists or (lambda rel: os.path.isdir(os.path.join(ROOT, rel)))
-    return [(label, why) for label, rel, why in REQUIRED_TREES if not exists(rel)]
+    present = present or _tree_has_sources
+    return [(label, why) for label, rel, why in REQUIRED_TREES
+            if not present(rel)]
 
 
 INCLUDE_RE = re.compile(r'^\s*`include\s+"([^"]+)"', re.M)
@@ -788,18 +813,40 @@ def self_test(verilator):
     # on any box. End to end it is the negative control in the PR: remove a tree
     # and the gate exits 2, not the ratchet-tighten 1.
     all_absent = {label for label, _ in
-                  missing_resolution_trees(exists=lambda rel: False)}
+                  missing_resolution_trees(present=lambda rel: False)}
     if all_absent != {label for label, _, _ in REQUIRED_TREES}:
         print("  [self-test] resolution-refusal REFUSE   FAILED "
               "(absent trees not all flagged: %s)" % sorted(all_absent))
         rc = 1
-    elif missing_resolution_trees(exists=lambda rel: True):
+    elif missing_resolution_trees(present=lambda rel: True):
         print("  [self-test] resolution-refusal REFUSE   FAILED "
               "(a present tree was flagged absent)")
         rc = 1
     else:
         print("  [self-test] resolution-refusal REFUSE   OK (every absent "
               "resolution tree refuses; none flagged when present)")
+    # A present-but-EMPTY tree must read as absent: isdir True is not enough,
+    # or a submodule pinned to an empty hdl/ under-counts without refusing
+    # ([R0] on PR #198). Proven on real temp dirs, no submodule needed.
+    with tempfile.TemporaryDirectory() as td:
+        empty = os.path.join(td, "empty")
+        sourced = os.path.join(td, "sourced")
+        os.makedirs(empty)
+        os.makedirs(sourced)
+        open(os.path.join(sourced, "m.sv"), "w").write("module m; endmodule\n")
+        saved = ROOT
+        try:
+            globals()["ROOT"] = td
+            bad = _tree_has_sources("empty") or not _tree_has_sources("sourced")
+        finally:
+            globals()["ROOT"] = saved
+        if bad:
+            print("  [self-test] empty-tree-is-absent      FAILED "
+                  "(empty dir passed, or a sourced dir failed)")
+            rc = 1
+        else:
+            print("  [self-test] empty-tree-is-absent      OK (a present but "
+                  "source-empty tree reads as absent)")
     return rc
 
 
@@ -890,12 +937,16 @@ def main():
     if a.pragmas or (a.self_test and not a.check):
         return rc
 
-    # REFUSE before measuring anything if a resolution tree is absent. Both the
-    # sweep below and the budget-lowering path further down would otherwise run
-    # over a tree missing the sources hdl/ instantiates, under-count, and either
-    # invite a ratchet tighten (--check) or quietly WRITE that lower number
-    # (default) - reddening dev for findings that were there all along (#186).
-    # This is exit 2, a setup refusal, deliberately NOT the exit-1 tighten path.
+    # REFUSE before measuring anything if a resolution tree is absent or empty.
+    # The sweep below and the budget-lowering path further down would otherwise
+    # run over a tree missing the sources hdl/ instantiates and under-count,
+    # inviting a ratchet tighten (--check). Today an absent tree also raises a
+    # MODMISSING the elaboration gate turns into an exit-1 before any budget is
+    # written, so the danger is the misleading tighten hint rather than a silent
+    # lower-write - but that backstop does not cover a present-but-empty tree,
+    # nor a future resolution tree whose absence drops findings without a
+    # MODMISSING. A clean up-front refusal covers all of them (#186). This is
+    # exit 2, a setup refusal, deliberately NOT the exit-1 tighten path.
     missing = missing_resolution_trees()
     if missing:
         print("LINT SETUP: REFUSED - a source tree lint reads to resolve hdl/ "

--- a/scripts/lint_rtl.py
+++ b/scripts/lint_rtl.py
@@ -414,6 +414,41 @@ def axis_lib():
     return os.path.relpath(axis, ROOT) if os.path.isdir(axis) else None
 
 
+#: The trees lint reads to RESOLVE the modules hdl/ instantiates, each with the
+#: directory whose absence makes axis_lib()/submodule_sources() skip it. These
+#: are exactly the paths those two functions test, kept in one place so the
+#: refusal below cannot drift from what the sweep actually consumes.
+REQUIRED_TREES = [
+    ("third_party/verilog-axis", "third_party/verilog-axis/rtl",
+     "the Forencich AXIS `-y` resolution root"),
+    ("protocol-processor", "protocol-processor/hdl",
+     "KL_pp_shadow's protocol_processor_top and its reset cone"),
+    ("gptp-processor", "gptp-processor/hdl",
+     "KL_gptp_shadow's KL_gptp_engine"),
+]
+
+
+def missing_resolution_trees(exists=None):
+    """(label, why) for every resolution tree lint needs that is absent.
+
+    The COUNT lint prints depends on every tree here: without one, Verilator
+    cannot bind the modules hdl/ instantiates, the reset/logic cone it needs to
+    SEE a finding is incomplete, and the finding silently disappears. Measured
+    2026-08-21: protocol-processor absent drops two hdl/milan SYNCASYNCNET
+    findings, 99 -> 97, and a fresh `git worktree add` has NO submodules, so a
+    lane running the documented `scripts/lint_rtl.py` there reads a lower count
+    AND is invited to tighten the ratchet to a number the real tree cannot meet
+    (#186). Refusing over an incomplete resolution set is the pp_srcs.py shape:
+    a count that proves nothing must not read as a pass.
+
+    external/ is deliberately NOT here: it is an SSH-only submodule lint never
+    reads. The full local-bar init set is in CONTRIBUTING 2.2. `exists`
+    overrides the directory test so the self-test drives every arm.
+    """
+    exists = exists or (lambda rel: os.path.isdir(os.path.join(ROOT, rel)))
+    return [(label, why) for label, rel, why in REQUIRED_TREES if not exists(rel)]
+
+
 INCLUDE_RE = re.compile(r'^\s*`include\s+"([^"]+)"', re.M)
 
 
@@ -749,6 +784,22 @@ def self_test(verilator):
                 rc = 1
                 for f in found:
                     print("        unexpected: %s" % f.replace("\n", " "))
+    # #186: the resolution-tree refusal, proven on its pure predicate so it runs
+    # on any box. End to end it is the negative control in the PR: remove a tree
+    # and the gate exits 2, not the ratchet-tighten 1.
+    all_absent = {label for label, _ in
+                  missing_resolution_trees(exists=lambda rel: False)}
+    if all_absent != {label for label, _, _ in REQUIRED_TREES}:
+        print("  [self-test] resolution-refusal REFUSE   FAILED "
+              "(absent trees not all flagged: %s)" % sorted(all_absent))
+        rc = 1
+    elif missing_resolution_trees(exists=lambda rel: True):
+        print("  [self-test] resolution-refusal REFUSE   FAILED "
+              "(a present tree was flagged absent)")
+        rc = 1
+    else:
+        print("  [self-test] resolution-refusal REFUSE   OK (every absent "
+              "resolution tree refuses; none flagged when present)")
     return rc
 
 
@@ -838,6 +889,28 @@ def main():
     # is the fast pragma-only mode.
     if a.pragmas or (a.self_test and not a.check):
         return rc
+
+    # REFUSE before measuring anything if a resolution tree is absent. Both the
+    # sweep below and the budget-lowering path further down would otherwise run
+    # over a tree missing the sources hdl/ instantiates, under-count, and either
+    # invite a ratchet tighten (--check) or quietly WRITE that lower number
+    # (default) - reddening dev for findings that were there all along (#186).
+    # This is exit 2, a setup refusal, deliberately NOT the exit-1 tighten path.
+    missing = missing_resolution_trees()
+    if missing:
+        print("LINT SETUP: REFUSED - a source tree lint reads to resolve hdl/ "
+              "is not checked out, so the violation count would be "
+              "under-reported:")
+        for label, why in missing:
+            print("  missing: %-26s (%s)" % (label, why))
+        print("  A fresh `git worktree add` inherits no submodules. Initialise "
+              "them (no network needed for these three):")
+        print("    git submodule update --init %s"
+              % " ".join(label for label, _ in missing))
+        print("  Refused rather than counted: a violation count over an "
+              "incomplete resolution set proves nothing and must not read as a "
+              "pass, nor invite a ratchet tighten - the pp_srcs.py rule.")
+        return 2
 
     decls = declarations()
     gaps = coverage_gaps(decls)


### PR DESCRIPTION
[A1]

## Status

GREEN — the gate refuses (exit 2) rather than under-count when a resolution tree is absent, names it and the fix, does not write a lowered budget, and is unchanged (PASS 99) with all trees present — `186-lint-refuse-missing-tree` -> `dev`. No RTL, no ratchet change.

## Linked Issue / roles

Closes #186.

Executor: `[A1]`. Internal + external reviewers: pending.

## Description

`scripts/lint_rtl.py` reads three submodule trees to RESOLVE the modules `hdl/` instantiates (`third_party/verilog-axis/rtl`, `protocol-processor/hdl`, `gptp-processor/hdl`). `submodule_sources()` and `axis_lib()` each SKIP an absent tree, so Verilator loses the cone it needs to see a finding, the count silently drops, and `--check` then prints `ratchet can be tightened`. A fresh `git worktree add` has no submodules, so a lane running the documented `scripts/lint_rtl.py` there reads the lower count and is invited to lower the ratchet to a number the real tree cannot meet — reddening `dev` for findings that were there all along.

The fix mirrors `pp_srcs.py`'s "refuse the empty list": before the sweep or the budget-lowering write, if any resolution tree is absent the gate REFUSES with exit 2 — deliberately NOT the exit-1 tighten path — naming each missing tree and the one `git submodule update --init` that fixes it.

**One measured correction, the tree wins.** #186's repro attributed the two lost `hdl/milan` SYNCASYNCNET findings to `third_party/verilog-axis`. Measured on current `dev` (`28234802`), it is **protocol-processor** that restores them (99); verilog-axis alone leaves it at 97. The submodule pin moved since the ticket. So the refusal covers every tree lint resolves against, not only the one the ticket named — which is also why the fix is keyed to the exact paths `axis_lib()`/`submodule_sources()` test, in one `REQUIRED_TREES` table.

## Authoritative references

- #186, `scripts/pp_srcs.py` (the "refuse rather than prove nothing" precedent), the memory that a worktree inherits no submodules
- CONTRIBUTING §2.2 (the worktree traps, now carrying the init set), §3 (the ratchet contract this protects)

## How to validate

```sh
python3 scripts/lint_rtl.py --self-test        # includes the resolution-refusal arm
python3 scripts/lint_rtl.py --check            # all trees present: PASS 99, exit 0
# negative control, in a tree with a resolution submodule absent:
mv protocol-processor/hdl /tmp/hide && python3 scripts/lint_rtl.py --check ; echo $?  # REFUSED, exit 2
mv /tmp/hide protocol-processor/hdl
```

Expected: `--self-test` passes with the new `resolution-refusal REFUSE OK` line; all-present is PASS 99 exit 0 (unchanged); an absent tree exits **2** (not 1), naming the tree and the init command; the default (budget-lowering) run refuses too and leaves `scripts/lint.budget` unwritten.

## Known limitations / out of scope

- It refuses on the three trees lint READS; `external` is SSH-only and no sim/lint/synth gate reads it, so it is documented as NOT required rather than checked.
- CI is unaffected: `verilator-lint` (rtl-fast.yml:71) already inits all three before `lint_rtl.py --check`.

## Definition of Done

- [x] Refuses rather than under-counts when a source tree it needs is absent (the pp_srcs.py shape).
- [x] The refusal names the missing tree and the command that fixes it (multi-tree message combines them).
- [x] Negative control proves the refusal fires with a non-zero exit that is NOT the tighten one (exit 2, verified for each tree; the default run also refuses and writes no budget).
- [x] The local-bar init set is written down in one place (CONTRIBUTING §2.2), with `external`'s SSH-only status stated.
- [x] `--self-test`, docs_check, check_doc_paths, gen_toc --check, lint --check --self-test all green; no em dash added.
- [ ] Internal + external review positive; post-merge containment.
