### PR TITLE
Prove the census compiler is RV32, register gate 1b's stand-downs, and control the reason pin

### DIFF
--- a/docs/integration/BAREMETAL_FIRMWARE.md
+++ b/docs/integration/BAREMETAL_FIRMWARE.md
@@ -111,8 +111,10 @@ directives. The identity check also follows the canonical `csr_default(A_ID)`
 literal through the defaults-ROM fill and the direct AXI read address. On a
 runner carrying Verilator, every CSR/datapath mutation must still elaborate as
 the real `milan_csr` top or option-on `milan_datapath` source closure before it
-counts; without Verilator that layer explicitly stands down and is not reported
-as elaborated evidence. The gate prints both its checked facts and open limits at run time;
+counts; without Verilator that layer explicitly stands down, is not reported
+as elaborated evidence, and is registered so the suite's closing line reads
+`ALL GATES PASS EXCEPT n NOT RUN` and names it. The gate prints both its
+checked facts and open limits at run time;
 neither this page nor the gate output may claim more than those measured facts.
 
 One constraint is answered by a tool rather than by reading text:
@@ -130,10 +132,25 @@ A second tool check runs alongside the text rules, and it is an **addition**
 rather than a replacement. Where an RV32 cross compiler is available, the gate
 compiles the firmware and requires that no function except `milan_reg()`
 materialises an address inside the Milan CSR window; where one is not, it
