### PR TITLE
Refuse a field declaring more than one constraint kind (#151)

### DIFF
--- a/tb/verilator/tsn_fuzz/README.md
+++ b/tb/verilator/tsn_fuzz/README.md
@@ -78,7 +78,19 @@ flowchart LR
   field's width and its spec constraint (`value` / `values` / `range` /
   `mask`); `tsn_model.py` turns those into per-field *legal* and *illegal*
   probe sets, plus reproducible constrained-random field sets via
-  `packet_gen --seed`.
+  `packet_gen --seed`. **Exactly one kind per field.** A field declaring two
+  or more (say `value: 3` beside `values: [1, 2, 3]`) is refused, fail-closed,
+  with one message naming the field and every kind it declares. The rule is
+  a single predicate, `tsn_model.kind_conflict()`, and `legal()`, `illegal()`
+  and `fuzz_ptp.grade_tx()` all ask it before they dispatch, so the three
+  readers cannot resolve a combination three ways (#151). Upstream resolves
+  it a fourth way -- `packet_builder.cpp::pickValue` merges `value` into
+  `values` and drops a `mask` or `range` standing beside them -- which is why
+  the combination is refused rather than re-resolved. No model at the pinned
+  tsn-gen rev declares two kinds (0 of 241 constrained fields across the 31
+  model files), so the campaign tallies do not move; `test_grade_tx.py`
+  proves the refusal by mutating the predicate and watching every refusal
+  case go red.
 * **`wire.py` owns the bytes.** It encodes/decodes the REAL 1722.1 layouts —
   the ones the silicon-proven C++ testbenches and the deployed boards use —
   and self-tests against their vectors (`python3 wire.py`).

--- a/tb/verilator/tsn_fuzz/fuzz_ptp.py
+++ b/tb/verilator/tsn_fuzz/fuzz_ptp.py
@@ -261,11 +261,23 @@ class Campaign:
         for name, _bits, con in model.fields:
             if name in skip or name not in got or not con:
                 continue
+            # ONE KIND PER FIELD, and tsn_model decides it, not this grader. A
+            # field declaring two kinds is refused before any dispatch, with
+            # the message legal()/illegal() raise for the same field, so the
+            # three readers cannot resolve a combination three ways (#151).
+            # The producer resolves it a fourth: packet_builder.cpp::pickValue
+            # merges `value` into `values` and drops a `mask` or `range`
+            # standing beside them, while the chain below used to stop at the
+            # first kind it met, so `value: 3` beside `values: [1, 2, 3]`
+            # would have graded a frame carrying 1 RED and blamed the DUT.
+            refused = tsn_model.kind_conflict(name, con)
+            if refused:
+                self.rep.ck("%s.%s declares one constraint kind"
+                            % (label, name), False, refused)
+                continue
             # Dispatch order matches tsn_model.legal()/illegal() exactly:
-            # value, values, range, mask. No field declares two kinds today,
-            # but a grader that resolved a combination differently from the
-            # generator that produced the stimulus would be judging by one
-            # rule what was built by another.
+            # value, values, range, mask. With one kind per field the order
+            # decides nothing; it is kept identical so the three stay diffable.
             if "value" in con:
                 if name in gaps:
                     self.eq_or_gap("%s.%s" % (label, name), got[name],

--- a/tb/verilator/tsn_fuzz/test_grade_tx.py
+++ b/tb/verilator/tsn_fuzz/test_grade_tx.py
@@ -2,11 +2,12 @@
 # SPDX-FileCopyrightText: 2026 Kebag Logic
 # SPDX-License-Identifier: CERN-OHL-W-2.0
 """
-Self-test for the campaign's field grader (`Campaign.grade_tx`).
+Self-test for the campaign's field grader (`Campaign.grade_tx`) and the one
+rule it shares with the probe generator (`tsn_model.kind_conflict`).
 
 This does NOT touch the DUT, Verilator or tsn-gen: it drives grade_tx with
 synthetic one-field models and hand-built frames, so it runs everywhere the
-campaigns themselves skip. That matters, because the defect it guards is
+campaigns themselves skip. That matters, because the defects it guards are
 invisible to the campaigns by construction.
 
 WHAT IT GUARDS. grade_tx dispatches on the constraint kind a tsn-gen model
@@ -16,24 +17,43 @@ no movement in the tally. The check did not exist. That is not hypothetical:
 an Announce `flags` pin was once replaced with `mask: [0x003F]` on the claim
 that the harness would catch a regression, and it would not have.
 
-So the two properties below are the point of this file:
+And before issue #151 the chain took the FIRST kind it met. The generator
+that builds the stimulus does not: upstream merges `value` into `values`,
+prefers that set over `range`, and applies `mask` only to an unconstrained
+draw (packet_builder.cpp::pickValue). A field declaring `value: 3` beside
+`values: [1, 2, 3]` was therefore legal as {1, 2, 3} to the producer and
+"must equal 3" to the grader: a false RED blaming a conformant DUT, the
+moment any model declared two kinds. None does today, so nothing red ever
+pointed at it.
+
+So the properties below are the point of this file:
   1. `mask:` is graded, and it grades what a mask actually asserts.
   2. Any kind grade_tx does NOT know fails CLOSED, naming the field and kind.
-
-A grader that silently ignores what it does not understand cannot be trusted
-to mean anything, so (2) is the durable half: it holds for constraint kinds
-nobody has invented yet, while (1) only covers the one we know about.
+  3. A field declaring MORE THAN ONE kind is REFUSED, fail-closed, with one
+     message naming the field and every kind, by the same predicate in
+     grade_tx, `Message.legal()` and `Message.illegal()`, so the three
+     readers cannot disagree again. Single-kind fields grade as before.
+  4. The refusal cases can fail. The predicate is mutated in place (bypassed,
+     made to name nothing, made to name only one kind) and every refusal
+     case must go red under each mutant while every single-kind case stays
+     green. A test that keeps passing when the thing it guards is removed
+     was never testing it, and (4) is what separates this file's proof from
+     an argument.
 """
 
 import contextlib
 import io
 import os
 import sys
+import tempfile
+
+import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from cosim import Report                                    # noqa: E402
 import fuzz_ptp                                             # noqa: E402
+import tsn_model                                            # noqa: E402
 
 
 class OneFieldModel:
@@ -47,27 +67,53 @@ class OneFieldModel:
         return self._fields
 
 
-def grade(field_bits, constraint, pdu):
-    """Grade one synthetic field and return (npass, nfail, first message).
+def grade_model(model, pdu):
+    """Run grade_tx over `model` and return (npass, nfail, what, detail).
 
-    The inner Report prints a banner and a `[FAIL]` line for every case that
-    is SUPPOSED to fail. Those are this file's expected results, not its
-    verdict, so stdout is swallowed while the grader runs -- otherwise the log
-    reads as a wall of failures and `suite_tally.py` would be scanning our
-    fixtures. Only the per-case verdict below is printed.
+    `what`/`detail` are the first recorded failure, or empty strings. The
+    inner Report prints a banner and a `[FAIL]` line for every case that is
+    SUPPOSED to fail. Those are this file's expected results, not its
+    verdict, so stdout is swallowed while the grader runs -- otherwise the
+    log reads as a wall of failures and `suite_tally.py` would be scanning
+    our fixtures. Only the per-case verdict below is printed.
     """
     with contextlib.redirect_stdout(io.StringIO()):
         rep = Report("grade_tx self-test", verbose=False)
         camp = fuzz_ptp.Campaign.__new__(fuzz_ptp.Campaign)  # no cosim socket
         camp.rep = rep
         frame = bytes(14) + bytes(pdu)      # extract_fields reads from byte 14
-        camp.grade_tx(OneFieldModel([("f", field_bits, constraint)]),
-                      frame, "t")
-    msg = ""
+        camp.grade_tx(model, frame, "t")
+    what = detail = ""
     if rep.failures:
         _sec, what, detail = rep.failures[0]
-        msg = "%s | %s" % (what, detail)
-    return rep.npass, rep.nfail, msg
+    return rep.npass, rep.nfail, what, detail
+
+
+def grade(field_bits, constraint, pdu, field="f"):
+    """Grade one synthetic field; see grade_model for the return shape."""
+    return grade_model(OneFieldModel([(field, field_bits, constraint)]), pdu)
+
+
+def message_model(field, bits, constraint):
+    """A tsn_model.Message holding one synthetic field, built without a YAML.
+
+    The whole surface legal()/illegal() touch is `.vars`; the loader itself
+    is exercised separately by loader_checks().
+    """
+    m = tsn_model.Message.__new__(tsn_model.Message)
+    m.path = "<synthetic>"
+    m.vars = {field: (bits, constraint)}
+    m.order = [field]
+    return m
+
+
+def refusal_of(fn, field):
+    """str() of the ValueError `fn(field)` raises, or None when it does not."""
+    try:
+        fn(field)
+    except ValueError as exc:
+        return str(exc)
+    return None
 
 
 CASES = [
@@ -111,17 +157,9 @@ CASES = [
     ("unknown kind names the KIND itself",
      8, {"regex": ["x"]}, [0x00], 0, 1, "regex"),
 
-    # Dispatch precedence. No field at the pinned rev declares two kinds, so
-    # a reordering of the if/elif chain is otherwise invisible. Pin the order
-    # tsn_model.legal() uses (value, values, range, mask) so the grader and the
-    # generator cannot silently disagree about which constraint governs.
-    ("precedence: value wins over mask",
-     8, {"value": 0x03, "mask": [0x0F]}, [0x01], 0, 1, "exp=3"),
-    ("precedence: values wins over range",
-     8, {"values": [1, 2], "range": [0, 255]}, [9], 0, 1, "legal"),
-    ("precedence: range wins over mask",
-     8, {"range": [1, 9], "mask": [0xFF]}, [200], 0, 1, "in [1,9]"),
-
+    # Every single-kind case, positive and negative: the refusal below must
+    # leave these exactly as they were. They are also the specificity control
+    # for the mutants at the end of the file, which must not move them.
     ("value: matching", 8, {"value": 0x42}, [0x42], 1, 0, ""),
     ("value: mismatching", 8, {"value": 0x42}, [0x43], 0, 1, "got=67"),
     ("range: inside", 8, {"range": [1, 9]}, [5], 1, 0, ""),
@@ -136,33 +174,253 @@ CASES = [
      8, {}, [0xFF], 0, 0, ""),
 ]
 
-# A floor, for the same reason the campaigns carry one: an empty CASES list
-# would print "0 checks: 0 PASS, 0 FAIL" and exit 0, which reads as success.
-MIN_CASES = 22
+#: the field name every refusal case uses, so the message can be required to
+#: carry it. Distinct from the one-letter "f" above: a one-letter needle would
+#: be found inside almost any message, which is no test of naming at all.
+DUAL = "dual_fld"
 
+# A field declaring MORE THAN ONE constraint kind is refused: 0 pass, 1 fail,
+# and the refusal message (the DETAIL, which is the predicate's own words, not
+# the check label that carries the field name anyway) names the field and
+# every kind, as the sorted parenthesised list.
+#
+# Every frame below is LEGAL under the old first-kind-wins dispatch, except the
+# second case, which is the issue's own scenario. That choice is what gives the
+# "refusal bypassed" mutant a clean pass/fail flip to be caught by, instead of
+# two failures that differ only in wording.
+REFUSALS = [
+    # (name, bits, constraint, pdu, needles the DETAIL must contain)
+    ("value+values: frame carries the value (first-kind-wins passed it)",
+     8, {"value": 3, "values": [1, 2, 3]}, [3],
+     (DUAL, "2 constraint kinds", "(value, values)")),
+    ("value+values: frame carries 1, legal upstream (first-kind-wins blamed "
+     "the DUT)",
+     8, {"value": 3, "values": [1, 2, 3]}, [1],
+     (DUAL, "(value, values)")),
+    ("value+range",
+     8, {"value": 5, "range": [1, 9]}, [5], (DUAL, "(range, value)")),
+    ("values+mask",
+     8, {"values": [1, 2], "mask": [0x0F]}, [2], (DUAL, "(mask, values)")),
+    ("value+mask",
+     8, {"value": 3, "mask": [0x0F]}, [3], (DUAL, "(mask, value)")),
+    ("values+range",
+     8, {"values": [1, 2], "range": [0, 255]}, [1], (DUAL, "(range, values)")),
+    ("range+mask",
+     8, {"range": [1, 9], "mask": [0xFF]}, [5], (DUAL, "(mask, range)")),
+    ("three kinds: value+values+range",
+     8, {"value": 3, "values": [1, 2, 3], "range": [0, 9]}, [3],
+     (DUAL, "3 constraint kinds", "(range, value, values)")),
+    ("all four kinds",
+     8, {"value": 3, "values": [1, 2, 3], "range": [0, 9], "mask": [0x0F]},
+     [3], (DUAL, "4 constraint kinds", "(mask, range, value, values)")),
+    # A key outside the grammar beside a known kind. #146's rule could not see
+    # it: `value` dispatched and `regex` was ignored in silence. One kind per
+    # field can, and names the foreign key in the message.
+    ("known kind beside an unknown one: value+regex",
+     8, {"value": 3, "regex": ["x"]}, [3], (DUAL, "(regex, value)")),
+    # A real width, so the refusal is not an 8-bit fixture artefact.
+    ("16b values+mask",
+     16, {"values": [0x803F], "mask": [0x803F]}, [0x80, 0x3F],
+     (DUAL, "(mask, values)")),
+]
+
+# Mutants of the shared predicate. Each is installed in place of
+# tsn_model.kind_conflict and must be DETECTED by every refusal case while
+# leaving every single-kind case untouched. The three are the three ways the
+# refusal could rot: it stops firing, it fires without saying what it refused,
+# or it names the field but not all of the kinds.
+MUTANTS = [
+    ("refusal bypassed: predicate returns None",
+     lambda name, con: None),
+    ("refusal names neither the field nor the kinds",
+     lambda name, con: "refused" if len(con) > 1 else None),
+    ("refusal names the field and only the FIRST kind",
+     lambda name, con: ("field %s declares constraint kinds (%s)"
+                        % (name, sorted(con)[0])) if len(con) > 1 else None),
+]
+
+# A floor, for the same reason the campaigns carry one: an emptied table would
+# print "0 checks: 0 PASS, 0 FAIL" and exit 0, which reads as success. It is
+# the exact tally this file produces today; adding a check raises it.
+MIN_CHECKS = 54
+
+
+def run_case(bits, con, pdu, want_p, want_f, needles, field="f",
+             detail_only=False):
+    """Grade one synthetic field and judge it: (ok, note)."""
+    npass, nfail, what, detail = grade(bits, con, pdu, field)
+    hay = detail if detail_only else "%s | %s" % (what, detail)
+    missing = [n for n in needles if n not in hay]
+    ok = npass == want_p and nfail == want_f and not missing
+    note = " pass=%d/%d fail=%d/%d" % (npass, want_p, nfail, want_f)
+    if needles:
+        note += ("  needles=%r %s"
+                 % (needles, "found" if not missing
+                    else "MISSING %r in %r" % (missing, hay)))
+    return ok, note
+
+
+def case_ok(case):
+    name, bits, con, pdu, want_p, want_f, needle = case
+    return run_case(bits, con, pdu, want_p, want_f,
+                    (needle,) if needle else ())[0]
+
+
+def refusal_ok(case):
+    name, bits, con, pdu, needles = case
+    return run_case(bits, con, pdu, 0, 1, needles, DUAL, detail_only=True)[0]
+
+
+class Tally:
+    def __init__(self):
+        self.total = 0
+        self.bad = 0
+
+    def check(self, name, ok, note=""):
+        self.total += 1
+        if not ok:
+            self.bad += 1
+        print("  [%s] %-62s%s" % ("ok  " if ok else "FAIL", name, note))
+        return ok
+
+
+def parity_checks(t):
+    """(3) legal()/illegal() refuse with the SAME message grade_tx reports.
+
+    One predicate means one message: the detail grade_tx records and the
+    ValueError the two probe generators raise must be equal, case by case.
+    """
+    for name, bits, con, pdu, _needles in REFUSALS:
+        _p, _f, _what, detail = grade(bits, con, pdu, DUAL)
+        m = message_model(DUAL, bits, con)
+        got_legal = refusal_of(m.legal, DUAL)
+        got_illegal = refusal_of(m.illegal, DUAL)
+        ok = bool(detail) and got_legal == detail and got_illegal == detail
+        t.check("same refusal from grade_tx, legal(), illegal(): %s" % name, ok,
+                "" if ok else "  grade_tx=%r legal=%r illegal=%r"
+                % (detail, got_legal, got_illegal))
+
+
+def shared_predicate_checks(t):
+    """(3) all three readers route through tsn_model.kind_conflict.
+
+    Replace the predicate with a sentinel that refuses everything and watch a
+    SINGLE-kind field be refused by all three with the sentinel's words. That
+    proves each reader asks the predicate before it dispatches, for every
+    constrained field, rather than keeping a private copy of the rule (which
+    equal messages alone could not distinguish from one shared rule).
+    """
+    saved = tsn_model.kind_conflict
+    tsn_model.kind_conflict = lambda name, con: "SENTINEL %s" % name
+    try:
+        _p, nfail, _what, detail = grade(8, {"value": 0x42}, [0x42], "solo")
+        t.check("grade_tx asks tsn_model.kind_conflict before it dispatches",
+                nfail == 1 and detail == "SENTINEL solo",
+                "" if detail == "SENTINEL solo" else "  got %r" % detail)
+        m = message_model("solo", 8, {"value": 0x42})
+        got = refusal_of(m.legal, "solo")
+        t.check("legal() asks tsn_model.kind_conflict before it dispatches",
+                got == "SENTINEL solo", "" if got == "SENTINEL solo"
+                else "  got %r" % got)
+        got = refusal_of(m.illegal, "solo")
+        t.check("illegal() asks tsn_model.kind_conflict before it dispatches",
+                got == "SENTINEL solo", "" if got == "SENTINEL solo"
+                else "  got %r" % got)
+    finally:
+        tsn_model.kind_conflict = saved
+
+
+def loader_checks(t):
+    """(3) through the real loader: a YAML model is refused after parsing.
+
+    The synthetic cases hand the predicate a dict. This closes the one way
+    they could be vacuous: a loader that normalised `value` into `values`
+    (upstream's documented reading of `value`) would leave the predicate
+    nothing to refuse, and every case above would still pass. So a model in
+    the real grammar, with a single-kind field beside a dual-kind one, goes
+    through tsn_model.Message(); the first must grade exactly as before and
+    the second must be refused by all three readers.
+    """
+    doc = {
+        "service": "grader_selftest",
+        "vars": [
+            {"var": "solo", "size": 8, "expected": {"value": 3}},
+            {"var": DUAL, "size": 8,
+             "expected": {"value": 3, "values": [1, 2, 3]}},
+        ],
+        "entities": [{"entity": "E", "interfaces": [
+            {"interface": "I", "vars": [{"var_ref": "solo"},
+                                         {"var_ref": DUAL}]}]}],
+    }
+    fd, path = tempfile.mkstemp(suffix=".yaml", prefix="grade_tx_selftest_")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            yaml.safe_dump(doc, fh)
+        m = tsn_model.Message(path)
+        t.check("loaded model: the single-kind field grades legal() as before",
+                m.legal("solo") == [3], "  got %r" % m.legal("solo"))
+        needles = (DUAL, "(value, values)")
+        got = refusal_of(m.legal, DUAL)
+        t.check("loaded model: legal() refuses the dual-kind field by name",
+                got is not None and all(n in got for n in needles),
+                "  got %r" % got)
+        got = refusal_of(m.illegal, DUAL)
+        t.check("loaded model: illegal() refuses the dual-kind field by name",
+                got is not None and all(n in got for n in needles),
+                "  got %r" % got)
+        npass, nfail, what, detail = grade_model(m, [3, 3])
+        ok = (npass, nfail) == (1, 1) and all(n in detail for n in needles)
+        t.check("loaded model: grade_tx grades solo and refuses dual_fld",
+                ok, " pass=%d/1 fail=%d/1 %s" % (npass, nfail, detail))
+    finally:
+        os.unlink(path)
+
+
+def mutation_checks(t):
+    """(4) every mutant of the predicate is caught, and only by the refusals."""
+    for mname, mutant in MUTANTS:
+        saved = tsn_model.kind_conflict
+        tsn_model.kind_conflict = mutant
+        try:
+            survivors = [c[0] for c in REFUSALS if refusal_ok(c)]
+            broken = [c[0] for c in CASES if not case_ok(c)]
+        finally:
+            tsn_model.kind_conflict = saved
+        t.check("mutant '%s' goes red in every refusal case (%d/%d)"
+                % (mname, len(REFUSALS) - len(survivors), len(REFUSALS)),
+                not survivors, "" if not survivors
+                else "  SURVIVED: %r" % survivors)
+        t.check("mutant '%s' leaves every single-kind case green (%d/%d)"
+                % (mname, len(CASES) - len(broken), len(CASES)),
+                not broken, "" if not broken else "  BROKE: %r" % broken)
 
 
 def main():
-    if len(CASES) < MIN_CASES:
-        print("grade_tx self-test: FAIL, only %d cases, expected at least %d"
-              % (len(CASES), MIN_CASES))
-        return 1
-    bad = 0
+    t = Tally()
+    print("[single-kind and unknown-kind fields]")
     for name, bits, con, pdu, want_p, want_f, needle in CASES:
-        npass, nfail, msg = grade(bits, con, pdu)
-        ok = (npass == want_p and nfail == want_f
-              and (not needle or needle in msg))
-        if not ok:
-            bad += 1
-        print("  [%s] %-46s pass=%d/%d fail=%d/%d%s"
-              % ("ok  " if ok else "FAIL", name, npass, want_p, nfail, want_f,
-                 "" if not needle else
-                 ("  needle=%r %s" % (needle, "found" if needle in msg
-                                      else "MISSING in %r" % msg))))
+        ok, note = run_case(bits, con, pdu, want_p, want_f,
+                            (needle,) if needle else ())
+        t.check(name, ok, note)
+    print("[a field declaring more than one kind is refused]")
+    for name, bits, con, pdu, needles in REFUSALS:
+        ok, note = run_case(bits, con, pdu, 0, 1, needles, DUAL,
+                            detail_only=True)
+        t.check(name, ok, note)
+    print("[one predicate for grade_tx, legal() and illegal()]")
+    parity_checks(t)
+    shared_predicate_checks(t)
+    loader_checks(t)
+    print("[the refusal cases can fail: mutants of the predicate]")
+    mutation_checks(t)
 
+    if t.total < MIN_CHECKS:
+        print("grade_tx self-test: FAIL, only %d checks, expected at least %d"
+              % (t.total, MIN_CHECKS))
+        return 1
     print("\ngrade_tx self-test: %d checks: %d PASS, %d FAIL"
-          % (len(CASES), len(CASES) - bad, bad))
-    return 1 if bad else 0
+          % (t.total, t.total - t.bad, t.bad))
+    return 1 if t.bad else 0
 
 
 if __name__ == "__main__":

--- a/tb/verilator/tsn_fuzz/tsn_model.py
+++ b/tb/verilator/tsn_fuzz/tsn_model.py
@@ -5,8 +5,9 @@
 tsn-gen protocol-model access — the field/constraint oracle for the campaign.
 
 tsn-gen carries the SPEC FIELD MODEL of every 1722.1 PDU: each field's bit
-width plus its spec constraint (`expected:` value / values / range / mask).
-This module turns that model into test material:
+width plus its spec constraint (`expected:` value / values / range / mask,
+exactly ONE kind per field -- see `kind_conflict`). This module turns that
+model into test material:
 
   * `Message.fields`          ordered (name, bits, constraint) for a PDU
   * `Message.legal(field)`    spec-LEGAL probe values for one field
@@ -58,6 +59,44 @@ def available():
     return os.path.isfile(PACKET_GEN) and os.access(PACKET_GEN, os.X_OK)
 
 
+#: the constraint kinds the model grammar allows under `expected:`. Upstream
+#: reads exactly these four (tsn-gen parser/src/protocol.cpp) and nothing else.
+CONSTRAINT_KINDS = ("value", "values", "range", "mask")
+
+
+def kind_conflict(name, con):
+    """ONE CONSTRAINT KIND PER FIELD, decided here and nowhere else (#151).
+
+    `con` is a field's `expected:` mapping. Returns None when it declares at
+    most one kind, else the refusal message naming the field and every kind
+    it declares. Every reader that dispatches on the kind -- `legal()`,
+    `illegal()` and fuzz_ptp's `grade_tx()` -- asks this first, so a field
+    carrying two kinds is refused the same way by all three instead of being
+    resolved three ways.
+
+    Why refuse rather than merge: the producer resolves a combination by its
+    own precedence (packet_builder.cpp::pickValue draws from value+values if
+    either is present, else from range, and applies mask only to an
+    unconstrained draw), and every consumer here used to take the first kind
+    the if/elif chain met. Those agree only while no field declares two; the
+    day one did, a frame the generator calls legal would be graded RED and
+    the failure would blame the DUT. There is no meaning for a field carrying
+    two kinds that three components could be trusted to share, so the
+    ambiguity is refused at the source rather than re-resolved.
+
+    Every key of the mapping counts as a declared kind. A key outside the
+    grammar already fails closed in grade_tx when it stands alone (#146);
+    beside a known kind it used to be ignored in silence, and now it is
+    refused by this rule with its name in the message.
+    """
+    kinds = sorted(con)
+    if len(kinds) < 2:
+        return None
+    return ("field %s declares %d constraint kinds (%s); a field takes exactly "
+            "one of %s, so it is refused"
+            % (name, len(kinds), ", ".join(kinds), "/".join(CONSTRAINT_KINDS)))
+
+
 class Message:
     """One PDU's spec field model, loaded from its tsn-gen YAML."""
 
@@ -105,8 +144,15 @@ class Message:
 
     # --------------------------------------------------------------- probes
     def legal(self, name):
-        """Spec-LEGAL probe values for one field (deduped, width-clamped)."""
+        """Spec-LEGAL probe values for one field (deduped, width-clamped).
+
+        Raises ValueError when the field declares more than one constraint
+        kind: `kind_conflict` is the one rule, and this is one of its readers.
+        """
         bits, exp = self.vars[name]
+        refused = kind_conflict(name, exp)
+        if refused:
+            raise ValueError(refused)
         full = (1 << bits) - 1
         out = []
         if "value" in exp:
@@ -126,8 +172,15 @@ class Message:
         return sorted({v & full for v in out})
 
     def illegal(self, name):
-        """Spec-ILLEGAL probe values (empty when the field is unconstrained)."""
+        """Spec-ILLEGAL probe values (empty when the field is unconstrained).
+
+        Raises ValueError on a field declaring more than one kind, exactly as
+        `legal()` does and for the same reason.
+        """
         bits, exp = self.vars[name]
+        refused = kind_conflict(name, exp)
+        if refused:
+            raise ValueError(refused)
         full = (1 << bits) - 1
         out = []
         if "value" in exp:


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, test tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- What changed and why.
- **[Authoritative references](#authoritative-references)** -- Requirements/specification clauses and docs.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout/dependency/environment commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands and expected result.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from CONTRIBUTING.md.

## Status

GREEN locally and hosted at exact head `150dbf4b` -- grader self-test 54/54 (was 22/22); both `tsn_fuzz` campaigns at the CI-pinned tsn-gen `fde65206`: AAF 164 pass / 0 fail / 0 gaps and gPTP 354 pass / 0 fail / 9 gaps, check lists identical before and after; docs, TOC, path, traceability, lint (99 <= 99) and diff gates pass. Hosted `rtl-fast`, `docs`, `elaborate` and the exhaustive `rtl-full` run (all eight shards and both aggregates) are green at this head; the evidence comment carries every count and exit code. Base at review `dev@9951aadb`; live `dev@0404c5b9` (#200 and #187 landed, path-disjoint from these four files). Candidate merge tree `b983439d` (live dev + this head + PR #202) was gated with the full Section 3 bar (finished 07:50 UTC, after the 07:40 UTC merge; the merged dev tree equals the candidate tree); the result is in the validation comment.

`151-refuse-dual-constraint-kinds` -> `dev` at exact head `150dbf4b70535b3696092317533b2206218864df`.

## Linked Issue / roles

Closes #151

Executor: `[A1]`
Internal cleared-context reviewer: `[R1]` POSITIVE at `150dbf4b` (2026-08-22 07:21 UTC)
External reviewer: none; merge authorized by the maintainer on one positive review (2026-08-22)

## Description

The defect (#151): three readers of a model field's `expected:` block dispatched on its constraint kind with first-kind-wins (`tsn_model.legal()`, `tsn_model.illegal()`, `fuzz_ptp.grade_tx()`), while the producer (tsn-gen `packet_builder.cpp::pickValue`) merges `value` into `values`, prefers that set over `range`, and applies `mask` only to an unconstrained draw. A field declaring `value: 3` beside `values: [1, 2, 3]` was legal as {1, 2, 3} to the generator and "must equal 3" to the grader: a false RED blaming a conformant DUT, the moment any model declared two kinds. None does today (measured below), so nothing red pointed at it.

The decision recorded on the ticket is implemented: refuse, do not merge.

| piece | change |
|---|---|
| `tb/verilator/tsn_fuzz/tsn_model.py` | `CONSTRAINT_KINDS` and `kind_conflict(name, con)`: the one rule. Returns None when the `expected:` mapping declares at most one kind, else one message naming the field and every kind it declares (sorted). `legal()` and `illegal()` ask it before they dispatch and raise `ValueError(message)`. |
| `tb/verilator/tsn_fuzz/fuzz_ptp.py` | `grade_tx()` asks `tsn_model.kind_conflict` before any dispatch, records one failing check `<label>.<field> declares one constraint kind` carrying that same message, and skips the field. The dispatch chain below it is unchanged, so single-kind fields grade exactly as before. |
| `tb/verilator/tsn_fuzz/test_grade_tx.py` | 22 -> 54 checks. 11 refusal cases (every pair of kinds, three kinds, all four, a known kind beside a foreign key, a 16-bit width); 11 parity checks that `grade_tx`, `legal()` and `illegal()` produce the same message case by case; 3 sentinel checks (replace the predicate, watch all three readers change) proving one shared predicate rather than three equal copies; 4 checks through the real YAML loader, closing the one way the synthetic cases could be vacuous (a loader that normalised `value` into `values` would leave nothing to refuse); 3 in-file mutants of the predicate (bypassed, names nothing, names only the first kind) that must go red in every refusal case and leave every single-kind case green. The three former "precedence" cases are gone: they pinned first-kind-wins, the contract this PR retires. |
| `tb/verilator/tsn_fuzz/README.md` | the grammar bullet states the one-kind rule, names the predicate, and says why refuse beats merge. |

Every key of the `expected:` mapping counts as a declared kind. The grammar has exactly four (upstream `protocol.cpp` reads `values`, `value`, `range`, `mask` and nothing else); a foreign key standing alone already fails closed (#146), and a foreign key beside a known kind used to be ignored in silence and is now refused by name (`value+regex` is one of the cases).

No RTL change. No campaign check added, renamed or removed: the committed `TEST_RESULTS.md` lists every check by name (#150) and both freshness gates pass at this head.

## Authoritative references

- Issue #151 and the decision recorded in its comments (refuse rather than merge).
- tsn-gen at the CI pin `fde652067d3618f47fba2c2e8eb05f6c9f6fa97f` (`TSN_GEN_REV` in `.github/workflows/rtl.yml`): `parser/src/protocol.cpp` lines 141 to 187 (the four kinds; `value` is pushed into the same `expectedValues` vector as `values`), `traffic-gen/src/packet_builder.cpp::pickValue` lines 44 to 80 (`expectedValues` first, then `range`, `mask` only on an unconstrained draw), `docs/03_protocol_yaml_reference.md` ("`expected.value`: shorthand for a one-element `values`").
- #146 (fail closed on an unknown kind, the shape this rule reuses), #147 (the dispatch-order alignment whose review found #151), #150 (checks recorded by name in `TEST_RESULTS.md`, which is what lets the freshness gate prove no check moved).
- `tb/verilator/tsn_fuzz/README.md`, "How it works".

## How to get into the same state

```sh
git fetch origin 151-refuse-dual-constraint-kinds
git checkout --detach 150dbf4b70535b3696092317533b2206218864df
git submodule update --init protocol-processor gptp-processor external third_party/verilog-axis
# optional, for the two campaigns: tsn-gen at the CI pin, built the way rtl.yml builds it
git clone https://github.com/kebag-logic/tsn-gen.git ~/tsn-gen-pin
git -C ~/tsn-gen-pin checkout fde652067d3618f47fba2c2e8eb05f6c9f6fa97f
git -C ~/tsn-gen-pin submodule update --init --recursive external/rapidyaml
cmake -S ~/tsn-gen-pin -B ~/tsn-gen-pin/build -DCMAKE_BUILD_TYPE=Release -DENABLE_PARSER_TESTS=OFF
cmake --build ~/tsn-gen-pin/build --target packet_gen --parallel
```

## How to validate

```sh
python3 tb/verilator/tsn_fuzz/test_grade_tx.py                   # 54 checks: 54 PASS, 0 FAIL
make -C tb/verilator/tsn_fuzz graderself                          # the same, through the sweep's entry point
TSN_GEN_ROOT=~/tsn-gen-pin make -C tb/verilator/tsn_fuzz aaf      # 164 pass, 0 fail, 0 known gaps; freshness 1 PASS
TSN_GEN_ROOT=~/tsn-gen-pin make -C tb/verilator/tsn_fuzz ptp      # 354 pass, 0 fail, 9 known gaps; freshness 1 PASS
python3 scripts/docs_check.py
python3 scripts/check_doc_paths.py
python3 scripts/gen_toc.py --check
python3 scripts/gen_toc.py --verify-anchors
python3 docs/traceability/gen_module_matrix.py --check
python3 scripts/lint_rtl.py --check
git diff --check origin/dev...HEAD
```

Expected result / pass criteria:

- Self-test 54/54, with the six mutant lines reading `goes red in every refusal case (11/11)` and `leaves every single-kind case green (19/19)`.
- Campaign tallies unchanged from `dev`: AAF 164/0/0, gPTP 354/0/9, each freshness gate `1 checks: 1 PASS, 0 FAIL`. Both campaign logs are line-for-line identical before and after (generation stamps aside).
- The static scan below reports `fields declaring MORE THAN ONE kind: 0` at the pin (measured: 31 model files, 420 vars, 241 with `expected:`, kinds seen exactly `mask`, `range`, `value`, `values`; the 7 802.1AS models alone: 128 vars, 93 constrained, 0 dual).
- The source-level mutation table (the refusal edited out of a scratch copy in 8 ways, the self-test red for every one) is in the evidence comment.

Static scan, run against the pinned clone:

```sh
python3 - ~/tsn-gen-pin/protocols tests/protocols <<'PY'
import collections, glob, os, sys, yaml
hist = collections.Counter(); multi = []; nvars = ncon = 0
files = sorted(f for r in sys.argv[1:] for f in glob.glob(os.path.join(r, "**", "*.yaml"), recursive=True))
for f in files:
    doc = yaml.safe_load(open(f))
    for v in (doc.get("vars", []) or []) if isinstance(doc, dict) else []:
        nvars += 1; exp = v.get("expected")
        if not isinstance(exp, dict): continue
        ncon += 1; keys = tuple(sorted(exp)); hist[keys] += 1
        if len(keys) > 1: multi.append((f, v.get("var"), keys))
print("model files: %d  vars: %d  with expected: %d  kinds seen: %s" % (len(files), nvars, ncon, sorted({k for ks in hist for k in ks})))
print("fields declaring MORE THAN ONE kind: %d %s" % (len(multi), multi))
PY
```

## Known limitations / out of scope

- `fuzz_ptp.py` reads `con["dst_mac"]["value"]` and `con["ethertype"]["value"]` from the Ethernet header model directly (the boot Pdelay_Req DA and EtherType checks). Those are pinned reads of a `value` kind on a model `grade_tx` never grades; they do not dispatch on a kind, so they cannot disagree about precedence, and they are left as they are.
- The refusal is applied where a kind is dispatched, not at model load. A dual-kind field surfaces as a failing check on the first frame graded against it, and as a `ValueError` from `legal()`/`illegal()`, which is where #146's rule lives too. Refusing in `Message.__init__` instead would turn the campaign's `model X loads` check red and then crash `cross_decode` on the missing model, a worse shape for the same verdict.
- The static scan is PR evidence, not a permanent gate: the refusal itself now runs inside the campaign, so a future dual-kind field goes red there, by name.
- The self-test tally moves from 22 to 54 because it is the grader's own test and grew; the campaign tallies do not move.
- No tsn-gen model changed and none needed to: the merge option on the ticket was not taken.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [x] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [x] Candidate merge result is validated per CONTRIBUTING.md
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done

