### PR TITLE
Align named build recipes with end-station configs

### DIFF
--- a/docs/integration/BUILDING.md
+++ b/docs/integration/BUILDING.md
@@ -21,7 +21,7 @@ The shipping software-profile claims are checked against the
 
 - **[0. The pipeline, and where it can refuse you](#0-the-pipeline-and-where-it-can-refuse-you)** -- What runs between `build.sh` and a shippable bitstream, and the asymmetry that is the whole point: **only the shape gate is automatic**. Timing, area and the silicon checklist are all read by hand, so a build can pass timing and area and still not be ship-cleared.
 - **[1. Usage](#1-usage)** -- The invocation table -- both boards in parallel, the place sweep, `TAG=`, argument passthrough, `--dry-run`, and the `flash` verb. Plus where outputs land and the one-liner that tells you which Vivado phase a detached build is in.
-- **[2. The named configurations](#2-the-named-configurations)** -- What each `cfg_*` recipe actually pins: part and speedgrade, DRAM, flash, and why `ax8x8` drops to one RX queue and 16 KB L2 to close. Read the `--eth-port` sub-section before flashing an AX -- a bitstream is built for **one** port, a mismatch leaves the board with no network, and the recipe is verified by grepping the port back out of the build log rather than trusted.
+- **[2. The named configurations](#2-the-named-configurations)** -- What each `cfg_*` recipe actually pins: part and speedgrade, DRAM, flash, RX queues, and cache shape. Read the `--eth-port` sub-section before flashing an AX -- a bitstream is built for **one** port, a mismatch leaves the board with no network, and the recipe is verified by grepping the port back out of the build log rather than trusted.
 - **[3. The launch discipline (why the script is not just a for-loop)](#3-the-launch-discipline-why-the-script-is-not-just-a-for-loop)** -- Five rules, each paid for: Vivado *errors* above 32 threads, three concurrent builds maximum, a 90 s stagger because concurrent elaborations race on `.git/index.lock`, and detached process groups because a bulk task-kill once reaped four running builds mid-route. Section 3.1 adds the shape gate and the three separate times this class of drift reached silicon.
 - **[4. After the build: load + console, per board](#4-after-the-build-load--console-per-board)** -- Per-board JTAG and console invocations (select by serial -- `ttyUSB` numbers renumber on any replug), the v3 flash layout with the bitstream at offset 0, and the retired warning about the old kernel-at-offset-0 map. `hostplane_smoke.sh` is mandatory after every flash.
 - **[5. Gates before a build is "good"](#5-gates-before-a-build-is-good)** -- The three gates with their thresholds, including two hard-won caveats: keep AX margin above +0.03 because QSPI flashboot corrupted below it, and OOC-synth a module before believing its hierarchical utilization line.
@@ -121,17 +121,15 @@ three-directive placement sweep. See
 
 Same board, but deliberately retains the Linux bring-up flow, cached Vexii
 CPU, ALSA sound-card rings and full Linux flash manifest. It uses
-`--num-streams 8`,
-`--rx-queues 1` (drops the RX1 DMA RSC/TCP-coalescing engine  -  pure
-Linux-throughput logic the audio path never touches  -  which removed the
-sys_clk critical path AND freed ~3 pct LUT), `--l2-bytes 16384`, place
-directive AltSpreadLogic_high. Closed 2026-07-24: WNS +0.080, LUT 85.15 pct,
-TNS 0, all seeds close (measured record in the `cfg_ax8x8` comment in
-`build.sh`). The CPU is the RV32 single-hart VexiiRiscv every other artifact
-of this shape describes: since 2026-08-22 (#157) the recipe states
-`--xlen 32 --cpu-count 1`, so the 2026-07-24 figures, measured on the RV64
-core the recipe implied until then, are an upper bound rather than this
-recipe's own.
+`--num-streams 8`, `--rx-queues 2`, `--l2-bytes 16384`, and place directive
+AltSpreadLogic_high. The second RX queue is required because a one-queue build
+has no flow-steer block; under bulk traffic, ptp4l then shares the bulk ring and
+the GM can be deposed. The 2026-07-24 close (WNS +0.080, LUT 85.15 pct, TNS 0)
+used one RX queue plus the old RV64 CPU and RV64-era refill/prefetch cache
+profile, so those figures are only a historical upper bound, not a result for
+the current recipe. The CPU is the RV32 single-hart VexiiRiscv every other
+artifact of this shape describes: since 2026-08-22 (#157) the recipe states
+`--xlen 32 --cpu-count 1`.
 
 #### Choosing the Ethernet port (`--eth-port`)
 
@@ -143,7 +141,7 @@ other variant over JTAG.
 | | |
 |---|---|
 | default | **`e1`** (`milan_soc.py --eth-port`, `choices=[e1, e2]`) |
-| `build.sh cfg_ax8x8` / `cfg_ax7101` | inherit the default → **e1** |
+| `build.sh cfg_ax8x8` / `cfg_ax7101` | pin `--eth-port e1` explicitly |
 | `sweep.sh ax7101` | pins it explicitly in that board's `OPTS` line |
 | bench cable (2026-07-27) | **e1** |
 
@@ -162,8 +160,14 @@ recorded in the build itself:
 
 ```sh
 grep -m1 -oE 'milan_soc\.py.*' <build>/litex.log | grep -o '\-\-eth-port [a-z0-9]*'
-# no match  =>  built with the e1 default
+# no match  =>  no explicit port was recorded; verify the producing recipe
 ```
+
+`scripts/check_sweep_shape.py` compares every design flag in each named
+`build.sh` recipe with the arguments implied by its end-station config,
+including the explicitly stated `--xlen` and `--cpu-count`. There are no active
+`PINNED` exceptions: every disagreement, missing config binding, or mismatched
+generated-entity directory fails the gate.
 
 `e2` exists as the fallback for the 2026-07-22 **e1 GMII-RX hardware fault**
 (cold-soak-proven). If that fault resurfaces, **move the cable first, then

--- a/scripts/check_sweep_shape.py
+++ b/scripts/check_sweep_shape.py
@@ -47,13 +47,24 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SWEEP = os.path.join(ROOT, "sw/litex/sweep.sh")
 BUILD = os.path.join(ROOT, "sw/litex/build.sh")
 
-# build.sh's named recipes are the OTHER path to a flashed bitstream (the
-# deployed ax8x8 gateware came from `build.sh ax8x8`), so they get the same
-# treatment: cfg function -> the end-station config it claims to build.
-# cfg_ax7101 has no counterpart (there is no 1x1 ax7101 config) and is skipped.
+# build.sh's named recipes are the OTHER path to a flashed bitstream, so they
+# get the same treatment: cfg function -> the end-station config it claims to
+# build. The deployed 8x8 image came from the x32f1_eto sweep; cfg_ax8x8 has
+# never produced a bitstream. This gate keeps that alternate recipe aligned
+# with the same graded config before anybody uses it.
 BUILD_CFGS = {
+    "ax7101": "configs/endstation_ax7101_1x1_tdm8.yaml",
     "ax8x8": "configs/endstation_ax7101_8x8.yaml",
     "arty":  "configs/endstation_arty_current.yaml",
+}
+
+# FLOW flags, not DESIGN flags: launch directives and per-run paths that
+# emit_soc_argv deliberately does not own. The config comparison ignores only
+# this explicit set; --entity-gen-dir is checked separately because it must
+# name the same config as BUILD_CFGS.
+FLOW_FLAGS = {
+    "--synth-directive", "--opt-directive", "--place-directive",
+    "--vivado-max-threads", "--output-dir", "--build",
 }
 
 # PINNED DIVERGENCES - live disagreements that are DELIBERATE (or at least
@@ -62,7 +73,7 @@ BUILD_CFGS = {
 # instead of being an untracked gap.
 #   (source, board/cfg, key): (source_value, config_value, reason)
 PINNED = {
-    # (empty) - the ax8x8 l2_bytes divergence was RESOLVED 2026-07-26 by
+    # The ax8x8 l2_bytes divergence was RESOLVED 2026-07-26 by
     # correcting configs/endstation_ax7101_8x8.yaml from 32768 to 16384.
     # The USER 32K authorisation belongs to the 1x1 bench shape
     # (build.sh cfg_ax7101, --rx-queues 2); cfg_ax8x8 is --l2-bytes 16384
@@ -81,9 +92,8 @@ PINNED = {
 # hangs at Liftoff with nothing naming the cause (8b5d0255, 2026-08-05). So
 # for these two flags an ABSENT flag is drift, not a default: the recipe must
 # state the value and it must equal what emit_soc_argv derives for the
-# config. Flag -> the key the drift report (and a PINNED entry) uses.
-# Deliberately NOT the whole flag-for-flag comparison the sweep.sh branch
-# makes: that widening, and the eight other divergences it surfaces, is #155.
+# config. The full flag-for-flag comparison below now subsumes these two flags;
+# this named set drives their dedicated absent-and-swapped negative controls.
 CPU_FLAGS = {"--xlen": "xlen", "--cpu-count": "cpu_count"}
 
 
@@ -262,57 +272,109 @@ def parse_build_sh(path=BUILD):
     return out
 
 
+def design_flags(flags):
+    """Drop launcher-only flags and compare the Scala profile as one value."""
+    design, scala = {}, []
+    for key, value in flags.items():
+        if key in FLOW_FLAGS:
+            continue
+        if key.startswith("--scala-args="):
+            scala.append(key[len("--scala-args="):])
+            continue
+        design[key] = value
+    if scala:
+        design["--scala-args"] = " ".join(sorted(scala))
+    return design
+
+
+def _entity_gen_dir_agrees(name, cfg_path, flags):
+    """Require a recipe to use the generated artifacts for its graded config."""
+    want = os.path.splitext(os.path.basename(cfg_path))[0]
+    got = flags.get("--entity-gen-dir")
+    msg = None
+    if got is True or not got:
+        msg = (f"cfg_{name}: no --entity-gen-dir. milan_soc.py refuses to "
+               f"launch without it, so this recipe cannot be run at all; it "
+               f"must name configs/generated/{want}")
+    elif os.path.basename(str(got).rstrip("/")) != want:
+        msg = (f"cfg_{name}: --entity-gen-dir names "
+               f"{os.path.basename(str(got).rstrip('/'))!r} but this recipe "
+               f"is graded against {os.path.basename(cfg_path)} - the "
+               f"gateware and generated artifacts would be different shapes")
+    if msg is None:
+        return []
+    print("SHAPE DRIFT: " + msg, file=sys.stderr)
+    return [msg]
+
+
 def check_build_sh(path=BUILD, quiet=False):
-    """build.sh recipe vs the end-station config it builds. Divergences listed
-    in PINNED are accepted (and re-verified); anything else is drift. `quiet`
-    drops the per-key agreement lines (the self-test's mutated copies have
-    nothing worth printing on the keys they left alone)."""
+    """Compare every build.sh design flag with emit_soc_argv, flag for flag.
+
+    Divergences listed in PINNED are accepted and re-verified against their
+    exact pair. Everything else is drift. This deliberately replaces the old
+    four-key subset, which could not see the #155 cache, CBS, port, playback,
+    or optional-block disagreements.
+    `quiet` suppresses successful agreement summaries while negative controls
+    exercise mutated copies.
+    """
     recipes = parse_build_sh(path)
     bad = []
+    unbound = sorted(set(recipes) - set(BUILD_CFGS))
+    for name in unbound:
+        msg = (f"build.sh cfg_{name} has no config binding in BUILD_CFGS; "
+               "an ungraded recipe could silently build a different shape")
+        print("SHAPE DRIFT: " + msg, file=sys.stderr)
+        bad.append(msg)
+
+    visited_pins = set()
     for name, cfg_path in sorted(BUILD_CFGS.items()):
         if name not in recipes:
-            bad.append(f"build.sh has no cfg_{name}")
+            msg = f"build.sh has no cfg_{name}"
+            print("SHAPE DRIFT: " + msg, file=sys.stderr)
+            bad.append(msg)
             continue
         f = recipes[name]
-        _b, c_ns, c_rxq, c_l2, c_lpf = config_shape(cfg_path)
-        got = {"num_streams": int(f.get("--num-streams", 1)),
-               "rx_queues":   int(f["--rx-queues"]),
-               "l2_bytes":    int(f["--l2-bytes"]),
-               "render_lpf":  "--no-render-lpf" not in f}
-        want = {"num_streams": c_ns, "rx_queues": c_rxq, "l2_bytes": c_l2,
-                "render_lpf": c_lpf}
-        # The CPU keys: the config side is what the builder EMITS for this
-        # config, never a value restated here, and the recipe side is the
-        # token as written - "(absent)" when it is not, which equals no
-        # emitted value, so an omission is reported as the drift it is.
-        implied = parse_flags(design_opts_expected(cfg_path))
-        for flag, k in CPU_FLAGS.items():
-            got[k] = f.get(flag, "(absent)")
-            want[k] = implied.get(flag, "(absent)")
-        for k in sorted(got):
-            pin = PINNED.get(("build.sh", name, k))
+        local = _entity_gen_dir_agrees(name, cfg_path, f)
+        got = design_flags(f)
+        want = design_flags(parse_flags(design_opts_expected(cfg_path)))
+        got.pop("--entity-gen-dir", None)  # checked above, by config basename
+        n_ok = n_pin = 0
+        for k in sorted(set(got) | set(want)):
+            pin_key = ("build.sh", name, k)
+            pin = PINNED.get(pin_key)
+            g = got.get(k, "(absent)")
+            w = want.get(k, "(absent)")
             if pin is not None:
-                if (got[k], want[k]) != pin[:2]:
+                visited_pins.add(pin_key)
+                n_pin += 1
+                if (g, w) != tuple(pin[:2]):
                     msg = (f"cfg_{name}: PINNED divergence on {k} no longer "
-                           f"holds (build.sh {got[k]} / config {want[k]}, "
-                           f"pinned {pin[0]} / {pin[1]}) - revisit the pin")
+                           f"holds (build.sh {g!r} / config {w!r}, pinned "
+                           f"{pin[0]!r} / {pin[1]!r}) - revisit the pin")
                     print("SHAPE DRIFT: " + msg, file=sys.stderr)
-                    bad.append(msg)
-                else:
+                    local.append(msg)
+                elif not quiet:
                     print(f"  [sweep-shape] build.sh cfg_{name}: {k} "
-                          f"{got[k]} != config {want[k]} - PINNED, known")
-            elif got[k] != want[k]:
-                msg = (f"cfg_{name}: {k} {got[k]} != "
-                       f"{os.path.basename(cfg_path)} {want[k]}")
-                if k in CPU_FLAGS.values():
-                    msg += (" - a CPU key must be STATED and equal: absent, "
-                            "the flag inherits milan_soc.py's default, which "
-                            "is not the builder's (#157)")
+                          f"{g!r} != config {w!r} - PINNED, known: {pin[2]}")
+            elif g != w:
+                msg = (f"cfg_{name}: design flag {k}: build.sh {g!r} != "
+                       f"config-implied {w!r} (emit_soc_argv of "
+                       f"{os.path.basename(cfg_path)})")
                 print("SHAPE DRIFT: " + msg, file=sys.stderr)
-                bad.append(msg)
-            elif not quiet:
-                print(f"  [sweep-shape] build.sh cfg_{name}: {k} {got[k]} "
-                      f"== {os.path.basename(cfg_path)}")
+                local.append(msg)
+            else:
+                n_ok += 1
+        if not local and not quiet:
+            print(f"  [sweep-shape] build.sh cfg_{name}: {n_ok} design flags "
+                  f"agree with {os.path.basename(cfg_path)} flag for flag "
+                  f"({n_pin} PINNED), and --entity-gen-dir names it")
+        bad += local
+
+    for pin_key in sorted(set(PINNED) - visited_pins):
+        msg = (f"PINNED divergence {pin_key!r} was never visited; remove the "
+               "stale exception or restore the recipe/config binding")
+        print("SHAPE DRIFT: " + msg, file=sys.stderr)
+        bad.append(msg)
     return bad
 
 
@@ -322,9 +384,10 @@ def self_test_build_sh(path=BUILD):
     Two mutated copies of build.sh: the REAL defect replayed - every
     `--xlen N` and `--cpu-count N` stripped, so each recipe would inherit
     milan_soc.py's defaults - and its value-swapped cousin (xlen flipped
-    between 32 and 64, one more hart). Each must be rejected on BOTH CPU keys
-    of BOTH recipes, or a key is vacuous. Returns the (mutation, cfg, key)
-    triples the gate FAILED to reject; empty means every key bit."""
+    between 32 and 64, one more hart). Each must be rejected on BOTH CPU flags
+    of all three recipes, or a check is vacuous. Returns the
+    (mutation, cfg, flag) triples the gate FAILED to reject; empty means every
+    flag bit."""
     txt = open(path).read()
     mutations = {
         "absent": re.sub(r"--(?:xlen|cpu-count) \d+ ?", "", txt),
@@ -350,11 +413,28 @@ def self_test_build_sh(path=BUILD):
         finally:
             os.unlink(tmp)
         for name in BUILD_CFGS:
-            for k in CPU_FLAGS.values():
-                if not any(re.match(rf"cfg_{name}: (PINNED divergence on )?{k} ",
-                                    b) for b in bad):
-                    missed.append((label, name, k))
+            for flag in CPU_FLAGS:
+                drift = f"cfg_{name}: design flag {flag}:"
+                pinned = f"cfg_{name}: PINNED divergence on {flag} "
+                if not any(b.startswith(drift) or b.startswith(pinned)
+                           for b in bad):
+                    missed.append((label, name, flag))
     return missed
+
+
+def mutate_build_recipe(text, name, old, new):
+    """Change one flag fragment inside one named recipe for a negative test."""
+    match = re.search(rf"^cfg_{re.escape(name)}\(\)\s*\{{.*?^\}}",
+                      text, re.M | re.S)
+    if not match:
+        raise ValueError(f"cfg_{name} recipe not found")
+    recipe = match.group(0)
+    count = recipe.count(old)
+    if count != 1:
+        raise ValueError(
+            f"{old!r} matched {count} times in cfg_{name}, want 1")
+    mutated = recipe.replace(old, new)
+    return text[:match.start()] + mutated + text[match.end():]
 
 
 def run_static(sweep_path=SWEEP, quiet=False):
@@ -446,8 +526,97 @@ def main():
                   + ", ".join(f"{m}/cfg_{n}/{k}" for m, n, k in missed),
                   file=sys.stderr)
             return 2
-        print("  [self-test] OK: xlen and cpu_count rejected on "
+        print("  [self-test] OK: --xlen and --cpu-count rejected on "
               f"{len(BUILD_CFGS)} build.sh recipes, absent and swapped")
+
+        # Negative controls for the named-build branch. These span the seven
+        # #155 repairs and the config-artifact binding. CPU absence/value
+        # mutations are covered above. Each edit starts from the pristine
+        # recipe so one mismatch cannot mask another.
+        build_mutations = [
+            ("cfg_ax8x8 loses its explicit Ethernet port",
+             "ax8x8", "--eth-port e1", "", "design flag --eth-port:"),
+            ("cfg_ax8x8 falls back to the playback-ring default",
+             "ax8x8", "--aaf-playback-streams 1", "",
+             "design flag --aaf-playback-streams:"),
+            ("cfg_ax8x8 stops spending the datapath-probe prune",
+             "ax8x8", "--no-datapath-probes", "",
+             "design flag --no-datapath-probes:"),
+            ("cfg_ax8x8 restores the class-B CBS instance",
+             "ax8x8", "--cbs-queues-mask 0x10",
+             "--cbs-queues-mask 0x18", "design flag --cbs-queues-mask:"),
+            ("cfg_ax8x8 adds an RV64-era prefetch Scala word",
+             "ax8x8", "--scala-args=--l2-general-slots=8",
+             "--scala-args=--l2-general-slots=8 "
+             "--scala-args=--lsu-hardware-prefetch=rpt",
+             "design flag --scala-args:"),
+            ("cfg_arty loses its class-A CBS mask",
+             "arty", "--cbs-queues-mask 0x10", "",
+             "design flag --cbs-queues-mask:"),
+            ("cfg_arty restores an RV64-era Scala slot count",
+             "arty", "--scala-args=--l2-general-slots=8",
+             "--scala-args=--l2-general-slots=16",
+             "design flag --scala-args:"),
+            ("cfg_arty loses its generated entity directory",
+             "arty", "--entity-gen-dir "
+             "$SOC_DIR/../../configs/generated/endstation_arty_current", "",
+             "no --entity-gen-dir"),
+            ("cfg_ax8x8 points at another config's generated artifacts",
+             "ax8x8", "configs/generated/endstation_ax7101_8x8",
+             "configs/generated/endstation_ax7101_1x1_tdm8",
+             "--entity-gen-dir names"),
+        ]
+        btxt = open(BUILD).read()
+        for why, name, old, new, expected in build_mutations:
+            try:
+                mutated = mutate_build_recipe(btxt, name, old, new)
+            except ValueError as exc:
+                print(f"self-test: {exc}", file=sys.stderr)
+                return 2
+            with tempfile.NamedTemporaryFile("w", suffix=".sh",
+                                             delete=False) as f:
+                f.write(mutated)
+                tmp = f.name
+            try:
+                print(f"  [self-test] {why} - expecting REJECT:")
+                bad_mut = check_build_sh(tmp, quiet=True)
+            finally:
+                os.unlink(tmp)
+            if not any(expected in drift for drift in bad_mut):
+                print(f"self-test FAILED: {why} did not report {expected!r}",
+                      file=sys.stderr)
+                return 2
+            print(f"  [self-test] OK: {len(bad_mut)} drift(s) reported")
+
+        # A newly added cfg_* function must not escape grading merely because
+        # BUILD_CFGS was not extended with its declarative config.
+        unbound_recipe = (
+            "cfg_unbound_selftest() {\n"
+            "    echo \"--board arty --cpu vexiiriscv --cpu-count 1 "
+            "--xlen 32\"\n"
+            "}\n\n")
+        mutated, count = re.subn(r"^(SWEEP_DIRECTIVES=)",
+                                  unbound_recipe + r"\1", btxt,
+                                  count=1, flags=re.M)
+        if count != 1:
+            print("self-test: SWEEP_DIRECTIVES anchor not found in build.sh",
+                  file=sys.stderr)
+            return 2
+        with tempfile.NamedTemporaryFile("w", suffix=".sh",
+                                         delete=False) as f:
+            f.write(mutated)
+            tmp = f.name
+        try:
+            print("  [self-test] unbound cfg_* recipe - expecting REJECT:")
+            bad_mut = check_build_sh(tmp, quiet=True)
+        finally:
+            os.unlink(tmp)
+        if not any("cfg_unbound_selftest has no config binding" in drift
+                   for drift in bad_mut):
+            print("self-test FAILED: unbound cfg_* recipe was accepted",
+                  file=sys.stderr)
+            return 2
+        print("  [self-test] OK: unbound cfg_* recipe rejected")
     return 0
 
 

--- a/sw/litex/build.sh
+++ b/sw/litex/build.sh
@@ -164,25 +164,28 @@ cfg_ax8x8() {    # 8-stream (64ch) shape. History: the 07-24 close used
     # the deployed 0x00010022 gateware (x32f1_eto, a sweep build: this recipe
     # has never produced a bitstream) are all RV32 single-hart. An RV64 SoC
     # under the RV32 boot chain hangs at Liftoff with nothing naming the
-    # cause (8b5d0255). The 07-24 close above was measured on that RV64 core,
-    # so it is an upper bound for this recipe, not its figure.
+    # cause (8b5d0255). The 07-24 close above was measured on that RV64 core
+    # and its RV64-era refill/prefetch cache profile, so it is an upper bound
+    # for this recipe, not its figure.
     echo "--board ax7101 --cpu vexiiriscv --cpu-count 1 --xlen 32 --software-profile linux \
           --all-blocks --coherent-dma --sound-card \
           --milan-clk-freq 100e6 --with-spiflash --flashboot full --gtx-tx-invert \
-          --timing-opt --floorplan --l2-bytes 16384 \
-          --scala-args=--lsu-l1-refill-count=8 --scala-args=--lsu-hardware-prefetch=rpt \
+          --timing-opt --floorplan --eth-port e1 --l2-bytes 16384 \
+          --scala-args=--lsu-l1-refill-count=2 --scala-args=--l2-down-pending=4 \
+          --scala-args=--l2-general-slots=8 \
           --uart-baudrate 115200 --rx-queues 2 --strip-probes --hs-page-bytes 16384 \
           --num-streams 8 --audio-interface tdm32 --audio-interface-master \
           --talker-wire-chans 8 --no-latency-taps --no-i2s-playback \
-          --aaf-playback \
+          --aaf-playback --aaf-playback-streams 1 \
           --entity-gen-dir $SOC_DIR/../../configs/generated/endstation_ax7101_8x8 \
-          --no-render-lpf --cbs-queues-mask 0x18 --synth-directive AreaOptimized_high \
+          --no-render-lpf --no-datapath-probes --cbs-queues-mask 0x10 \
+          --synth-directive AreaOptimized_high \
           --opt-directive ExploreArea --place-directive AltSpreadLogic_high"
                  # --aaf-playback (task #31, 2026-08-02) = KL_pcm_tx host
                  # playback ring -> the chmap capture RING bucket: the ALSA
                  # playback direction (snd-kl-milan pb-dma window; DT
-                 # kl,playback-streams). ONE ring served (the START-SMALL
-                 # --aaf-playback-streams default; full-N OOC'd 2216 LUT,
+                 # kl,playback-streams). ONE ring served (stated explicitly;
+                 # full-N OOC'd 2216 LUT,
                  # one-ring ~1/8th) - its 4 pairs reach any talker's wire
                  # slots through the 64ch chmap. The render sample bank
                  # behind it is unloaded on this padless board and sweeps.
@@ -196,7 +199,7 @@ cfg_ax8x8() {    # 8-stream (64ch) shape. History: the 07-24 close used
                  # loop THD+N record, however, was measured THROUGH the filter
                  # and must be re-measured before it is quoted against this
                  # bitstream. Drop the flag to put the filter back.
-                 # eth-port defaults to e1 (the bench default, same as cfg_ax7101).
+                 # eth-port is pinned to e1 (the bench default, same as cfg_ax7101).
                  # If the AX cable is on e2, append `-- --eth-port e2`; AX42's guard
                  # reset scope covers either PHY's tx/gtx path.
 }
@@ -219,8 +222,8 @@ cfg_arty() {     # Arty A7-100 small endstation: MII 100M, QSPI flashboot (probe
           --all-blocks --coherent-dma --sound-card \
           --sys-clk-freq 83.333e6 --milan-clk-freq 50e6 --with-spiflash --flashboot full \
           --uart-baudrate 115200 --timing-opt --strip-probes --l2-bytes 65536 \
-          --scala-args=--lsu-l1-refill-count=8 --scala-args=--lsu-hardware-prefetch=rpt \
-          --scala-args=--l2-down-pending=8 --scala-args=--l2-general-slots=16 \
+          --scala-args=--lsu-l1-refill-count=2 --scala-args=--l2-down-pending=4 \
+          --scala-args=--l2-general-slots=8 --cbs-queues-mask 0x10 \
           --entity-gen-dir $SOC_DIR/../../configs/generated/endstation_arty_current \
           --rx-queues 2 --hs-page-bytes 16384"
 }
@@ -256,6 +259,7 @@ done
 #  refusing to launch Vivado if the model is missing or unbuildable. So the
 #  shape check below still covers only the `svh`; the descriptors now police
 #  themselves, per build, and cannot be another config's.)
+ENTITY_CFG_ax7101="configs/endstation_ax7101_1x1_tdm8.yaml"
 ENTITY_CFG_ax8x8="configs/endstation_ax7101_8x8.yaml"
 ENTITY_CFG_arty="configs/endstation_arty_current.yaml"
 for c in "${CONFIGS[@]}"; do


### PR DESCRIPTION
[A0]

## Contents

- **Status** - Latest cleared-context review is negative; a new head is required.
- **Linked issue / roles** - Issue #155, executor, and required independent reviewers.
- **Description** - Seven recipe/config alignments plus a fail-closed full-shape gate.
- **Decision evidence** - Why the config side wins for each of the seven rows.
- **How to reproduce and validate** - Exact checkout, commands, and pass criteria.
- **Known limitations / out of scope** - Artifact-dependent arms and hardware evidence.
- **Definition of Done** - Current merge-bar state.

## Status

[R1] NEGATIVE on the latest cleared-context review: documented `-- <extra args>` can override `--entity-gen-dir` after the hard gate validates the original recipe, and a valid single-quoted `cfg_*` recipe escapes the unbound-recipe guard. See [the complete review evidence](https://github.com/kebag-logic/milan-fpga/pull/205#issuecomment-5379643481). A new head and re-review are required.

The exact PR head remains locally green and has 20/20 hosted checks, but GitHub ran those checks against its cached `07e16609` base. Remote `dev` has advanced to `1e441d5e`; the cleared reviewer produced a conflict-free current-base candidate locally, but that candidate has not received hosted CI.

Exact head: `360639340f06dfccb2ab1a0813d350d7d01332b8`
Current remote base: `dev@1e441d5e312c4c80529f33cad7459c79a7bca56b`
GitHub cached base at review time: `07e1660987d12b3d5927a5bec9de1ae7e7b69e83`

## Linked issue / roles

Closes #155. Related: #157, resolved by PR #202 before this candidate was rebased.

Executor: `[A0]`
Internal cleared-context reviewer: required
External reviewer: required

## Description

Exact reproduction found seven #155-owned divergences: two CBS masks, two Scala profiles, and three AX8x8 optional/default flags.

- Align `cfg_ax8x8` with `endstation_ax7101_8x8.yaml`: explicit Ethernet port `e1`, one playback stream, datapath probes pruned, class-A-only CBS mask `0x10`, and the config-derived RV32 cache profile.
- Align `cfg_arty` with `endstation_arty_current.yaml`: CBS mask `0x10` and the same config-derived RV32 profile.
- Compare every design flag of all three bound `build.sh` recipes with `endstation_builder.emit_soc_argv`, including explicit `--xlen` and `--cpu-count`.
- Keep `PINNED = {}`. A missing or changed CPU flag is ordinary drift, not an exception.
- Reject missing bindings, stale pins, generated-entity/config mismatches, and unknown parsed `cfg_*` recipes.
- Add negative controls for all nine #155 alignment/entity cases, absent and swapped CPU flags on all three recipes, and an unbound recipe.
- Apply the hard generated-entity pre-build gate to `cfg_ax7101`, `cfg_ax8x8`, and `cfg_arty`.
- Correct the build documentation and provenance: deployed 8x8 gateware came from the `x32f1_eto` sweep; `cfg_ax8x8` has never produced a bitstream.

## Decision evidence

The deployed `0x00010022` 8x8 gateware came from the `x32f1_eto` sweep, whose command is derived from the end-station config and checked before launch. The named `cfg_ax8x8` recipe is an alternate path with no produced bitstream, so the deployed/config side is authoritative.

| Row | Config value | Old recipe value and origin | Why the config side wins / public evidence |
|---|---|---|---|
| AX8x8 `--eth-port` | `e1` from the 8x8 YAML and bench contract | absent, inherited from the `cfg_ax8x8` origin `8a98d265`; SoC default was also `e1` | No design move: the edit makes the existing default explicit. The deployed sweep and documented cable contract use `e1`. |
| AX8x8 `--aaf-playback-streams` | `1` from `playback_rings: 1` | absent when playback was added in `0e26b2f9`; SoC default was `1` | No design move: one ring was already the effective value; the recipe now records it explicitly. |
| AX8x8 `--no-datapath-probes` | present from `datapath_probes: false` | absent in the `8a98d265` recipe lineage, meaning probes present | The deployed sweep carries the prune and the recipe has never built a bitstream. No standalone DPROBES OOC resource figure is claimed. |
| AX8x8 `--cbs-queues-mask` | `0x10`, class-A queue only | `0x18`, introduced in `b2d83723` when the emitter still built A+B | Milan streams and CRF are class A; `SRP_SR_CLASSES` contains A only and the loader refuses class B. The measured class-B instance cost, 417 LUT + 211 FF + 6 DSP, is recorded in the class-A-only comment in `sw/builder/endstation_builder.py`. |
| AX8x8 Scala profile | refill 2, down-pending 4, general-slots 8, no RPT prefetch | refill 8 plus RPT prefetch from the RV64-era `8a98d265` close | `SOC_DEFAULTS`, the config-derived sweep, and deployed `x32f1_eto` all carry the RV32 profile. The old close also used RV64, so its timing/area result is only an upper bound for this recipe. |
| Arty `--cbs-queues-mask` | `0x10`, class A only | absent in the `207192cc` recipe lineage, selecting the RTL/SoC all-queue default | The current Arty config and sweep derive class-A-only shaping. The DUT is retired and this named recipe has no newer contrary bitstream evidence. |
| Arty Scala profile | refill 2, down-pending 4, general-slots 8, no RPT prefetch | refill 8, RPT, down-pending 8, general-slots 16 from the `207192cc` RV64-era lineage | The current Arty config and generated sweep fragment carry the RV32 words; #157/PR #202 made the recipe explicitly RV32 single-hart. |

Count reconciliation: #155 listed ten flag disagreements; #157 owned two `--xlen` rows and Arty `--cpu-count`. PR #202 resolved those three before this rebase, leaving the seven rows above and no pins.

## Authoritative references

- Issue #155 acceptance scope and its config-vs-recipe decision requirement.
- Issue #157 and PR #202 for the resolved RV32/single-hart decision and deployed sweep provenance.
- `sw/builder/endstation_builder.py`: `emit_soc_argv` is the config-to-SoC contract; its class-A-only comment carries the class-B instance measurement.
- `configs/endstation_ax7101_8x8.yaml` and `configs/endstation_arty_current.yaml`: graded end-station declarations.
- `docs/integration/BUILDING.md`: named-build and Ethernet-port operator contract.

## How to get into the same state

```sh
git fetch origin
git switch --detach 360639340f06dfccb2ab1a0813d350d7d01332b8
git submodule update --init protocol-processor gptp-processor third_party/verilog-axis
```

Use the repository-described LiteX/VexiiRiscv environment for the elaboration gate.

## How to validate

```sh
python3 scripts/check_sweep_shape.py --self-test
bash -n sw/litex/build.sh
python3 sw/builder/test_builder.py --require-elaboration

python3 scripts/docs_check.py
python3 scripts/check_doc_paths.py
python3 scripts/gen_toc.py --check
python3 scripts/gen_toc.py --verify-anchors
python3 scripts/check_feature_status.py --self-test
python3 scripts/check_soc_sources.py
python3 docs/traceability/gen_module_matrix.py --check
python3 scripts/pp_srcs.py --check --selftest
python3 scripts/lint_rtl.py --check
git diff --check origin/dev...HEAD
```

Pass criteria and current result:

- Production shape gate: Arty 20/0 pins, AX7101 27/0, AX8x8 32/0.
- CPU controls: stripping all `--xlen`/`--cpu-count` flags and swapping 32/64 plus hart count are rejected on both flags for all three recipes: 6 named drifts per mutation.
- Named-build controls: all nine #155 alignment/entity mutations are rejected naming the changed key; an injected unbound recipe is rejected by name.
- Builder: all gates pass except the two explicitly recorded artifact-dependent arms; 5/5 recipes reach the real datapath instance.
- Docs: 0 findings across 213 pages; 1,118 cited paths resolve; TOC 152; anchors 91; feature status 18/18.
- Sources/traceability/lint: 41 instantiated modules / 69 sources; matrix 65 modules / 0 untested; processor manifest 40 sources; RTL lint 99 <= ratchet 99.
- `bash -n` and `git diff --check`: clean.

Hosted CI is green at this exact head against GitHub's cached `07e16609` base. It has not validated the current-`dev` candidate. The PR changes no RTL, testbench, synthesis source, or submodule pin.

## Known limitations / out of scope

- Builder gates 11 and 19b do not run locally without the historical Vivado utilization report and a `csr.csv` build artifact; the test runner names both omissions and does not count them as coverage.
- No new bitstream or board run was performed. This change aligns launch recipes and fails before Vivado; `cfg_ax8x8` has never produced a bitstream.
- With the tracked generated entity currently owned by the 1x1 config, individual `build.sh ax8x8 --dry-run` and `build.sh arty --dry-run` calls correctly refuse. Regenerate the chosen config's entity definitions before launching it.
- No standalone DPROBES OOC area number exists in public evidence; this PR does not invent one.

## Definition of Done

- [x] Linked Issue acceptance criteria are implemented
- [x] New behavior has self-checking positive and negative tests
- [ ] Latest R1 blocker and minor finding are fixed on a rebased head
- [x] Required local verification bar passes
- [x] Documentation and seven-row decision evidence are updated
- [x] Hosted CI is green at the new head
- [ ] Internal cleared-context re-review is positive
- [ ] External review is positive
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per `CONTRIBUTING.md`
- [ ] Post-merge containment is checked before Issue #155 moves to Done