-stands down and says so in its printed verdict. A deterministic host-only
-self-test supplies a compiler selection that is known not to be RV32, makes
-any attempted compile fail, and checks that the same observed no-run verdict
-produces the printed `STOOD DOWN` claim.
+stands down, says so in its printed verdict, and registers that stand-down so
+the suite's closing line names it.
+
+**A candidate is the RV32 target only if it says it is.** The probe that
+selects the compiler is RISC-V assembly under a guard on `__riscv_xlen`,
+because `riscv64-elf-gcc` assembles that asm exactly as an RV32 GCC does. A
+candidate is tried bare first, then driven with `-march=rv32i -mabi=ilp32`,
+and the flag set that answered is carried into every census and mutation
+compile the gate makes; a candidate no flag set drives at 32 bits stands down
+rather than being adopted. Without the width guard a 64-bit GCC was accepted
+as "the exact RV32 target", every mutation compile then ran at 64 bits, and
+the firmware's own `(volatile uint32_t *)(MILAN_CSR_BASE + offset)` became an
+`-Werror` int-to-pointer-cast that failed the suite on a pristine tree (#206).
+Three self-tests hold it: a stub compiler drives the probe through all three
+candidate shapes (already RV32, 64-bit with an rv32 multilib, 64-bit only), a
+deterministic host-only and a deterministic 64-bit-candidate selection each
+make any attempted compile fail and check that the same observed no-run
+verdict produces the printed `STOOD DOWN` claim, and the probe is re-run
+against the live compiler asking for a 64-bit target, which must fail.
 
 **What this gate does not prove.** The CRC check has a measured control-flow
 escape. Gate 1b finds the `crc32()` assignment and mismatch block and requires
@@ -174,7 +191,9 @@ typedef struct { volatile uint32_t ctrl; } *milan_adp_blk;
 That is a durable pre-AEM entity advertise. When an RV32 cross compiler is
 available, the compiled census sees the materialised CSR address and rejects
 the edit. When the compiled census stands down for want of that compiler, the
-edit is outside both active instruments and the gate reports `ALL GATES PASS`.
+edit is outside both active instruments and the gate still passes, under a
+closing line that reads `ALL GATES PASS EXCEPT n NOT RUN` and names the
+census arm as one of the `n`.
 Closing the property on every supported runner still requires #153 and #162
 together. #153 owns the verifier/control-flow proof and the
 `entity_advertise()` choke point; #162 owns a census that resolves CSR store
@@ -244,7 +263,7 @@ The rest are refusals, and each one costs a legitimate edit:
 | Firmware `MILAN_ID` and `MILAN_ID_MAGIC` equal the comment-blanked, directive-closed RTL `A_ID` address and readback default | otherwise inactive decoy text can hide a live address/value change that teaches the token-level guard to validate a different CSR or forged identity |
 | The `MILAN_ID` local is not assigned or addressed between its CSR read and mismatch guard | otherwise an intervening `id = MILAN_ID_MAGIC` forges the verdict while preserving every ordering anchor |
 | The identity refusal remains the exact `if (id != MILAN_ID_MAGIC)` spelling | an equivalent comparison such as `if ((id ^ MILAN_ID_MAGIC) != 0u)` is refused because this bounded model anchors the mismatch block by that exact expression; accepting another form requires extending the recognizer and its paired controls |
-| A fifth pointer cast, a fifth pointer store or a third `asm` statement | the compiled census does not cover all three, so the sets are what bound address formation |
+| A fifth pointer cast, a fifth pointer store or a third `asm` statement | the compiled census does not cover all three, so the sets are what bound address formation; a store planted inside the address helper the census exempts by name is measured invisible to the census on every run where the census is live, which is why those 2 mutants stay reason-pinned on the cast set rather than on the helper's own return-provenance rule (that rule keeps its own mutant, "milan_reg() ignores its offset") |
 | No multi-line `#define` anywhere in the file | the gate reads macro bodies one physical line at a time |
 | No C backslash-newline anywhere in the file | translation phase 2 deletes the pair and can join tokens before an offset-preserving text census; independent space, tab, form-feed and vertical-tab mutants pin every whitespace form the recognizer accepts; a real preprocessor-token reader may retire this refusal |
 | No `#ifdef`/`#if` outside `load_aem_image()` | the gate would read one arm while the compiler takes the other |

--- a/docs/integration/BAREMETAL_FIRMWARE.md
+++ b/docs/integration/BAREMETAL_FIRMWARE.md
@@ -113,7 +113,12 @@ runner carrying Verilator, every CSR/datapath mutation must still elaborate as
 the real `milan_csr` top or option-on `milan_datapath` source closure before it
 counts; without Verilator that layer explicitly stands down, is not reported
 as elaborated evidence, and is registered so the suite's closing line reads
-`ALL GATES PASS EXCEPT n NOT RUN` and names it. The gate prints both its
+`ALL GATES PASS EXCEPT n NOT RUN` and names it. Every arm of gate 1b that can
+decline is registered that way: the RTL elaboration layer, the compiled
+census, and the `MAKEFLAGS += -e` entry on a make that does not re-read
+MAKEFLAGS mid-parse. The last of those is not a missing tool; the construct
+is present and simply has nothing to detect on that make, and its skip text
+says so. The gate prints both its
 checked facts and open limits at run time;
 neither this page nor the gate output may claim more than those measured facts.
 
@@ -145,12 +150,38 @@ rather than being adopted. Without the width guard a 64-bit GCC was accepted
 as "the exact RV32 target", every mutation compile then ran at 64 bits, and
 the firmware's own `(volatile uint32_t *)(MILAN_CSR_BASE + offset)` became an
 `-Werror` int-to-pointer-cast that failed the suite on a pristine tree (#206).
-Three self-tests hold it: a stub compiler drives the probe through all three
-candidate shapes (already RV32, 64-bit with an rv32 multilib, 64-bit only), a
-deterministic host-only and a deterministic 64-bit-candidate selection each
-make any attempted compile fail and check that the same observed no-run
-verdict produces the printed `STOOD DOWN` claim, and the probe is re-run
-against the live compiler asking for a 64-bit target, which must fail.
+The compiler is not taken at its word twice over: every census compile's own
+`.attribute arch` is read back out of the assembly the gate is about to
+census, because a wrapper can honour `-march=rv32i` on the probe and drop it
+on the census call. A toolchain that declares no arch attribute is reported
+as declaring none rather than blamed for it.
+
+Five self-tests hold this. Four of them run on any machine, RISC-V compiler
+or not: (a) a stub compiler drives the probe through all three candidate
+shapes (already RV32, 64-bit with an rv32 multilib, 64-bit only) and the
+recorded argv is read back to prove the driver flags reach the compiler;
+(b) a deterministic host-only selection and (c) a deterministic
+64-bit-candidate selection each make any attempted compile fail and check
+that the same observed no-run verdict produces the printed `STOOD DOWN`
+claim; and (d) the arch check is driven over `rv32` text, `rv64` text and
+text with no attribute at all. The fifth runs only on a runner where the
+census is live: the probe is re-run against the adopted compiler, under this
+run's own flags, asking for a 64-bit target, and must fail. Where no
+candidate is adopted there is nothing to re-probe, so the census stands down,
+the closing verdict names that arm, and the gate's evidence line says the
+live measurement did not happen instead of claiming it did.
+
+**A pristine tree can still redden for a toolchain reason, and that is a
+deliberate open item.** Where the census compiler IS the RV32 target and the
+census compile nevertheless fails, the gate raises rather than standing down:
+a source it cannot compile is a source whose CSR stores it cannot census, and
+converting that into a stand-down would let a genuinely uncensusable firmware
+pass. The message names the compiler and quotes its last diagnostic, so the
+attribution is correct, but a toolchain with unusable headers therefore
+reddens a clean checkout. Separating "this toolchain cannot compile any
+conforming source" from "this source is uncensusable" needs a positive
+control compiled first, which is a design of its own and is not part of #206.
+It is not reachable on either toolchain this repository is built with.
 
 **What this gate does not prove.** The CRC check has a measured control-flow
 escape. Gate 1b finds the `crc32()` assignment and mismatch block and requires

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -1787,6 +1787,12 @@ def test_baremetal_profile_contract():
         os.path.join(os.path.expanduser("~"),
                      "br-milan-rv32/host/bin/riscv32-linux-gcc"),
         "riscv64-elf-gcc", "riscv32-unknown-elf-gcc", "cc", "gcc")
+    #: The flag sets that can make one of those candidates the RV32 target,
+    #: tried in order. The EMPTY one comes first because a compiler built
+    #: for rv32 may carry no multilib for a bare `rv32i`, so driving one
+    #: that needs no driving would stand the census down on the very tool
+    #: it exists for.
+    rv32_drivers = ((), ("-march=rv32i", "-mabi=ilp32"))
 
     def census_headers(root):
         """The stub header set the census compiles against, written from
@@ -1825,36 +1831,86 @@ def test_baremetal_profile_contract():
     #: firmware's RISC-V asm, which is what makes the census authoritative.
     census_used = {}
 
+    def rv32_probe_source(xlen):
+        """The census probe: the RISC-V asm the firmware also writes, under
+        a guard on the width the compiler is about to compile FOR.
+
+        The probe used to be the asm alone, and `riscv64-elf-gcc` assembles
+        `nop` with a `t0` clobber exactly as an RV32 GCC does. So a 64-bit
+        compiler answered YES to "are you the exact RV32 target", every
+        census was then taken with 64-bit pointers, and the firmware's own
+        `(volatile uint32_t *)(MILAN_CSR_BASE + offset)` became an -Werror
+        int-to-pointer-cast RED that failed the suite on a pristine tree
+        (#206). __riscv_xlen is the compiler's own statement of that width,
+        so no multilib default can out-spell it."""
+        return (f"#if !defined(__riscv_xlen) || __riscv_xlen != {xlen}\n"
+                f"#error \"this compiler is not a {xlen}-bit RISC-V target\"\n"
+                "#endif\n"
+                "void f(void){__asm__ volatile(\"nop\" ::: \"t0\");}\n")
+
+    def census_probe(candidate, driver, xlen=32, runner=None):
+        """Compile the probe once; True when `candidate` driven by `driver`
+        IS a RISC-V target of `xlen` bits."""
+        run = subprocess.run if runner is None else runner
+        with tempfile.TemporaryDirectory(prefix="milan-cc-") as probe_dir:
+            probe_path = os.path.join(probe_dir, "probe.c")
+            with open(probe_path, "w") as fh:
+                fh.write(rv32_probe_source(xlen))
+            built = run(
+                [candidate] + list(driver) +
+                ["-S", "-o", os.path.join(probe_dir, "p.s"), probe_path],
+                capture_output=True, text=True)
+        return built.returncode == 0
+
+    def census_rv32_driver(candidate, runner=None):
+        """The first flag set that makes `candidate` the RV32 target, or
+        None when none of them does."""
+        for driver in rv32_drivers:
+            if census_probe(candidate, driver, runner=runner):
+                return driver
+        return None
+
+    def census_candidate_answers(candidate):
+        try:
+            version = subprocess.run([candidate, "--version"],
+                                     capture_output=True, text=True)
+        except (OSError, ValueError):
+            return False
+        return version.returncode == 0
+
     def census_compiler():
         if census_used:
             return census_used.get("compiler")
-        probe_src = ("void f(void){__asm__ volatile(\"nop\" ::: \"t0\");}\n")
-        for candidate in census_compilers:
-            try:
-                version = subprocess.run([candidate, "--version"],
-                                         capture_output=True, text=True)
-            except (OSError, ValueError):
-                continue
-            if version.returncode:
-                continue
-            with tempfile.TemporaryDirectory(prefix="milan-cc-") as probe_dir:
-                probe_path = os.path.join(probe_dir, "probe.c")
-                with open(probe_path, "w") as fh:
-                    fh.write(probe_src)
-                built = subprocess.run(
-                    [candidate, "-S", "-o", os.path.join(probe_dir, "p.s"),
-                     probe_path], capture_output=True, text=True)
-            census_used.update(compiler=candidate,
-                               target=built.returncode == 0)
-            return candidate
-        census_used.update(compiler=None, target=False)
-        return None
+        present = [c for c in census_compilers if census_candidate_answers(c)]
+        for candidate in present:
+            driver = census_rv32_driver(candidate)
+            if driver is not None:
+                census_used.update(compiler=candidate, target=True,
+                                   flags=tuple(driver))
+                return candidate
+        #: Nothing here is the RV32 target, driven or bare. Name the first
+        #: compiler that at least ANSWERS, so the stand-down says which tool
+        #: declined rather than reporting a bare "no": on a box whose only
+        #: RISC-V GCC is 64-bit-only, that name is the actionable half.
+        census_used.update(compiler=present[0] if present else None,
+                           target=False, flags=())
+        return census_used["compiler"]
 
     #: The CSR address helper's name, derived from the shipping firmware so
-    #: the printed summary cannot drift from what the census enforces.
-    reg_helper_name = re.search(
+    #: the printed summary cannot drift from what the census enforces. A
+    #: firmware with no such helper -- an EMPTY milan_baremetal.c is the
+    #: degenerate case -- used to reach `.group(1)` on None and fail the
+    #: suite with an AttributeError blaming nothing, which is the one kind
+    #: of red a gate must never produce (#206).
+    reg_helper_declaration = re.search(
         r"\bstatic\s+inline\s+volatile\s+uint32_t\s*\*\s*(\w+)\s*\(",
-        firmware_source).group(1)
+        firmware_source)
+    assert reg_helper_declaration, \
+        "the firmware declares no `static inline volatile uint32_t *` CSR " \
+        "address helper, so this gate cannot name the one function that is " \
+        "allowed to form a CSR address and cannot scope the census it is " \
+        "about to take; refusing rather than reporting a bounded result"
+    reg_helper_name = reg_helper_declaration.group(1)
     #: Every mutant that reaches a control register outside milan_reg()
     #: fails on this one sentence, whatever spelled it.
     CENSUS_PIN = "materialises one elsewhere"
@@ -1864,11 +1920,15 @@ def test_baremetal_profile_contract():
         assert verdict["ran"] == verdict["target"], \
             "compiled-census verdict contradicts its execution state"
         compiler = os.path.basename(verdict.get("compiler") or "no")
+        driver = " ".join(verdict.get("flags") or ())
         if verdict["ran"]:
-            return f"answered by {compiler}"
-        return (f"STOOD DOWN: {compiler} compiler is not the RV32 target, "
-                "so the compiled census did not run and the text rules "
-                "above carry this on their own")
+            return (f"answered by {compiler}" +
+                    (f", driven at RV32 with {driver}" if driver else
+                     ", which is the RV32 target with no flags"))
+        return (f"STOOD DOWN: {compiler} compiler is not the RV32 target and "
+                "no flag set here drives it as one, so the compiled census "
+                "did not run and the text rules above carry this on their "
+                "own")
 
     def assert_compiled_census_is_clean(firmware, label="firmware",
                                         selection=None, runner=None):
@@ -1894,9 +1954,11 @@ def test_baremetal_profile_contract():
         if selection is None:
             compiler = census_compiler()
             target = bool(census_used.get("target"))
+            driver = tuple(census_used.get("flags") or ())
         else:
             compiler = selection.get("compiler")
             target = bool(selection.get("target"))
+            driver = tuple(selection.get("flags") or ())
         if compiler and not target:
             # GENUINELY stand down. The previous revision printed
             # "STOOD DOWN" and then ran the census anyway: `-S` does not
@@ -1904,7 +1966,8 @@ def test_baremetal_profile_contract():
             # and returned a real x86 verdict while the printed line said
             # the text rules were carrying it alone. A stand-down message
             # that is false is worse than no stand-down.
-            return {"compiler": compiler, "target": False, "ran": False}
+            return {"compiler": compiler, "target": False, "ran": False,
+                    "flags": driver}
         assert compiler, \
             "the compiled census needs a C compiler and found none of " \
             f"{list(census_compilers)}: this gate cannot bound CSR stores " \
@@ -1917,7 +1980,8 @@ def test_baremetal_profile_contract():
                 fh.write(firmware)
             assembly = os.path.join(root, "census.s")
             built = run(
-                [compiler, "-std=gnu99", "-O0", "-fno-inline", "-S",
+                [compiler] + list(driver) +
+                ["-std=gnu99", "-O0", "-fno-inline", "-S",
                  "-o", assembly, f"-I{root}", source],
                 capture_output=True, text=True)
             if built.returncode != 0:
@@ -1949,7 +2013,8 @@ def test_baremetal_profile_contract():
             f" reaches a control register without passing the bit-0 census, " \
             f"whatever cast, typedef, macro, member access or asm template " \
             f"spelled it; found {hits[:3]}"
-        return {"compiler": compiler, "target": True, "ran": True}
+        return {"compiler": compiler, "target": True, "ran": True,
+                "flags": driver}
 
     # Force the non-target branch without depending on which compilers the
     # machine happens to have. If stand-down ever invokes the compiler, the
@@ -1971,6 +2036,85 @@ def test_baremetal_profile_contract():
            "compiled census did not run" in host_only_note, \
         "host-only census execution and its printed stand-down claim diverge"
 
+    #: ... and the SECOND way a candidate is not the target, which is the
+    #: one that got through: a 64-bit RISC-V GCC. It assembles the probe's
+    #: asm, so the old probe called it the exact RV32 target; the census it
+    #: would then take is a 64-bit census, printed beside a line claiming
+    #: RV32. Both halves are self-tested here without depending on which
+    #: compilers this machine happens to carry.
+    #:
+    #: First the probe's own decision, over the three shapes a box can
+    #: present, driven through a stub so the answer is the same everywhere.
+    def stub_compiler(accepts):
+        """A compiler that succeeds only for the driver flag sets in
+        `accepts`, and records every argv it was handed."""
+        seen = []
+
+        def run(command, **kwargs):
+            seen.append(tuple(command))
+            #: The probe's argv is [cc] + driver + [-S, -o, out, src], so
+            #: the driver is what is left after both fixed ends. Reading it
+            #: back this way is also what proves the flags REACH the
+            #: compiler rather than being recorded and dropped.
+            return subprocess.CompletedProcess(
+                command, 0 if tuple(command[1:-4]) in accepts else 1, "", "")
+        return run, seen
+
+    native_run, native_seen = stub_compiler({()})
+    assert census_rv32_driver("stub-rv32-gcc", runner=native_run) == (), \
+        "a compiler that is ALREADY the RV32 target must be taken bare: " \
+        "driving it with an -march its multilib set may not carry would " \
+        "stand the census down on the one tool it exists for"
+    assert len(native_seen) == 1, \
+        "the RV32 probe kept probing after a candidate had answered"
+    driven_run, driven_seen = stub_compiler({rv32_drivers[1]})
+    assert census_rv32_driver("stub-rv64-multilib-gcc",
+                              runner=driven_run) == rv32_drivers[1], \
+        "a 64-bit RISC-V GCC with an rv32 multilib must be DRIVEN as RV32, " \
+        "not accepted as it stands"
+    assert len(driven_seen) == 2 and \
+        tuple(driven_seen[1][1:-4]) == rv32_drivers[1], \
+        "the RV32 driver flags did not reach the compiler that needs them"
+    rv64_only_run, rv64_only_seen = stub_compiler(set())
+    assert census_rv32_driver("stub-rv64-only-gcc",
+                              runner=rv64_only_run) is None, \
+        "a candidate that no flag set here drives as RV32 must be refused " \
+        "by the probe, not adopted as the exact RV32 target"
+    assert len(rv64_only_seen) == len(rv32_drivers), \
+        "the RV32 probe gave up before it had tried every driver"
+
+    #: ... and then the consequence, exactly as the host-only case above:
+    #: a refused candidate compiles NOTHING and says so in the words the
+    #: user reads.
+    rv64_calls = []
+
+    def forbidden_rv64_census(*args, **kwargs):
+        rv64_calls.append((args, kwargs))
+        raise AssertionError("64-bit compiled census ran after stand-down")
+
+    rv64_verdict = assert_compiled_census_is_clean(
+        firmware_source, "64-bit-candidate stand-down self-test",
+        selection={"compiler": "riscv64-elf-gcc", "target": False},
+        runner=forbidden_rv64_census)
+    rv64_note = format_census_verdict(rv64_verdict)
+    assert not rv64_calls and not rv64_verdict["ran"] and \
+           "STOOD DOWN" in rv64_note and "riscv64-elf-gcc" in rv64_note and \
+           "compiled census did not run" in rv64_note, \
+        "64-bit-candidate census execution and its printed stand-down " \
+        "claim diverge"
+
+    #: ANTI-VACUITY, on the real tool this run selected: the same probe
+    #: asking for a 64-bit target must FAIL under the very flags the census
+    #: is about to use. A width guard that has never been seen to refuse
+    #: anything is not evidence that the census is a 32-bit census.
+    if census_compiler() and census_used.get("target"):
+        assert not census_probe(census_used["compiler"],
+                                census_used["flags"], xlen=64), \
+            "the census probe accepts a 64-bit target under the flags it " \
+            f"selected for {census_used['compiler']}, so it is not deciding " \
+            "the register width and the census it authorises could be a " \
+            "64-bit census printed as the RV32 one"
+
     def assert_target_compiles(firmware, label, allow_warnings=False):
         """Prove one mutation is accepted C for the exact RV32 target.
 
@@ -1983,12 +2127,17 @@ def test_baremetal_profile_contract():
         compiler = census_compiler()
         if not compiler or not census_used.get("target"):
             return False
+        driver = list(census_used.get("flags") or ())
         with tempfile.TemporaryDirectory(prefix="milan-compile-") as root:
             census_headers(root)
             source = os.path.join(root, "milan_baremetal.c")
             with open(source, "w") as fh:
                 fh.write(firmware)
-            flags = [compiler, "-std=gnu99", "-Wall", "-Wextra"]
+            #: The SAME driver the probe selected. Without it a multilib
+            #: riscv64 GCC compiled every mutant for RV64, where the
+            #: firmware's own 32-bit pointer cast is an -Werror error, and
+            #: the failure was reported as a defect in the mutation (#206).
+            flags = [compiler] + driver + ["-std=gnu99", "-Wall", "-Wextra"]
             if not allow_warnings:
                 flags.append("-Werror")
             built = subprocess.run(
@@ -3221,6 +3370,18 @@ def test_baremetal_profile_contract():
 
     baseline_census_verdict = assert_boot_contract(
         firmware_source, docs_source, csr_source)
+    #: A stand-down that is only PRINTED inside the gate is the shape of
+    #: #154: the gate says it declined, main() then says ALL GATES PASS, and
+    #: the absence of a proof reads as the presence of one. Register it, so
+    #: the final verdict counts and names it (#206).
+    if not baseline_census_verdict["ran"]:
+        skip("gate 1b",
+             "the compiled CSR-address census: "
+             f"{os.path.basename(baseline_census_verdict['compiler'] or 'no')}"
+             " is not the RV32 target and no flag set here drives it as one, "
+             "so the four census-only mutations, the phase-2 splice compile "
+             "proofs and the census of the shipping firmware itself did not "
+             "run")
 
     def replace_once(source, old, new, label):
         changed = source.replace(old, new, 1)
@@ -4481,6 +4642,29 @@ def test_baremetal_profile_contract():
     helper_body_store_mutations = tuple(
         (label, helper_body_store_for(baseline, label))
         for label, baseline in helper_store_baselines)
+    #: WHY these two stay pinned on the cast set instead of on the
+    #: address-helper provenance rule that names the same function (#206).
+    #: Rule 6's own comment records the ordering; this MEASURES what the
+    #: ordering buys. The compiled census exempts the helper BY NAME, so a
+    #: store planted inside it is invisible to the census -- and these two
+    #: are the only mutants left that demonstrate the cast set catching a
+    #: shape the census cannot see, which is the evidence round nine
+    #: deleted and #187 restored. Re-pinning them on the provenance rule
+    #: would retire that evidence; the provenance rule already has its own
+    #: reason-pinned mutant ("milan_reg() ignores its offset"). So: run the
+    #: census over each of them here and require it to come back CLEAN.
+    helper_store_census_blind = 0
+    helper_store_census_asked = 0
+    if baseline_census_verdict["ran"]:
+        helper_store_census_asked = len(helper_body_store_mutations)
+        for label, mutation in helper_body_store_mutations:
+            blind = assert_compiled_census_is_clean(
+                mutation, f"exempted-helper store, {label} baseline")
+            assert blind["ran"], \
+                "the exempted-helper blindness control did not actually " \
+                "run the census, so it proves nothing about which " \
+                "instrument has to catch this shape"
+            helper_store_census_blind += 1
     #: An address the compiler never prints as a whole-window immediate: at
     #: -O0 it is built with slli/ori, so the census's regex has nothing to
     #: match. This is not only adversarial: a firmware serving two CSR bases
@@ -5320,8 +5504,14 @@ def test_baremetal_profile_contract():
          docs_source, csr_source,
          "firmware must not splice physical source lines with backslash-newline")
         for name, mutation in phase2_whitespace_splices)
+    #: The label names the INSTRUMENT, because the rule that fires and the
+    #: rule the function name suggests are not the same one and the reason
+    #: pin is the honest half: rule 5 (the cast set) runs before rule 6 (the
+    #: helper's return provenance) deliberately, and the blindness control
+    #: beside the mutants' definition measures what that ordering buys.
     mutations += tuple(
-        (f"entity enabled by a store inside the exempted address helper "
+        (f"entity enabled by a store inside the exempted address helper, "
+         f"refused by the CAST SET and invisible to the census "
          f"({label} baseline)", mutation, docs_source, csr_source,
          "the firmware's casts to a pointer are pinned")
         for label, mutation in helper_body_store_mutations)
@@ -5354,6 +5544,25 @@ def test_baremetal_profile_contract():
              "lets the ENVIRONMENT decide what gets compiled",
              env_override_flags),
         )
