### PR TITLE
build.sh cfg_ax8x8 and cfg_arty state the RV32 single-hart CPU their configs declare

### DIFF
--- a/docs/integration/BUILDING.md
+++ b/docs/integration/BUILDING.md
@@ -127,7 +127,11 @@ Linux-throughput logic the audio path never touches  -  which removed the
 sys_clk critical path AND freed ~3 pct LUT), `--l2-bytes 16384`, place
 directive AltSpreadLogic_high. Closed 2026-07-24: WNS +0.080, LUT 85.15 pct,
 TNS 0, all seeds close (measured record in the `cfg_ax8x8` comment in
-`build.sh`).
+`build.sh`). The CPU is the RV32 single-hart VexiiRiscv every other artifact
+of this shape describes: since 2026-08-22 (#157) the recipe states
+`--xlen 32 --cpu-count 1`, so the 2026-07-24 figures, measured on the RV64
+core the recipe implied until then, are an upper bound rather than this
+recipe's own.
 
 #### Choosing the Ethernet port (`--eth-port`)
 
@@ -174,6 +178,10 @@ xc7a100t**csg324-1** (SAME die, SLOWER speedgrade  -  expect tighter WNS at
 --flashboot full`; the S25FL128S flashboot increment has landed) and
 `--strip-probes`. Role: AVDECC/Milan interop peer and the 100 Mbit CBS
 test point (`is_1g=0` slope branch); not a throughput peer.
+Its CPU is one RV32 VexiiRiscv hart (`--cpu-count 1 --xlen 32`, stated
+since 2026-08-22, #157, matching `configs/endstation_arty_current.yaml` and
+the `sweep.sh` arty leg). The Arty is a retired DUT, so the recipe is proven
+to elaborate by `sw/builder/test_builder.py` gate 23g rather than built.
 
 ### Adding a configuration
 
@@ -212,17 +220,20 @@ exists so they cannot be forgotten:
 [`sw/litex/sweep.sh`](../../sw/litex/sweep.sh) refuses to launch unless the command line it composed
 equals the end-station config it claims to build. It checks `--num-streams`,
 `--rx-queues` and `--l2-bytes` against `configs/endstation_<shape>.yaml`, and
-`build.sh`'s `cfg_*` recipes against the same configs. Exit non-zero = no
-Vivado runs.
+`build.sh`'s `cfg_*` recipes against the same configs; for those recipes
+`--xlen` and `--cpu-count` must also be stated and equal the config's (since
+2026-08-22, #157: an absent flag inherits `milan_soc.py`'s RV64 default, not
+the builder's RV32). Exit non-zero = no Vivado runs.
 
 Why it exists: this class of bug is only visible on silicon and has now bitten
-three times.
+four times.
 
 | Date | Knob | Symptom |
 |---|---|---|
 | 2026-07-22 | `i_mac_events` | RMON counters fully tested, permanently zero on hardware (tied off in SoC glue) |
 | 2026-07-24 | `--rx-queues` | `sweep.sh` passed `1` for both boards; the deployed Arty gateware has 2. A queue-count change moves every DMA window by `0x74` under an unchanged DTB |
 | 2026-07-26 | `--num-streams` | `sweep.sh` passed **nothing**, so `sweep.sh ax7101` built the default 1x1 datapath while the config, the docs and the build directories all called it 8x8 |
+| 2026-08-22 | `--xlen` / `--cpu-count` | `build.sh cfg_ax8x8` and `cfg_arty` passed no `--xlen`; `milan_soc.py` defaults to 64 where the builder defaults to 32, so both elaborated RV64 under configs, a sweep table and a boot chain that are RV32 single-hart (#157) |
 
 Per board, `sweep.sh` sets the design defaults first and *then* sources
 `configs/generated/sweep_opts_<board>.sh`, so a fragment that predates a knob
@@ -232,7 +243,7 @@ rides as `NS=` (or, for the historical `sweep_opts_arty_4x4.sh`, inline in
 
 ```sh
 python3 scripts/check_sweep_shape.py              # static check, no shell/Vivado
-python3 scripts/check_sweep_shape.py --self-test  # + prove a wrong NS is rejected
+python3 scripts/check_sweep_shape.py --self-test  # + prove a wrong NS, xlen or cpu-count is rejected
 SWEEP_CFG=configs/endstation_arty_4x4.yaml sw/litex/sweep.sh arty 4x4   # non-default shape
 ```
 

--- a/scripts/check_sweep_shape.py
+++ b/scripts/check_sweep_shape.py
@@ -14,6 +14,10 @@ invisible until silicon:
   * 2026-07-26 (this gate): sweep.sh passed NO `--num-streams` AT ALL, so
     `sweep.sh ax7101` built the DEFAULT 1x1 datapath while the config, the docs
     and the build directories all called it 8x8.
+  * 2026-08-22 (#157): build.sh's Linux recipes passed NO `--xlen` AT ALL,
+    and milan_soc.py defaults it to 64 where the builder defaults it to 32,
+    so `build.sh cfg_ax8x8` and `cfg_arty` elaborated an RV64 core under
+    configs, a sweep table and a boot chain that are all RV32 single-hart.
 
 Same shape both times: a build knob that lives in the declarative end-station
 config, is NOT carried by the script that builds, and silently defaults.  This
@@ -67,6 +71,20 @@ PINNED = {
     # at 16384. Keep this dict as the place to record a DELIBERATE, dated
     # divergence rather than letting one go untracked.
 }
+
+# CPU WIDTH AND HART COUNT (2026-08-22, #157). The two entry points default
+# this one decision opposite ways: milan_soc.py --xlen defaults to 64, and
+# only its baremetal profile refuses anything else, while the builder's
+# SOC_DEFAULTS says 32 and one hart. A build.sh recipe that omitted --xlen
+# therefore elaborated an RV64 core under an RV32 config and an RV32 boot
+# chain, and the symptom of that is a board that prints a BIOS banner and
+# hangs at Liftoff with nothing naming the cause (8b5d0255, 2026-08-05). So
+# for these two flags an ABSENT flag is drift, not a default: the recipe must
+# state the value and it must equal what emit_soc_argv derives for the
+# config. Flag -> the key the drift report (and a PINNED entry) uses.
+# Deliberately NOT the whole flag-for-flag comparison the sweep.sh branch
+# makes: that widening, and the eight other divergences it surfaces, is #155.
+CPU_FLAGS = {"--xlen": "xlen", "--cpu-count": "cpu_count"}
 
 
 def _yaml():
@@ -244,9 +262,11 @@ def parse_build_sh(path=BUILD):
     return out
 
 
-def check_build_sh(path=BUILD):
+def check_build_sh(path=BUILD, quiet=False):
     """build.sh recipe vs the end-station config it builds. Divergences listed
-    in PINNED are accepted (and re-verified); anything else is drift."""
+    in PINNED are accepted (and re-verified); anything else is drift. `quiet`
+    drops the per-key agreement lines (the self-test's mutated copies have
+    nothing worth printing on the keys they left alone)."""
     recipes = parse_build_sh(path)
     bad = []
     for name, cfg_path in sorted(BUILD_CFGS.items()):
@@ -261,6 +281,14 @@ def check_build_sh(path=BUILD):
                "render_lpf":  "--no-render-lpf" not in f}
         want = {"num_streams": c_ns, "rx_queues": c_rxq, "l2_bytes": c_l2,
                 "render_lpf": c_lpf}
+        # The CPU keys: the config side is what the builder EMITS for this
+        # config, never a value restated here, and the recipe side is the
+        # token as written - "(absent)" when it is not, which equals no
+        # emitted value, so an omission is reported as the drift it is.
+        implied = parse_flags(design_opts_expected(cfg_path))
+        for flag, k in CPU_FLAGS.items():
+            got[k] = f.get(flag, "(absent)")
+            want[k] = implied.get(flag, "(absent)")
         for k in sorted(got):
             pin = PINNED.get(("build.sh", name, k))
             if pin is not None:
@@ -276,12 +304,57 @@ def check_build_sh(path=BUILD):
             elif got[k] != want[k]:
                 msg = (f"cfg_{name}: {k} {got[k]} != "
                        f"{os.path.basename(cfg_path)} {want[k]}")
+                if k in CPU_FLAGS.values():
+                    msg += (" - a CPU key must be STATED and equal: absent, "
+                            "the flag inherits milan_soc.py's default, which "
+                            "is not the builder's (#157)")
                 print("SHAPE DRIFT: " + msg, file=sys.stderr)
                 bad.append(msg)
-            else:
+            elif not quiet:
                 print(f"  [sweep-shape] build.sh cfg_{name}: {k} {got[k]} "
                       f"== {os.path.basename(cfg_path)}")
     return bad
+
+
+def self_test_build_sh(path=BUILD):
+    """Negative controls for the build.sh CPU keys (#157).
+
+    Two mutated copies of build.sh: the REAL defect replayed - every
+    `--xlen N` and `--cpu-count N` stripped, so each recipe would inherit
+    milan_soc.py's defaults - and its value-swapped cousin (xlen flipped
+    between 32 and 64, one more hart). Each must be rejected on BOTH CPU keys
+    of BOTH recipes, or a key is vacuous. Returns the (mutation, cfg, key)
+    triples the gate FAILED to reject; empty means every key bit."""
+    txt = open(path).read()
+    mutations = {
+        "absent": re.sub(r"--(?:xlen|cpu-count) \d+ ?", "", txt),
+        "swapped": re.sub(
+            r"--cpu-count (\d+)",
+            lambda m: f"--cpu-count {int(m.group(1)) + 1}",
+            re.sub(r"--xlen (\d+)",
+                   lambda m: f"--xlen {32 if m.group(1) == '64' else 64}",
+                   txt)),
+    }
+    missed = []
+    for label, mut in mutations.items():
+        if mut == txt:
+            sys.exit("self-test: could not mutate the CPU flags in build.sh "
+                     f"({label})")
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as f:
+            f.write(mut)
+            tmp = f.name
+        try:
+            print(f"  [self-test] build.sh --xlen/--cpu-count {label} - "
+                  "expecting REJECT on both keys of every recipe:")
+            bad = check_build_sh(tmp, quiet=True)
+        finally:
+            os.unlink(tmp)
+        for name in BUILD_CFGS:
+            for k in CPU_FLAGS.values():
+                if not any(re.match(rf"cfg_{name}: (PINNED divergence on )?{k} ",
+                                    b) for b in bad):
+                    missed.append((label, name, k))
+    return missed
 
 
 def run_static(sweep_path=SWEEP, quiet=False):
@@ -367,6 +440,14 @@ def main():
             return 2
         print(f"  [self-test] OK: {len(bad_mut)} drift(s) reported for the "
               "mutated sweep.sh")
+        missed = self_test_build_sh()
+        if missed:
+            print("self-test FAILED: build.sh CPU-flag mutations accepted on "
+                  + ", ".join(f"{m}/cfg_{n}/{k}" for m, n, k in missed),
+                  file=sys.stderr)
+            return 2
+        print("  [self-test] OK: xlen and cpu_count rejected on "
+              f"{len(BUILD_CFGS)} build.sh recipes, absent and swapped")
     return 0
 
 

--- a/sw/litex/build.sh
+++ b/sw/litex/build.sh
@@ -158,7 +158,15 @@ cfg_ax8x8() {    # 8-stream (64ch) shape. History: the 07-24 close used
                  # a dedicated sweep read port in the then-current ACMP listener
                  # context (deleted 2026-08-13 with the legacy plane). Result
                  # 2026-07-24: WNS +0.080, LUT 85.15%, TNS 0 (all seeds close).
-    echo "--board ax7101 --cpu vexiiriscv --cpu-count 1 --software-profile linux \
+    # 2026-08-22 (#157): --xlen 32 is STATED. This recipe carried no --xlen
+    # from its creation (8a98d265, 07-24) and milan_soc.py defaults to 64, so
+    # it implied an RV64 core while the 8x8 config, SOC_DEFAULTS, sweep.sh and
+    # the deployed 0x00010022 gateware (x32f1_eto, a sweep build: this recipe
+    # has never produced a bitstream) are all RV32 single-hart. An RV64 SoC
+    # under the RV32 boot chain hangs at Liftoff with nothing naming the
+    # cause (8b5d0255). The 07-24 close above was measured on that RV64 core,
+    # so it is an upper bound for this recipe, not its figure.
+    echo "--board ax7101 --cpu vexiiriscv --cpu-count 1 --xlen 32 --software-profile linux \
           --all-blocks --coherent-dma --sound-card \
           --milan-clk-freq 100e6 --with-spiflash --flashboot full --gtx-tx-invert \
           --timing-opt --floorplan --l2-bytes 16384 \
@@ -199,7 +207,15 @@ cfg_arty() {     # Arty A7-100 small endstation: MII 100M, QSPI flashboot (probe
     # Flash = bitstream@0 + the full-manifest Linux images (QSPI self-boot on
     # both boards; the old kernel-at-0 / JTAG-SRAM-only layout died with the
     # manifest-full port - see board_facts above + docs/integration/QSPI_FLASHBOOT.md).
-    echo "--board arty --cpu vexiiriscv --cpu-count 2 --software-profile linux \
+    # 2026-08-22 (#157): --cpu-count 1 --xlen 32 are STATED, matching
+    # configs/endstation_arty_current.yaml, the sweep.sh arty leg and
+    # configs/generated/sweep_opts_arty.sh. The 2-hart count dated from the
+    # launcher's first commit (207192cc) and never matched a deployed Arty
+    # bitstream (the m0019 ship was one hart); the absent --xlen implied RV64
+    # through milan_soc.py's default. The Arty is a retired DUT
+    # (docs/findings/BENCH_TOPOLOGY.md), so this recipe is proven to reach
+    # the Instance (test_builder gate 23g), not built.
+    echo "--board arty --cpu vexiiriscv --cpu-count 1 --xlen 32 --software-profile linux \
           --all-blocks --coherent-dma --sound-card \
           --sys-clk-freq 83.333e6 --milan-clk-freq 50e6 --with-spiflash --flashboot full \
           --uart-baudrate 115200 --timing-opt --strip-probes --l2-bytes 65536 \


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, test tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- What changed and why.
- **[Authoritative references](#authoritative-references)** -- Requirements/specification clauses and docs.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout/dependency/environment commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands and expected result.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from CONTRIBUTING.md.

## Status

GREEN locally and hosted at exact head `f98ab407`: shape gate agrees on 6 keys x 2 recipes and its self-test rejects 12/12 mutations; the builder suite reports `ALL GATES PASS` with gate 23g reaching `Instance("milan_datapath")` for the corrected `build.sh cfg_ax8x8` and `cfg_arty` (4/5 shipped recipes at the branch head, where the fifth row was #184's recorded `sweep.sh arty`; 5/5 on the candidate now that PR #200 is merged); docs, TOC, doc-path, lint ratchet (99 <= 99) and `git diff --check` pass. No RTL changed. Hosted `rtl-fast`, `docs`, `elaborate` (real recipe elaboration) and both exhaustive `rtl-full` runs are green at this head. Base at review `dev@9951aadb`; live `dev@0404c5b9` (#200 and #187 landed; the only overlap is BUILDING.md prose, merged clean). Candidate merge tree `b983439d` (live dev + PR #201 + this head) was gated with the full Section 3 bar (finished 07:50 UTC, after the 07:40 UTC merge; the merged dev tree equals the candidate tree); the result is in the validation comment.

`157-build-sh-xlen` -> `dev` at exact head `f98ab40785f96521fb730c464e1784b430ef4a63`.

## Linked Issue / roles

Closes #157

Relates to #155 (the other eight recipe/config divergences stay there), #156 (gate 23g is what proves the corrected recipes run) and #184 / PR #200 (the Arty sweep leg).

Executor: `[A1]`
Internal cleared-context reviewer: `[R1]` POSITIVE at `f98ab407` (2026-08-22 07:21 UTC); its MINOR on the pre-existing 8x8 provenance comment in `scripts/check_sweep_shape.py` is a follow-up (see the merge comment)
External reviewer: none; merge authorized by the maintainer on one positive review (2026-08-22)

## Description

The decision and its evidence table were recorded on #157 (comment of 2026-08-22) BEFORE this fix was committed, as the ticket requires. In one line: every artifact except the two `build.sh` recipes says RV32 with one hart, the deployed 8x8 gateware (VERSION 0x00010022, `x32f1_eto`, `docs/testing/CAMPAIGN_RV32G_TRIAGE.md:3-4`) was built that way by the sweep, and `build.sh cfg_ax8x8` has never produced a bitstream. The configs win; the recipes lost.

| piece | change |
|---|---|
| `sw/litex/build.sh` `cfg_ax8x8` | `--xlen 32` stated; it was absent, so `milan_soc.py`'s default of 64 applied. `--cpu-count 1` already matched. Dated comment, including that the 2026-07-24 close record was measured on the RV64 core and is now an upper bound |
| `sw/litex/build.sh` `cfg_arty` | `--cpu-count 2` -> `--cpu-count 1` and `--xlen 32` stated, matching `configs/endstation_arty_current.yaml`, the `sweep.sh` arty leg and `configs/generated/sweep_opts_arty.sh`. Dated comment |
| `scripts/check_sweep_shape.py` | the `build.sh` branch compares two more keys, `xlen` and `cpu_count`. The config side is derived from `endstation_builder.emit_soc_argv`, never restated; the recipe side is the token as written, and an ABSENT flag is reported as drift, so no recipe can inherit `milan_soc.py`'s default again. `--self-test` gains two negative controls on a mutated copy of `build.sh`: the real defect replayed (both flags stripped from every recipe) and the value-swapped case (xlen flipped between 32 and 64, one more hart); each must be rejected on both keys of both recipes. `PINNED` stays `{}`: PR #135 was closed unmerged, so the ticket's "delete the `--xlen` / `--cpu-count` entries from `PINNED`" step has nothing to delete |
| `docs/integration/BUILDING.md` | the `ax8x8` and `arty` recipe descriptions now state the CPU; section 3.1 documents the two new keys and adds the 2026-08-22 row to the "bitten" table |

A precision on the ticket text: `configs/endstation_ax7101_8x8.yaml` and `configs/endstation_arty_current.yaml` do not carry an `xlen` key. Neither has a `soc:` section at all, so both inherit `SOC_DEFAULTS` (xlen 32, cpu_count 1); only `configs/endstation_ax7101_1x1_tdm8.yaml:84` writes `xlen: 32` literally. The contract is the same either way, and the gate reads it through the builder rather than the YAML.

Not touched, on purpose: the other eight #155 divergences (`--cbs-queues-mask`, `--scala-args`, `--no-datapath-probes`, `--eth-port`, `--aaf-playback-streams`). They stay in #155 together with the full flag-for-flag widening of the `build.sh` branch.

## Authoritative references

- The #157 decision comment of 2026-08-22 (the artifact-by-artifact evidence table).
- `sw/builder/endstation_builder.py:301-316` `SOC_DEFAULTS`: xlen 32, one hart, "the PROVEN rv32 CPU words (launch_x32f1 -> sweep.sh BASE, 08-05/06)".
- `sw/litex/milan_soc.py:6625-6628` (the 64 default) and `:6928-6930` (the RV32 guard that covers only the baremetal profile).
- Commit 8b5d0255 (2026-08-05): the sweep BASE builds the RV32 CPU; the RV64 drift hung every build at Liftoff. Commit e52230bb (2026-07-31): `--xlen` honoured on the vexiiriscv path.
- `docs/testing/CAMPAIGN_RV32G_TRIAGE.md:3-4`, `docs/findings/TCP_THROUGHPUT_COLLAPSE_0803.md:29-32` and `:172`, `docs/findings/BENCH_TOPOLOGY.md:86-93`: the deployed 8x8 gateware is single-hart RV32.
- `docs/tooling/virtual-e2e-env.md:71-88`, `docs/testing/TRUE_E2E_REQUIREMENTS.md:36`: the Linux tuple is RV32, never a silent RV64 fallback.
- `docs/integration/BUILDING.md` section 3.1 (the shape gate) and `docs/testing/TESTING.md` (gate 23g, the elaboration proof).

## How to get into the same state

```sh
git fetch origin 157-build-sh-xlen
git checkout --detach f98ab40785f96521fb730c464e1784b430ef4a63
git submodule update --init protocol-processor gptp-processor external third_party/verilog-axis
# The elaboration gates need a LiteX interpreter with sw/litex/patches applied,
# which .github/workflows/elaborate.yml installs. On a bench box, name one:
export MILAN_LITEX_PYTHON=$HOME/litex-milan/venv/bin/python3
```

## How to validate

```sh
python3 scripts/check_sweep_shape.py
python3 scripts/check_sweep_shape.py --self-test
python3 sw/builder/test_builder.py
python3 sw/builder/test_builder.py --require-elaboration
bash -n sw/litex/build.sh
python3 scripts/docs_check.py
python3 scripts/check_doc_paths.py
python3 scripts/gen_toc.py --check
python3 scripts/lint_rtl.py --check
git diff --check origin/dev...HEAD
```

Expected result / pass criteria:

- Shape gate: `sweep shape gate: OK`, with six `[sweep-shape] build.sh cfg_arty:` and six `cfg_ax8x8:` agreement lines (num_streams, rx_queues, l2_bytes, render_lpf, xlen, cpu_count). `--self-test` prints 12 `SHAPE DRIFT` lines (4 for the sweep NS mutation, 4 for the absent CPU flags, 4 for the swapped ones) and ends with `[self-test] OK: xlen and cpu_count rejected on 2 build.sh recipes, absent and swapped`, exit 0.
- Builder suite: `ALL GATES PASS`; gate 23g reports 4/5 shipped recipes reach `Instance("milan_datapath")`, with `build.sh cfg_ax8x8` and `build.sh cfg_arty` among those that do. The `--require-elaboration` run gives the same tally and does not skip.
- `bash -n` silent; `docs_check: 0 finding(s)`; `doc path gate: OK`; `TOC gate: OK`; `LINT GATE: PASS (99 violation(s) <= ratchet 99)`; `git diff --check` silent.

## Known limitations / out of scope

- No bitstream is built and no board is flashed. The bench is down (ticket history), the Arty is retired, and neither corrected recipe has ever produced a deployed artifact. The proof offered is elaboration to the Instance (gate 23g), not a place-and-route close: the `cfg_ax8x8` 2026-07-24 figures (WNS +0.080, LUT 85.15 percent) were measured on the RV64 core and now read as an upper bound, the RV32 core being smaller (`docs/HISTORY_PRE_SHORTEN_0731.md:942`, -1,896 LUT in context).
- `cfg_arty` keeps its RV64-era cache words (`--l2-bytes 65536`, refill 8, rpt prefetch, down-pending 8, general-slots 16); only the CPU width and hart count move. Whether those words should follow the sweep's lean set is #155's `--scala-args` row.
- `PINNED` is untouched and the `build.sh` branch still compares six named keys rather than the full flag set; #155 carries that widening.
- `sweep.sh arty` was recorded unrunnable (#184) at the branch head; PR #200 has since merged, so gate 23g reports 5/5 on the candidate with nothing to change here.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [x] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [x] Candidate merge result is validated per CONTRIBUTING.md
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done

