### PR TITLE
Make the nightly and manual full-CI paths executable on dev with one authoritative SHA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,9 @@
 
 ## Linked Issue / roles
 
-Closes/relates to: #
+Closes #
+Relates to #
+<!-- `Closes #N` is the GitHub keyword form: `dev` is the default branch since 2026-08-22, so the Issue closes when this PR merges; name an Issue this PR must not close under `Relates to`. -->
 
 Executor: `[A<n>]`
 Internal cleared-context reviewer: `[R<n>]`

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
 
 jobs:
@@ -29,6 +29,17 @@ jobs:
           python3 sw/builder/test_builder.py
       - name: SoC source-list gate (Vivado would fail 40 min in without this)
         run: python3 scripts/check_soc_sources.py
+
+      # CI event and SHA contract gate (#174, #181): the four workflow files
+      # and docs/testing/CI_WORKFLOWS.md must agree on the triggers, the cron
+      # time, the public check names, cancel-in-progress and the one-SHA rule
+      # (no checkout overrides `ref`; workers record it, aggregates verify it).
+      # --selftest mutates each item on in-memory copies and requires a
+      # finding for each. Placed after the builder gates, which install pyyaml.
+      - name: CI event and SHA contract gate
+        run: |
+          python3 scripts/ci_events.py --check
+          python3 scripts/ci_events.py --selftest
 
       # Cited-path gate: a backticked `hdl/...` in prose is the first thing a
       # reader follows and nothing else links it to the tree. Two tree-wide

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -5,9 +5,14 @@ on:
     branches: [dev]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  # The dispatcher chooses the ref (`gh workflow run rtl.yml --ref <branch>`)
+  # and there are no inputs: the run validates that ref's tip, pinned as
+  # GITHUB_SHA exactly like every other event.
   workflow_dispatch:
-  # GitHub schedules only the default branch. This becomes active when this
-  # workflow revision reaches main; pushes to dev are covered immediately.
+  # `dev` is the repository default branch (since 2026-08-22, #174), and
+  # GitHub schedules the default branch only, so this cron validates dev's
+  # tip at 01:17 UTC. scripts/ci_events.py holds docs/testing/CI_WORKFLOWS.md
+  # to the same time string.
   schedule:
     - cron: "17 1 * * *"
 
@@ -28,10 +33,29 @@ jobs:
     outputs:
       run_full: ${{ steps.gate.outputs.run_full }}
       rtl: ${{ steps.gate.outputs.rtl }}