+    #: NEGATIVE CONTROL for the reason pin itself, which is what turns "the
+    #: mutant was refused" into "the mutant was refused BY THE RULE IT
+    #: BREAKS". The elaboration layer, the census and the recognizer each
+    #: had a self-test proving they can fail; this had none, and replacing
+    #: its assertion with `assert True or because in str(exc)` left the
+    #: focused gate green at 144/144 (#206). Run it with a mutant that IS
+    #: rejected, under a reason no rule in this file prints.
+    try:
+        assert_rejected("reason-pin negative control", wrong_reg_address,
+                        docs_source, csr_source,
+                        "a reason no rule in this gate has ever printed")
+    except AssertionError as exc:
+        assert "mutation was rejected for the wrong reason" in str(exc), \
+            f"the reason-pin control failed for the wrong reason: {exc}"
+    else:
+        raise AssertionError(
+            "assert_rejected() accepted a mutation refused under a reason it "
+            "was never given, so every `because` above is decorative and the "
+            "mutation table proves only that something said no")
     for mutation in mutations:
         assert_rejected(*mutation)
     if verilator:
@@ -5382,6 +5591,16 @@ def test_baremetal_profile_contract():
             "safety property they break; ")
     else:
         counted = len(mutations) - rtl_mutant_elaboration["requested"]
