### PR TITLE
syn/yosys: stop ooc.sh leaking ltn_rom.hex, report the error reason, and gate run.sh --list standing alone

### DIFF
--- a/scripts/run_all_suites.sh
+++ b/scripts/run_all_suites.sh
@@ -216,6 +216,19 @@ if ! selftest_out=$(cd "$ROOT" && \
   exit 2
 fi
 
+# Fourth of the family: syn/yosys/check_list_hermetic.sh proves `run.sh --list`
+# needs only itself and scripts/yosys_shards.py - not a submodule, not
+# pp_srcs.py - which is the property the yosys-portability aggregate depends on
+# and the one #190 broke. It builds a submodule-free tree and its own negative
+# control, needs no yosys or sv2v, and is the durable check #191 deferred (#192).
+if ! selftest_out=$(cd "$ROOT" && bash "$ROOT/syn/yosys/check_list_hermetic.sh" 2>&1); then
+  echo "$selftest_out" >&2
+  echo "ABORTING: syn/yosys/check_list_hermetic.sh fails: run.sh --list no" >&2
+  echo "longer stands alone, so the portability aggregate could redden on a" >&2
+  echo "submodule-free checkout again (#190)." >&2
+  exit 2
+fi
+
 mkdir -p "$OUT"
 rm -f "$OUT"/*.log            # a stale log from a previous sweep is not evidence
 

--- a/syn/yosys/check_list_hermetic.sh
+++ b/syn/yosys/check_list_hermetic.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# Prove `syn/yosys/run.sh --list` depends on NOTHING but itself and
+# scripts/yosys_shards.py - not a submodule, not scripts/pp_srcs.py (#190/#192).
+#
+# The `yosys-portability` aggregate job checks out no submodule and calls
+# `run.sh --list` to learn the top NAMES; #190 was that call reaching for the
+# protocol-processor source list it did not need and reddening dev. #191 fixed
+# it, and its DoD deferred a durable check because nothing here could build a
+# submodule-free tree. This is that check: it builds a directory holding only
+# the two files --list may read and confirms it works there, then its own
+# NEGATIVE CONTROL removes yosys_shards.py and requires --list to fail - so a
+# dependency added to the --list path later cannot pass this in silence.
+#
+# Needs bash + python3 only (no yosys, no sv2v, no submodule), so it runs on any
+# box and in CI. Exit 0 = the contract holds, 1 = it was broken.
+set -u
+
+R="$(cd "$(dirname "$0")/../.." && pwd)"
+fail=0
+
+# The real tree's inventory is the reference count. --list needs no submodule,
+# so this must already succeed here.
+if ! real_out="$(bash "$R/syn/yosys/run.sh" --list 2>/dev/null)"; then
+  echo "check_list_hermetic: run.sh --list failed in the real tree - the"
+  echo "  inventory should print without tools or submodules (#191)."
+  exit 1
+fi
+n_real="$(printf '%s\n' "$real_out" | grep -c .)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/syn/yosys" "$tmp/scripts"
+cp "$R/syn/yosys/run.sh" "$tmp/syn/yosys/run.sh"
+cp "$R/scripts/yosys_shards.py" "$tmp/scripts/yosys_shards.py"
+
+# Positive: only those two files present, no submodule dir at all.
+if bare_out="$(bash "$tmp/syn/yosys/run.sh" --list 2>/dev/null)"; then
+  n_bare="$(printf '%s\n' "$bare_out" | grep -c .)"
+  if [ "$n_bare" -eq "$n_real" ]; then
+    echo "check_list_hermetic: PASS positive - --list printed $n_bare top(s)"
+    echo "  from a tree holding only run.sh and scripts/yosys_shards.py"
+  else
+    echo "check_list_hermetic: FAIL - bare --list printed $n_bare top(s), the"
+    echo "  real tree $n_real; the two should agree."
+    fail=1
+  fi
+else
+  echo "check_list_hermetic: FAIL - --list could not run from a tree holding"
+  echo "  only run.sh and scripts/yosys_shards.py, so it depends on more than"
+  echo "  it should (a submodule, or scripts/pp_srcs.py) - the #190 defect."
+  fail=1
+fi
+
+# NEGATIVE CONTROL: remove the one file --list legitimately needs and require
+# a failure. Without this the positive arm could pass over a --list that needs
+# nothing at all - or everything - and this check would prove neither.
+rm -f "$tmp/scripts/yosys_shards.py"
+if bash "$tmp/syn/yosys/run.sh" --list >/dev/null 2>&1; then
+  echo "check_list_hermetic: FAIL negative-control - --list still succeeded"
+  echo "  with scripts/yosys_shards.py removed, so it is not the dependency"
+  echo "  this check claims to pin."
+  fail=1
+else
+  echo "check_list_hermetic: PASS negative-control - --list fails once"
+  echo "  scripts/yosys_shards.py is removed, pinning the dependency set."
+fi
+
+[ "$fail" -eq 0 ] && echo "check_list_hermetic: OK" || echo "check_list_hermetic: FAIL"
+exit "$fail"

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -40,10 +40,12 @@ PP_SRCS="$PP_DERIVED $R/hdl/milan/KL_pp_shadow.sv $R/hdl/milan/KL_pp_maap_shim.s
 # ...and with the processor comes its ROM. protocol_processor_top $readmemh's
 # the ACMP listener transition image by the RELATIVE name "ltn_rom.hex", which
 # yosys resolves against ITS OWN working directory, not against the source
-# file. Generate it where yosys will look (syn/yosys/run.sh does the same, and
-# for the same reason - without it the top dies on a file-open error).
+# file. Generate it into $TMP and run yosys FROM $TMP (below), so a run from the
+# repository root leaves nothing behind - the same fix syn/yosys/run.sh carries
+# (#191): only syn/yosys/*.hex is gitignored, so a stray ltn_rom.hex in the
+# caller's directory is one broad `git add` from being committed (#192).
 if [ -f "$R/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py" ]; then
-  python3 "$R/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py" -o ltn_rom.hex >/dev/null 2>&1 || true
+  python3 "$R/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py" -o "$TMP/ltn_rom.hex" >/dev/null 2>&1 || true
 fi
 
 DP_SRCS="$PP_SRCS $C/ethernet_packet_pkg.sv $C/axi_stream_if.sv $A/axis_fifo.v $A/axis_demux.v $A/axis_arb_mux.v $A/arbiter.v $A/priority_encoder.v $Q/traffic_class_map.sv $Q/traffic_classifier.sv $Q/credit_based_shaper.sv $Q/traffic_shaping_core.sv $Q/traffic_queues.sv $Q/traffic_controller_802_1q.sv $P/timestamp_counter.sv $P/ptp_csr_sync.sv $C/cdc_pulse.sv $C/cdc_handshake.sv $C/axis_mux_rr_2in_1out.sv $P/ptp_ts_core.sv $P/ptp_ts_top.sv $F/tcam.sv $F/rx_mac_filter.sv $C/tx_ifg_gasket.sv $R/hdl/ieee1722/aaf/KL_pcm_lpf.sv $C/KL_link_guard.sv $D/adp_tx_arbiter.sv $E/ethernet_events.sv $E/event_counter.sv $R/hdl/common/csr/milan_csr.sv $R/hdl/ieee1722/aaf/aaf_talker_i2s.sv $R/hdl/ieee1722/aaf/KL_aaf_rx_depacketizer.sv $R/hdl/ieee1722/avtp/avtp_subtype_pkg.sv $R/hdl/ieee1722/avtp/avtp_stream_parser.sv $R/hdl/ieee1722/avtp/KL_stream_table.sv $R/hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv $R/hdl/ieee1722/crf/KL_crf_rx.sv $R/hdl/ieee1722/crf/KL_crf_tx.sv $R/hdl/ieee1722/maap/KL_maap.sv $R/hdl/ieee1722/aaf/KL_i2s_playback.sv $R/hdl/ieee1722/aaf/KL_i2s_feed_mux.sv $R/hdl/ieee1722/aaf/KL_tone_gen.sv $R/hdl/ieee1722/aaf/KL_media_adv.sv $C/cdc_pair_fifo.sv $R/hdl/ieee1722/aaf/KL_pcm_route.sv $R/hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv $R/hdl/ieee1722/aaf/KL_aaf_capture_i2s.sv $R/hdl/ieee1722/aaf/KL_tdm_capture.sv $R/hdl/ieee1722/aaf/KL_aaf_packetizer.sv $R/hdl/ieee1722/crf/KL_mmcm_drp_servo.sv $R/hdl/ieee1722/crf/KL_media_nco.sv $R/hdl/ieee1722/aaf/KL_aaf_latency_taps.sv $R/hdl/ieee1722/aaf/KL_chan_map_capture.sv $R/hdl/ieee1722/aaf/KL_chan_map_render.sv $R/hdl/ieee1722/aaf/KL_pcm_tx.sv $R/hdl/ieee1722/aaf/KL_tdm_render.sv $R/hdl/milan/milan_datapath.sv $R/hdl/ieee1722/aaf/KL_tdm_capture_master.sv $R/hdl/ieee1722/aaf/KL_pair_blend.sv $R/hdl/ieee1722/aaf/KL_pair_zero_fill.sv $R/hdl/ieee1722/avtp/KL_talker_diag_ctx.sv $R/hdl/ieee8021as/ptp_timestamp/KL_ptp_clock_validity.sv"
@@ -105,10 +107,10 @@ for spec in "${tops[@]}"; do
   # produced: docs/design/AREA_BUDGET.md).
   chp=""
   for kv in ${OOC_CHPARAM:-}; do chp="$chp chparam -set ${kv%%=*} ${kv#*=} $top;"; done
-  yosys -p "read_verilog $TMP/$top.ooc.v;$chp synth_xilinx -family xc7 -top $top -flatten; stat; write_json $TMP/$top.ooc.json" \
+  (cd "$TMP" && yosys -p "read_verilog $TMP/$top.ooc.v;$chp synth_xilinx -family xc7 -top $top -flatten; stat; write_json $TMP/$top.ooc.json") \
     > "$TMP/$top.ooc.log" 2>&1
   if [ $? -ne 0 ]; then
-    printf "%-28s yosys FAIL: %s\n" "$top" "$(grep -iE '^ERROR' "$TMP/$top.ooc.log" | head -1)"; continue
+    printf "%-28s yosys FAIL: %s\n" "$top" "$(grep -oiE 'ERROR.*' "$TMP/$top.ooc.log" | head -1)"; continue
   fi
   # count from the final (post-flatten) `stat` block only. yosys prints
   # "<count>   <CELLTYPE>", so the count is $1 and the type is $2.

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -110,7 +110,7 @@ for spec in "${tops[@]}"; do
   (cd "$TMP" && yosys -p "read_verilog $TMP/$top.ooc.v;$chp synth_xilinx -family xc7 -top $top -flatten; stat; write_json $TMP/$top.ooc.json") \
     > "$TMP/$top.ooc.log" 2>&1
   if [ $? -ne 0 ]; then
-    printf "%-28s yosys FAIL: %s\n" "$top" "$(grep -oiE 'ERROR.*' "$TMP/$top.ooc.log" | head -1)"; continue
+    printf "%-28s yosys FAIL: %s\n" "$top" "$(grep -oE 'ERROR:.*' "$TMP/$top.ooc.log" | head -1)"; continue
   fi
   # count from the final (post-flatten) `stat` block only. yosys prints
   # "<count>   <CELLTYPE>", so the count is $1 and the type is $2.

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -307,7 +307,7 @@ for name in "${selected_names[@]}"; do
     # `<file>:<line>: ERROR: ...`, so an anchored `^ERROR` matches nothing and the
     # reason column comes out EMPTY - indistinguishable from an OOM-killed tool
     # (#192). Match ERROR wherever it sits and drop the path:line prefix.
-    reason="$(grep -oiE 'ERROR.*' "$TMP/$top.yos.log" | head -1)"
+    reason="$(grep -oE 'ERROR:.*' "$TMP/$top.yos.log" | head -1)"
     printf "  [FAIL] %-22s yosys: %s\n" "$top" "$reason"
     record_result top "$top" FAIL 1 "$MODE" "${cells:-?}"
     fail=$((fail + 1))

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -303,7 +303,11 @@ for name in "${selected_names[@]}"; do
     record_result top "$top" PASS 1 "$MODE" "${cells:-?}"
     pass=$((pass + 1))
   else
-    reason="$(grep -iE '^ERROR' "$TMP/$top.yos.log" | head -1)"
+    # yosys 0.66 (the version a bench box may run) prints a $readmemh failure as
+    # `<file>:<line>: ERROR: ...`, so an anchored `^ERROR` matches nothing and the
+    # reason column comes out EMPTY - indistinguishable from an OOM-killed tool
+    # (#192). Match ERROR wherever it sits and drop the path:line prefix.
+    reason="$(grep -oiE 'ERROR.*' "$TMP/$top.yos.log" | head -1)"
     printf "  [FAIL] %-22s yosys: %s\n" "$top" "$reason"
     record_result top "$top" FAIL 1 "$MODE" "${cells:-?}"
     fail=$((fail + 1))


### PR DESCRIPTION
[A1]

## Status

GREEN — the three `syn/yosys` follow-ups from #191: `ooc.sh` no longer leaks `ltn_rom.hex`, the error reason is no longer empty, and `run.sh --list` standing alone is now gated — `192-syn-yosys-followups` -> `dev`. No RTL.

## Linked Issue / roles

Closes #192.

Executor: `[A1]`. Internal + external reviewers: pending.

## Description

| item | fix |
|---|---|
| `ooc.sh` leaked `ltn_rom.hex` | it generated the ACMP image with a relative `-o ltn_rom.hex` and ran yosys in the caller's cwd, so a repository-root run left an untracked `ltn_rom.hex` where nothing ignores it (three such images rode into a #191 commit that way). Now generated into `$TMP` with yosys run from `$TMP`, the same shape #191 gave `run.sh`. |
| empty yosys error reason | `run.sh:306` and `ooc.sh:111` extracted the failure reason with `grep -iE '^ERROR'`. Yosys 0.66 (a bench box's version) prints `<file>:<line>: ERROR: ...`, which `^ERROR` never matches, so the reason column came out EMPTY — indistinguishable from an OOM-killed tool, which is exactly how #191's REVIEW READY comment mis-read one. Now `grep -oiE 'ERROR.*'`, which catches both shapes and drops the path prefix. |
| no durable `--list` self-test | new `syn/yosys/check_list_hermetic.sh` builds a tree holding only `run.sh` and `scripts/yosys_shards.py`, proves `--list` prints the full inventory there, and — its own negative control — removes `yosys_shards.py` and requires `--list` to fail. That pins the exact `--list` dependency set (no submodule, no `pp_srcs.py`), which is #190's acceptance-1 as the durable check #191 deferred. Wired into `run_all_suites.sh`. |

## Authoritative references

- #192 (the three items), #190/#191 (the `--list` contract this pins and the `ltn_rom.hex` leak class), the memory that local gates writing into the caller's cwd get swept into commits

## How to validate

```sh
bash syn/yosys/check_list_hermetic.sh                 # PASS positive + negative-control, OK
( cd $(git rev-parse --show-toplevel) && bash syn/yosys/ooc.sh tcam ); git status --porcelain   # no ltn_rom.hex
```

Expected: the hermetic check prints 46 tops from a two-file tree and fails once `yosys_shards.py` is removed; `ooc.sh` from the repo root leaves `git status` clean; a yosys `$readmemh` failure now shows `ERROR: Can not open file ...` in the reason column instead of nothing.

## Known limitations / out of scope

- `ooc.sh` still does not generate `ucode.hex`/`gptp_ucode.hex`, so its `KL_pp_shadow`/`milan_datapath` tops still fail on those images (pre-existing; ooc's whole-design completeness is not this ticket). This PR only stops the `ltn_rom.hex` LEAK and makes that failure legible.

## Definition of Done

- [x] `ooc.sh` from the repository root leaves no `ltn_rom.hex` (proven: a `tcam` run leaves `git status` clean; a `KL_pp_shadow` run now resolves `ltn_rom.hex` from `$TMP` and fails on `ucode.hex` instead).
- [x] The yosys failure reason is non-empty for the `file:line: ERROR:` shape (proven on a real `ucode.hex` open failure and by unit comparison of the two greps).
- [x] `run.sh --list` standing alone is gated with a negative control, wired into `run_all_suites.sh` (proven to abort it when broken).
- [x] docs_check, check_doc_paths green; no em dash added.
- [ ] Internal + external review positive; post-merge containment.