+      target_sha: ${{ steps.target.outputs.target_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # One authoritative SHA per run (#174, decision 2). GitHub pins
+      # GITHUB_SHA for every event: a push or PR merge commit, the tip of dev
+      # for the schedule, the chosen ref's tip for a dispatch. Every job below
+      # checks out that SHA (no checkout overrides `ref`, which
+      # scripts/ci_events.py refuses), every worker records it beside its
+      # evidence, and both aggregates refuse evidence for any other tree.
+      - name: Print the event and pin the one SHA this run validates
+        id: target
+        run: |
+          set -euo pipefail
+          echo "event=$GITHUB_EVENT_NAME ref=$GITHUB_REF sha=$GITHUB_SHA"
+          head="$(git rev-parse HEAD)"
+          if [ "$head" != "$GITHUB_SHA" ]; then
+            echo "checkout HEAD $head is not GITHUB_SHA $GITHUB_SHA" >&2
+            exit 1
+          fi
+          echo "target_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Decide whether this exact head needs the exhaustive gates
         id: gate
@@ -86,6 +110,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch RTL dependencies
         run: git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
+
+      # Record the tree this worker validates beside its evidence, and refuse
+      # to start on any other. The record is not a *.log, so suite_tally.py
+      # never reads it; the verilator-suites aggregate does.
+      - name: Record the tree this worker validates
+        env:
+          TARGET_SHA: ${{ needs.full-ci-gate.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          head="$(git rev-parse HEAD)"
+          if [ "$head" != "$GITHUB_SHA" ] || [ "$GITHUB_SHA" != "$TARGET_SHA" ]; then
+            echo "checkout $head, GITHUB_SHA $GITHUB_SHA and gate target $TARGET_SHA must be one SHA" >&2
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/suite-logs"
+          printf '%s\n' "$GITHUB_SHA" > "$RUNNER_TEMP/suite-logs/TARGET_SHA"
+          echo "target_sha=$GITHUB_SHA"
 
       - name: Cache the pinned Verilator build
         id: cache-verilator
@@ -194,6 +235,22 @@ jobs:
         with:
           pattern: suite-logs-*
           path: ${{ runner.temp }}/all-suite-logs
+
+      # Refuse evidence for any tree but this run's (#174, decision 2): every
+      # shard must carry a TARGET_SHA equal to the gate's target, to this
+      # job's GITHUB_SHA and to its checkout. A missing record is a failure,
+      # never a skip; so is an empty download.
+      - name: Require every shard to have validated this run's SHA
+        if: ${{ always() }}
+        env:
+          GATE_SHA: ${{ needs.full-ci-gate.outputs.target_sha }}
+        run: |
+          shopt -s nullglob
+          roots=("$RUNNER_TEMP"/all-suite-logs/suite-logs-*)
+          python3 scripts/ci_events.py --require-target-sha \
+            --sha gate="$GATE_SHA" --sha run="$GITHUB_SHA" \
+            --sha checkout="$(git rev-parse HEAD)" -- "${roots[@]}"
+
       - name: Prove exhaustive ownership and tally every log
         if: ${{ always() }}
         run: |
@@ -214,6 +271,7 @@ jobs:
             echo "one or more Verilator workers ended: $SHARD_RESULT" >&2
             exit 1
           fi
+          echo "verilator-suites: every worker succeeded at $GITHUB_SHA"
 
   # Weighted longest-processing-time assignment isolates the two dominant
   # tops and balances the remaining 44 without changing the local serial gate.
@@ -231,6 +289,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fetch RTL dependencies
         run: git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
+
+      # Same record as the Verilator workers. Not a *.result, so yosys_tally.py
+      # never reads it; the yosys-portability aggregate does.
+      - name: Record the tree this worker validates
+        env:
+          TARGET_SHA: ${{ needs.full-ci-gate.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          head="$(git rev-parse HEAD)"
+          if [ "$head" != "$GITHUB_SHA" ] || [ "$GITHUB_SHA" != "$TARGET_SHA" ]; then
+            echo "checkout $head, GITHUB_SHA $GITHUB_SHA and gate target $TARGET_SHA must be one SHA" >&2
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/yosys-results"
+          printf '%s\n' "$GITHUB_SHA" > "$RUNNER_TEMP/yosys-results/TARGET_SHA"
+          echo "target_sha=$GITHUB_SHA"
+
       - name: Install Yosys
         run: |
           sudo apt-get update -qq
@@ -274,6 +349,19 @@ jobs:
         with:
           pattern: yosys-results-*
           path: ${{ runner.temp }}/all-yosys-results
+
+      # Same refusal as verilator-suites, over the Yosys evidence.
+      - name: Require every shard to have validated this run's SHA
+        if: ${{ always() }}
+        env:
+          GATE_SHA: ${{ needs.full-ci-gate.outputs.target_sha }}
+        run: |
+          shopt -s nullglob
+          roots=("$RUNNER_TEMP"/all-yosys-results/yosys-results-*)
+          python3 scripts/ci_events.py --require-target-sha \
+            --sha gate="$GATE_SHA" --sha run="$GITHUB_SHA" \
+            --sha checkout="$(git rev-parse HEAD)" -- "${roots[@]}"
+
       - name: Reconcile the live inventory and structural gates
         if: ${{ always() }}
         run: |
@@ -297,3 +385,4 @@ jobs:
             echo "one or more Yosys workers ended: $SHARD_RESULT" >&2
             exit 1
           fi
+          echo "yosys-portability: every worker succeeded at $GITHUB_SHA"

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -65,8 +65,9 @@ jobs:
       # naming what they saw (a value they could not read refuses too). PR and
       # push runs are about the tree, not the setting: they print the value
       # and carry on, so a drift is visible on every run and fatal on the runs
-      # it would misdirect. scripts/ci_events.py holds the decision and this
-      # step's fail-closed shape.
+      # it would misdirect. scripts/ci_events.py holds the decision and pins
+      # this step's script verbatim (whitespace aside): one unconditional
+      # live read into `observed`, one verifier call after it, nothing else.
       - name: Assert the repository default branch is dev
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -57,6 +57,25 @@ jobs:
           fi
           echo "target_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
+      # The cron was inert for three weeks because the default branch was
+      # `main` (#174), and no gate that reads files can see that repository
+      # setting. So the runs it governs read it live: a scheduled run
+      # validates the default branch's tip and a dispatch exists only because
+      # the workflow is on that branch, so both refuse unless it is `dev`,
+      # naming what they saw (a value they could not read refuses too). PR and
+      # push runs are about the tree, not the setting: they print the value
+      # and carry on, so a drift is visible on every run and fatal on the runs
+      # it would misdirect. scripts/ci_events.py holds the decision and this
+      # step's fail-closed shape.
+      - name: Assert the repository default branch is dev
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          observed="$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch 2>/dev/null || echo unreadable)"
+          python3 scripts/ci_events.py --require-default-branch \
+            --event "$GITHUB_EVENT_NAME" --observed "$observed"
+
       - name: Decide whether this exact head needs the exhaustive gates
         id: gate
         env:

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -259,7 +259,10 @@ jobs:
       # Refuse evidence for any tree but this run's (#174, decision 2): every
       # shard must carry a TARGET_SHA equal to the gate's target, to this
       # job's GITHUB_SHA and to its checkout. A missing record is a failure,
-      # never a skip; so is an empty download.
+      # never a skip; so is an empty download, and so is any count of shard
+      # directories but the worker matrix size (--expect). scripts/ci_events.py
+      # derives this step's script from the download step and the matrix and
+      # pins it, its keys, its env and its `if` verbatim.
       - name: Require every shard to have validated this run's SHA
         if: ${{ always() }}
         env:
@@ -267,7 +270,7 @@ jobs:
         run: |
           shopt -s nullglob
           roots=("$RUNNER_TEMP"/all-suite-logs/suite-logs-*)
-          python3 scripts/ci_events.py --require-target-sha \
+          python3 scripts/ci_events.py --require-target-sha --expect 4 \
             --sha gate="$GATE_SHA" --sha run="$GITHUB_SHA" \
             --sha checkout="$(git rev-parse HEAD)" -- "${roots[@]}"
 
@@ -378,7 +381,7 @@ jobs:
         run: |
           shopt -s nullglob
           roots=("$RUNNER_TEMP"/all-yosys-results/yosys-results-*)
-          python3 scripts/ci_events.py --require-target-sha \
+          python3 scripts/ci_events.py --require-target-sha --expect 4 \
             --sha gate="$GATE_SHA" --sha run="$GITHUB_SHA" \
             --sha checkout="$(git rev-parse HEAD)" -- "${roots[@]}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,7 +379,8 @@ A task is complete only when:
 - the change lands in `dev`;
 - post-merge containment is clean;
 - authoritative documentation is current;
-- the Issue is manually closed and moved to `Done`.
+- the Issue is closed (by the merge through `Closes #N`, or by hand) and
+  moved to `Done`.
 
 The hosted long-gate schedule does not weaken the mandatory local commands in
 [CONTRIBUTING.md](CONTRIBUTING.md). Green CI alone is not proof of correctness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ flowchart LR
     G -->|clean| M[merge to dev]
     M --> C[branch stops moving<br/>run containment]
     C -->|finding| F[follow-up issue + PR]
-    C -->|clean| D[close issue manually<br/>Done]
+    C -->|clean| D[card to Done<br/>issue closed by the merge]
 ```
 
 1. **Move the issue to *In progress*** on the project board before the first
@@ -71,9 +71,11 @@ flowchart LR
    built twice on 2026-08-16 because the issue was filed after the work
    started.
 2. **Cut the branch from the issue**: `gh issue develop <N> --base dev`.
-   This links the branch and issue on GitHub. Because `dev` is not the
-   repository's default branch, merging its PR does not auto-close the issue.
-   Close the issue manually only after the post-merge containment check passes.
+   This links the branch and issue on GitHub. Since 2026-08-22 `dev` is the
+   repository's default branch, so a PR body carrying `Closes #N` closes the
+   issue when the PR merges; the board's *Done* still waits for the post-merge
+   containment check. Before that date `main` was the default and the keyword
+   never fired, which is why older issues were closed by hand.
 3. **Do the work on that branch**, with the Section 3 verification bar met *on the
    branch* — a PR is not the place to discover the sweep is red.
 4. **Open the PR** against `dev`, with the template below and the
@@ -169,8 +171,9 @@ flowchart LR
    #86 a round was in flight. For #77 the stated bar had been met, but review
    did not stop. A check run at merge time cannot see later pushes. The moment
    that catches them is the one where the card moves to *Done*. Once
-   containment is clean, close the issue manually and move its project item to
-   *Done*.
+   containment is clean, move the project item to *Done*; the merge closed the
+   issue itself when the PR body carried `Closes #N`, so close it by hand only
+   when it did not.
 
    `--no-fetch` disables Git ref refresh only. A `--merged-prs` sweep still
    queries GitHub for the merged PR list and branch timeline evidence.
@@ -178,12 +181,13 @@ flowchart LR
    Its `--selftest` runs inside `scripts/run_all_suites.sh` next to
    `suite_tally.py`'s, so the tool cannot rot into a green that means nothing
    between merges. The check *itself* is still a thing a person runs: nothing
-   here can schedule a post-merge action, and CI does not run on `dev`
-   at all (both workflows are `on: push: branches: [main]`). That gap is worth
-   closing separately. A `push: [dev]` trigger would run the bar and the
-   containment self-test on the merge result. It would still need an explicit
-   `check_merge_containment.py --merged-prs` step to render a live containment
-   verdict.
+   here schedules a post-merge action. Every push to `dev` runs the hosted
+   gates on the merge result (`rtl-fast.yml`, `rtl.yml`, `docs.yml` and
+   `elaborate.yml` all subscribe `push: dev`; the event contract is in
+   [docs/testing/CI_WORKFLOWS.md](docs/testing/CI_WORKFLOWS.md)), and the
+   Verilator sweep carries this self-test with it, but no workflow runs
+   `check_merge_containment.py --merged-prs`, so a live containment verdict is
+   still rendered by hand.
 
    **Do not hand-roll it by reading `git log` output.** The script uses
    `git rev-list --count` and `git merge-base --is-ancestor` because one prints

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -6,12 +6,14 @@ reduce the local verification bar in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Contents
 
-- **[Fast feedback](#fast-feedback)** — What runs on every pull-request update and why docs-only changes avoid RTL tool setup.
-- **[Exhaustive validation](#exhaustive-validation)** — When the full Verilator and Yosys inventories run and how exact-head evidence is preserved.
-- **[Elaboration](#elaboration)** — The one job that installs LiteX and observes what elaboration hands the datapath Instance, and what makes it red.
-- **[Pull-request state](#pull-request-state)** — How draft and ready states control hosted long jobs without changing local responsibilities.
-- **[Local commands](#local-commands)** — The serial commands that remain the authoritative developer-side gates.
-- **[Failure and cancellation semantics](#failure-and-cancellation-semantics)** — How missing artifacts, superseded commits, and resumed work are handled.
+- **[Fast feedback](#fast-feedback)** -- What runs on every pull-request update and why docs-only changes avoid RTL tool setup.
+- **[Exhaustive validation](#exhaustive-validation)** -- When the full Verilator and Yosys inventories run and how exact-head evidence is preserved.
+- **[Nightly and manual dispatch](#nightly-and-manual-dispatch)** -- The cron on the tip of `dev`, how to start a run by hand, and the two situations in which an agent should.
+- **[Elaboration](#elaboration)** -- The one job that installs LiteX and observes what elaboration hands the datapath Instance, and what makes it red.
+- **[Pull-request state](#pull-request-state)** -- How draft and ready states control hosted long jobs without changing local responsibilities.
+- **[Issue closing on merge](#issue-closing-on-merge)** -- What `Closes #N` does now that `dev` is the default branch, and what still waits for containment.
+- **[Local commands](#local-commands)** -- The serial commands that remain the authoritative developer-side gates.
+- **[Failure and cancellation semantics](#failure-and-cancellation-semantics)** -- How missing artifacts, superseded commits, and resumed work are handled.
 
 ## Fast feedback
 
@@ -41,14 +43,17 @@ portability pass.
 - a non-draft PR is opened or updated;
 - a draft PR is marked ready for review;
 - `dev` receives a push;
-- the nightly schedule starts after this workflow revision reaches the
-  repository's default branch;
-- a maintainer starts it manually.
+- the nightly schedule fires, at 01:17 UTC (`17 1 * * *`), on the tip of `dev`;
+- someone dispatches it by hand, on any branch.
 
-GitHub executes scheduled workflows only from the default branch. The repository
-currently develops on `dev` while `main` is the default, so the nightly trigger
-is staged by this change but does not become active until the workflow revision
-reaches `main`. Pull requests and pushes to `dev` are covered immediately.
+`dev` has been the repository default branch since 2026-08-22 (#174, decision
+3; `main` is the release branch, fast-forwarded deliberately). GitHub runs
+scheduled workflows from the default branch only, so the cron validates the
+tip of `dev` as it stands at 01:17 UTC, and `workflow_dispatch` is launchable
+for any branch. Both paths are in
+[Nightly and manual dispatch](#nightly-and-manual-dispatch). Until 2026-08-22
+the default was `main`, which carried neither trigger, and no scheduled or
+dispatched run had ever occurred; the first scheduled run is recorded on #174.
 
 The workflow keeps the public aggregate names `verilator-suites` and
 `yosys-portability`.
@@ -72,6 +77,45 @@ top. The `yosys-portability` aggregate rejects:
 
 The tap-purity report remains informational in the combined Yosys script, which
 preserves the existing local policy. Its result is still recorded exactly once.
+
+## Nightly and manual dispatch
+
+**The nightly** validates whatever `dev` points at when the cron fires. Its
+value is environment drift: the Verilator cache, the apt Yosys, the pinned
+`tsn-gen` revision and the LiteX pins all move under a tree that did not, and
+without the nightly the next pull request is the first thing to find out. A
+red nightly on a tree whose last push was green is therefore a toolchain or
+dependency finding, not a regression of the tree; file it as an Issue against
+the pin or cache it names. `gh run list --workflow rtl.yml --event schedule`
+lists the scheduled runs.
+
+**Manual dispatch** starts the exhaustive workflow on the tip of a branch:
+
+```sh
+gh workflow run rtl.yml --ref <branch>
+gh run list --workflow rtl.yml --event workflow_dispatch --limit 3
+```
+
+The run uses the `rtl.yml` of that branch and validates that branch's tip,
+pinned as `GITHUB_SHA` like every other event; there are no inputs. Its
+concurrency group is the branch ref, so a dispatched run neither cancels nor
+is cancelled by a pull-request run of the same branch.
+
+An agent uses dispatch in two situations:
+
+1. **A draft head that needs exhaustive evidence without flipping ready.** The
+   draft state is the cost lever: hosted workers stay idle while a PR is
+   changing. When a draft needs the full inventory once, for example to
+   measure a sweep before asking for review, dispatch on the branch instead of
+   marking the PR ready and back.
+2. **Recovery after a cancelled or expired run.** A ready PR whose last full
+   run was cancelled by a later push that never completed, or whose artifacts
+   have passed their 3-day retention, is re-validated on its exact head
+   without an empty commit.
+
+The merge bar reads exact-head evidence. A dispatched run names the SHA it
+validated in its gate output, so a reviewer compares that line with the PR
+head before counting it.
 
 ## Elaboration
 
@@ -124,10 +168,30 @@ Before marking a PR ready:
 Marking the PR ready starts the hosted exhaustive jobs on that exact head. A
 later commit to a ready PR cancels obsolete work and starts a new full run.
 Convert the PR back to draft before resuming exploratory implementation. Do not
-claim hosted long-gate success for a commit other than the current PR head.
+claim hosted long-gate success for a commit other than the current PR head. A
+draft that needs the exhaustive gates once is dispatched by hand (see
+[Nightly and manual dispatch](#nightly-and-manual-dispatch)) rather than
+flipped ready and back.
 
 A docs-only ready PR remains cheap: the long workflow starts, classifies the
 diff, and skips its RTL workers with explicit skipped results.
+
+## Issue closing on merge
+
+Since `dev` became the default branch on 2026-08-22, a PR body carrying the
+GitHub keyword form `Closes #N` closes Issue N when the PR merges into `dev`.
+The PR template therefore carries separate `Closes #` and `Relates to #`
+lines; its former `Closes/relates to: #` line was not a form GitHub reads, and
+a body written that way leaves the Issue open.
+
+A closed Issue is not a finished one. The project board's Done transition
+still waits for the post-merge containment check that
+[CONTRIBUTING.md](../../CONTRIBUTING.md) requires, run when the branch has
+stopped moving; an Issue the merge closed whose card is not Done is in that
+window. `scripts/check_merge_review_integrity.py` keeps reporting a merged PR
+whose linked Issue is open, for bodies in a form GitHub does not read and for
+the history before 2026-08-22, when every PR merged into a non-default branch
+and the keyword never fired.
 
 ## Local commands
 
@@ -172,7 +236,8 @@ inventory and separately require every worker result to be `success`.
 Workflow concurrency is scoped to the PR or branch. A new commit cancels older
 runs because their evidence no longer describes the current head. Converting a
 PR to draft starts a no-op run in the same group, which releases hosted runners
-from obsolete exhaustive work.
+from obsolete exhaustive work. A dispatched run and a scheduled run are scoped
+to their branch ref, and a push to that branch cancels them the same way.
 
 Push validation on `dev` checks the actual merge result. It complements, but
 does not replace, the explicit post-merge containment check required by

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -9,6 +9,7 @@ reduce the local verification bar in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 - **[Fast feedback](#fast-feedback)** -- What runs on every pull-request update and why docs-only changes avoid RTL tool setup.
 - **[Exhaustive validation](#exhaustive-validation)** -- When the full Verilator and Yosys inventories run and how exact-head evidence is preserved.
 - **[Nightly and manual dispatch](#nightly-and-manual-dispatch)** -- The cron on the tip of `dev`, how to start a run by hand, and the two situations in which an agent should.
+- **[One authoritative SHA](#one-authoritative-sha)** -- How every job of a run is pinned to one tree, what the workers record, what the aggregates refuse, and the gate that holds the files to this page.
 - **[Elaboration](#elaboration)** -- The one job that installs LiteX and observes what elaboration hands the datapath Instance, and what makes it red.
 - **[Pull-request state](#pull-request-state)** -- How draft and ready states control hosted long jobs without changing local responsibilities.
 - **[Issue closing on merge](#issue-closing-on-merge)** -- What `Closes #N` does now that `dev` is the default branch, and what still waits for containment.
@@ -114,8 +115,49 @@ An agent uses dispatch in two situations:
    without an empty commit.
 
 The merge bar reads exact-head evidence. A dispatched run names the SHA it
-validated in its gate output, so a reviewer compares that line with the PR
-head before counting it.
+validated in its gate output and in both aggregate verdicts, so a reviewer
+compares that line with the PR head before counting it.
+
+## One authoritative SHA
+
+GitHub pins `GITHUB_SHA` once per run, for every event: the pushed commit, the
+merge commit of a pull request, the tip of `dev` for a schedule, the tip of
+the chosen ref for a dispatch. Every `actions/checkout` step that does not
+override `ref` checks out that commit, so every job of an exhaustive run
+validates one tree. The workflow makes that explicit and machine-checked
+(#174, decision 2):
+
+- the `full-ci-gate` job prints `event=... ref=... sha=...`, refuses a
+  checkout whose `HEAD` is not `GITHUB_SHA`, and exports the SHA as its
+  `target_sha` output;
+- every Verilator and Yosys worker refuses to start unless its checkout, its
+  `GITHUB_SHA` and the gate's `target_sha` are one value, then writes that
+  value into a `TARGET_SHA` file beside its evidence, inside the artifact it
+  uploads. The file is neither a `*.log` nor a `*.result`, so neither tally
+  reads it;
+- both aggregates run `scripts/ci_events.py --require-target-sha` over the
+  downloaded shards before they tally anything, and print the SHA in their
+  verdict.
+
+The aggregates refuse, and the check fails rather than skips:
+
+- a shard directory without a `TARGET_SHA` record, including the empty
+  placeholder the aggregate creates when the download produced nothing;
+- a record that is not a 40-digit hexadecimal commit id;
+- a record naming any tree but this run's;
+- a gate `target_sha`, aggregate `GITHUB_SHA` and aggregate checkout that are
+  not one value.
+
+`scripts/ci_events.py --check` holds the workflow files to this contract and
+to the trigger contract above: no `actions/checkout` step in `rtl.yml`
+overrides `ref`, every job that uploads an artifact records the SHA first,
+every job that downloads artifacts verifies it, the trigger lists, the
+`cancel-in-progress` rule and the public check names `rtl-fast`,
+`verilator-suites`, `yosys-portability` and `elaborate` are what this page
+says, and the cron time string on this page matches the YAML. Its
+`--selftest` removes or alters each item on in-memory copies and requires
+the check to catch every one, and fails if the checker is stubbed to find
+nothing. Both run in the hosted docs job.
 
 ## Elaboration
 
@@ -230,8 +272,10 @@ syn/yosys/run.sh --mode elaborate --no-structural \
 ## Failure and cancellation semantics
 
 A worker is not trusted merely because an aggregate job was able to download
-something. Both aggregate jobs compare artifacts with the live repository
-inventory and separately require every worker result to be `success`.
+something. Both aggregate jobs refuse evidence recorded for any tree but the
+run's own (see [One authoritative SHA](#one-authoritative-sha)), compare
+artifacts with the live repository inventory, and separately require every
+worker result to be `success`.
 
 Workflow concurrency is scoped to the PR or branch. A new commit cancels older
 runs because their evidence no longer describes the current head. Converting a

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -31,7 +31,12 @@ pull-request update and on every push to `dev`. It produces one stable
 A change containing only living documentation or an Issue template skips the
 Verilator and Yosys setup jobs. The aggregate still completes, so a docs-only PR
 does not leave a required verdict pending. Mixed changes are treated as RTL
-relevant. An empty or unresolvable diff is also treated as RTL relevant.
+relevant. An empty or unresolvable diff is also treated as RTL relevant. A
+submodule pointer (`protocol-processor`, `gptp-processor`, `external`,
+`third_party/...`, read from `.gitmodules`) or `.gitmodules` itself is never
+docs-only: it moves the RTL the sweep elaborates without touching a file under
+`hdl/`, and `scripts/ci_scope.py --selftest` proves a classifier that files
+any one of them as documentation is rejected.
 
 The elaboration smoke proves that the integration-heavy source lists lower and
 resolve. It does not replace generic synthesis and must not be reported as a
@@ -131,10 +136,20 @@ those runs are about the tree, not the setting, and a contributor's PR must
 not go red for a repository setting it cannot change. A drift is therefore
 visible on every run and fatal on the first run it would misdirect, instead
 of surfacing as a nightly that silently stopped. `ci_events.py --check`
-requires the step, its token and its fail-closed shape; `--selftest` covers
-the step removed, the token missing, the live read replaced by an echo, the
-event not passed, the step neutered by `continue-on-error` or `|| true`, and
-the decision itself for every event class.
+requires the step, its token and its fail-closed shape, and pins the step's
+script verbatim (whitespace aside) to three lines: `set -euo pipefail`, one
+unconditional `observed="$(gh api ...)"` read, one verifier call after it. A
+substring recognizer was fooled by a decoy, a literal `observed=dev` beside a
+`gh api` inside `if false`; the pin refuses it, and the structural reasons
+name what a deviation did: a second assignment, a value not sourced from the
+live call, control flow around the read, a comment line, the call before the
+read. `--selftest` covers the step removed, the token missing, the live read
+replaced by an echo, the event not passed, the step neutered by
+`continue-on-error` or `|| true`, the decoy itself, a literal after the real
+read and after the call, `gh api` in a comment only, `observed` from another
+command, two assignments, the call before the read, an extra line, a missing
+`set` line, a whitespace-only reformatting that must still pass, and the
+decision itself for every event class.
 
 ## One authoritative SHA
 
@@ -154,8 +169,12 @@ validates one tree. The workflow makes that explicit and machine-checked
   uploads. The file is neither a `*.log` nor a `*.result`, so neither tally
   reads it;
 - both aggregates run `scripts/ci_events.py --require-target-sha` over the
-  downloaded shards before they tally anything, and print the SHA in their
-  verdict.
+  downloaded shards before they tally anything, passing exactly three
+  sources, `--sha gate="$GATE_SHA"` (the gate's `target_sha` through the step
+  env), `--sha run="$GITHUB_SHA"` and `--sha checkout="$(git rev-parse
+  HEAD)"`, and print the SHA in their verdict. The verifier refuses any other
+  source set, a dropped source or an unknown label included, so an aggregate
+  cannot quietly stop proving that the gate, the run and its checkout agree.
 
 The aggregates refuse, and the check fails rather than skips:
 
@@ -164,7 +183,7 @@ The aggregates refuse, and the check fails rather than skips:
 - a record that is not a 40-digit hexadecimal commit id;
 - a record naming any tree but this run's;
 - a gate `target_sha`, aggregate `GITHUB_SHA` and aggregate checkout that are
-  not one value.
+  not one value, or a source set that is not exactly those three.
 
 `scripts/ci_events.py --check` holds the workflow files to this contract and
 to the trigger contract above: no `actions/checkout` step in `rtl.yml`

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -135,21 +135,46 @@ not agreement. A pull-request or push run prints the value and carries on:
 those runs are about the tree, not the setting, and a contributor's PR must
 not go red for a repository setting it cannot change. A drift is therefore
 visible on every run and fatal on the first run it would misdirect, instead
-of surfacing as a nightly that silently stopped. `ci_events.py --check`
-requires the step, its token and its fail-closed shape, and pins the step's
-script verbatim (whitespace aside) to three lines: `set -euo pipefail`, one
-unconditional `observed="$(gh api ...)"` read, one verifier call after it. A
-substring recognizer was fooled by a decoy, a literal `observed=dev` beside a
-`gh api` inside `if false`; the pin refuses it, and the structural reasons
-name what a deviation did: a second assignment, a value not sourced from the
-live call, control flow around the read, a comment line, the call before the
-read. `--selftest` covers the step removed, the token missing, the live read
-replaced by an echo, the event not passed, the step neutered by
-`continue-on-error` or `|| true`, the decoy itself, a literal after the real
-read and after the call, `gh api` in a comment only, `observed` from another
-command, two assignments, the call before the read, an extra line, a missing
-`set` line, a whitespace-only reformatting that must still pass, and the
-decision itself for every event class.
+of surfacing as a nightly that silently stopped. `ci_events.py --check` holds
+the assertion in its fail-closed shape, which is exactly these four things:
+
+1. **The script text.** The step's `run:` is pinned verbatim (whitespace
+   aside) to three lines: `set -euo pipefail`, one unconditional
+   `observed="$(gh api ...)"` read, one verifier call after it. A substring
+   recognizer was fooled by a decoy, a literal `observed=dev` beside a
+   `gh api` inside `if false`; the pin refuses it, and the structural reasons
+   name what a deviation did: a second assignment, a value not sourced from
+   the live call, control flow around the read, a comment line, the call
+   before the read.
+2. **The step keys.** The step carries exactly `name`, `env` and `run`, and
+   its `env` exactly `GH_TOKEN`. A key beside a canonical script decides
+   whether, on which events, or by which interpreter it runs: `if: false`,
+   an `if:` naming only the events the assertion does not govern,
+   `shell: bash -n {0}` (parsed, never executed), `continue-on-error`, a
+   `working-directory`, or a `GH_HOST` / `GH_CONFIG_DIR` that points `gh`
+   away from this repository. Each refusal names the key.
+3. **The job keys.** `full-ci-gate` carries no `if`, no `continue-on-error`
+   and no `defaults`, and the workflow carries no top-level `defaults` (a
+   `defaults.run.shell: bash -n {0}` parses every script and executes none).
+4. **The verifier steps.** Each aggregate's `--require-target-sha` step
+   carries exactly `name`, `if`, `env` and `run`; its `if` is exactly
+   `${{ always() }}` (any other condition can skip the verification, and a
+   skipped step passes the job); its `env` exactly `GATE_SHA`; and its
+   script equals a canonical form derived from the job's own download step
+   and the worker matrix, so `--expect` is the shard count and no line can
+   reassign a source before the call. The aggregate jobs keep their
+   documented `if` verbatim and carry no `continue-on-error` or `defaults`.
+
+`--selftest` covers, one at a time: the step removed, the token missing, the
+live read replaced by an echo, the event not passed, `|| true`, the decoy
+itself, a literal after the real read and after the call, `gh api` in a
+comment only, `observed` from another command, two assignments, the call
+before the read, an extra line, a missing `set` line; each key escape above
+on the step, on the job, on the workflow and on the verifier steps; a
+verifier that reassigns `GATE_SHA`, passes the wrong `--expect`, passes none,
+or keeps `--expect` while the matrix grows; an aggregate `if` loosened or
+dropped; a whitespace-only reformatting of both scripts that must still pass;
+and the decision itself for every event class.
 
 ## One authoritative SHA
 
@@ -169,12 +194,14 @@ validates one tree. The workflow makes that explicit and machine-checked
   uploads. The file is neither a `*.log` nor a `*.result`, so neither tally
   reads it;
 - both aggregates run `scripts/ci_events.py --require-target-sha` over the
-  downloaded shards before they tally anything, passing exactly three
-  sources, `--sha gate="$GATE_SHA"` (the gate's `target_sha` through the step
-  env), `--sha run="$GITHUB_SHA"` and `--sha checkout="$(git rev-parse
-  HEAD)"`, and print the SHA in their verdict. The verifier refuses any other
-  source set, a dropped source or an unknown label included, so an aggregate
-  cannot quietly stop proving that the gate, the run and its checkout agree.
+  downloaded shards before they tally anything, passing `--expect 4` (the
+  worker matrix size) and exactly three sources, `--sha gate="$GATE_SHA"`
+  (the gate's `target_sha` through the step env), `--sha run="$GITHUB_SHA"`
+  and `--sha checkout="$(git rev-parse HEAD)"`, and print the SHA in their
+  verdict. The verifier refuses any other source set, a dropped source or an
+  unknown label included, and any shard-directory count but `--expect`, so
+  an aggregate cannot quietly stop proving that the gate, the run and its
+  checkout agree, or tally three shards as four.
 
 The aggregates refuse, and the check fails rather than skips:
 
@@ -183,7 +210,8 @@ The aggregates refuse, and the check fails rather than skips:
 - a record that is not a 40-digit hexadecimal commit id;
 - a record naming any tree but this run's;
 - a gate `target_sha`, aggregate `GITHUB_SHA` and aggregate checkout that are
-  not one value, or a source set that is not exactly those three.
+  not one value, or a source set that is not exactly those three;
+- fewer or more shard directories than the worker matrix produces.
 
 `scripts/ci_events.py --check` holds the workflow files to this contract and
 to the trigger contract above: no `actions/checkout` step in `rtl.yml`

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -118,6 +118,24 @@ The merge bar reads exact-head evidence. A dispatched run names the SHA it
 validated in its gate output and in both aggregate verdicts, so a reviewer
 compares that line with the PR head before counting it.
 
+**The default-branch assertion.** The cron was inert for three weeks because
+the default branch was `main`, and no gate that reads files can see that
+repository setting. So `full-ci-gate` reads it live on every run, with
+`gh api repos/<owner>/<repo> --jq .default_branch` handed to
+`scripts/ci_events.py --require-default-branch`, and prints
+`default_branch=<observed> expected=dev event=<event>`. A scheduled or
+dispatched run refuses to continue unless the observed value is `dev`, naming
+the branch it saw; a value it could not read refuses too, since an unknown is
+not agreement. A pull-request or push run prints the value and carries on:
+those runs are about the tree, not the setting, and a contributor's PR must
+not go red for a repository setting it cannot change. A drift is therefore
+visible on every run and fatal on the first run it would misdirect, instead
+of surfacing as a nightly that silently stopped. `ci_events.py --check`
+requires the step, its token and its fail-closed shape; `--selftest` covers
+the step removed, the token missing, the live read replaced by an echo, the
+event not passed, the step neutered by `continue-on-error` or `|| true`, and
+the decision itself for every event class.
+
 ## One authoritative SHA
 
 GitHub pins `GITHUB_SHA` once per run, for every event: the pushed commit, the
@@ -151,7 +169,8 @@ The aggregates refuse, and the check fails rather than skips:
 `scripts/ci_events.py --check` holds the workflow files to this contract and
 to the trigger contract above: no `actions/checkout` step in `rtl.yml`
 overrides `ref`, every job that uploads an artifact records the SHA first,
-every job that downloads artifacts verifies it, the trigger lists, the
+every job that downloads artifacts verifies it, the gate carries the
+default-branch assertion in its fail-closed shape, the trigger lists, the
 `cancel-in-progress` rule and the public check names `rtl-fast`,
 `verilator-suites`, `yosys-portability` and `elaborate` are what this page
 says, and the cron time string on this page matches the YAML. Its

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -759,8 +759,12 @@ host-only.
 * **CI now runs the RTL gates too** (2026-07-26).
   [`.github/workflows/docs.yml`](../../.github/workflows/docs.yml) runs the docs
   gate (twice — the second time with `.git` deleted, so the tarball/zip path
-  stays honest), the traceability no-drift gate and the end-station builder
-  gates; [`.github/workflows/rtl.yml`](../../.github/workflows/rtl.yml) runs the
+  stays honest), the traceability no-drift gate, the end-station builder
+  gates and the CI event and SHA contract gate
+  ([`scripts/ci_events.py`](../../scripts/ci_events.py) `--check` and
+  `--selftest`, which hold the four workflow files to the trigger, cron,
+  public-name and one-SHA contract that
+  [`CI_WORKFLOWS.md`](CI_WORKFLOWS.md) states); [`.github/workflows/rtl.yml`](../../.github/workflows/rtl.yml) runs the
   whole Verilator sweep via [`scripts/run_all_suites.sh`](../../scripts/run_all_suites.sh), the ratcheted RTL lint
   (Section 4b) and the Yosys portability sweep. The RTL jobs initialize both
   `verilog-axis` and `protocol-processor`. The docs workflow also initializes

--- a/scripts/check_merge_review_integrity.py
+++ b/scripts/check_merge_review_integrity.py
@@ -225,8 +225,10 @@ def assess_pr(pr, issue_is_open):
         if issue_is_open(n):
             findings.append(Finding(
                 pr["number"], "open-issue",
-                "body says it closes #%d, which is still OPEN (a `dev` merge "
-                "does not auto-close it)" % n))
+                "body says it closes #%d, which is still OPEN (the merge did "
+                "not close it: not a keyword form GitHub reads, merged before "
+                "2026-08-22 when `dev` was not the default branch, or "
+                "reopened since)" % n))
     return findings
 
 

--- a/scripts/check_merge_review_integrity.py
+++ b/scripts/check_merge_review_integrity.py
@@ -11,10 +11,19 @@ nothing detected either:
      historical evidence), and it merged anyway. A maintainer overriding a
      NEGATIVE is a legitimate act - so this does NOT block a merge - but after
      the fact nobody could tell it happened.
-  2. A PR whose body says `Closes #N` merged and left #N open. GitHub only
-     auto-closes a linked Issue when the PR merges into the DEFAULT branch;
-     here PRs merge into `dev`, so `Closes #N` never fires and the Issue sits
-     open with its work already shipped (#159 did exactly this).
+  2. A PR whose body says `Closes #N` merged and left #N open. Until
+     2026-08-22 that was the ordinary outcome: GitHub auto-closes a linked
+     Issue only when the PR merges into the DEFAULT branch, the default was
+     `main`, and every PR merged into `dev`, so `Closes #N` never fired and
+     the Issue sat open with its work already shipped (#159 did exactly
+     this). Since 2026-08-22 `dev` IS the default branch (#174, decision 3)
+     and the keyword fires on merge. The check stays, for three reasons: a
+     body in the template's former `Closes/relates to: #N` form, or any other
+     form GitHub does not read as a keyword, still leaves the Issue open; the
+     merged-PR window reaches back into the history where the keyword never
+     fired; and an Issue reopened after its PR merged should not sit unnoticed
+     either. What it reports is the same fact in every case: shipped work
+     whose Issue is open.
 
 WHAT IT READS. The verdict is not GitHub's formal review decision - this repo's
 reviews are COMMENT-type, so `reviewDecision` is always blank. The `[R<n>]

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -37,10 +37,23 @@ never a skip. `--check` refuses any `actions/checkout` step in rtl.yml that
 overrides `ref`, requires every artifact-uploading job to record the SHA and
 every artifact-downloading job to verify it.
 
+THE DEFAULT-BRANCH ASSERTION ([R1] on PR #204). The cron was inert because of
+a repository SETTING, and a gate that reads files cannot see a setting. So the
+gate job reads it live on every run (`gh api repos/$GITHUB_REPOSITORY --jq
+.default_branch`) and hands it to `--require-default-branch`: a scheduled or
+dispatched run refuses to continue unless the default branch is `dev`, naming
+the branch it saw, and refuses a value it could not read, since an unknown is
+not agreement. A pull-request or push run prints the value and carries on:
+those runs are about the tree, not the setting, and a contributor's PR must
+not go red for a setting it cannot change. `--check` requires the step, its
+token and its fail-closed shape (no `continue-on-error`, no `|| true`).
+
     scripts/ci_events.py --check        # the live tree against the contract
     scripts/ci_events.py --selftest     # mutation arms over in-memory copies
     scripts/ci_events.py --require-target-sha --sha gate=<sha> \\
         --sha run=<sha> --sha checkout=<sha> -- <shard-dir>...
+    scripts/ci_events.py --require-default-branch --event <event> \\
+        --observed <branch>
 
 Exit 0 = clean, 1 = a finding, 2 = cannot run (pyyaml absent, a file missing
 or unparseable, usage).
@@ -79,6 +92,14 @@ GATE_JOB = "full-ci-gate"
 GATE_OUTPUT = "target_sha"
 #: How an aggregate invokes the verifier (the first token after the script).
 VERIFY_FLAG = "--require-target-sha"
+#: How the gate invokes the live default-branch assertion, and the events
+#: whose run the repository default-branch setting governs: a schedule runs
+#: on the default branch's tip, a dispatch exists only because the workflow
+#: is on that branch. The expected branch is PUSH_BRANCH, derived, not a
+#: second literal: the branch the workflows run on push is the branch that
+#: must be the default.
+DEFAULT_BRANCH_FLAG = "--require-default-branch"
+DEFAULT_BRANCH_EVENTS = ("schedule", "workflow_dispatch")
 #: Public check names the merge bar reads (AGENTS.md section 7), per file.
 PUBLIC_NAMES = {
     RTL_FULL: ("verilator-suites", "yosys-portability"),
@@ -300,6 +321,7 @@ def check_rtl_full(c, wf, policy):
                      and "GITHUB_SHA" in step_text(s) for s in steps(gate))
         c.item(prints, path, f"job `{GATE_JOB}` must print the event name and "
                "GITHUB_SHA in one step")
+        check_default_branch_step(c, path, gate)
 
     # Every job that uploads evidence records the SHA first; every job that
     # downloads evidence verifies it against the gate's output.
@@ -323,6 +345,33 @@ def check_rtl_full(c, wf, policy):
             needs = needs if isinstance(needs, list) else [needs]
             c.item(GATE_JOB in needs, path,
                    f"job `{jid}` must need `{GATE_JOB}` to read its output")
+
+
+def check_default_branch_step(c, path, gate):
+    """The gate reads the repository default branch live and hands it to
+    --require-default-branch, in a shape that cannot be neutered quietly."""
+    found = [s for s in steps(gate) if DEFAULT_BRANCH_FLAG in step_text(s)]
+    c.item(len(found) == 1, path, f"job `{GATE_JOB}` must run scripts/"
+           f"ci_events.py {DEFAULT_BRANCH_FLAG} in exactly one step "
+           f"(found {len(found)})")
+    if len(found) != 1:
+        return
+    step = found[0]
+    text = step_text(step)
+    env = step.get("env") if isinstance(step.get("env"), dict) else {}
+    token = str(env.get("GH_TOKEN", "")).strip()
+    c.item(token == "${{ github.token }}", path, "the default-branch step "
+           f"must carry GH_TOKEN: ${{{{ github.token }}}} (found {token!r})")
+    c.item("ci_events.py" in text and "gh api" in text
+           and "$GITHUB_REPOSITORY" in text and ".default_branch" in text,
+           path, "the default-branch step must read the live setting with "
+           "gh api repos/$GITHUB_REPOSITORY --jq .default_branch")
+    c.item('--event "$GITHUB_EVENT_NAME"' in text and "--observed" in text,
+           path, "the default-branch step must pass --event "
+           "\"$GITHUB_EVENT_NAME\" and --observed to the verifier")
+    neutered = bool(step.get("continue-on-error")) or "|| true" in text
+    c.item(not neutered, path, "the default-branch step must fail closed: "
+           "no continue-on-error, no `|| true`")
 
 
 def check_rtl_fast(c, wf):
@@ -401,6 +450,37 @@ def check_records(shas, roots):
     else:
         lines.append(f"target-sha: OK, {len(roots)} record(s) all {expected}")
     return findings, lines
+
+
+# --------------------------------------------------------------------------
+# --require-default-branch: the live repository-setting assertion
+# --------------------------------------------------------------------------
+
+def check_default_branch(event, observed):
+    """(findings, lines) for one run's view of the repository default branch.
+
+    `event` is GITHUB_EVENT_NAME, `observed` what `gh api` returned (or the
+    placeholder the gate substitutes when it could not read it). The events
+    in DEFAULT_BRANCH_EVENTS refuse anything but PUSH_BRANCH, an unreadable
+    value included; every other event prints and continues."""
+    if not event:
+        raise CannotRun("--event is required: the decision depends on it")
+    observed = (observed or "").strip()
+    governed = event in DEFAULT_BRANCH_EVENTS
+    shown = observed or "<empty>"
+    lines = [f"default_branch={shown} expected={PUSH_BRANCH} event={event} "
+             f"({'governed' if governed else 'informational'})"]
+    if observed == PUSH_BRANCH:
+        lines.append("default-branch: OK")
+        return [], lines
+    if governed:
+        return [f"the repository default branch is {shown!r}, not "
+                f"{PUSH_BRANCH!r}: a {event} run would validate the wrong "
+                "branch; refusing"], lines
+    lines.append(f"default-branch: WARNING, {shown!r} is not {PUSH_BRANCH!r}; "
+                 f"this {event} run continues, the next scheduled or "
+                 "dispatched run will refuse")
+    return [], lines
 
 
 # --------------------------------------------------------------------------
@@ -532,6 +612,36 @@ def _mutations():
         job = jobs(w[RTL_FULL])["verilator-suites"]
         job["needs"] = [n for n in job["needs"] if n != GATE_JOB]
 
+    def db_step(w):
+        for s in steps(jobs(w[RTL_FULL])[GATE_JOB]):
+            if DEFAULT_BRANCH_FLAG in step_text(s):
+                return s
+        raise AssertionError("fixture drift: no default-branch step")
+
+    def m_db_step_removed(w):
+        strip_steps(w, RTL_FULL, GATE_JOB, DEFAULT_BRANCH_FLAG)
+
+    def m_db_token_missing(w):
+        del db_step(w)["env"]["GH_TOKEN"]
+
+    def m_db_no_live_read(w):
+        s = db_step(w)
+        assert "gh api" in s["run"]
+        s["run"] = s["run"].replace("gh api", "echo")
+
+    def m_db_event_not_passed(w):
+        s = db_step(w)
+        assert '--event "$GITHUB_EVENT_NAME"' in s["run"]
+        s["run"] = s["run"].replace('--event "$GITHUB_EVENT_NAME"',
+                                    "--event push")
+
+    def m_db_continue_on_error(w):
+        db_step(w)["continue-on-error"] = True
+
+    def m_db_or_true(w):
+        s = db_step(w)
+        s["run"] = s["run"].rstrip("\n") + " || true\n"
+
     def m_docs_no_check(w):
         for job in jobs(w[DOCS]).values():
             for s in steps(job):
@@ -587,6 +697,18 @@ def _mutations():
          m_yosys_aggregate_no_verify, VERIFY_FLAG),
         ("rtl aggregate no longer needs the gate", m_aggregate_without_gate,
          f"must need `{GATE_JOB}`"),
+        ("rtl default-branch step removed", m_db_step_removed,
+         "exactly one step"),
+        ("rtl default-branch step without GH_TOKEN", m_db_token_missing,
+         "GH_TOKEN"),
+        ("rtl default-branch step reads nothing live", m_db_no_live_read,
+         "gh api"),
+        ("rtl default-branch step without the event", m_db_event_not_passed,
+         "--event"),
+        ("rtl default-branch step neutered by continue-on-error",
+         m_db_continue_on_error, "fail closed"),
+        ("rtl default-branch step neutered by || true", m_db_or_true,
+         "fail closed"),
         ("rtl public name verilator-suites renamed",
          m_rename_job(RTL_FULL, "verilator-suites"), "`verilator-suites`"),
         ("rtl public name yosys-portability renamed",
@@ -734,6 +856,48 @@ def selftest(root):
             else:
                 problems.append(f"records arm failed: {name}")
 
+    # --require-default-branch arms: the decision for every event class. An
+    # inverted or weakened comparison fails one of these, which is what makes
+    # the YAML shape checks above worth having.
+    def refuses(event, observed):
+        f, _ = check_default_branch(event, observed)
+        return bool(f) and any(observed in x or "<empty>" in x for x in f)
+
+    def passes(event, observed):
+        f, _ = check_default_branch(event, observed)
+        return not f
+
+    def warns(event, observed):
+        f, lines = check_default_branch(event, observed)
+        return not f and any("WARNING" in x for x in lines)
+
+    db_cases = [
+        ("schedule on dev passes", passes("schedule", PUSH_BRANCH)),
+        ("dispatch on dev passes", passes("workflow_dispatch", PUSH_BRANCH)),
+        ("schedule on main refuses, naming main", refuses("schedule", "main")),
+        ("dispatch on main refuses", refuses("workflow_dispatch", "main")),
+        ("schedule with an unreadable value refuses",
+         refuses("schedule", "unreadable")),
+        ("schedule with an empty value refuses", refuses("schedule", "")),
+        ("schedule with surrounding whitespace still passes",
+         passes("schedule", f" {PUSH_BRANCH}\n")),
+        ("pull_request on main warns and continues",
+         warns("pull_request", "main")),
+        ("push on main warns and continues", warns("push", "main")),
+    ]
+    try:
+        check_default_branch("", PUSH_BRANCH)
+    except CannotRun:
+        db_cases.append(("a missing event cannot run", True))
+    else:
+        db_cases.append(("a missing event cannot run", False))
+    for name, ok in db_cases:
+        checked_arms += 1
+        if ok:
+            print(f"  ok   default-branch: {name}")
+        else:
+            problems.append(f"default-branch arm failed: {name}")
+
     if problems:
         for p in problems:
             print("  FAIL " + p)
@@ -789,6 +953,19 @@ def run_require(sha_args, roots):
     return RC_FINDING if findings else RC_OK
 
 
+def run_require_default_branch(event, observed):
+    try:
+        findings, lines = check_default_branch(event, observed)
+    except CannotRun as exc:
+        print(f"ci_events: cannot run: {exc}")
+        return RC_CANNOT_RUN
+    for line in lines:
+        print(line)
+    for f in findings:
+        print("  FAIL " + f)
+    return RC_FINDING if findings else RC_OK
+
+
 def main(argv):
     parser = argparse.ArgumentParser(
         description="Hold the CI workflow files to their documented event "
@@ -800,11 +977,19 @@ def main(argv):
                       help="mutation arms over in-memory copies")
     mode.add_argument("--require-target-sha", action="store_true",
                       help="verify every shard's TARGET_SHA record")
+    mode.add_argument("--require-default-branch", action="store_true",
+                      help="assert the live repository default branch for "
+                           "the events it governs")
     parser.add_argument("--root", type=pathlib.Path, default=ROOT,
                         help="repository root (default: this script's)")
     parser.add_argument("--sha", action="append", default=[],
                         metavar="LABEL=SHA",
                         help="a source of the run's SHA (gate, run, checkout)")
+    parser.add_argument("--event", default="",
+                        help="GITHUB_EVENT_NAME (--require-default-branch)")
+    parser.add_argument("--observed", default="",
+                        help="the default branch gh api reported "
+                             "(--require-default-branch)")
     parser.add_argument("roots", nargs="*",
                         help="shard evidence directories (--require-target-sha)")
     args = parser.parse_args(argv[1:])
@@ -812,6 +997,8 @@ def main(argv):
         return run_check(args.root)
     if args.selftest:
         return selftest(args.root)
+    if args.require_default_branch:
+        return run_require_default_branch(args.event, args.observed)
     return run_require(args.sha, args.roots)
 
 

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Hold the CI workflow files to their documented event and SHA contract.
+
+WHY THIS EXISTS (issues #174, #181). The hosted CI contract lives in four
+workflow files and one page of prose, docs/testing/CI_WORKFLOWS.md, and for
+three weeks they disagreed in ways nothing measured:
+
+  * rtl.yml carried a nightly cron that could not fire. GitHub schedules only
+    the default branch, the default was `main`, and main's rtl.yml had no
+    `schedule` at all. The page said the cron was "staged".
+  * docs.yml ran on `push: [main]` only, so the docs gate never ran on a merge
+    result, while CONTRIBUTING.md said "CI does not run on dev at all" after
+    rtl-fast.yml and rtl.yml had started running on every push to dev.
+  * The public check names the merge bar reads (`rtl-fast`, `verilator-suites`,
+    `yosys-portability`, `elaborate`) were held only by convention.
+
+Since 2026-08-22 `dev` is the repository default branch (#174, decision 3), so
+the cron and `gh workflow run rtl.yml --ref <branch>` are executable and the
+page states the contract. This gate keeps the files and the page from drifting
+apart again. `--check` parses the workflow files with pyyaml and asserts every
+item the page promises; `--selftest` removes or alters each item, one at a
+time, on in-memory copies and requires the check to catch each one, and fails
+if the checker is stubbed to find nothing.
+
+THE SHA CONTRACT (#174, decision 2). GitHub pins GITHUB_SHA once per run for
+every event: the pushed commit, the merge commit of a pull request, the tip of
+the default branch for a schedule, the tip of the chosen ref for a dispatch.
+Every checkout that does not override `ref` therefore validates one tree. The
+exhaustive workflow makes that explicit: the gate job prints event, ref and SHA
+and exports `target_sha`; every worker writes GITHUB_SHA into a TARGET_SHA file
+beside its evidence; both aggregates run `--require-target-sha` over the
+downloaded shards and refuse a missing record, a record naming another tree, or
+a gate/run/checkout SHA that is not one value. A missing record is a failure,
+never a skip. `--check` refuses any `actions/checkout` step in rtl.yml that
+overrides `ref`, requires every artifact-uploading job to record the SHA and
+every artifact-downloading job to verify it.
+
+    scripts/ci_events.py --check        # the live tree against the contract
+    scripts/ci_events.py --selftest     # mutation arms over in-memory copies
+    scripts/ci_events.py --require-target-sha --sha gate=<sha> \\
+        --sha run=<sha> --sha checkout=<sha> -- <shard-dir>...
+
+Exit 0 = clean, 1 = a finding, 2 = cannot run (pyyaml absent, a file missing
+or unparseable, usage).
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import pathlib
+import re
+import sys
+import tempfile
+
+RC_OK, RC_FINDING, RC_CANNOT_RUN = 0, 1, 2
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+RTL_FULL = ".github/workflows/rtl.yml"
+RTL_FAST = ".github/workflows/rtl-fast.yml"
+DOCS = ".github/workflows/docs.yml"
+ELABORATE = ".github/workflows/elaborate.yml"
+POLICY = "docs/testing/CI_WORKFLOWS.md"
+WORKFLOWS = (RTL_FULL, RTL_FAST, DOCS, ELABORATE)
+FILES = WORKFLOWS + (POLICY,)
+
+#: The pull-request activity types both RTL workflows subscribe, exactly.
+PR_TYPES = ("opened", "reopened", "synchronize", "ready_for_review",
+            "converted_to_draft")
+#: The branch every workflow must run on when pushed to.
+PUSH_BRANCH = "dev"
+#: The record every worker writes beside its evidence.
+RECORD = "TARGET_SHA"
+#: The gate job of the exhaustive workflow and the output it exports.
+GATE_JOB = "full-ci-gate"
+GATE_OUTPUT = "target_sha"
+#: How an aggregate invokes the verifier (the first token after the script).
+VERIFY_FLAG = "--require-target-sha"
+#: Public check names the merge bar reads (AGENTS.md section 7), per file.
+PUBLIC_NAMES = {
+    RTL_FULL: ("verilator-suites", "yosys-portability"),
+    RTL_FAST: ("rtl-fast",),
+    ELABORATE: ("elaborate",),
+}
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+CRON_RE = re.compile(r"^\s*(\d{1,2})\s+(\d{1,2})\s+\*\s+\*\s+\*\s*$")
+
+
+class CannotRun(Exception):
+    """An input the check cannot judge: missing, unparseable, no pyyaml."""
+
+
+# --------------------------------------------------------------------------
+# Loading
+# --------------------------------------------------------------------------
+
+def load_yaml(text, path):
+    try:
+        import yaml  # noqa: WPS433  (deliberately late: absence is rc 2)
+    except ImportError as exc:
+        raise CannotRun("pyyaml is not importable; install python3-yaml "
+                        "or `pip install pyyaml`") from exc
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise CannotRun(f"{path}: does not parse as YAML: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise CannotRun(f"{path}: top level is not a mapping")
+    return doc
+
+
+def read_tree(root):
+    """The five files as text, keyed by their repository-relative path."""
+    world = {}
+    for rel in FILES:
+        path = root / rel
+        try:
+            world[rel] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise CannotRun(f"{rel}: cannot read: {exc}") from exc
+    return world
+
+
+def parse_world(world):
+    """Text world -> parsed world: YAML mappings for workflows, text for the
+    policy page. Raises CannotRun for anything it cannot judge."""
+    parsed = {}
+    for rel in FILES:
+        if rel not in world:
+            raise CannotRun(f"{rel}: missing")
+        parsed[rel] = (load_yaml(world[rel], rel) if rel in WORKFLOWS
+                       else world[rel])
+    return parsed
+
+
+# --------------------------------------------------------------------------
+# Helpers over a parsed workflow
+# --------------------------------------------------------------------------
+
+def triggers(wf):
+    """The `on:` mapping. PyYAML 1.1 reads the bare key `on` as boolean True,
+    so accept both spellings; anything else is an empty contract."""
+    on = wf.get("on", wf.get(True))
+    return on if isinstance(on, dict) else {}
+
+
+def jobs(wf):
+    j = wf.get("jobs")
+    return j if isinstance(j, dict) else {}
+
+
+def steps(job):
+    s = job.get("steps") if isinstance(job, dict) else None
+    return [x for x in s if isinstance(x, dict)] if isinstance(s, list) else []
+
+
+def display_name(job_id, job):
+    name = job.get("name") if isinstance(job, dict) else None
+    return name if isinstance(name, str) and name.strip() else job_id
+
+
+def step_text(step):
+    """Everything a step says: its run script plus its env values, so an
+    expression passed through `env:` counts as referenced."""
+    parts = []
+    run = step.get("run")
+    if isinstance(run, str):
+        parts.append(run)
+    env = step.get("env")
+    if isinstance(env, dict):
+        parts.extend(str(v) for v in env.values())
+    return "\n".join(parts)
+
+
+def uses(step, action):
+    u = step.get("uses")
+    return isinstance(u, str) and (u == action or u.startswith(action + "@"))
+
+
+def cron_time(cron):
+    """`M H * * *` -> `HH:MM UTC`, or None for any other shape."""
+    m = CRON_RE.match(cron) if isinstance(cron, str) else None
+    if not m:
+        return None
+    minute, hour = int(m.group(1)), int(m.group(2))
+    if not (0 <= minute <= 59 and 0 <= hour <= 23):
+        return None
+    return f"{hour:02d}:{minute:02d} UTC"
+
+
+# --------------------------------------------------------------------------
+# The contract
+# --------------------------------------------------------------------------
+
+class Contract:
+    def __init__(self):
+        self.checked = 0
+        self.findings = []
+        self.notes = []
+
+    def item(self, ok, path, what):
+        self.checked += 1
+        if not ok:
+            self.findings.append(f"{path}: {what}")
+
+
+def check_push_and_pr(c, path, wf, exact_types):
+    on = triggers(wf)
+    push = on.get("push")
+    branches = push.get("branches") if isinstance(push, dict) else None
+    c.item(isinstance(branches, list) and PUSH_BRANCH in branches, path,
+           f"push must subscribe branches including `{PUSH_BRANCH}` "
+           f"(found {branches!r})")
+    c.item("pull_request" in on, path, "must subscribe pull_request")
+    if exact_types:
+        pr = on.get("pull_request")
+        types = pr.get("types") if isinstance(pr, dict) else None
+        ok = (isinstance(types, list) and len(types) == len(PR_TYPES)
+              and set(types) == set(PR_TYPES))
+        c.item(ok, path, "pull_request.types must be exactly "
+               f"{list(PR_TYPES)} (found {types!r})")
+
+
+def check_cancel_in_progress(c, path, wf):
+    conc = wf.get("concurrency")
+    cancel = conc.get("cancel-in-progress") if isinstance(conc, dict) else None
+    c.item(cancel is True, path,
+           f"concurrency.cancel-in-progress must be true (found {cancel!r})")
+    group = conc.get("group") if isinstance(conc, dict) else None
+    ok = (isinstance(group, str) and "github.event.pull_request.number" in group
+          and "github.ref" in group)
+    c.item(ok, path, "concurrency.group must scope to the PR number or the "
+           f"ref (found {group!r})")
+
+
+def check_public_names(c, path, wf):
+    names = {display_name(jid, j) for jid, j in jobs(wf).items()}
+    for want in PUBLIC_NAMES.get(path, ()):
+        c.item(want in names, path,
+               f"public check name `{want}` must exist as a job (found "
+               f"{sorted(names)})")
+
+
+def check_rtl_full(c, wf, policy):
+    path = RTL_FULL
+    check_push_and_pr(c, path, wf, exact_types=True)
+    on = triggers(wf)
+
+    # Dispatch: present, and no inputs. The documented command has none, and a
+    # required input would make `gh workflow run rtl.yml --ref <branch>` fail.
+    c.item("workflow_dispatch" in on, path, "must subscribe workflow_dispatch")
+    dispatch = on.get("workflow_dispatch")
+    has_inputs = isinstance(dispatch, dict) and bool(dispatch.get("inputs"))
+    c.item(not has_inputs, path, "workflow_dispatch must carry no inputs: the "
+           "dispatcher chooses the ref and nothing else")
+
+    # Schedule: exactly one cron of the `M H * * *` shape, stated on the page
+    # both as the literal string and as the rendered time.
+    sched = on.get("schedule")
+    crons = ([e.get("cron") for e in sched if isinstance(e, dict)]
+             if isinstance(sched, list) else [])
+    c.item(len(crons) == 1, path,
+           f"schedule must carry exactly one cron (found {crons!r})")
+    cron = crons[0] if len(crons) == 1 else None
+    when = cron_time(cron)
+    c.item(when is not None, path,
+           f"cron must be a daily `M H * * *` entry (found {cron!r})")
+    if when is not None:
+        c.item(f"`{cron}`" in policy, POLICY,
+               f"must state the cron string `{cron}`")
+        c.item(when in policy, POLICY,
+               f"must state the cron's time as {when}")
+        c.notes.append(f"cron `{cron}` renders {when}; the policy page states both")
+
+    check_cancel_in_progress(c, path, wf)
+    check_public_names(c, path, wf)
+
+    # One authoritative SHA: no checkout overrides the event's pinned commit.
+    for jid, job in jobs(wf).items():
+        for n, step in enumerate(steps(job), 1):
+            if uses(step, "actions/checkout"):
+                with_ = step.get("with")
+                overrides = isinstance(with_, dict) and "ref" in with_
+                c.item(not overrides, path,
+                       f"job `{jid}` step {n}: actions/checkout must not "
+                       f"override `ref` (found {with_!r})")
+
+    # The gate prints the event and the SHA, and exports target_sha.
+    gate = jobs(wf).get(GATE_JOB)
+    c.item(isinstance(gate, dict), path, f"job `{GATE_JOB}` must exist")
+    if isinstance(gate, dict):
+        outputs = gate.get("outputs")
+        c.item(isinstance(outputs, dict) and GATE_OUTPUT in outputs, path,
+               f"job `{GATE_JOB}` must export the `{GATE_OUTPUT}` output")
+        prints = any("GITHUB_EVENT_NAME" in step_text(s)
+                     and "GITHUB_SHA" in step_text(s) for s in steps(gate))
+        c.item(prints, path, f"job `{GATE_JOB}` must print the event name and "
+               "GITHUB_SHA in one step")
+
+    # Every job that uploads evidence records the SHA first; every job that
+    # downloads evidence verifies it against the gate's output.
+    ref = f"needs.{GATE_JOB}.outputs.{GATE_OUTPUT}"
+    for jid, job in jobs(wf).items():
+        ss = steps(job)
+        upload_at = next((i for i, s in enumerate(ss)
+                          if uses(s, "actions/upload-artifact")), None)
+        if upload_at is not None:
+            recorded = any(RECORD in step_text(s) and "GITHUB_SHA" in step_text(s)
+                           and ref in step_text(s) for s in ss[:upload_at])
+            c.item(recorded, path, f"job `{jid}` uploads evidence and must "
+                   f"first write GITHUB_SHA into {RECORD}, checked against "
+                   f"{ref}")
+        if any(uses(s, "actions/download-artifact") for s in ss):
+            verifies = any(VERIFY_FLAG in step_text(s) and ref in step_text(s)
+                           and "ci_events.py" in step_text(s) for s in ss)
+            c.item(verifies, path, f"job `{jid}` downloads evidence and must "
+                   f"run scripts/ci_events.py {VERIFY_FLAG} against {ref}")
+            needs = job.get("needs")
+            needs = needs if isinstance(needs, list) else [needs]
+            c.item(GATE_JOB in needs, path,
+                   f"job `{jid}` must need `{GATE_JOB}` to read its output")
+
+
+def check_rtl_fast(c, wf):
+    check_push_and_pr(c, RTL_FAST, wf, exact_types=True)
+    check_cancel_in_progress(c, RTL_FAST, wf)
+    check_public_names(c, RTL_FAST, wf)
+
+
+def check_docs(c, wf):
+    check_push_and_pr(c, DOCS, wf, exact_types=False)
+    texts = [step_text(s) for j in jobs(wf).values() for s in steps(j)]
+    for flag in ("--check", "--selftest"):
+        wired = any(f"scripts/ci_events.py {flag}" in t for t in texts)
+        c.item(wired, DOCS, f"must run `python3 scripts/ci_events.py {flag}` "
+               "(this gate is not a gate unless a workflow runs it)")
+
+
+def check_elaborate(c, wf):
+    check_push_and_pr(c, ELABORATE, wf, exact_types=False)
+    check_public_names(c, ELABORATE, wf)
+
+
+def check(parsed):
+    """The whole contract over a parsed world. Returns a Contract."""
+    c = Contract()
+    check_rtl_full(c, parsed[RTL_FULL], parsed[POLICY])
+    check_rtl_fast(c, parsed[RTL_FAST])
+    check_docs(c, parsed[DOCS])
+    check_elaborate(c, parsed[ELABORATE])
+    return c
+
+
+# --------------------------------------------------------------------------
+# --require-target-sha: the aggregate-side verifier
+# --------------------------------------------------------------------------
+
+def check_records(shas, roots):
+    """`shas` maps a label (gate, run, checkout) to the SHA that source
+    reports; `roots` are the downloaded shard directories. Returns
+    (findings, lines): every finding is a refusal, lines are the verdict."""
+    findings, lines = [], []
+    for label, sha in shas.items():
+        if not SHA_RE.match(sha or ""):
+            findings.append(f"{label} SHA {sha!r} is not a 40-digit lowercase "
+                            "hexadecimal commit id")
+    distinct = sorted(set(shas.values()))
+    if len(distinct) != 1:
+        findings.append("the sources disagree on which tree this run "
+                        "validates: " + ", ".join(f"{k}={v}" for k, v in
+                                                  sorted(shas.items())))
+    expected = distinct[0] if len(distinct) == 1 else None
+    if not roots:
+        findings.append("no shard evidence directory to verify: the download "
+                        "produced nothing, which is a failure, not a skip")
+    for root in roots:
+        record = pathlib.Path(root) / RECORD
+        name = pathlib.Path(root).name
+        if not record.is_file():
+            findings.append(f"{name}: {RECORD} missing, the worker did not "
+                            "record the tree it validated")
+            continue
+        try:
+            got = record.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError) as exc:
+            findings.append(f"{name}: {RECORD} unreadable: {exc}")
+            continue
+        if not SHA_RE.match(got):
+            findings.append(f"{name}: {RECORD} holds {got!r}, not a commit id")
+        elif expected is not None and got != expected:
+            findings.append(f"{name}: validated {got}, this run is {expected}")
+        else:
+            lines.append(f"  ok   {name}  {got}")
+    if findings:
+        lines.append(f"target-sha: {len(findings)} finding(s); refusing this "
+                     "evidence")
+    else:
+        lines.append(f"target-sha: OK, {len(roots)} record(s) all {expected}")
+    return findings, lines
+
+
+# --------------------------------------------------------------------------
+# Self-test
+# --------------------------------------------------------------------------
+
+def _mutations():
+    """(name, path-or-None, mutate(parsed_world), expected finding fragment).
+
+    Every arm alters ONE contract item on a deep copy of the pristine parsed
+    world and names the fragment the finding must carry. Arms that touch the
+    policy page mutate its text and assert the text actually changed, so an
+    arm cannot pass because its edit found nothing to edit."""
+
+    def on(w, path):
+        return triggers(w[path])
+
+    def policy_replace(w, old, new):
+        assert old in w[POLICY], f"fixture drift: {old!r} not on the page"
+        w[POLICY] = w[POLICY].replace(old, new)
+
+    def first_checkout(w, path=RTL_FULL):
+        for job in jobs(w[path]).values():
+            for s in steps(job):
+                if uses(s, "actions/checkout"):
+                    return s
+        raise AssertionError("fixture drift: no checkout step")
+
+    def job_steps(w, path, jid):
+        return jobs(w[path])[jid]["steps"]
+
+    def strip_steps(w, path, jid, needle):
+        ss = job_steps(w, path, jid)
+        kept = [s for s in ss if needle not in step_text(s)]
+        assert len(kept) < len(ss), f"fixture drift: no step mentions {needle}"
+        jobs(w[path])[jid]["steps"] = kept
+
+    def m_push_main(path):
+        def f(w):
+            on(w, path)["push"]["branches"] = ["main"]
+        return f
+
+    def m_drop_pr(path):
+        def f(w):
+            del on(w, path)["pull_request"]
+        return f
+
+    def m_pr_type_missing(path):
+        def f(w):
+            on(w, path)["pull_request"]["types"].remove("converted_to_draft")
+        return f
+
+    def m_pr_type_extra(path):
+        def f(w):
+            on(w, path)["pull_request"]["types"].append("labeled")
+        return f
+
+    def m_cancel_false(path):
+        def f(w):
+            w[path]["concurrency"]["cancel-in-progress"] = False
+        return f
+
+    def m_no_concurrency(path):
+        def f(w):
+            del w[path]["concurrency"]
+        return f
+
+    def m_rename_job(path, jid):
+        def f(w):
+            jobs(w[path])[jid]["name"] = jid + "-renamed"
+        return f
+
+    def m_drop_dispatch(w):
+        del on(w, RTL_FULL)["workflow_dispatch"]
+
+    def m_dispatch_inputs(w):
+        on(w, RTL_FULL)["workflow_dispatch"] = {
+            "inputs": {"ref": {"type": "string", "required": True}}}
+
+    def m_drop_schedule(w):
+        del on(w, RTL_FULL)["schedule"]
+
+    def m_two_crons(w):
+        on(w, RTL_FULL)["schedule"].append({"cron": "17 13 * * *"})
+
+    def m_cron_moved(w):
+        on(w, RTL_FULL)["schedule"][0]["cron"] = "17 2 * * *"
+
+    def m_cron_shape(w):
+        on(w, RTL_FULL)["schedule"][0]["cron"] = "*/15 * * * *"
+
+    def m_page_time(w):
+        policy_replace(w, "01:17 UTC", "02:17 UTC")
+
+    def m_page_cron(w):
+        policy_replace(w, "`17 1 * * *`", "`17 1 * * 1-5`")
+
+    def m_checkout_ref(w):
+        first_checkout(w)["with"] = {"ref": "dev"}
+
+    def m_checkout_ref_deep(w):
+        s = first_checkout(w)
+        s.setdefault("with", {})["ref"] = "${{ github.event.pull_request.head.sha }}"
+
+    def m_drop_gate_output(w):
+        del jobs(w[RTL_FULL])[GATE_JOB]["outputs"][GATE_OUTPUT]
+
+    def m_gate_silent(w):
+        strip_steps(w, RTL_FULL, GATE_JOB, "GITHUB_EVENT_NAME")
+
+    def m_worker_no_record(w):
+        strip_steps(w, RTL_FULL, "verilator-shards", RECORD)
+
+    def m_yosys_no_record(w):
+        strip_steps(w, RTL_FULL, "yosys-shards", RECORD)
+
+    def m_record_after_upload(w):
+        ss = job_steps(w, RTL_FULL, "verilator-shards")
+        rec = next(i for i, s in enumerate(ss) if RECORD in step_text(s))
+        ss.append(ss.pop(rec))
+
+    def m_aggregate_no_verify(w):
+        strip_steps(w, RTL_FULL, "verilator-suites", VERIFY_FLAG)
+
+    def m_yosys_aggregate_no_verify(w):
+        strip_steps(w, RTL_FULL, "yosys-portability", VERIFY_FLAG)
+
+    def m_aggregate_without_gate(w):
+        job = jobs(w[RTL_FULL])["verilator-suites"]
+        job["needs"] = [n for n in job["needs"] if n != GATE_JOB]
+
+    def m_docs_no_check(w):
+        for job in jobs(w[DOCS]).values():
+            for s in steps(job):
+                if "scripts/ci_events.py --check" in step_text(s):
+                    s["run"] = s["run"].replace("scripts/ci_events.py --check",
+                                                "true")
+                    return
+        raise AssertionError("fixture drift: docs.yml does not run --check")
+
+    def m_docs_no_selftest(w):
+        for job in jobs(w[DOCS]).values():
+            for s in steps(job):
+                if "scripts/ci_events.py --selftest" in step_text(s):
+                    s["run"] = s["run"].replace(
+                        "scripts/ci_events.py --selftest", "true")
+                    return
+        raise AssertionError("fixture drift: docs.yml does not run --selftest")
+
+    return [
+        # rtl.yml triggers
+        ("rtl push on main, not dev", m_push_main(RTL_FULL), "push must subscribe"),
+        ("rtl no pull_request", m_drop_pr(RTL_FULL), "must subscribe pull_request"),
+        ("rtl PR type missing", m_pr_type_missing(RTL_FULL), "pull_request.types"),
+        ("rtl PR type extra", m_pr_type_extra(RTL_FULL), "pull_request.types"),
+        ("rtl no workflow_dispatch", m_drop_dispatch, "workflow_dispatch"),
+        ("rtl dispatch with inputs", m_dispatch_inputs, "no inputs"),
+        ("rtl no schedule", m_drop_schedule, "exactly one cron"),
+        ("rtl two crons", m_two_crons, "exactly one cron"),
+        ("rtl cron moved, page unchanged", m_cron_moved, "cron's time"),
+        ("rtl cron not daily", m_cron_shape, "daily"),
+        ("page states another time", m_page_time, "cron's time"),
+        ("page states another cron string", m_page_cron, "cron string"),
+        ("rtl cancel-in-progress false", m_cancel_false(RTL_FULL),
+         "cancel-in-progress"),
+        ("rtl no concurrency block", m_no_concurrency(RTL_FULL),
+         "cancel-in-progress"),
+        # rtl.yml SHA contract
+        ("rtl checkout overrides ref", m_checkout_ref, "must not override `ref`"),
+        ("rtl checkout ref via expression", m_checkout_ref_deep,
+         "must not override `ref`"),
+        ("rtl gate drops target_sha output", m_drop_gate_output,
+         f"`{GATE_OUTPUT}` output"),
+        ("rtl gate prints nothing", m_gate_silent, "print the event name"),
+        ("rtl Verilator worker records nothing", m_worker_no_record,
+         f"write GITHUB_SHA into {RECORD}"),
+        ("rtl Yosys worker records nothing", m_yosys_no_record,
+         f"write GITHUB_SHA into {RECORD}"),
+        ("rtl record written after the upload", m_record_after_upload,
+         f"write GITHUB_SHA into {RECORD}"),
+        ("rtl verilator-suites skips the verifier", m_aggregate_no_verify,
+         VERIFY_FLAG),
+        ("rtl yosys-portability skips the verifier",
+         m_yosys_aggregate_no_verify, VERIFY_FLAG),
+        ("rtl aggregate no longer needs the gate", m_aggregate_without_gate,
+         f"must need `{GATE_JOB}`"),
+        ("rtl public name verilator-suites renamed",
+         m_rename_job(RTL_FULL, "verilator-suites"), "`verilator-suites`"),
+        ("rtl public name yosys-portability renamed",
+         m_rename_job(RTL_FULL, "yosys-portability"), "`yosys-portability`"),
+        # rtl-fast.yml
+        ("fast push on main, not dev", m_push_main(RTL_FAST), "push must subscribe"),
+        ("fast PR type missing", m_pr_type_missing(RTL_FAST), "pull_request.types"),
+        ("fast cancel-in-progress false", m_cancel_false(RTL_FAST),
+         "cancel-in-progress"),
+        ("fast public name rtl-fast renamed", m_rename_job(RTL_FAST, "rtl-fast"),
+         "`rtl-fast`"),
+        # docs.yml
+        ("docs push on main, not dev", m_push_main(DOCS), "push must subscribe"),
+        ("docs no pull_request", m_drop_pr(DOCS), "must subscribe pull_request"),
+        ("docs does not run --check", m_docs_no_check, "--check"),
+        ("docs does not run --selftest", m_docs_no_selftest, "--selftest"),
+        # elaborate.yml
+        ("elaborate push on main, not dev", m_push_main(ELABORATE),
+         "push must subscribe"),
+        ("elaborate public name renamed", m_rename_job(ELABORATE, "elaborate"),
+         "`elaborate`"),
+    ]
+
+
+def _run_mutations(checker, pristine):
+    """Apply every arm to a deep copy and require `checker` to name the
+    expected fragment. Returns the list of arms that did NOT bite."""
+    misses = []
+    for name, mutate, want in _mutations():
+        world = copy.deepcopy(pristine)
+        mutate(world)
+        findings = checker(world)
+        if not any(want in f for f in findings):
+            misses.append(f"[{name}] expected a finding naming {want!r}, got "
+                          f"{findings or 'no findings'}")
+    return misses
+
+
+def selftest(root):
+    problems = []
+    checked_arms = 0
+
+    # The pristine tree is clean, and the contract is non-trivial.
+    try:
+        pristine = parse_world(read_tree(root))
+    except CannotRun as exc:
+        print(f"selftest: cannot load the pristine tree: {exc}")
+        return RC_CANNOT_RUN
+    clean = check(pristine)
+    if clean.findings:
+        problems.append("pristine tree is not clean: " +
+                        "; ".join(clean.findings))
+    if clean.checked < 30:
+        problems.append(f"only {clean.checked} contract item(s) checked; the "
+                        "contract has shrunk")
+
+    # Every arm bites, one item at a time.
+    real = lambda w: check(w).findings  # noqa: E731
+    misses = _run_mutations(real, pristine)
+    arms = _mutations()
+    checked_arms += len(arms)
+    for m in misses:
+        problems.append("mutation not caught: " + m)
+    for name, _, _ in arms:
+        if not any(name in m for m in misses):
+            print(f"  ok   caught: {name}")
+
+    # Vacuity: a checker stubbed to find nothing must fail every arm above.
+    stubbed = _run_mutations(lambda w: [], pristine)
+    if len(stubbed) != len(arms):
+        problems.append(f"vacuity: a stub checker failed only {len(stubbed)} "
+                        f"of {len(arms)} arms; the arms do not depend on the "
+                        "checker")
+    else:
+        print(f"  ok   vacuity: a stub that finds nothing fails all {len(arms)} arms")
+
+    # Inputs the check cannot judge are rc 2, never a pass.
+    for name, world in (
+        ("missing rtl.yml", {k: v for k, v in read_tree(root).items()
+                             if k != RTL_FULL}),
+        ("unparseable rtl.yml", dict(read_tree(root), **{RTL_FULL: "on: [\n"})),
+        ("scalar rtl.yml", dict(read_tree(root), **{RTL_FULL: "just text\n"})),
+    ):
+        try:
+            parse_world(world)
+        except CannotRun:
+            print(f"  ok   cannot-run: {name}")
+            checked_arms += 1
+        else:
+            problems.append(f"{name} was accepted instead of refused")
+
+    # --require-target-sha arms, over a temporary directory.
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    other = "fedcba9876543210fedcba9876543210fedcba98"
+    with tempfile.TemporaryDirectory() as td:
+        base = pathlib.Path(td)
+
+        def shards(n, content=sha + "\n"):
+            roots = []
+            for i in range(n):
+                d = base / f"suite-logs-{i}"
+                d.mkdir(exist_ok=True)
+                (d / RECORD).write_text(content)
+                (d / f"suite{i}.log").write_text("checks: 1\n")
+                roots.append(d)
+            return roots
+
+        three = dict(gate=sha, run=sha, checkout=sha)
+        cases = []
+        roots = shards(4)
+        f, _ = check_records(three, roots)
+        cases.append(("four matching records pass", not f))
+        (roots[2] / RECORD).unlink()
+        f, _ = check_records(three, roots)
+        cases.append(("a missing record is refused and named",
+                      any("suite-logs-2" in x and "missing" in x for x in f)))
+        roots = shards(4)
+        (roots[1] / RECORD).write_text(other + "\n")
+        f, _ = check_records(three, roots)
+        cases.append(("a record for another tree is refused",
+                      any("suite-logs-1" in x and other in x for x in f)))
+        (roots[1] / RECORD).write_text("not-a-sha\n")
+        f, _ = check_records(three, roots)
+        cases.append(("a malformed record is refused",
+                      any("not a commit id" in x for x in f)))
+        roots = shards(4)
+        f, _ = check_records(dict(gate=sha, run=other, checkout=sha), roots)
+        cases.append(("gate/run disagreement is refused",
+                      any("disagree" in x for x in f)))
+        f, _ = check_records(dict(gate=sha, run=sha, checkout=""), roots)
+        cases.append(("an empty source SHA is refused",
+                      any("checkout" in x and "not a 40-digit" in x for x in f)))
+        f, _ = check_records(three, [])
+        cases.append(("no shard directory at all is refused, not skipped",
+                      any("produced nothing" in x for x in f)))
+        none = base / "none"
+        none.mkdir()
+        f, _ = check_records(three, [none])
+        cases.append(("the empty placeholder directory is refused",
+                      any("none" in x and "missing" in x for x in f)))
+        for name, ok in cases:
+            checked_arms += 1
+            if ok:
+                print(f"  ok   records: {name}")
+            else:
+                problems.append(f"records arm failed: {name}")
+
+    if problems:
+        for p in problems:
+            print("  FAIL " + p)
+        print(f"selftest: {len(problems)} FAILURE(S)")
+        return RC_FINDING
+    print(f"selftest: PASS ({clean.checked} contract items, {checked_arms} "
+          "arms)")
+    return RC_OK
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def run_check(root):
+    try:
+        c = check(parse_world(read_tree(root)))
+    except CannotRun as exc:
+        print(f"ci_events: cannot run: {exc}")
+        return RC_CANNOT_RUN
+    for note in c.notes:
+        print("  note " + note)
+    for f in c.findings:
+        print("  FAIL " + f)
+    if c.findings:
+        print(f"ci_events: {len(c.findings)} finding(s) over {c.checked} "
+              "contract item(s)")
+        return RC_FINDING
+    print(f"ci_events: OK ({c.checked} contract item(s) across "
+          f"{len(WORKFLOWS)} workflow files and {POLICY})")
+    return RC_OK
+
+
+def run_require(sha_args, roots):
+    shas = {}
+    for arg in sha_args:
+        if "=" not in arg:
+            print(f"ci_events: --sha expects label=sha, got {arg!r}")
+            return RC_CANNOT_RUN
+        label, value = arg.split("=", 1)
+        if label in shas:
+            print(f"ci_events: --sha {label} given twice")
+            return RC_CANNOT_RUN
+        shas[label] = value.strip()
+    if not shas:
+        print("ci_events: --require-target-sha needs at least one --sha label=sha")
+        return RC_CANNOT_RUN
+    findings, lines = check_records(shas, [pathlib.Path(r) for r in roots])
+    for line in lines:
+        print(line)
+    for f in findings:
+        print("  FAIL " + f)
+    return RC_FINDING if findings else RC_OK
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Hold the CI workflow files to their documented event "
+                    "and SHA contract.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true",
+                      help="the live tree against the contract")
+    mode.add_argument("--selftest", action="store_true",
+                      help="mutation arms over in-memory copies")
+    mode.add_argument("--require-target-sha", action="store_true",
+                      help="verify every shard's TARGET_SHA record")
+    parser.add_argument("--root", type=pathlib.Path, default=ROOT,
+                        help="repository root (default: this script's)")
+    parser.add_argument("--sha", action="append", default=[],
+                        metavar="LABEL=SHA",
+                        help="a source of the run's SHA (gate, run, checkout)")
+    parser.add_argument("roots", nargs="*",
+                        help="shard evidence directories (--require-target-sha)")
+    args = parser.parse_args(argv[1:])
+    if args.check:
+        return run_check(args.root)
+    if args.selftest:
+        return selftest(args.root)
+    return run_require(args.sha, args.roots)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -100,6 +100,36 @@ VERIFY_FLAG = "--require-target-sha"
 #: must be the default.
 DEFAULT_BRANCH_FLAG = "--require-default-branch"
 DEFAULT_BRANCH_EVENTS = ("schedule", "workflow_dispatch")
+#: The default-branch step's script, pinned verbatim after whitespace
+#: normalization ([R1] on PR #204, second round). A substring recognizer was
+#: fooled by a decoy: `observed=dev` beside a `gh api` inside `if false`.
+#: So the script is held to exactly these three lines, one unconditional
+#: live read into `observed` and one verifier call after it, and the
+#: structural reasons in check_default_branch_step name what a deviation
+#: did before the whole-script comparison refuses it.
+CANONICAL_OBSERVED = ('observed="$(gh api "repos/$GITHUB_REPOSITORY" '
+                      '--jq .default_branch 2>/dev/null || echo unreadable)"')
+CANONICAL_CALL = ("python3 scripts/ci_events.py --require-default-branch "
+                  '--event "$GITHUB_EVENT_NAME" --observed "$observed"')
+CANONICAL_DEFAULT_BRANCH_SCRIPT = ("set -euo pipefail", CANONICAL_OBSERVED,
+                                   CANONICAL_CALL)
+OBSERVED_ASSIGNMENT = re.compile(
+    r"(?:^|[;&|(]\s*|\b(?:export|local|declare|readonly|typeset)\s+)"
+    r"observed\s*\+?=")
+CONTROL_FLOW = re.compile(
+    r"(?:^|[;&|(]\s*)(?:if|case|for|while|until|select|function)\b"
+    r"|\b(?:then|fi|esac|do|done)\b|\(\)\s*\{")
+#: The SHA sources every aggregate passes to --require-target-sha, exactly:
+#: the gate's exported target, the aggregate's own run, and its checkout.
+#: The verifier refuses any other set ([R1], second round: with `run` and
+#: `checkout` dropped from both aggregates, everything stayed green).
+REQUIRED_SHA_LABELS = ("gate", "run", "checkout")
+REQUIRED_SHA_ARGS = {
+    "gate": '--sha gate="$GATE_SHA"',
+    "run": '--sha run="$GITHUB_SHA"',
+    "checkout": '--sha checkout="$(git rev-parse HEAD)"',
+}
+SHA_LABEL_RE = re.compile(r"--sha\s+([A-Za-z_]+)=")
 #: Public check names the merge bar reads (AGENTS.md section 7), per file.
 PUBLIC_NAMES = {
     RTL_FULL: ("verilator-suites", "yosys-portability"),
@@ -337,14 +367,55 @@ def check_rtl_full(c, wf, policy):
                    f"first write GITHUB_SHA into {RECORD}, checked against "
                    f"{ref}")
         if any(uses(s, "actions/download-artifact") for s in ss):
-            verifies = any(VERIFY_FLAG in step_text(s) and ref in step_text(s)
-                           and "ci_events.py" in step_text(s) for s in ss)
+            vsteps = [s for s in ss if VERIFY_FLAG in step_text(s)
+                      and "ci_events.py" in step_text(s)]
+            verifies = any(ref in step_text(s) for s in vsteps)
             c.item(verifies, path, f"job `{jid}` downloads evidence and must "
                    f"run scripts/ci_events.py {VERIFY_FLAG} against {ref}")
             needs = job.get("needs")
             needs = needs if isinstance(needs, list) else [needs]
             c.item(GATE_JOB in needs, path,
                    f"job `{jid}` must need `{GATE_JOB}` to read its output")
+            if vsteps:
+                check_sha_sources(c, path, jid, vsteps[0])
+
+
+def check_sha_sources(c, path, jid, step):
+    """An aggregate passes exactly the three SHA sources, each in the form
+    that binds it to what it claims: the gate's exported target through the
+    step env, the aggregate's own GITHUB_SHA, and its checkout HEAD."""
+    run = step.get("run") if isinstance(step.get("run"), str) else ""
+    script = " ".join(normalize_script(run))
+    labels = SHA_LABEL_RE.findall(script)
+    missing = [l for l in REQUIRED_SHA_LABELS if l not in labels]
+    unknown = sorted(set(labels) - set(REQUIRED_SHA_LABELS))
+    dup = sorted({l for l in labels if labels.count(l) > 1})
+    c.item(not missing and not unknown and not dup, path,
+           f"job `{jid}` must pass --sha for exactly "
+           f"{', '.join(REQUIRED_SHA_LABELS)}"
+           + (f"; missing: {', '.join(missing)}" if missing else "")
+           + (f"; unknown: {', '.join(unknown)}" if unknown else "")
+           + (f"; repeated: {', '.join(dup)}" if dup else ""))
+    for label, want in REQUIRED_SHA_ARGS.items():
+        c.item(want in script, path, f"job `{jid}` must pass {want} "
+               f"(the {label} source in its binding form)")
+    env = step.get("env") if isinstance(step.get("env"), dict) else {}
+    gate_ref = f"${{{{ needs.{GATE_JOB}.outputs.{GATE_OUTPUT} }}}}"
+    c.item(str(env.get("GATE_SHA", "")).strip() == gate_ref, path,
+           f"job `{jid}` must bind GATE_SHA to {gate_ref} in the step env")
+
+
+def normalize_script(run):
+    """Whitespace-normalized lines of a step script: continuation lines
+    joined, runs of blanks collapsed, blank lines dropped. Comment lines stay,
+    because a comment is not canonical either."""
+    joined = re.sub(r"\\\n", " ", run or "")
+    lines = []
+    for raw in joined.splitlines():
+        line = " ".join(raw.split())
+        if line:
+            lines.append(line)
+    return lines
 
 
 def check_default_branch_step(c, path, gate):
@@ -362,13 +433,35 @@ def check_default_branch_step(c, path, gate):
     token = str(env.get("GH_TOKEN", "")).strip()
     c.item(token == "${{ github.token }}", path, "the default-branch step "
            f"must carry GH_TOKEN: ${{{{ github.token }}}} (found {token!r})")
-    c.item("ci_events.py" in text and "gh api" in text
-           and "$GITHUB_REPOSITORY" in text and ".default_branch" in text,
-           path, "the default-branch step must read the live setting with "
-           "gh api repos/$GITHUB_REPOSITORY --jq .default_branch")
-    c.item('--event "$GITHUB_EVENT_NAME"' in text and "--observed" in text,
-           path, "the default-branch step must pass --event "
-           "\"$GITHUB_EVENT_NAME\" and --observed to the verifier")
+    run = step.get("run") if isinstance(step.get("run"), str) else ""
+    lines = normalize_script(run)
+    code = [(i, l) for i, l in enumerate(lines) if not l.startswith("#")]
+    # Structural reasons first, so a refusal names what went wrong.
+    assigns = [(i, l) for i, l in code if OBSERVED_ASSIGNMENT.search(l)]
+    c.item(len(assigns) == 1, path, "the default-branch step must assign "
+           f"`observed` exactly once (found {len(assigns)}): a second "
+           "assignment shadows the live value")
+    c.item(bool(assigns) and all(l == CANONICAL_OBSERVED for _, l in assigns),
+           path, "the default-branch step's observed value is not sourced "
+           f"from the live API call: expected exactly {CANONICAL_OBSERVED} "
+           f"(found {[l for _, l in assigns] or 'no assignment'})")
+    flow = [l for _, l in code if CONTROL_FLOW.search(l)]
+    c.item(not flow, path, "the default-branch step must read the setting "
+           f"unconditionally: control flow found ({flow})")
+    comments = [l for l in lines if l.startswith("#")]
+    c.item(not comments, path, "the default-branch step script carries no "
+           "comment lines (a `gh api` in a comment reads nothing; comments "
+           f"belong above the step): {comments}")
+    calls = [(i, l) for i, l in code if DEFAULT_BRANCH_FLAG in l]
+    c.item(len(calls) == 1 and calls[0][1] == CANONICAL_CALL, path,
+           "the default-branch step must call the verifier exactly as "
+           f"`{CANONICAL_CALL}` (found {[l for _, l in calls]})")
+    c.item(bool(assigns) and bool(calls) and calls[-1][0] > assigns[0][0],
+           path, "the verifier call must follow the live read")
+    c.item(tuple(lines) == CANONICAL_DEFAULT_BRANCH_SCRIPT, path,
+           "the default-branch step script is not the canonical form: "
+           f"expected exactly {list(CANONICAL_DEFAULT_BRANCH_SCRIPT)} "
+           f"(found {lines})")
     neutered = bool(step.get("continue-on-error")) or "|| true" in text
     c.item(not neutered, path, "the default-branch step must fail closed: "
            "no continue-on-error, no `|| true`")
@@ -413,6 +506,15 @@ def check_records(shas, roots):
     reports; `roots` are the downloaded shard directories. Returns
     (findings, lines): every finding is a refusal, lines are the verdict."""
     findings, lines = [], []
+    missing = [l for l in REQUIRED_SHA_LABELS if l not in shas]
+    unknown = sorted(set(shas) - set(REQUIRED_SHA_LABELS))
+    if missing or unknown:
+        findings.append("the SHA sources must be exactly "
+                        f"{', '.join(REQUIRED_SHA_LABELS)}"
+                        + (f"; missing: {', '.join(missing)}" if missing else "")
+                        + (f"; unknown: {', '.join(unknown)}" if unknown else "")
+                        + ": an aggregate that drops a source cannot prove "
+                        "the gate, the run and its checkout agree")
     for label, sha in shas.items():
         if not SHA_RE.match(sha or ""):
             findings.append(f"{label} SHA {sha!r} is not a 40-digit lowercase "
@@ -642,6 +744,64 @@ def _mutations():
         s = db_step(w)
         s["run"] = s["run"].rstrip("\n") + " || true\n"
 
+    def set_db_script(w, *lines):
+        db_step(w)["run"] = "\n".join(lines) + "\n"
+
+    def m_db_decoy_if_false(w):
+        # The reviewer's decoy: a literal beside an unreachable live read.
+        set_db_script(w, "set -euo pipefail", "observed=dev", "if false; then",
+                      "  " + CANONICAL_OBSERVED, "fi", CANONICAL_CALL)
+
+    def m_db_literal_after_call(w):
+        set_db_script(w, *CANONICAL_DEFAULT_BRANCH_SCRIPT, "observed=dev")
+
+    def m_db_literal_after_read(w):
+        set_db_script(w, "set -euo pipefail", CANONICAL_OBSERVED,
+                      "observed=dev", CANONICAL_CALL)
+
+    def m_db_gh_api_in_comment(w):
+        set_db_script(w, "set -euo pipefail", "# " + CANONICAL_OBSERVED,
+                      "observed=dev", CANONICAL_CALL)
+
+    def m_db_other_command(w):
+        set_db_script(w, "set -euo pipefail",
+                      'observed="$(git symbolic-ref --short '
+                      'refs/remotes/origin/HEAD | sed s,origin/,,)"',
+                      CANONICAL_CALL)
+
+    def m_db_two_assignments(w):
+        set_db_script(w, "set -euo pipefail", CANONICAL_OBSERVED,
+                      CANONICAL_OBSERVED, CANONICAL_CALL)
+
+    def m_db_call_before_read(w):
+        set_db_script(w, "set -euo pipefail", CANONICAL_CALL,
+                      CANONICAL_OBSERVED)
+
+    def m_db_extra_line(w):
+        set_db_script(w, *CANONICAL_DEFAULT_BRANCH_SCRIPT, "echo done")
+
+    def m_db_no_set(w):
+        set_db_script(w, CANONICAL_OBSERVED, CANONICAL_CALL)
+
+    def verify_step(w, jid):
+        for s in steps(jobs(w[RTL_FULL])[jid]):
+            if VERIFY_FLAG in step_text(s):
+                return s
+        raise AssertionError(f"fixture drift: no verifier step in {jid}")
+
+    def m_drop_sha(jid, label):
+        def f(w):
+            s = verify_step(w, jid)
+            want = REQUIRED_SHA_ARGS[label]
+            assert want in s["run"], f"fixture drift: {want} not in {jid}"
+            s["run"] = s["run"].replace(want + " ", "").replace(want, "")
+        return f
+
+    def m_extra_sha(w):
+        s = verify_step(w, "verilator-suites")
+        s["run"] = s["run"].replace(VERIFY_FLAG,
+                                    VERIFY_FLAG + ' --sha extra="$GITHUB_SHA"')
+
     def m_docs_no_check(w):
         for job in jobs(w[DOCS]).values():
             for s in steps(job):
@@ -709,6 +869,42 @@ def _mutations():
          m_db_continue_on_error, "fail closed"),
         ("rtl default-branch step neutered by || true", m_db_or_true,
          "fail closed"),
+        ("rtl default-branch decoy: observed=dev beside gh api in `if false`",
+         m_db_decoy_if_false, "not sourced from the live API call"),
+        ("rtl default-branch decoy: control flow around the live read",
+         m_db_decoy_if_false, "unconditionally"),
+        ("rtl default-branch literal observed=dev after the real call",
+         m_db_literal_after_call, "exactly once (found 2)"),
+        ("rtl default-branch literal observed=dev after the real read",
+         m_db_literal_after_read, "exactly once (found 2)"),
+        ("rtl default-branch gh api inside a comment only",
+         m_db_gh_api_in_comment, "not sourced from the live API call"),
+        ("rtl default-branch comment line in the script",
+         m_db_gh_api_in_comment, "no comment lines"),
+        ("rtl default-branch observed from a different command",
+         m_db_other_command, "not sourced from the live API call"),
+        ("rtl default-branch two observed assignments",
+         m_db_two_assignments, "exactly once (found 2)"),
+        ("rtl default-branch verifier called before the read",
+         m_db_call_before_read, "must follow the live read"),
+        ("rtl default-branch script with an extra line", m_db_extra_line,
+         "not the canonical form"),
+        ("rtl default-branch script without set -euo pipefail", m_db_no_set,
+         "not the canonical form"),
+        ("rtl verilator-suites drops --sha gate",
+         m_drop_sha("verilator-suites", "gate"), "missing: gate"),
+        ("rtl verilator-suites drops --sha run",
+         m_drop_sha("verilator-suites", "run"), "missing: run"),
+        ("rtl verilator-suites drops --sha checkout",
+         m_drop_sha("verilator-suites", "checkout"), "missing: checkout"),
+        ("rtl yosys-portability drops --sha gate",
+         m_drop_sha("yosys-portability", "gate"), "missing: gate"),
+        ("rtl yosys-portability drops --sha run",
+         m_drop_sha("yosys-portability", "run"), "missing: run"),
+        ("rtl yosys-portability drops --sha checkout",
+         m_drop_sha("yosys-portability", "checkout"), "missing: checkout"),
+        ("rtl verilator-suites passes an unknown --sha label", m_extra_sha,
+         "unknown: extra"),
         ("rtl public name verilator-suites renamed",
          m_rename_job(RTL_FULL, "verilator-suites"), "`verilator-suites`"),
         ("rtl public name yosys-portability renamed",
@@ -849,12 +1045,48 @@ def selftest(root):
         f, _ = check_records(three, [none])
         cases.append(("the empty placeholder directory is refused",
                       any("none" in x and "missing" in x for x in f)))
+        roots = shards(4)
+        f, _ = check_records(dict(gate=sha, run=sha), roots)
+        cases.append(("a dropped checkout source is refused",
+                      any("missing: checkout" in x for x in f)))
+        f, _ = check_records(dict(run=sha, checkout=sha), roots)
+        cases.append(("a dropped gate source is refused",
+                      any("missing: gate" in x for x in f)))
+        f, _ = check_records(dict(gate=sha), roots)
+        cases.append(("a lone gate source is refused",
+                      any("missing: run, checkout" in x for x in f)))
+        f, _ = check_records({}, roots)
+        cases.append(("no source at all is refused",
+                      any("missing: gate, run, checkout" in x for x in f)))
+        f, _ = check_records(dict(three, extra=sha), roots)
+        cases.append(("an unknown source label is refused",
+                      any("unknown: extra" in x for x in f)))
         for name, ok in cases:
             checked_arms += 1
             if ok:
                 print(f"  ok   records: {name}")
             else:
                 problems.append(f"records arm failed: {name}")
+
+    # The canonical pin is whitespace-invariant: re-indenting and continuing
+    # the same three lines differently is the same script and must pass.
+    world = copy.deepcopy(pristine)
+    for s in steps(jobs(world[RTL_FULL])[GATE_JOB]):
+        if DEFAULT_BRANCH_FLAG in step_text(s):
+            s["run"] = ("  set   -euo pipefail\n\n"
+                        '  observed="$(gh api "repos/$GITHUB_REPOSITORY" \\\n'
+                        "      --jq .default_branch 2>/dev/null \\\n"
+                        '      || echo unreadable)"\n'
+                        "  python3 scripts/ci_events.py \\\n"
+                        "    --require-default-branch \\\n"
+                        '    --event "$GITHUB_EVENT_NAME" \\\n'
+                        '    --observed "$observed"\n')
+    checked_arms += 1
+    if check(world).findings:
+        problems.append("whitespace-only reformatting of the canonical script "
+                        f"was refused: {check(world).findings}")
+    else:
+        print("  ok   canonical pin is whitespace-invariant")
 
     # --require-default-branch arms: the decision for every event class. An
     # inverted or weakened comparison fails one of these, which is what makes
@@ -942,9 +1174,6 @@ def run_require(sha_args, roots):
             print(f"ci_events: --sha {label} given twice")
             return RC_CANNOT_RUN
         shas[label] = value.strip()
-    if not shas:
-        print("ci_events: --require-target-sha needs at least one --sha label=sha")
-        return RC_CANNOT_RUN
     findings, lines = check_records(shas, [pathlib.Path(r) for r in roots])
     for line in lines:
         print(line)

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -130,6 +130,29 @@ REQUIRED_SHA_ARGS = {
     "checkout": '--sha checkout="$(git rev-parse HEAD)"',
 }
 SHA_LABEL_RE = re.compile(r"--sha\s+([A-Za-z_]+)=")
+EXPECT_RE = re.compile(r"--expect\s+(\S+)")
+#: The keys a pinned step may carry, and nothing else ([R1] on PR #204,
+#: third round): a key beside the script decides whether, on which events,
+#: or by which interpreter the script runs. `if: false`, `if: ${{
+#: github.event_name == 'pull_request' }}`, `shell: bash -n {0}`,
+#: `continue-on-error: true`, a `timeout-minutes`, a `working-directory`,
+#: an extra `GH_HOST` or `GH_CONFIG_DIR` in env: each left the script text
+#: canonical and the assertion dead. So the key set is pinned, the env key
+#: set is pinned, and the verifier step's one permitted `if` is pinned.
+ASSERT_STEP_KEYS = ("name", "env", "run")
+ASSERT_STEP_ENV = ("GH_TOKEN",)
+VERIFY_STEP_KEYS = ("name", "if", "env", "run")
+VERIFY_STEP_IF = "${{ always() }}"
+VERIFY_STEP_ENV = ("GATE_SHA",)
+#: Job keys that stop a job, or its steps, from running as written. The
+#: gate job carries none of them; an aggregate job carries its documented
+#: `if` and nothing else from this list; the workflow carries no top-level
+#: `defaults` (a `defaults.run.shell: bash -n {0}` parses every script and
+#: executes none).
+JOB_NEUTER_KEYS = ("if", "continue-on-error", "defaults")
+AGGREGATE_JOB_IF = ("${{ always() && !cancelled() && "
+                    f"needs.{GATE_JOB}.outputs.run_full == 'true' }}}}")
+RUNNER_TEMP_PREFIX = "${{ runner.temp }}/"
 #: Public check names the merge bar reads (AGENTS.md section 7), per file.
 PUBLIC_NAMES = {
     RTL_FULL: ("verilator-suites", "yosys-portability"),
@@ -352,6 +375,10 @@ def check_rtl_full(c, wf, policy):
         c.item(prints, path, f"job `{GATE_JOB}` must print the event name and "
                "GITHUB_SHA in one step")
         check_default_branch_step(c, path, gate)
+        check_job_keys(c, path, GATE_JOB, gate)
+    c.item("defaults" not in wf, path, "the workflow must carry no top-level "
+           f"`defaults` (found {wf.get('defaults')!r}): a `defaults.run.shell`"
+           " changes how every script runs")
 
     # Every job that uploads evidence records the SHA first; every job that
     # downloads evidence verifies it against the gate's output.
@@ -378,6 +405,122 @@ def check_rtl_full(c, wf, policy):
                    f"job `{jid}` must need `{GATE_JOB}` to read its output")
             if vsteps:
                 check_sha_sources(c, path, jid, vsteps[0])
+                check_verify_step(c, path, wf, jid, job, vsteps[0])
+            check_job_keys(c, path, jid, job, allowed_if=AGGREGATE_JOB_IF)
+
+
+def check_job_keys(c, path, jid, job, allowed_if=None):
+    """A job that must run as written carries no `if` (or exactly the one
+    documented), no `continue-on-error`, no `defaults`; each refusal names
+    the key."""
+    for key in JOB_NEUTER_KEYS:
+        if key not in job:
+            continue
+        if key == "if" and allowed_if is not None:
+            got = str(job.get("if")).strip()
+            c.item(got == allowed_if, path, f"job `{jid}` `if` must be exactly "
+                   f"`{allowed_if}` (found `{got}`)")
+            continue
+        c.item(False, path, f"job `{jid}` must carry no `{key}` "
+               f"(found {job.get(key)!r}): it decides whether the job runs "
+               "as written")
+    if allowed_if is not None:
+        c.item("if" in job, path, f"job `{jid}` must carry its documented "
+               f"`if` `{allowed_if}`")
+
+
+def pinned_step_keys(c, path, what, step, keys, env_keys):
+    """A pinned step carries exactly `keys`, its env exactly `env_keys`;
+    every surplus or missing key is named."""
+    have = [k for k in step.keys() if isinstance(k, str)]
+    extra = sorted(set(have) - set(keys))
+    missing = [k for k in keys if k not in have]
+    for key in ("if", "shell", "continue-on-error"):
+        if key in extra:
+            c.item(False, path, f"{what} must carry no `{key}` "
+                   f"(found {step.get(key)!r}): it decides whether or how "
+                   "the script runs")
+    c.item(not extra and not missing, path, f"{what} keys must be exactly "
+           f"{', '.join(keys)}" + (f"; surplus: {', '.join(extra)}" if extra
+                                   else "")
+           + (f"; missing: {', '.join(missing)}" if missing else ""))
+    env = step.get("env") if isinstance(step.get("env"), dict) else {}
+    env_have = sorted(str(k) for k in env.keys())
+    env_extra = sorted(set(env_have) - set(env_keys))
+    env_missing = [k for k in env_keys if k not in env_have]
+    c.item(not env_extra and not env_missing, path, f"{what} env must be "
+           f"exactly {', '.join(env_keys)}"
+           + (f"; surplus: {', '.join(env_extra)} (a GH_HOST or GH_CONFIG_DIR"
+              " redirects gh away from this repository)" if env_extra else "")
+           + (f"; missing: {', '.join(env_missing)}" if env_missing else ""))
+
+
+def matrix_size(wf, job):
+    """The shard count of the worker job this aggregate needs: the length of
+    that job's `strategy.matrix.shard` list, derived, not restated."""
+    needs = job.get("needs")
+    needs = needs if isinstance(needs, list) else [needs]
+    for n in needs:
+        worker = jobs(wf).get(n) if isinstance(n, str) else None
+        strat = worker.get("strategy") if isinstance(worker, dict) else None
+        matrix = strat.get("matrix") if isinstance(strat, dict) else None
+        shard = matrix.get("shard") if isinstance(matrix, dict) else None
+        if isinstance(shard, list) and shard:
+            return len(shard)
+    return None
+
+
+def canonical_verify_script(wf, job):
+    """The verifier step's script, derived from the job's own download step
+    (where the shards land, what they are called) and the worker matrix
+    (how many there are). None when the job has no usable download step."""
+    dl = next((s for s in steps(job) if uses(s, "actions/download-artifact")),
+              None)
+    with_ = dl.get("with") if isinstance(dl, dict) and isinstance(
+        dl.get("with"), dict) else {}
+    pattern, dest = with_.get("pattern"), with_.get("path")
+    n = matrix_size(wf, job)
+    if (not isinstance(pattern, str) or not isinstance(dest, str)
+            or not dest.startswith(RUNNER_TEMP_PREFIX) or n is None):
+        return None
+    base = dest[len(RUNNER_TEMP_PREFIX):].strip("/")
+    return (
+        "shopt -s nullglob",
+        f'roots=("$RUNNER_TEMP"/{base}/{pattern})',
+        f"python3 scripts/ci_events.py {VERIFY_FLAG} --expect {n} "
+        + " ".join(REQUIRED_SHA_ARGS[l] for l in REQUIRED_SHA_LABELS)
+        + ' -- "${roots[@]}"',
+    )
+
+
+def check_verify_step(c, path, wf, jid, job, step):
+    """The aggregate's verifier step: pinned keys, the one permitted `if`,
+    env exactly GATE_SHA, and a script equal to the derived canonical form
+    (so `--expect` is the worker matrix size and no line can reassign a
+    source before the call)."""
+    what = f"job `{jid}` verifier step"
+    pinned_step_keys(c, path, what, step, VERIFY_STEP_KEYS, VERIFY_STEP_ENV)
+    got_if = str(step.get("if", "")).strip()
+    c.item(got_if == VERIFY_STEP_IF, path, f"{what} `if` must be exactly "
+           f"`{VERIFY_STEP_IF}` (found `{got_if}`): any other condition can "
+           "skip the verification, and a skipped step passes the job")
+    run = step.get("run") if isinstance(step.get("run"), str) else ""
+    lines = normalize_script(run)
+    canon = canonical_verify_script(wf, job)
+    c.item(canon is not None, path, f"{what}: the download step must name a "
+           f"`pattern` and a `path` under `{RUNNER_TEMP_PREFIX}`, and the "
+           "aggregate must need a worker with a `strategy.matrix.shard` list")
+    if canon is None:
+        return
+    script = " ".join(lines)
+    m = EXPECT_RE.search(script)
+    want_n = canon[2].split("--expect ")[1].split()[0]
+    c.item(m is not None and m.group(1) == want_n, path, f"{what} must pass "
+           f"--expect {want_n}, the worker matrix size "
+           f"(found {m.group(1) if m else 'no --expect'})")
+    c.item(tuple(lines) == canon, path, f"{what} script is not the canonical "
+           f"form derived from its download step and worker matrix: expected "
+           f"exactly {list(canon)} (found {lines})")
 
 
 def check_sha_sources(c, path, jid, step):
@@ -429,6 +572,8 @@ def check_default_branch_step(c, path, gate):
         return
     step = found[0]
     text = step_text(step)
+    pinned_step_keys(c, path, "the default-branch step", step,
+                     ASSERT_STEP_KEYS, ASSERT_STEP_ENV)
     env = step.get("env") if isinstance(step.get("env"), dict) else {}
     token = str(env.get("GH_TOKEN", "")).strip()
     c.item(token == "${{ github.token }}", path, "the default-branch step "
@@ -501,11 +646,19 @@ def check(parsed):
 # --require-target-sha: the aggregate-side verifier
 # --------------------------------------------------------------------------
 
-def check_records(shas, roots):
+def check_records(shas, roots, expect):
     """`shas` maps a label (gate, run, checkout) to the SHA that source
-    reports; `roots` are the downloaded shard directories. Returns
+    reports; `roots` are the downloaded shard directories; `expect` is the
+    worker matrix size, which the root count must equal. Returns
     (findings, lines): every finding is a refusal, lines are the verdict."""
+    if not isinstance(expect, int) or expect < 1:
+        raise CannotRun("--expect <n> is required: the number of shard "
+                        "directories the worker matrix produces")
     findings, lines = [], []
+    if len(roots) != expect:
+        findings.append(f"expected {expect} shard director(y/ies), the worker "
+                        f"matrix size, found {len(roots)}: a missing or "
+                        "surplus shard is a failure, not a skip")
     missing = [l for l in REQUIRED_SHA_LABELS if l not in shas]
     unknown = sorted(set(shas) - set(REQUIRED_SHA_LABELS))
     if missing or unknown:
@@ -802,6 +955,51 @@ def _mutations():
         s["run"] = s["run"].replace(VERIFY_FLAG,
                                     VERIFY_FLAG + ' --sha extra="$GITHUB_SHA"')
 
+    # The third-round escapes: keys beside a canonical script ([R1]).
+    def set_step_key(getter, key, value):
+        def f(w):
+            getter(w)[key] = value
+        return f
+
+    def set_env_key(getter, key, value):
+        def f(w):
+            getter(w)["env"][key] = value
+        return f
+
+    def set_job_key(jid, key, value):
+        def f(w):
+            jobs(w[RTL_FULL])[jid][key] = value
+        return f
+
+    def m_top_defaults(w):
+        w[RTL_FULL]["defaults"] = {"run": {"shell": "bash -n {0}"}}
+
+    def m_verify_assigns_gate(w):
+        s = verify_step(w, "verilator-suites")
+        s["run"] = 'GATE_SHA="$GITHUB_SHA"\n' + s["run"]
+
+    def m_verify_expect_wrong(w):
+        s = verify_step(w, "yosys-portability")
+        assert "--expect 4" in s["run"]
+        s["run"] = s["run"].replace("--expect 4", "--expect 3")
+
+    def m_verify_expect_missing(w):
+        s = verify_step(w, "verilator-suites")
+        assert "--expect 4 " in s["run"]
+        s["run"] = s["run"].replace("--expect 4 ", "")
+
+    def m_matrix_grows_expect_stays(w):
+        jobs(w[RTL_FULL])["verilator-shards"]["strategy"]["matrix"]["shard"].append(4)
+
+    def m_aggregate_if_loosened(w):
+        jobs(w[RTL_FULL])["verilator-suites"]["if"] = "${{ always() }}"
+
+    def m_aggregate_if_dropped(w):
+        del jobs(w[RTL_FULL])["yosys-portability"]["if"]
+
+    va = lambda w: verify_step(w, "verilator-suites")  # noqa: E731
+    ya = lambda w: verify_step(w, "yosys-portability")  # noqa: E731
+
     def m_docs_no_check(w):
         for job in jobs(w[DOCS]).values():
             for s in steps(job):
@@ -905,6 +1103,66 @@ def _mutations():
          m_drop_sha("yosys-portability", "checkout"), "missing: checkout"),
         ("rtl verilator-suites passes an unknown --sha label", m_extra_sha,
          "unknown: extra"),
+        # [R1] third round: escapes beside the script.
+        ("E9 assert step if: false", set_step_key(db_step, "if", False),
+         "must carry no `if`"),
+        ("E10 assert step if: pull_request only",
+         set_step_key(db_step, "if", "${{ github.event_name == 'pull_request' }}"),
+         "must carry no `if`"),
+        ("E11 assert step shell: bash -n",
+         set_step_key(db_step, "shell", "bash -n {0}"), "must carry no `shell`"),
+        ("E12 full-ci-gate continue-on-error",
+         set_job_key(GATE_JOB, "continue-on-error", True),
+         "must carry no `continue-on-error`"),
+        ("E13 full-ci-gate if: not schedule",
+         set_job_key(GATE_JOB, "if", "${{ github.event_name != 'schedule' }}"),
+         "must carry no `if`"),
+        ("E14 assert step env GH_HOST",
+         set_env_key(db_step, "GH_HOST", "example.invalid"), "surplus: GH_HOST"),
+        ("E14b assert step env GH_CONFIG_DIR",
+         set_env_key(db_step, "GH_CONFIG_DIR", "/tmp/gh"), "surplus: GH_CONFIG_DIR"),
+        ("E17 full-ci-gate defaults.run.shell bash -n",
+         set_job_key(GATE_JOB, "defaults", {"run": {"shell": "bash -n {0}"}}),
+         "must carry no `defaults`"),
+        ("workflow-level defaults.run.shell", m_top_defaults,
+         "no top-level `defaults`"),
+        ("assert step extra key working-directory",
+         set_step_key(db_step, "working-directory", "/tmp"),
+         "surplus: working-directory"),
+        ("assert step continue-on-error",
+         set_step_key(db_step, "continue-on-error", True),
+         "must carry no `continue-on-error`"),
+        ("S8 verilator-suites verifier if: false", set_step_key(va, "if", False),
+         "`if` must be exactly"),
+        ("yosys-portability verifier if: pull_request only",
+         set_step_key(ya, "if", "${{ github.event_name == 'pull_request' }}"),
+         "`if` must be exactly"),
+        ("verifier step shell: bash -n", set_step_key(ya, "shell", "bash -n {0}"),
+         "must carry no `shell`"),
+        ("verifier step continue-on-error",
+         set_step_key(va, "continue-on-error", True),
+         "must carry no `continue-on-error`"),
+        ("verifier step env GITHUB_SHA override",
+         set_env_key(va, "GITHUB_SHA", "0" * 40), "surplus: GITHUB_SHA"),
+        ("S5 verifier script reassigns GATE_SHA", m_verify_assigns_gate,
+         "not the canonical form"),
+        ("R4 verifier --expect disagrees with the matrix", m_verify_expect_wrong,
+         "--expect 4"),
+        ("R4 verifier without --expect", m_verify_expect_missing,
+         "no --expect"),
+        ("R4 matrix grows, --expect stays", m_matrix_grows_expect_stays,
+         "--expect 5"),
+        ("aggregate job if loosened", m_aggregate_if_loosened,
+         "`if` must be exactly"),
+        ("aggregate job if dropped", m_aggregate_if_dropped,
+         "documented `if`"),
+        ("aggregate job continue-on-error",
+         set_job_key("verilator-suites", "continue-on-error", True),
+         "must carry no `continue-on-error`"),
+        ("aggregate job defaults.run.shell",
+         set_job_key("yosys-portability", "defaults",
+                     {"run": {"shell": "bash -n {0}"}}),
+         "must carry no `defaults`"),
         ("rtl public name verilator-suites renamed",
          m_rename_job(RTL_FULL, "verilator-suites"), "`verilator-suites`"),
         ("rtl public name yosys-portability renamed",
@@ -1015,50 +1273,63 @@ def selftest(root):
         three = dict(gate=sha, run=sha, checkout=sha)
         cases = []
         roots = shards(4)
-        f, _ = check_records(three, roots)
-        cases.append(("four matching records pass", not f))
+        f, _ = check_records(three, roots, 4)
+        cases.append(("four matching records with --expect 4 pass", not f))
+        f, _ = check_records(three, roots[:3], 4)
+        cases.append(("three of four shard directories are refused",
+                      any("expected 4" in x and "found 3" in x for x in f)))
+        f, _ = check_records(three, roots, 3)
+        cases.append(("a surplus shard directory is refused",
+                      any("expected 3" in x and "found 4" in x for x in f)))
+        try:
+            check_records(three, roots, None)
+        except CannotRun:
+            cases.append(("a missing --expect cannot run", True))
+        else:
+            cases.append(("a missing --expect cannot run", False))
         (roots[2] / RECORD).unlink()
-        f, _ = check_records(three, roots)
+        f, _ = check_records(three, roots, 4)
         cases.append(("a missing record is refused and named",
                       any("suite-logs-2" in x and "missing" in x for x in f)))
         roots = shards(4)
         (roots[1] / RECORD).write_text(other + "\n")
-        f, _ = check_records(three, roots)
+        f, _ = check_records(three, roots, 4)
         cases.append(("a record for another tree is refused",
                       any("suite-logs-1" in x and other in x for x in f)))
         (roots[1] / RECORD).write_text("not-a-sha\n")
-        f, _ = check_records(three, roots)
+        f, _ = check_records(three, roots, 4)
         cases.append(("a malformed record is refused",
                       any("not a commit id" in x for x in f)))
         roots = shards(4)
-        f, _ = check_records(dict(gate=sha, run=other, checkout=sha), roots)
+        f, _ = check_records(dict(gate=sha, run=other, checkout=sha), roots, 4)
         cases.append(("gate/run disagreement is refused",
                       any("disagree" in x for x in f)))
-        f, _ = check_records(dict(gate=sha, run=sha, checkout=""), roots)
+        f, _ = check_records(dict(gate=sha, run=sha, checkout=""), roots, 4)
         cases.append(("an empty source SHA is refused",
                       any("checkout" in x and "not a 40-digit" in x for x in f)))
-        f, _ = check_records(three, [])
+        f, _ = check_records(three, [], 4)
         cases.append(("no shard directory at all is refused, not skipped",
-                      any("produced nothing" in x for x in f)))
+                      any("produced nothing" in x for x in f)
+                      and any("found 0" in x for x in f)))
         none = base / "none"
         none.mkdir()
-        f, _ = check_records(three, [none])
+        f, _ = check_records(three, [none], 1)
         cases.append(("the empty placeholder directory is refused",
                       any("none" in x and "missing" in x for x in f)))
         roots = shards(4)
-        f, _ = check_records(dict(gate=sha, run=sha), roots)
+        f, _ = check_records(dict(gate=sha, run=sha), roots, 4)
         cases.append(("a dropped checkout source is refused",
                       any("missing: checkout" in x for x in f)))
-        f, _ = check_records(dict(run=sha, checkout=sha), roots)
+        f, _ = check_records(dict(run=sha, checkout=sha), roots, 4)
         cases.append(("a dropped gate source is refused",
                       any("missing: gate" in x for x in f)))
-        f, _ = check_records(dict(gate=sha), roots)
+        f, _ = check_records(dict(gate=sha), roots, 4)
         cases.append(("a lone gate source is refused",
                       any("missing: run, checkout" in x for x in f)))
-        f, _ = check_records({}, roots)
+        f, _ = check_records({}, roots, 4)
         cases.append(("no source at all is refused",
                       any("missing: gate, run, checkout" in x for x in f)))
-        f, _ = check_records(dict(three, extra=sha), roots)
+        f, _ = check_records(dict(three, extra=sha), roots, 4)
         cases.append(("an unknown source label is refused",
                       any("unknown: extra" in x for x in f)))
         for name, ok in cases:
@@ -1081,12 +1352,23 @@ def selftest(root):
                         "    --require-default-branch \\\n"
                         '    --event "$GITHUB_EVENT_NAME" \\\n'
                         '    --observed "$observed"\n')
+    for s in steps(jobs(world[RTL_FULL])["yosys-portability"]):
+        if VERIFY_FLAG in step_text(s):
+            s["run"] = ("shopt   -s nullglob\n"
+                        'roots=("$RUNNER_TEMP"/all-yosys-results/yosys-results-*)\n'
+                        "python3 scripts/ci_events.py \\\n"
+                        "  --require-target-sha --expect 4 \\\n"
+                        '  --sha gate="$GATE_SHA" \\\n'
+                        '  --sha run="$GITHUB_SHA" \\\n'
+                        '  --sha checkout="$(git rev-parse HEAD)" \\\n'
+                        '  -- "${roots[@]}"\n')
     checked_arms += 1
     if check(world).findings:
-        problems.append("whitespace-only reformatting of the canonical script "
+        problems.append("whitespace-only reformatting of the canonical scripts "
                         f"was refused: {check(world).findings}")
     else:
-        print("  ok   canonical pin is whitespace-invariant")
+        print("  ok   canonical pins are whitespace-invariant (assert step "
+              "and verifier step)")
 
     # --require-default-branch arms: the decision for every event class. An
     # inverted or weakened comparison fails one of these, which is what makes
@@ -1163,7 +1445,7 @@ def run_check(root):
     return RC_OK
 
 
-def run_require(sha_args, roots):
+def run_require(sha_args, roots, expect):
     shas = {}
     for arg in sha_args:
         if "=" not in arg:
@@ -1174,7 +1456,12 @@ def run_require(sha_args, roots):
             print(f"ci_events: --sha {label} given twice")
             return RC_CANNOT_RUN
         shas[label] = value.strip()
-    findings, lines = check_records(shas, [pathlib.Path(r) for r in roots])
+    try:
+        findings, lines = check_records(shas, [pathlib.Path(r) for r in roots],
+                                        expect)
+    except CannotRun as exc:
+        print(f"ci_events: cannot run: {exc}")
+        return RC_CANNOT_RUN
     for line in lines:
         print(line)
     for f in findings:
@@ -1214,6 +1501,9 @@ def main(argv):
     parser.add_argument("--sha", action="append", default=[],
                         metavar="LABEL=SHA",
                         help="a source of the run's SHA (gate, run, checkout)")
+    parser.add_argument("--expect", type=int, default=None, metavar="N",
+                        help="shard directories the worker matrix produces "
+                             "(--require-target-sha)")
     parser.add_argument("--event", default="",
                         help="GITHUB_EVENT_NAME (--require-default-branch)")
     parser.add_argument("--observed", default="",
@@ -1228,7 +1518,7 @@ def main(argv):
         return selftest(args.root)
     if args.require_default_branch:
         return run_require_default_branch(args.event, args.observed)
-    return run_require(args.sha, args.roots)
+    return run_require(args.sha, args.roots, args.expect)
 
 
 if __name__ == "__main__":

--- a/scripts/ci_scope.py
+++ b/scripts/ci_scope.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
-"""Classify a changed-file list as docs-only or RTL/tooling relevant."""
+"""Classify a changed-file list as docs-only or RTL/tooling relevant.
+
+A submodule pointer is never docs-only. The gitlink entries (`protocol-processor`,
+`gptp-processor`, `external`, `third_party/...`) and `.gitmodules` itself move
+the RTL the sweep elaborates without touching a file under `hdl/`, so they are
+read from `.gitmodules` and classified relevant before any documentation rule
+is consulted ([R1] on PR #204). Without `.gitmodules` the rule has nothing to
+read and the documentation rules alone decide, which still classifies a bare
+gitlink path as relevant because it carries no documentation suffix.
+"""
 
 from __future__ import annotations
 
 import argparse
+import pathlib
+import re
 import sys
 from collections.abc import Iterable, Sequence
 
@@ -24,6 +35,26 @@ DOC_FILES = {
 }
 DOC_SUFFIXES = (".md", ".rst")
 
+GITMODULES = pathlib.Path(__file__).resolve().parent.parent / ".gitmodules"
+
+
+def submodule_paths(gitmodules: pathlib.Path = GITMODULES) -> tuple[str, ...]:
+    """The `path = ...` entries of .gitmodules, derived rather than listed."""
+    try:
+        text = gitmodules.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    return tuple(m.group(1).strip()
+                 for m in re.finditer(r"^\s*path\s*=\s*(\S+)", text, re.M))
+
+
+SUBMODULE_PATHS = submodule_paths() + (".gitmodules",)
+
+
+def is_submodule_path(clean: str) -> bool:
+    return (clean in SUBMODULE_PATHS
+            or clean.startswith(tuple(p + "/" for p in SUBMODULE_PATHS)))
+
 
 def is_doc_only_path(path: str) -> bool:
     clean = path.strip()
@@ -31,6 +62,8 @@ def is_doc_only_path(path: str) -> bool:
         clean = clean[2:]
     if not clean:
         return True
+    if is_submodule_path(clean):
+        return False
     if clean in DOC_FILES:
         return True
     if clean.startswith(DOC_PREFIXES):
@@ -46,6 +79,7 @@ def is_rtl_relevant(paths: Iterable[str]) -> bool:
 
 
 def selftest() -> int:
+    global SUBMODULE_PATHS
     cases = [
         (["docs/testing/CI_WORKFLOWS.md"], False),
         (["README.md", "AGENTS.md"], False),
@@ -57,6 +91,13 @@ def selftest() -> int:
         ([".github/workflows/rtl.yml"], True),
         (["docs/x.md", "tb/verilator/cdc/Makefile"], True),
         ([], True),
+        # Submodule pointers move RTL without a file under hdl/ ([R1], PR #204).
+        (["gptp-processor"], True),
+        (["protocol-processor"], True),
+        (["external"], True),
+        (["third_party/verilog-axis"], True),
+        ([".gitmodules"], True),
+        (["docs/x.md", "gptp-processor"], True),
     ]
     failures = 0
     for paths, expected in cases:
@@ -64,6 +105,34 @@ def selftest() -> int:
         ok = got == expected
         print(f"  {'ok  ' if ok else 'FAIL'} {paths!r}: rtl={got}")
         failures += 0 if ok else 1
+
+    # The submodule rule is derived from .gitmodules, so prove the derivation
+    # saw the tree: every pointer this repository carries must be listed.
+    for want in ("protocol-processor", "gptp-processor", "external",
+                 "third_party/verilog-axis", ".gitmodules"):
+        ok = want in SUBMODULE_PATHS
+        print(f"  {'ok  ' if ok else 'FAIL'} submodule rule names {want}")
+        failures += 0 if ok else 1
+
+    # Mutation arm: a classifier whose rules file any one pointer as
+    # documentation must be caught by the cases above, or they bind nothing.
+    # The mutation edits the real rule tables, not a copy of the logic.
+    pristine_paths, pristine_files = SUBMODULE_PATHS, set(DOC_FILES)
+    try:
+        for victim in ("gptp-processor", "protocol-processor", "external",
+                       "third_party/verilog-axis", ".gitmodules"):
+            SUBMODULE_PATHS = tuple(x for x in pristine_paths if x != victim)
+            DOC_FILES.add(victim)
+            caught = any(is_rtl_relevant(paths) != expected
+                         for paths, expected in cases)
+            DOC_FILES.discard(victim)
+            print(f"  {'ok  ' if caught else 'FAIL'} mutation: {victim} filed "
+                  "as docs-only is rejected")
+            failures += 0 if caught else 1
+    finally:
+        SUBMODULE_PATHS = pristine_paths
+        DOC_FILES.clear()
+        DOC_FILES.update(pristine_files)
     print("selftest:", "PASS" if failures == 0 else f"{failures} FAILURE(S)")
     return 1 if failures else 0
 


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, test tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- What changed and why.
- **[Live scenario table](#live-scenario-table)** -- The acceptance criteria of #181 as run URLs, exact SHAs and observed results.
- **[Authoritative references](#authoritative-references)** -- Requirements/specification clauses and docs.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout/dependency/environment commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands and expected result.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from CONTRIBUTING.md.

## Status

HOLD per [R1] rounds 1 to 3 (2026-08-22 07:22, 11:40 and 12:33 UTC); round 3 answered at exact head `5aa085f90e82a563c7f6704c2901d7c91528f953`. Sequencing decision recorded on #174 (https://github.com/kebag-logic/milan-fpga/issues/174#issuecomment-5380051581) and #181 (https://github.com/kebag-logic/milan-fpga/issues/181#issuecomment-5380051868): the first scheduled run is POST-MERGE CONTAINMENT for #181, because GitHub runs the `rtl.yml` that is on `dev` and `dev` does not carry this PR's `ci_events.py`, `TARGET_SHA` records or default-branch assertion until the merge. This PR therefore carries `Relates to #181` and no closing keyword at all; #181 and #174 stay open until that run (first occurrence 01:17 UTC on 2026-08-23, after the merge) is recorded on both. Acceptance is NOT claimed complete for that row.

GREEN locally at `5aa085f90e82a563c7f6704c2901d7c91528f953`: `ci_events.py --check` 79 contract items OK, `--selftest` PASS with 114 arms (84 mutation arms caught, including the round-2 decoys, the six dropped-source arms and the round-3 key escapes E9 to E17 and S8, vacuity over all 84, 3 cannot-run, 16 record arms, the whitespace-invariance arm over both pinned scripts, 10 default-branch decision arms); `ci_scope --selftest` 16 cases + 5 derivation checks + 5 mutation arms PASS; `check_merge_review_integrity` 18/18; all 4 workflow files YAML-load; docs_check 0 findings / 213 files; doc path (1116), TOC (152), anchor (91) and feature-status gates OK; lint ratchet 99 <= 99; `git diff --check origin/dev...HEAD` clean; 0 em dashes on added lines. No RTL changed.

Hosted at `5aa085f90e82a563c7f6704c2901d7c91528f953`: manual dispatch https://github.com/kebag-logic/milan-fpga/actions/runs/32573569318 GREEN 11 of 11 on the branch tip, its gate printing the GOVERNED lines `default_branch=dev expected=dev event=workflow_dispatch (governed)` / `default-branch: OK`, both aggregates `target-sha: OK, 4 record(s)`; `rtl-full` ready run https://github.com/kebag-logic/milan-fpga/actions/runs/32573571778 GREEN 11 of 11 on merge commit `23a91408b50be4cab6961698b2ae2efe6daf69bc` (parents: current `dev@050d534f` and this head), 2,118,373 checks, 0 failures, 46 of 46 tops; `rtl-fast` 32573571814, `docs` 32573571817 (hosted `ci_events` check 79 items, selftest 114 arms) and `elaborate` 32573571880 green.

`181-nightly-manual-on-dev` -> `dev`, cut from `dev@9951aadb`, merge-base `9904f27f`; live `origin/dev` = `050d534f0dff50ca2bd202a25cfbd153bc9d9285`, path overlap with this branch 0 files.

## Linked Issue / roles

Relates to #181 (stays OPEN until the first post-merge scheduled run is recorded there, per the sequencing decision https://github.com/kebag-logic/milan-fpga/issues/174#issuecomment-5380051581), #174 (the option-A decision and the sequencing decision; stays OPEN for the same run) and #179 (closed as overtaken).

No closing keyword, on purpose (see the sequencing decision).

Executor: `[A1]`
Internal cleared-context reviewer: pending `[R<n>]`
External reviewer: pending

## Description

Implements the #174 decision of 2026-08-22 (https://github.com/kebag-logic/milan-fpga/issues/174#issuecomment-5378453167). `dev` is the repository default branch since that morning, which makes the staged `17 1 * * *` cron and `gh workflow run rtl.yml --ref <branch>` executable; this PR makes the workflow files, the public check names and the documentation agree on that, and makes the one-authoritative-SHA rule explicit and machine-checked.

| piece | change |
|---|---|
| `.github/workflows/rtl.yml` | the "staged until this revision reaches main" comments are replaced by the true statement. `full-ci-gate` prints `event= ref= sha=`, refuses a checkout whose `HEAD` is not `GITHUB_SHA`, and exports `target_sha`. New since [R1]: the gate reads the repository default branch live (`gh api repos/$GITHUB_REPOSITORY --jq .default_branch`, `GH_TOKEN: ${{ github.token }}`) and hands it to `scripts/ci_events.py --require-default-branch --event "$GITHUB_EVENT_NAME" --observed ...`: a `schedule` or `workflow_dispatch` run refuses unless it is `dev`, naming what it saw (an unreadable value refuses too); a `pull_request` or `push` run prints `default_branch=... expected=dev event=...` and continues, because those runs are about the tree and a contributor's PR must not go red for a setting it cannot change. Every Verilator and Yosys worker refuses to start unless its checkout, `GITHUB_SHA` and the gate's `target_sha` are one value, then writes `GITHUB_SHA` into a `TARGET_SHA` file beside its evidence (not a `*.log` or `*.result`, so neither tally reads it). Both aggregates run `scripts/ci_events.py --require-target-sha` over the downloaded shards before tallying and print the SHA in their verdict. No `ref:` override on any checkout; shard counts, job names, public check names, concurrency group and the PR event list are unchanged; `workflow_dispatch` stays without inputs |
| `.github/workflows/docs.yml` | `push: branches: [dev, main]`; runs `scripts/ci_events.py --check` and `--selftest` next to the other documentation gates |
| `scripts/ci_events.py` (new) | `--check` parses the four workflow files with pyyaml and asserts the documented trigger contract (push on `dev`, the five PR types, `workflow_dispatch` without inputs, one cron whose time string matches `CI_WORKFLOWS.md`, `cancel-in-progress`, no checkout `ref`, `target_sha` exported, every uploading job records and every downloading job verifies, the public names `rtl-fast` / `verilator-suites` / `yosys-portability` / `elaborate`, the gate wired into `docs.yml`, and since [R1] the default-branch step in its fail-closed shape: present exactly once, carrying `GH_TOKEN`, reading `gh api ... .default_branch`, passing `--event "$GITHUB_EVENT_NAME"`, with no `continue-on-error` and no `|| true`). `--require-default-branch` is the decision, self-tested for every event class. Since [R1] round 2: the step's script is pinned verbatim after whitespace normalization (`set -euo pipefail`; one `observed="$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch 2>/dev/null || echo unreadable)"`; one verifier call after it), with structural reasons first (exactly one `observed` assignment; sourced from the live call; no control flow; no comment lines; the call after the read) and the whole-script comparison as the backstop; and every aggregate must pass exactly the sources `gate`, `run`, `checkout` in their binding forms, which `--require-target-sha` also refuses to run without. Since [R1] round 3: the step's KEYS are pinned (exactly `name`, `env`, `run`; env exactly `GH_TOKEN`), `full-ci-gate` carries no `if` / `continue-on-error` / `defaults` and the workflow no top-level `defaults`, each verifier step carries exactly `name`, `if` (= `${{ always() }}`), `env` (= `GATE_SHA`), `run` with a script pinned to a canonical form DERIVED from its download step and the worker matrix (`--expect 4`), and the aggregate jobs keep their documented `if`; every refusal names the key. `--require-target-sha --expect <n>` refuses any shard-directory count but the matrix size. `--selftest` removes or alters each item one at a time on in-memory copies and requires a finding for each, passes the pristine files, and fails if the checker is stubbed to find nothing. `--require-target-sha` is the aggregate-side verifier with its own arms. Exit 0/1/2, fail-closed |
| `docs/testing/CI_WORKFLOWS.md` | the staged paragraphs are gone; states that `dev` is the default branch since 2026-08-22, the nightly on dev's tip at 01:17 UTC, how to dispatch and when an agent does, the SHA contract and what the aggregates refuse, what `Closes #N` does on merge |
| `CONTRIBUTING.md`, `AGENTS.md`, `.github/PULL_REQUEST_TEMPLATE.md` | the "merging does not auto-close" and "both workflows are `push: [main]`" statements are corrected; the template's `Closes/relates to: #` (not a GitHub keyword form) becomes `Closes #` and `Relates to #` lines |
| `scripts/check_merge_review_integrity.py` | docstring item 2 says why the open-Issue check still exists now that `Closes #N` fires on merge; `--selftest` unchanged and green |
| `docs/testing/TESTING.md` | the new gate listed where the docs-workflow gates are enumerated |

## Live scenario table

Evidence is this PR's own runs unless a row cites another exact-head run of this repository. Filled in as each scenario completes.

| scenario | run | SHA | observed |
|---|---|---|---|
| docs-only draft (commit A, PR opened as draft) | rtl-fast https://github.com/kebag-logic/milan-fpga/actions/runs/32557770869, rtl-full https://github.com/kebag-logic/milan-fpga/actions/runs/32557770851 | head `64d912a8` | rtl-fast green with `verilator-lint` and `yosys-elaboration` SKIPPED (`changes`, `bdd-conformance` success); rtl-full gate `draft=true rtl=false run_full=false`, every worker and both aggregates skipped; docs 32557770867 and elaborate 32557770857 green |
| RTL/tooling-relevant draft (commit B, `synchronize`) | rtl-fast https://github.com/kebag-logic/milan-fpga/actions/runs/32557940245, rtl-full https://github.com/kebag-logic/milan-fpga/actions/runs/32557940236 | head `87cf2a02`, PR merge commit `bf8fbbae` | rtl-fast ran `verilator-lint` and `yosys-elaboration`, all green; rtl-full gate printed `event=pull_request ref=refs/pull/204/merge sha=bf8fbbae0b0db4dfb5f3835f6f33403f81d36244` then `draft=true rtl=true run_full=false`, workers and aggregates skipped. No "Invalid workflow file" run after the push |
| ready-for-review full run | https://github.com/kebag-logic/milan-fpga/actions/runs/32558236567 | head `87cf2a02`, merge commit `bf8fbbae` | gate `event=pull_request ... sha=bf8fbbae...`, `draft=false rtl=true run_full=true`; all 4 Verilator and 4 Yosys workers started (then cancelled by the next row, by design). The completed ready run on the final head is the last row of this group |
| later commit to a ready PR, previous run cancelled | cancelled https://github.com/kebag-logic/milan-fpga/actions/runs/32558236567, replacement https://github.com/kebag-logic/milan-fpga/actions/runs/32558285871 | `87cf2a02` -> `502fdbf7` (merge commit `eec9bbc4`) | push of commit C at 06:56:56 UTC: 32558236567 ended `cancelled` (8 workers + 2 aggregates cancelled), 32558285871 started with `draft=false rtl=true run_full=true` on the new merge commit |
| conversion to draft cancels the exhaustive run | no-op run https://github.com/kebag-logic/milan-fpga/actions/runs/32558328886 | `502fdbf7` (merge commit `eec9bbc4`) | `gh pr ready --undo` at 06:57:56 UTC: 32558285871 ended `cancelled`; the `converted_to_draft` run 32558328886 completed `success` with `draft=true rtl=true run_full=false` and every worker skipped |
| push to dev (latest) | rtl-full https://github.com/kebag-logic/milan-fpga/actions/runs/32557000817, rtl-fast https://github.com/kebag-logic/milan-fpga/actions/runs/32557000852, elaborate 32557000897 | `dev@9904f27f` (merge of PR #200) | all three success, rtl-full with 8 workers and both aggregates green. No `docs` run existed for that push because `docs.yml` was `push: [main]`; this PR adds `dev`, so the merge of this PR is the first dev push the docs gate covers |
| manual dispatch at the final head (`gh workflow run rtl.yml --ref 181-nightly-manual-on-dev`, once; the GOVERNED branch of the default-branch assertion on a hosted runner) | https://github.com/kebag-logic/milan-fpga/actions/runs/32573569318 | `5aa085f90e82a563c7f6704c2901d7c91528f953` | gate `event=workflow_dispatch ref=refs/heads/181-nightly-manual-on-dev sha=5aa085f90e82a563c7f6704c2901d7c91528f953`, `default_branch=dev expected=dev event=workflow_dispatch (governed)`, `default-branch: OK`, `Non-PR event: exhaustive validation required.`; all 8 workers `target_sha=5aa085f9...`; `verilator-suites` `target-sha: OK, 4 record(s) all 5aa085f9...`, `checks: 2118265 in-suite failures: 0`, `every worker succeeded at 5aa085f9...`; `yosys-portability` `target-sha: OK, 4 record(s) all 5aa085f9...`, `Yosys evidence: expected=46 observed=46 errors=0`, `every worker succeeded at 5aa085f9...`; success 11 of 11 jobs (started 12:39:15 UTC, completed 13:04:45 UTC). The branch tip carries 108 fewer checks than the merge commit because dev's newer tests are not on it |
| manual dispatch at `502fdbf7` (before the default-branch step existed) | https://github.com/kebag-logic/milan-fpga/actions/runs/32558366642 | `502fdbf769f9dc12000b1fc051fa3fb2742c7c0b` | started 06:58:47 UTC from live repository state (dev is the default branch, the branch's own `rtl.yml`). Gate printed `event=workflow_dispatch ref=refs/heads/181-nightly-manual-on-dev sha=502fdbf769f9dc12000b1fc051fa3fb2742c7c0b`; all 8 workers printed `target_sha=502fdbf7...`; `verilator-suites`: `target-sha: OK, 4 record(s) all 502fdbf7...`, `checks: 2118265 in-suite failures: 0`, `every worker succeeded at 502fdbf7...`; `yosys-portability`: `target-sha: OK, 4 record(s) all 502fdbf7...`, `Yosys evidence: expected=46 observed=46 errors=0`, `every worker succeeded at 502fdbf7...`. Conclusion success, 11 of 11 jobs |
| ready-for-review full run on the final head | https://github.com/kebag-logic/milan-fpga/actions/runs/32558380313 | head `502fdbf7`, merge commit `eec9bbc492173de425e2c39c1e6ae60a55ba3210` | `gh pr ready` at 06:59:05 UTC. Gate `event=pull_request ref=refs/pull/204/merge sha=eec9bbc4...`, `draft=false rtl=true run_full=true`; 8 of 8 workers recorded `eec9bbc4...`; both aggregates `target-sha: OK, 4 record(s) all eec9bbc4...`; 2,118,265 checks, 0 failures; 46 of 46 tops; both `every worker succeeded at eec9bbc4...`. Conclusion success, 11 of 11 jobs |
| ready-for-review full run on the current head (`synchronize` after [R1]) | https://github.com/kebag-logic/milan-fpga/actions/runs/32560407685 | head `7211419c39f93f2528fc66affe84c36304122ab8`, merge commit `1def1d6b0646c455046964a94bf87a2ee2da06ae` onto `dev@07e16609` | gate `event=pull_request ref=refs/pull/204/merge sha=1def1d6b...`, the new assertion `default_branch=dev expected=dev event=pull_request (informational)` / `default-branch: OK`, `draft=false rtl=true run_full=true`; 8 of 8 workers recorded `1def1d6b...`; both aggregates `target-sha: OK, 4 record(s)`; 2,118,309 checks, 0 failures; 46 of 46 tops; success 11 of 11 jobs |
| ready-for-review full run on the current head (`synchronize` after [R1] round 2) | https://github.com/kebag-logic/milan-fpga/actions/runs/32571306412 | head `910d9f015c335ff160618f4e91557a0f5c4da6d3`, merge commit `de0e488993de008bdab4af6702ad4b7321aab292` onto current `dev@050d534f` | gate `event=pull_request ref=refs/pull/204/merge sha=de0e4889...`, `default_branch=dev expected=dev event=pull_request (informational)` / `default-branch: OK`, `draft=false rtl=true run_full=true`; 8 of 8 workers recorded `de0e4889...`; both aggregates `target-sha: OK, 4 record(s)`; 2,118,373 checks, 0 failures; 46 of 46 tops; success 11 of 11 jobs |
| ready-for-review full run on the final head (`synchronize` after [R1] round 3) | https://github.com/kebag-logic/milan-fpga/actions/runs/32573571778 | head `5aa085f90e82a563c7f6704c2901d7c91528f953`, merge commit `23a91408b50be4cab6961698b2ae2efe6daf69bc` onto `dev@050d534f0dff50ca2bd202a25cfbd153bc9d9285` | gate `event=pull_request ref=refs/pull/204/merge sha=23a91408...`, `default_branch=dev expected=dev event=pull_request (informational)` / `default-branch: OK`, `draft=false rtl=true run_full=true`; 8 of 8 workers recorded `23a91408...`; both aggregates `target-sha: OK, 4 record(s)`; 2,118,373 checks, 0 failures; 46 of 46 tops; success 11 of 11 jobs; the merge commit's parents are `050d534f` (current dev) and this head |
| first scheduled run | POST-MERGE CONTAINMENT per https://github.com/kebag-logic/milan-fpga/issues/174#issuecomment-5380051581: first occurrence 01:17 UTC on 2026-08-23 after the merge (cron `17 1 * * *`, the `rtl.yml` on dev's tip at that moment, which carries this PR only once merged). Recorded on #181 and #174 with: run URL, exact `dev` SHA, the gate line `event=schedule ref=refs/heads/dev sha=...`, the `default_branch=dev ... default-branch: OK` line, all 4+4 worker results, both aggregates' `TARGET_SHA` verdicts. Not an acceptance row of this PR; a red run opens a follow-up Issue + PR per CONTRIBUTING step 7 | | |

## Authoritative references

- #174, the maintainer's decision comment of 2026-08-22: https://github.com/kebag-logic/milan-fpga/issues/174#issuecomment-5378453167 (decisions 1 to 4; this PR is decision 2 and the documentation half of decision 3).
- PR #176, merged at `44a2ff56`: `rtl-fast.yml` and the sharded `rtl.yml` this PR amends.
- The external review that retired the first attempt: https://github.com/kebag-logic/milan-fpga/pull/176#issuecomment-5367605655 (finding 1: "make one authoritative target SHA drive every scheduled/manual worker and aggregate"; finding 3: the scenario list).
- GitHub event contract: `schedule` runs from the default branch; `workflow_dispatch` runs the chosen ref; `GITHUB_SHA` is pinned per run for every event.
- `docs/testing/CI_WORKFLOWS.md`, `AGENTS.md` sections 6 and 7, `CONTRIBUTING.md` sections 3 and 5.

## How to get into the same state

```sh
git fetch origin 181-nightly-manual-on-dev
git checkout --detach origin/181-nightly-manual-on-dev
git submodule update --init protocol-processor gptp-processor external third_party/verilog-axis
python3 -c "import yaml; print(yaml.__version__)"   # pyyaml is the only dependency
```

## How to validate

```sh
python3 scripts/ci_events.py --check
python3 scripts/ci_events.py --selftest
python3 scripts/ci_scope.py --selftest
python3 scripts/check_merge_review_integrity.py --selftest
for f in .github/workflows/*.yml; do python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f"; done
python3 scripts/docs_check.py
python3 scripts/check_doc_paths.py
python3 scripts/gen_toc.py --check && python3 scripts/gen_toc.py --verify-anchors
python3 scripts/check_feature_status.py --self-test
python3 scripts/lint_rtl.py --check
git diff --check origin/dev...HEAD
```

Expected result / pass criteria: every command exits 0; `ci_events.py --check` prints the contract items it verified and the cron rendering `17 1 * * *` = 01:17 UTC; `--selftest` lists each mutation arm as caught and ends with the vacuity arm; `lint_rtl.py` prints `99 violation(s) <= ratchet 99` (no RTL changed). The hosted evidence is the table above, not a local sweep.

## Known limitations / out of scope

- The first scheduled run cannot be produced before the merge: the cron runs the `rtl.yml` on `dev`, which carries none of this PR's machinery until then. By the sequencing decision it is post-merge containment, recorded on #181 and #174; everything else in the table is live evidence from this PR's own runs.
- Decoy resistance of the default-branch gate is bounded by what a static check can see: the step script is pinned verbatim (whitespace aside), the step's keys and env, the gate job's keys, the workflow's top-level `defaults` and both verifier steps are pinned too, so changing what `observed` holds, or whether and how the step runs, means changing pinned text that `--check` refuses with a reason naming it. What no static check can prove is that GitHub's API answered truthfully and that the scheduler picks dev's tip; the dispatch run at this head exercises the governed branch on a hosted runner, and the post-merge scheduled run observes the scheduler.
- The default-branch assertion reads a repository setting, so it is a live API call in the gate, not a file check: a GitHub API failure on a scheduled or dispatched run reads as `unreadable` and refuses (a red nightly for an API blip is visible and retriable by dispatch; a silent pass is not), and never fails a PR or push run.
- `actionlint` is not installed on the bench box. GitHub's own parse on push is the substitute: a malformed workflow shows as a failed run named "Invalid workflow file", checked with `gh run list --branch 181-nightly-manual-on-dev` after every push.
- No RTL, test semantics, pins or accepted-warning sets change; the 52-suite sweep is not run locally on purpose, the hosted exhaustive runs in the table are the evidence for it.
- The follow-up ruleset on `dev` (#174 decision 4) is not part of this PR. Note for it: the docs workflow's check names are `docs-check`, `wire-accountability` and `docs-check-no-git`; there is no single check named `docs`.
- `elaborate.yml` and `rtl-fast.yml` triggers are unchanged; the docs agree with them.
- Observed on this PR: a dispatched run's check runs do not appear in `gh pr checks 204` (run 32558366642 is absent from the list while the PR-event runs are present), so the docs tell a reviewer to read the dispatched run's gate-printed SHA against the PR head rather than the checks tab. Also observed: `gh pr checks` renders the `rtl-fast` aggregate of a run cancelled by `cancel-in-progress` (the `converted_to_draft` fast run 32558328908) as `fail`; the superseding run on the same head, 32558380288, is green.
- On a `pull_request` event the authoritative SHA is the PR merge commit (here `eec9bbc4` for head `502fdbf7`), which is what GitHub pins and what every checkout validates; the docs say so. A reviewer comparing SHAs uses `git rev-parse refs/pull/204/merge` or the gate line, not the branch head.
- `scripts/check_doc_paths.py` prints a pre-existing note that its `ALLOW` entry for `scripts/ci_scope.py` is stale; not touched here.

## Definition of Done

- [ ] Linked Issue acceptance criteria are satisfied: every row but one; the first scheduled run is post-merge containment for #181 (sequencing decision on #174) and is recorded there after the merge
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per CONTRIBUTING.md
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done (for this lane that check includes the first scheduled run of 2026-08-23)