+        #: Registered, not merely printed, for the same reason as the census
+        #: stand-down above: this arm declined and the final verdict has to
+        #: say so (#206). The malformed-RTL self-test is inside the same
+        #: branch, so it is named here rather than left to vanish silently.
+        skip("gate 1b",
+             "RTL mutation elaboration: no Verilator on this runner, so all "
+             f"{rtl_mutant_elaboration['requested']} RTL mutation variants "
+             "counted as structural rejections only, and the deliberately "
+             "malformed-RTL self-test that proves the elaborator can refuse "
+             "did not run")
         rtl_mutant_note = (
             "RTL mutation elaboration STOOD DOWN for all "
             f"{rtl_mutant_elaboration['requested']} RTL variants because "
@@ -5398,7 +5617,10 @@ def test_baremetal_profile_contract():
           "and TX-mux facts are direct in their inspected generate arms and "
           "free of comment, preprocessor and static-generate decoys; "
           "PHC/gPTP are "
-          "live from reset and independent of AEM; the "
+          "live from reset TO THE ptp_timestamp PORT and independent of "
+          "AEM, which is where this gate's measurement stops: a tie-off "
+          "INSIDE ptp_ts_top still elaborates and is milan_dp's to catch; "
+          "the "
           "milan_reg()/milan_read()/milan_write() "
           "bodies pin address and value provenance, the firmware identity "
           "offset and magic equal RTL A_ID's address and default, and "
@@ -5438,7 +5660,14 @@ def test_baremetal_profile_contract():
           "legitimate Makefile edits accepted, which until this round were "
           "prose in a PR body and are now the only executable statement this "
           "gate has of what a legitimate edit IS; deterministic host-only "
-          "stand-down execution/wording self-test passed")
+          "and 64-bit-candidate stand-down execution/wording self-tests "
+          "passed, the RV32 probe decided all three candidate shapes "
+          "(already RV32, 64-bit with an rv32 multilib, 64-bit only) "
+          "against a stub and refused a 64-bit target under this run's own "
+          f"flags, the reason pin refused a wrong `because`, and "
+          f"{helper_store_census_blind}/{helper_store_census_asked} "
+          "exempted-helper stores were measured INVISIBLE to the compiled "
+          "census, which is why they stay pinned on the cast set")
     print("  [gate 1b] ... and the text this reads is the text that runs, by "
           "TEXT RULES and by TOOLS together, because each has been measured "
           "to miss what the other holds. The text rules bound address "

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -1870,6 +1870,48 @@ def test_baremetal_profile_contract():
                 return driver
         return None
 
+    #: The census's OWN assembly has to be 32-bit, not just the compiler it
+    #: was taken with. The probe proves the candidate CAN be driven at RV32;
+    #: only the emitted assembly proves the census invocation WAS. GCC states
+    #: it, so read it back rather than trusting the argv: [R1] on PR #212
+    #: built a wrapper that honours the rv32 flags everywhere except the
+    #: census call, and only the four census-only mutants caught it, and only
+    #: indirectly.
+    census_arch_re = re.compile(r'^\s*\.attribute\s+arch\s*,\s*"([^"]*)"',
+                                re.M)
+    census_arch_seen = {"stated": 0, "unstated": 0}
+
+    def assert_census_arch_is_rv32(assembly_text, label):
+        """The arch the census assembly declares, or None when the toolchain
+        declares none. A toolchain that states nothing cannot be blamed for
+        it, so the absence is REPORTED rather than reddened."""
+        found = census_arch_re.search(assembly_text)
+        arch = found.group(1) if found else None
+        assert arch is None or arch.startswith("rv32"), \
+            f"the compiled census of the {label} was emitted for {arch}, " \
+            "not for an rv32 target: the probe adopted this compiler as the " \
+            "RV32 target and the census invocation did not follow it there, " \
+            "so every pointer width, address and immediate in the assembly " \
+            "this gate is about to read belongs to a different machine"
+        return arch
+
+    assert assert_census_arch_is_rv32(
+        '\t.attribute arch, "rv32i2p1_m2p0"\n', "arch self-test") == \
+        "rv32i2p1_m2p0", \
+        "the census arch check cannot read the directive GCC actually emits"
+    try:
+        assert_census_arch_is_rv32('\t.attribute arch, "rv64i2p1"\n',
+                                   "arch self-test")
+    except AssertionError as exc:
+        assert "not for an rv32 target" in str(exc), exc
+    else:
+        raise AssertionError(
+            "the census arch check accepted rv64 assembly, so it cannot say "
+            "which machine the census it reads was taken on")
+    assert assert_census_arch_is_rv32("\tnop\n", "arch self-test") is None, \
+        "assembly with no arch attribute must come back unstated, not " \
+        "invented: a toolchain that declares none cannot be blamed for it"
+
     def census_candidate_answers(candidate):
         try:
             version = subprocess.run([candidate, "--version"],
@@ -1922,9 +1964,12 @@ def test_baremetal_profile_contract():
         compiler = os.path.basename(verdict.get("compiler") or "no")
         driver = " ".join(verdict.get("flags") or ())
         if verdict["ran"]:
+            arch = verdict.get("arch")
             return (f"answered by {compiler}" +
                     (f", driven at RV32 with {driver}" if driver else
-                     ", which is the RV32 target with no flags"))
+                     ", which is the RV32 target with no flags") +
+                    (f", emitting {arch} assembly" if arch else
+                     ", whose assembly declares no arch attribute"))
         return (f"STOOD DOWN: {compiler} compiler is not the RV32 target and "
                 "no flag set here drives it as one, so the compiled census "
                 "did not run and the text rules above carry this on their "
@@ -1987,12 +2032,26 @@ def test_baremetal_profile_contract():
             if built.returncode != 0:
                 # Reached only when the compiler IS the RV32 target, since a
                 # non-target one returned above without compiling anything.
+                #
+                # DECIDED, not overlooked ([R1] SUGGESTION on PR #212): this
+                # stays a RED and does not become a stand-down. An RV32
+                # toolchain with unusable headers therefore reddens a clean
+                # checkout, which is the class #206 exists to remove, but the
+                # alternative lets a firmware this gate genuinely cannot
+                # census pass as "the toolchain's fault". Telling the two
+                # apart needs a positive control compiled first, which is a
+                # design of its own; not reachable on either toolchain this
+                # repository is built with, and recorded in
+                # docs/integration/BAREMETAL_FIRMWARE.md rather than left to
+                # be rediscovered.
                 raise AssertionError(
                     f"the compiled census could not build the {label} with "
                     f"{compiler}, which IS the RV32 target: a source this "
                     "gate cannot compile is a source whose CSR stores it "
                     f"cannot census; {built.stderr.strip().splitlines()[-1:]}")
             text = open(assembly, encoding="utf-8", errors="replace").read()
+        arch = assert_census_arch_is_rv32(text, label)
+        census_arch_seen["stated" if arch else "unstated"] += 1
         hits, where = [], "<file scope>"
         for line in text.splitlines():
             named = re.match(r"^([A-Za-z_][\w.]*):", line)
@@ -2014,7 +2073,7 @@ def test_baremetal_profile_contract():
             f"whatever cast, typedef, macro, member access or asm template " \
             f"spelled it; found {hits[:3]}"
         return {"compiler": compiler, "target": True, "ran": True,
-                "flags": driver}
+                "flags": driver, "arch": arch}
 
     # Force the non-target branch without depending on which compilers the
     # machine happens to have. If stand-down ever invokes the compiler, the
@@ -2107,7 +2166,9 @@ def test_baremetal_profile_contract():
     #: asking for a 64-bit target must FAIL under the very flags the census
     #: is about to use. A width guard that has never been seen to refuse
     #: anything is not evidence that the census is a 32-bit census.
+    rv32_probe_refused_64 = False
     if census_compiler() and census_used.get("target"):
+        rv32_probe_refused_64 = True
         assert not census_probe(census_used["compiler"],
                                 census_used["flags"], xlen=64), \
             "the census probe accepts a 64-bit target under the flags it " \
@@ -5544,6 +5605,21 @@ def test_baremetal_profile_contract():
              "lets the ENVIRONMENT decide what gets compiled",
              env_override_flags),
         )
+    else:
+        #: Registered, like the census and Verilator arms, because dropping
+        #: this entry moves the tally silently and the verdict has to say so
+        #: ([R1] on PR #212 measured 98/98 -> 97/97 with the arm printed
+        #: mid-log and absent from the verdict). The WORDING is deliberately
+        #: not the other two's: nothing is missing from this runner. The
+        #: construct is present and simply does nothing on a make that does
+        #: not re-read MAKEFLAGS mid-parse, so the mutant would be a control
+        #: that cannot fail rather than an instrument that is unavailable.
+        skip("gate 1b",
+             "the MAKEFLAGS += -e mutation: this make does not re-read "
+             "MAKEFLAGS mid-parse, so the construct hands the environment "
+             "nothing here and the entry would be a control with nothing to "
+             "detect. No tool is missing from this runner; the mutant has "
+             "no effect to observe on THIS make")
     #: NEGATIVE CONTROL for the reason pin itself, which is what turns "the
     #: mutant was refused" into "the mutant was refused BY THE RULE IT
     #: BREAKS". The elaboration layer, the census and the recognizer each
@@ -5611,6 +5687,37 @@ def test_baremetal_profile_contract():
             f"{counted}/{counted} non-RTL mutations rejected on the safety "
             "property they break; the structurally rejected RTL variants "
             "are excluded from this mutation count; ")
+    #: Both clauses below are gated on the SAME condition as the
+    #: measurement they report. The CI shape (only cc and gcc, no Verilator,
+    #: no RV32 compiler) used to read "refused a 64-bit target under this
+    #: run's own flags" beside "0/0 exempted-helper stores were measured
+    #: INVISIBLE", and neither had happened: the live re-probe is gated on a
+    #: candidate having been adopted and the blindness control on the census
+    #: having run ([R1] on PR #212). A stand-down message that is false is
+    #: worse than no stand-down, and that applies to this fix's own output.
+    if rv32_probe_refused_64:
+        live_probe_note = (
+            ", and on this run's live invocation ("
+            + (" ".join(census_used.get("flags") or ()) or "no driver flags")
+            + ") the probe refused a 64-bit target while "
+            f"{census_arch_seen['stated']} census compile(s) declared an "
+            f"rv32 arch and {census_arch_seen['unstated']} declared none")
+    else:
+        live_probe_note = (
+            "; NOT measured on this run: no candidate here is the RV32 "
+            "target, so there was no live invocation to re-probe at 64 bits "
+            "and no census assembly to read an arch attribute out of")
+    if helper_store_census_asked:
+        helper_blind_note = (
+            f"; and {helper_store_census_blind}/{helper_store_census_asked} "
+            "exempted-helper stores were measured INVISIBLE to the compiled "
+            "census, which is why they stay pinned on the cast set")
+    else:
+        helper_blind_note = (
+            "; the exempted-helper blindness control did NOT run here, "
+            "because the census stood down, so on this runner those two "
+            "mutants stay pinned on the cast set with that measurement "
+            "absent")
     print("  [gate 1b] bounded boot-contract model: the PHC CSR output, "
           "datapath binding and ptp_timestamp consumer are direct, and "
           "comment-blanked CSR, MAC, timestamp, both RXFILT_P-arm, shadow "
@@ -5663,11 +5770,12 @@ def test_baremetal_profile_contract():
           "and 64-bit-candidate stand-down execution/wording self-tests "
           "passed, the RV32 probe decided all three candidate shapes "
           "(already RV32, 64-bit with an rv32 multilib, 64-bit only) "
-          "against a stub and refused a 64-bit target under this run's own "
-          f"flags, the reason pin refused a wrong `because`, and "
-          f"{helper_store_census_blind}/{helper_store_census_asked} "
-          "exempted-helper stores were measured INVISIBLE to the compiled "
-          "census, which is why they stay pinned on the cast set")
+          "against a stub, and the census arch check accepted rv32 "
+          "assembly, refused rv64 assembly and reported unattributed "
+          "assembly as unstated"
+          + live_probe_note +
+          "; the reason pin refused a wrong `because`"
+          + helper_blind_note)
     print("  [gate 1b] ... and the text this reads is the text that runs, by "
           "TEXT RULES and by TOOLS together, because each has been measured "
           "to miss what the other holds. The text rules bound address "


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)** - Green, the exact head and base, and the measured tallies.
- **[Linked Issue / roles](#linked-issue--roles)** - Public task, executor, reviewers.
- **[Description](#description)** - What was wrong and what it is now, item by item.
- **[Round 2: the R1 delta](#round-2-the-r1-delta)** - The two MINORs, the MAKEFLAGS answer, and both SUGGESTIONs decided.
- **[Authoritative references](#authoritative-references)** - The Issues and files this answers.
- **[How to get into the same state](#how-to-get-into-the-same-state)** - Clone, branch, toolchain.
- **[How to validate](#how-to-validate)** - The commands, with the before and after numbers.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** - The declined item, its two residuals, and the recorded open item.
- **[Definition of Done](#definition-of-done)** - The merge bar.

## Status

GREEN. `206-boot-gate-self-integrity` -> `dev`.

- head `18900848d41db74265d13997dca3be4f37b4d5fb` (round 2; round 1 was `98390cee`)
- base `4ec73a1532fa82d29997f25493cadc19a0ef4a31` (`origin/dev`, merge of #208)

`python3 sw/builder/test_builder.py` exit 0 in 265 s, 144/144 mutations rejected
on the safety property they break, 46/46 RTL mutation variants elaborated, 71
census compiles all declaring an `rv32` arch and 0 declaring none,
`ALL GATES PASS EXCEPT 2 NOT RUN` (gates 11 and 19b, both "no build tree on
disk", unchanged from `dev`). The same suite on `dev` exits 1 in 1.7 s when the
box's RISC-V compiler is the distribution `riscv64-elf-gcc`.

## Linked Issue / roles

Closes #206
Relates to #177, #162, #153, #187

Executor: `[A1]`
Internal cleared-context reviewer: `[R1]` (POSITIVE on `98390cee`, two MINORs answered in round 2)
External reviewer: `[R?]`

## Description

Gate 1b asks a compiler for the truth about the firmware, so the gate's own
statement about WHICH compiler it asked has to be true. It was not.

### 1. The census probe accepted a 64-bit RISC-V compiler (MAJOR)

The probe was `void f(void){__asm__ volatile("nop" ::: "t0");}`. A 64-bit
`riscv64-elf-gcc` assembles that exactly as an RV32 GCC does, so it was adopted
as "the exact RV32 target", and `assert_target_compiles()` then built every
mutant for RV64 where the firmware's own
`(volatile uint32_t *)(MILAN_CSR_BASE + offset)` is an `-Werror`
int-to-pointer-cast error. The suite died on a pristine tree and blamed a
mutation.

Now the probe is that same asm under `#if !defined(__riscv_xlen) ||
__riscv_xlen != 32`, which is the compiler's own statement of the width it is
about to compile for. Each candidate is tried bare first (a native rv32 GCC may
carry no multilib for a bare `rv32i`, and driving it would stand the census
down on the one tool it exists for), then driven with
`-march=rv32i -mabi=ilp32`. The flag set that answered is recorded and carried
into every census compile and every mutation compile, and it is printed:
`answered by riscv64-elf-gcc, driven at RV32 with -march=rv32i -mabi=ilp32`.
A candidate no flag set drives at 32 bits is not adopted; the census stands
down and the suite exits 0.

Round 2 adds the other half: **the census reads its own assembly back.** Every
census compile's `.attribute arch` must say `rv32`, because a compiler can
honour the flags on the probe and drop them on the census call. A toolchain
that declares no attribute is reported as declaring none, never blamed for it.

Candidate selection also changed shape: the old loop stopped at the first
candidate whose `--version` worked, whatever the probe said. It now scans for
the first candidate that IS the RV32 target, and only if none is falls back to
naming the first compiler that answered, so the stand-down says which tool
declined.

### 2. Gate 1b's stand-downs now reach the suite verdict line

All three of them go through `skip()`, so the closing line counts and names
them: the RTL elaboration arm, the compiled census, and (round 2) the
`MAKEFLAGS += -e` entry. All use the default row kind, so
`--require-elaboration` is unchanged.

### 3. The reason pin has a negative control

`assert_rejected()` is what turns "the mutant was refused" into "the mutant was
refused by the rule it breaks", and it was the one instrument in the gate with
no self-test. A control now calls it with a real mutant and a `because` no rule
in the file prints, and requires `mutation was rejected for the wrong reason`.

### 4. Self-tests

Four run on any machine, RISC-V compiler or not: a stub compiler drives the
probe through all 3 candidate shapes (already RV32; 64-bit with an rv32
multilib, where the recorded argv is read back to prove the flags reach the
compiler; 64-bit only); a host-only and a 64-bit-candidate stand-down selection
each force any compile to fail and require the printed `STOOD DOWN` wording to
describe that same observed no-run state; and the arch check is driven over
`rv32` text, `rv64` text and text with no attribute. A fifth runs only where
the census is live: the probe is re-run against the adopted compiler under this
run's own flags asking for a 64-bit target, and must fail.

### 5. Smaller items from the Issue

| Item | Disposition |
|---|---|
| Empty `milan_baremetal.c` died on `AttributeError: 'NoneType' object has no attribute 'group'` | Fixed: named refusal |
| "PHC/gPTP are live from reset" overclaims what the gate measures | Fixed: "live from reset TO THE ptp_timestamp PORT ... a tie-off INSIDE ptp_ts_top still elaborates and is milan_dp's to catch" |
| `helper_body_store_mutations` pinned on the cast set, not on the helper's own provenance rule | DECLINED with a substitution. See [Known limitations](#known-limitations--out-of-scope). |

## Round 2: the R1 delta

`[R1]` returned POSITIVE on `98390cee` with two MINORs, an answer to the
MAKEFLAGS question, and two SUGGESTIONs. All five are answered at `18900848`.

**MINOR 1, Tests (fixed).** In the CI shape the closing evidence line claimed
two measurements that had not happened. Both clauses are now gated on the same
condition as the measurement they report, so the CI shape prints
`NOT measured on this run: no candidate here is the RV32 target ...` and
`the exempted-helper blindness control did NOT run here, because the census
stood down ...` instead. This is the ticket's own principle applied to the fix.

**MINOR 2, Docs (fixed).** `BAREMETAL_FIRMWARE.md` no longer states the live
64-bit re-probe unconditionally; it now separates the four self-tests that run
anywhere from the fifth that needs a live census, says the census stands down
and is named in the verdict where it does not, and the miscount is gone (the
sentence said "three" over four listed items; it is now five, enumerated).

**MAKEFLAGS (registered).** One `skip()` inside the existing branch, row kind.
The wording deliberately does not match the other two arms: nothing is missing
from the runner, the construct is present and simply does nothing on a make
that does not re-read MAKEFLAGS mid-parse, so the skip says "No tool is missing
from this runner; the mutant has no effect to observe on THIS make".

**SUGGESTION 1 (taken).** The census assembly's own `.attribute arch` is read
back and must be `rv32`. This closes the residual `[R1]` found: a compiler
honest on the probe and dishonest on the census call.

**SUGGESTION 2 (declined, recorded).** An RV32 target with unusable headers
still reddens a pristine tree. The decision and its reason are now written at
the raise site in `test_builder.py` and in `BAREMETAL_FIRMWARE.md`, not left to
be rediscovered: converting that RED into a stand-down would let a firmware the
gate genuinely cannot census pass as "the toolchain's fault". Telling the two
apart needs a positive control compiled before the firmware, which is a design
of its own, is not #206, and is not reachable on either toolchain this
repository is built with.

## Authoritative references

- #206 (this defect, filed by the second cleared-context round on #187)
- #177 (the boot gate and its two-toolchain stand-down contract)
- #162, #153 (the source-text refusal and control-flow gaps this does not close)
- `sw/builder/test_builder.py` gate 1b, `docs/integration/BAREMETAL_FIRMWARE.md`

## How to get into the same state

```sh
git clone git@github.com:kebag-logic/milan-fpga.git
cd milan-fpga
git checkout 206-boot-gate-self-integrity   # 18900848
git submodule update --init --recursive
export PATH=$PATH:$HOME/br-milan-rv32/host/bin   # APPEND: prepending shadows python3
```

The interesting environments are the ones WITHOUT the Buildroot tree. `HOME`
redirected at an empty directory removes the absolute
`~/br-milan-rv32/host/bin/riscv32-linux-gcc` candidate and leaves Arch's
`/usr/bin/riscv64-elf-gcc` (GCC 15.2.0) as the census compiler.

## How to validate

```sh
# 1. the suite, as the bench runs it
python3 sw/builder/test_builder.py

# 2. the reported defect: the box's compiler is riscv64-elf-gcc
mkdir -p /tmp/emptyhome
HOME=/tmp/emptyhome python3 sw/builder/test_builder.py

# 3. THE REFUSAL: a 64-bit GCC that cannot be driven at rv32 must STAND DOWN
mkdir -p /tmp/nomultilib && cat > /tmp/nomultilib/riscv64-elf-gcc <<'SH'
#!/bin/bash
for a in "$@"; do case "$a" in -march=rv32*|-mabi=ilp32*)
  echo "riscv64-elf-gcc: error: cannot find suitable multilib set for '$a'" >&2
  exit 1;; esac; done
exec /usr/bin/riscv64-elf-gcc "$@"
SH
chmod +x /tmp/nomultilib/riscv64-elf-gcc
HOME=/tmp/emptyhome PATH=/tmp/nomultilib:$PATH python3 sw/builder/test_builder.py

# 4. THE OTHER REFUSAL (round 2): honest on the probe, dishonest on the census
mkdir -p /tmp/liar && cat > /tmp/liar/riscv64-elf-gcc <<'SH'
#!/bin/bash
args=(); census=0; werror=0
for a in "$@"; do case "$a" in *milan_baremetal.c) census=1;; -Werror) werror=1;; esac; done
for a in "$@"; do
  if [ $census = 1 ] && [ $werror = 0 ]; then
    case "$a" in -march=rv32*|-mabi=ilp32*) continue;; esac
  fi
  args+=("$a")
done
exec /usr/bin/riscv64-elf-gcc "${args[@]}"
SH
chmod +x /tmp/liar/riscv64-elf-gcc
HOME=/tmp/emptyhome PATH=/tmp/liar:$PATH python3 sw/builder/test_builder.py

# 5. the CI shape (docs.yml:28): only cc and gcc, no Verilator, empty HOME
# 6. the stand-down reaches the verdict line: hide Verilator from PATH
# 7. the elaboration job's mode
MILAN_LITEX_PYTHON=$HOME/litex-milan/venv/bin/python3 \
PYTHONPATH=<litex>:<liteeth>:<pythondata-cpu-vexiiriscv> \
python3 sw/builder/test_builder.py --require-elaboration

# 8. hygiene and docs
python3 scripts/lint_rtl.py --check
python3 scripts/docs_check.py
python3 scripts/check_doc_paths.py
python3 scripts/gen_toc.py --check
python3 scripts/gen_toc.py --verify-anchors
python3 docs/traceability/gen_module_matrix.py --check
git diff --check
```

Expected result, all measured in this clone: BEFORE on `dev` at `4ec73a15`
(or, for the round 2 rows, on `98390cee`), AFTER at `18900848`.

| # | Condition | BEFORE | AFTER |
|---|---|---|---|
| 1 | bench: Buildroot `riscv32-linux-gcc`, Verilator | exit 0, 263.6 s, 144/144 mutations, 46/46 RTL variants, `EXCEPT 2 NOT RUN` | exit 0, 265 s, 144/144, 46/46, `EXCEPT 2 NOT RUN`; census `answered by riscv32-linux-gcc, which is the RV32 target with no flags, emitting rv32i2p1_m2p0_a2p1_zicsr2p0_zifencei2p0 assembly`; 71 census compiles rv32, 0 unstated |
| 2 | census compiler is `riscv64-elf-gcc` | **exit 1 in 1.7 s**, `-Werror=int-to-pointer-cast`, no verdict line | exit 0, 226.6 s, 144/144, 46/46, `driven at RV32 with -march=rv32i -mabi=ilp32` |
| 3 | 64-bit GCC, no rv32 multilib | unreachable (row 2 goes red first) | exit 0, 215.6 s, `STOOD DOWN`, 140/140 mutations, verdict NAMES the census arm |
| 4 | honest probe, dishonest census invocation | `98390cee`: **exit 1 after 213.2 s**, caught only indirectly as `entity enabled through a typedef'd pointer and an access macro mutation passed the boot-contract gate` | **exit 1 in 1.2 s**, named directly: `the compiled census of the firmware was emitted for rv64i2p1_..., not for an rv32 target` |
| 5 | Verilator hidden from `PATH` | `dev`: exit 0, 156.3 s, verdict `EXCEPT 2 NOT RUN`, gate 1b absent | exit 0, 159 s, 98/98 non-RTL, `EXCEPT 3 NOT RUN`, gate 1b named |
| 6 | CI shape (only `cc`/`gcc`, no Verilator, empty `HOME`) | `98390cee`: exit 0, 104.5 s, claims `refused a 64-bit target under this run's own flags` and `0/0 exempted-helper stores were measured INVISIBLE`, neither measured | exit 0, 109.6 s, 94/94 non-RTL, `EXCEPT 12 NOT RUN`; the line now reads `NOT measured on this run: no candidate here is the RV32 target ...` and `the exempted-helper blindness control did NOT run here` |
| 7 | a make that ignores `-e` (emulated by pinning `makeflags_e_bites = False`), Verilator hidden | `98390cee`: exit 0, 112.5 s, 97/97, arm printed mid-log, verdict `EXCEPT 1 NOT RUN`, arm absent | exit 0, 111.7 s, 97/97, verdict `EXCEPT 2 NOT RUN`, arm named as `the MAKEFLAGS += -e mutation: this make does not re-read MAKEFLAGS mid-parse ...` |
| 8 | `--require-elaboration` | exit 0 | exit 0, 266 s, `2 arm(s) did not run for recorded reasons` |
| 9 | empty `sw/firmware/milan_baremetal/milan_baremetal.c` | `AttributeError ... .group` at `test_builder.py:1857` | named refusal |

Row 5 note: the Issue predicted `EXCEPT 4 NOT RUN` because gate 23g also
skipped on the reporter's box. Here gate 23g runs, so the count is 2 -> 3.

### The fix is mutation-tested, not asserted

Each row is a copy of the module with one deliberate deletion, run with `HOME`
empty so `riscv64-elf-gcc` is the census candidate. All re-measured at
`18900848`.

| Degenerate case | Result |
|---|---|
| delete the `__riscv_xlen` guard from the probe source | **exit 1 in 0.5 s**: `the census probe accepts a 64-bit target under the flags it selected for riscv64-elf-gcc, so it is not deciding the register width` |
| delete the guard AND the live anti-vacuity re-probe | **exit 1 in 1.1 s**: now caught one layer down by the arch readback, `the compiled census of the firmware was emitted for rv64i2p1_...` |
| keep the guard, drop the recorded driver flags from `assert_target_compiles()` | **exit 1 in 1.6 s**: #206 reproduced verbatim |
| `assert arch is None or arch.startswith("rv32")` -> `assert True or ...` | **exit 1 in 0.3 s**: its own self-test fires, `the census arch check accepted rv64 assembly, so it cannot say which machine the census it reads was taken on` |
| `assert because in str(exc)` -> `assert True or because in str(exc)` | BEFORE `dev`: focused gate exit 0 in 213.8 s, 144/144, 46/46. AFTER: **exit 1 in 33.5 s** |

### Other gates at `18900848`

| Gate | Result |
|---|---|
| `scripts/lint_rtl.py --check` | PASS, 99 violations <= ratchet 99, 22 waived |
| `scripts/docs_check.py` | 0 findings across 213 md files |
| `scripts/check_doc_paths.py` | OK, 1130 cited paths resolve |
| `scripts/gen_toc.py --check` / `--verify-anchors` | OK, 152 pages / 91 fragment links |
| `docs/traceability/gen_module_matrix.py --check` | up to date, 65 modules, 0 untested |
| `scripts/check_sweep_shape.py`, `pp_srcs.py --check --selftest`, `check_soc_sources.py` | OK |
| `scripts/ci_scope.py --selftest` | PASS |
| `scripts/check_merge_review_integrity.py --selftest` | 18/18 PASS |
| `git diff --check` | clean |
| `cd tests && behave` | 15 features, 334 scenarios, 1571 steps, 0 failed |
| `scripts/run_all_suites.sh` (at `98390cee`, no RTL changed since) | 52/52 suites, 2117789 checks, 0 failures, 928 s |

## Known limitations / out of scope

**The Issue's third smaller item is DECLINED, with a substitution.** It asks
that the two `helper_body_store_mutations` be re-pinned on
`milan_reg() must return exactly MILAN_CSR_BASE plus the offset`, or the rules
reordered so that rule fires first. Neither was done:

- The compiled census exempts the address helper BY NAME, so a store planted
  inside it is invisible to the census. These 2 mutants are the only ones left
  that demonstrate the cast set catching a shape the census cannot see, which
  is the evidence round nine deleted and #187 restored.
- The provenance rule keeps its own reason-pinned mutant,
  "milan_reg() ignores its offset".
- The substitution: on every run where the census is live, the census is run
  over each helper-store mutant and required to come back CLEAN, printed as
  `2/2 exempted-helper stores were measured INVISIBLE to the compiled census`.
  The mutant labels now name the instrument that refuses them.

`[R1]` judged the substitution sound and explicitly did not raise it as a
finding, having broken the blindness control to confirm it fires. Its two
honest residuals are recorded here so the trade-off stays visible:

1. The control measures that the census is BLIND to a body store. It does not
   prove that rule 6 could catch one; that remains an ordering decision.
2. The control only runs where the census is live. On a runner without an RV32
   compiler the two mutants stay pinned on the cast set with the measurement
   absent, and the gate now says exactly that instead of printing `0/0`.

Also out of scope, unchanged by this PR:

- An RV32 toolchain with unusable headers still reddens a pristine tree, with
  correct attribution. Decided deliberately in round 2 and recorded at the
  raise site and in the docs; see [Round 2](#round-2-the-r1-delta).
- The compiled census still resolves store targets by matching printed
  literals, so a paged base or an `slli`/`ori` address is outside it (#162).
- The AEM verifier's control-flow reachability is still textual (#153).
- No RTL changed, so no Verilator harness moved.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied (4 met, 1 declined with a measured reason and a substitute control, which the criterion allows and `[R1]` accepted)
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [x] Internal cleared-context review is positive (`[R1]` POSITIVE on `98390cee`; two MINORs answered at `18900848`)
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done
