### PR TITLE
Export the gPTP stamper's messageType tag beside the sequenceId, and scope the reorder claim to what is proved

### DIFF
--- a/docs/design/GPTP_PLANE.md
+++ b/docs/design/GPTP_PLANE.md
@@ -108,10 +108,19 @@ The plane has four seams:
   stamper (only the shaped data path does), so `KL_gptp_txstamp`
   observes the TRUE MAC boundary: armed by the plane's lane sof, it
   latches the counter at an 0x88F7 frame's first beat and returns
-  {ts, sequenceId} for the engine's pending exchange. Observer-pure
-  (`check_tap_purity` holds). One gPTP stack per port is the operating
-  assumption -- two transmitting stacks is itself invalid, and the A/B
-  bring-up keeps exactly one talking.
+  {ts, sequenceId, messageType} for the engine's pending exchange.
+  BOTH tags travel, since #214: a Pdelay_Req carries our own request
+  counter and a Pdelay_Resp echoes the peer's, so the 16-bit sequence
+  alone cannot say which leg a stamp belongs to, and on a link where
+  both ends run this plane the two counters start equal at boot and
+  advance together at 1 Hz. Two frames of one messageType are never
+  outstanding at once, so the pair separates them. The engine consumes
+  the sequence half today and the type half waits at its boundary
+  (`KL_gptp_shadow`'s `txts_type_i`, mirrored on `dbg_txts_type_o`)
+  until Mister-M-alt/FPGA-gPTP#28's follow-up matches on both.
+  Observer-pure (`check_tap_purity` holds). One gPTP stack per port is
+  the operating assumption -- two transmitting stacks is itself
+  invalid, and the A/B bring-up keeps exactly one talking.
 - **Inside the engine**, the ingress stamp ping-pongs with the message
   bank (stage at sof, commit at eof, length-qualified) -- the fabric
   bench found the single-register race this retires; the donor's

--- a/hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv
+++ b/hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv
@@ -497,7 +497,9 @@ module KL_gptp_shadow #(
   //! registered here, deliberately: the stamper already holds
   //! {ts_ns_o, ts_seq_o, ts_type_o} in registers, and the engine samples
   //! the txts_* face COMBINATIONALLY in the cycle txts_valid_i is high
-  //! (KL_gptp_engine.sv:278-280 latches txts_seq_i there). A register in
+  //! (KL_gptp_engine's `if (txts_valid_i) ... txts_pend_seq_r <=
+  //! txts_seq_i` latches it there; no line number, the pin moves). A
+  //! register in
   //! this path would add no persistence and one cycle of lag, so at the
   //! sampling cycle it would still carry the PREVIOUS stamp's type and a
   //! consumer would credit one leg's egress time to another's claim --

--- a/hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv
+++ b/hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv
@@ -32,8 +32,15 @@
 //                ingress-latency correction (REQ-PTP-06 lineage), and the
 //                silicon round (#117) measures it. The EGRESS timestamp
 //                comes back from KL_gptp_txstamp at the MAC boundary via
-//                the txts_* face, seq-matched, because the control lane
-//                does not traverse ptp_ts_top's stamper.
+//                the txts_* face, tagged with the transmitted frame's
+//                sequenceId AND messageType, because the control lane does
+//                not traverse ptp_ts_top's stamper. The engine consumes
+//                the sequence tag today; the type tag is carried to its
+//                boundary and mirrored on dbg_txts_type_o until the
+//                submodule matches on both (milan-fpga #214,
+//                Mister-M-alt/FPGA-gPTP#28), because a sequenceId alone
+//                cannot separate a Pdelay_Req from a Pdelay_Resp when the
+//                two counters coincide.
 //
 //                A control frame offered while the FIFO cannot take it is
 //                LOST and counted, never hidden (the tap cannot
@@ -85,6 +92,7 @@ module KL_gptp_shadow #(
     input  wire        txts_valid_i,
     input  wire [63:0] txts_ns_i,
     input  wire [15:0] txts_seq_i,
+    input  wire [3:0]  txts_type_i,   //! messageType of the stamped frame
 
     //! pulses at the FIRST accepted beat of each plane frame entering the
     //! merge chain -- the boundary stamper's take decision samples at a
@@ -111,7 +119,8 @@ module KL_gptp_shadow #(
     output wire  [63:0] dbg_rx_ts_o,      //! the ts entry feeding the engine
     output wire         dbg_tspush_v_o,   //! bench probes: side-FIFO push
     output wire  [63:0] dbg_tspush_o,
-    output wire         dbg_tspop_v_o     //! side-FIFO pop (engine sof)
+    output wire         dbg_tspop_v_o,    //! side-FIFO pop (engine sof)
+    output logic [3:0]  dbg_txts_type_o   //! the last returned type tag
 );
 
   localparam int unsigned KEEP_W_C = TDATA_WIDTH_P / 8;
@@ -480,6 +489,18 @@ module KL_gptp_shadow #(
   always_ff @(posedge clk_i) begin : adj_latch
     if (!rst_n)        phc_adj_o <= '0;
     else if (adj_we_w) phc_adj_o <= $signed(adj_val_w);
+  end
+
+  //! The stamper's messageType tag, held for the last returned stamp. The
+  //! engine's txts_* face takes the sequenceId only at the pinned
+  //! submodule, so the second half of the tag stops here and is published
+  //! for the bench and for forensics; when the engine matches on both
+  //! (Mister-M-alt/FPGA-gPTP#28) this register feeds its port instead of
+  //! only this output. Holding rather than pulsing keeps it readable after
+  //! the one-cycle txts_valid_i, exactly like the stamp itself.
+  always_ff @(posedge clk_i) begin : txts_type_hold
+    if (!rst_n)            dbg_txts_type_o <= 4'd0;
+    else if (txts_valid_i) dbg_txts_type_o <= txts_type_i;
   end
 
   // ======================================================================= //

--- a/hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv
+++ b/hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv
@@ -36,8 +36,10 @@
 //                sequenceId AND messageType, because the control lane does
 //                not traverse ptp_ts_top's stamper. The engine consumes
 //                the sequence tag today; the type tag is carried to its
-//                boundary and mirrored on dbg_txts_type_o until the
-//                submodule matches on both (milan-fpga #214,
+//                boundary and presented live on dbg_txts_type_o, the
+//                PORT and not a register, so it is valid in the same
+//                cycle the engine samples the face, until the submodule
+//                matches on both (milan-fpga #214,
 //                Mister-M-alt/FPGA-gPTP#28), because a sequenceId alone
 //                cannot separate a Pdelay_Req from a Pdelay_Resp when the
 //                two counters coincide.
@@ -120,7 +122,7 @@ module KL_gptp_shadow #(
     output wire         dbg_tspush_v_o,   //! bench probes: side-FIFO push
     output wire  [63:0] dbg_tspush_o,
     output wire         dbg_tspop_v_o,    //! side-FIFO pop (engine sof)
-    output logic [3:0]  dbg_txts_type_o   //! the last returned type tag
+    output wire  [3:0]  dbg_txts_type_o   //! the stamp's type tag, live
 );
 
   localparam int unsigned KEEP_W_C = TDATA_WIDTH_P / 8;
@@ -491,17 +493,19 @@ module KL_gptp_shadow #(
     else if (adj_we_w) phc_adj_o <= $signed(adj_val_w);
   end
 
-  //! The stamper's messageType tag, held for the last returned stamp. The
-  //! engine's txts_* face takes the sequenceId only at the pinned
-  //! submodule, so the second half of the tag stops here and is published
-  //! for the bench and for forensics; when the engine matches on both
-  //! (Mister-M-alt/FPGA-gPTP#28) this register feeds its port instead of
-  //! only this output. Holding rather than pulsing keeps it readable after
-  //! the one-cycle txts_valid_i, exactly like the stamp itself.
-  always_ff @(posedge clk_i) begin : txts_type_hold
-    if (!rst_n)            dbg_txts_type_o <= 4'd0;
-    else if (txts_valid_i) dbg_txts_type_o <= txts_type_i;
-  end
+  //! The stamper's messageType tag, passed straight through. NOT
+  //! registered here, deliberately: the stamper already holds
+  //! {ts_ns_o, ts_seq_o, ts_type_o} in registers, and the engine samples
+  //! the txts_* face COMBINATIONALLY in the cycle txts_valid_i is high
+  //! (KL_gptp_engine.sv:278-280 latches txts_seq_i there). A register in
+  //! this path would add no persistence and one cycle of lag, so at the
+  //! sampling cycle it would still carry the PREVIOUS stamp's type and a
+  //! consumer would credit one leg's egress time to another's claim --
+  //! the mis-crediting of Mister-M-alt/FPGA-gPTP#28 over again, off by a
+  //! leg instead of a sequence. When the engine matches on both tags this
+  //! wire feeds its port; tb/verilator/gptp_shadow asserts the equality
+  //! AT the valid cycle so the lag cannot come back.
+  assign dbg_txts_type_o = txts_type_i;
 
   // ======================================================================= //
   //  TX gearbox: 1 B/clk up to wide beats, whole frames onto the lane      //

--- a/hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv
+++ b/hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv
@@ -13,18 +13,40 @@
 //                are captured HERE: on the final merged TX stream, an
 //                EtherType 0x88F7 frame latches the PHC at its first beat
 //                and reports {ts, sequenceId, msgType} once the sequence
-//                lanes pass -- the engine matches by its pending exchange.
+//                lanes pass. Both tags travel because neither alone
+//                identifies the transmitter: a Pdelay_Req carries our own
+//                request counter while a Pdelay_Resp echoes the peer's, so
+//                two legs can hold the same 16-bit sequenceId at once, and
+//                on a link where both ends run this plane the two counters
+//                start equal at boot and stay equal at 1 Hz. Two frames of
+//                the SAME messageType cannot be outstanding together, so
+//                {sequenceId, msgType} separates every pair the engine has
+//                to tell apart (milan-fpga #214, Mister-M-alt/FPGA-gPTP#28).
 //
 //                ARMED counting keeps this the PLANE'S stamper: the plane
 //                pulses armed_i as each of its frames enters the merge
 //                chain, and only that many 0x88F7 boundary frames are
-//                stamped. Frames arbitrated between the plane's lane and
-//                the boundary cannot reorder (the merge chain locks per
-//                frame downstream of the lane), so the count pairs frames
-//                exactly while the plane is the only gPTP transmitter.
-//                Running a second gPTP stack (ptp4l) on the same port
-//                while the plane transmits is itself invalid -- the A/B
+//                stamped. What that counting guarantees, exactly: the
+//                plane's own frames cannot reorder against each other,
+//                because they leave on ONE AXI-Stream lane and every
+//                arbiter in the merge chain locks a frame from tlast to
+//                tlast rather than interleaving beats (proved for
+//                adp_tx_arbiter by tb/verilator/adp_tx, "frame not
+//                interleaved (single tag)"). What it does NOT guarantee is
+//                exclusivity: a foreign 0x88F7 frame from another stack on
+//                the same port would be counted as ours, which is why
+//                running ptp4l beside the plane is invalid -- the A/B
 //                bring-up comparison keeps exactly one of them talking.
+//                The order premise is not load-bearing any more either:
+//                the engine matches the returning stamp by its {sequenceId,
+//                msgType} tag, not by position. No bench proves the merge
+//                chain end to end for THIS module; tb/verilator/gptp_shadow
+//                watches the lane with no arbiter between (it proves the
+//                stamper pairs back-to-back frames in order, one stamp
+//                each, tagged with their own header fields), and a full
+//                proof would need tb/verilator/milan_dp to run the gPTP
+//                lane against a contending source and check the pairing
+//                survives (milan-fpga #214).
 //
 //                PURE OBSERVER: this module drives nothing on the stream
 //                it watches (check_tap_purity holds).
@@ -49,10 +71,11 @@ module KL_gptp_txstamp #(
     //! one pulse per plane frame that entered the merge chain
     input  wire armed_i,
 
-    //! the stamp, seq-matched by the engine
+    //! the stamp, matched by the engine on {sequenceId, msgType}
     output logic        ts_valid_o,
     output logic [63:0] ts_ns_o,
-    output logic [15:0] ts_seq_o
+    output logic [15:0] ts_seq_o,
+    output logic [3:0]  ts_type_o    //! messageType of the stamped frame
 );
 
   localparam logic [15:0] ET_GPTP_C = 16'h88F7;
@@ -63,10 +86,13 @@ module KL_gptp_txstamp #(
   //! plane frames in flight between the lane and the boundary
   logic [3:0] armed_r;
 
-  //! wire bytes 12,13 = beat-1 lanes 4,5; sequenceId = wire bytes 44,45 =
-  //! beat-5 lanes 4,5 (byte b = beat b/8, lane b%8)
+  //! wire bytes 12,13 = beat-1 lanes 4,5; messageType = the low nibble of
+  //! wire byte 14 = beat-1 lane 6 (802.1AS-2011 11.4.2.1, the high nibble
+  //! is transportSpecific); sequenceId = wire bytes 44,45 = beat-5 lanes
+  //! 4,5 (byte b = beat b/8, lane b%8)
   logic [2:0]  bcnt_r;                  //! beats 0..5 tracked, saturates
   logic        is_gptp_r, take_r;
+  logic [3:0]  mtype_r;                 //! latched with the EtherType
   logic [63:0] ts_r;
 
   always_ff @(posedge clk_i) begin
@@ -75,10 +101,12 @@ module KL_gptp_txstamp #(
       bcnt_r     <= 3'd0;
       is_gptp_r  <= 1'b0;
       take_r     <= 1'b0;
+      mtype_r    <= 4'd0;
       ts_r       <= 64'd0;
       ts_valid_o <= 1'b0;
       ts_ns_o    <= 64'd0;
       ts_seq_o   <= 16'd0;
+      ts_type_o  <= 4'd0;
     end else begin
       ts_valid_o <= 1'b0;
 
@@ -96,12 +124,15 @@ module KL_gptp_txstamp #(
           is_gptp_r <= 1'b0;
           take_r    <= (armed_r != 4'd0) | armed_i;
         end
-        if (bcnt_r == 3'd1)
+        if (bcnt_r == 3'd1) begin
           is_gptp_r <= ({tx_tdata_i[39:32], tx_tdata_i[47:40]} == ET_GPTP_C);
+          mtype_r   <= tx_tdata_i[51:48];   //! byte 14 low nibble
+        end
         if ((bcnt_r == 3'd5) && is_gptp_r && take_r) begin
           ts_valid_o <= 1'b1;
           ts_ns_o    <= ts_r;
           ts_seq_o   <= {tx_tdata_i[39:32], tx_tdata_i[47:40]};
+          ts_type_o  <= mtype_r;
         end
         if (tx_tlast_i)          bcnt_r <= 3'd0;
         else if (bcnt_r != 3'd7) bcnt_r <= bcnt_r + 3'd1;
@@ -109,9 +140,10 @@ module KL_gptp_txstamp #(
     end
   end
 
-  //! an observer reads only the lanes it needs
+  //! an observer reads only the lanes it needs: lane 6's low nibble is the
+  //! messageType above, its high nibble (transportSpecific) is not read
   logic unused_w;
-  assign unused_w = ^{tx_tdata_i[63:48], tx_tdata_i[31:0]};
+  assign unused_w = ^{tx_tdata_i[63:52], tx_tdata_i[31:0]};
 
 endmodule : KL_gptp_txstamp
 `default_nettype wire

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -6088,6 +6088,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     wire                     gts_valid_w;
     wire [63:0]              gts_ns_w;
     wire [15:0]              gts_seq_w;
+    wire [3:0]               gts_type_w;
 
     KL_gptp_shadow #(
         .TDATA_WIDTH_P (TDATA_WIDTH),
@@ -6113,6 +6114,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
         .txts_valid_i    (gts_valid_w),
         .txts_ns_i       (gts_ns_w),
         .txts_seq_i      (gts_seq_w),
+        .txts_type_i     (gts_type_w),
         .tx_sent_o       (gtx_sent_w),
         .pub_gm_id_o     (gptp_pub_gm_w),
         .pub_parent_id_o (gptp_pub_parent_w),
@@ -6128,7 +6130,8 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
         .dbg_rx_ts_o     (),
         .dbg_tspush_v_o  (),
         .dbg_tspush_o    (),
-        .dbg_tspop_v_o   ()
+        .dbg_tspop_v_o   (),
+        .dbg_txts_type_o ()
     );
 
     adp_tx_arbiter #(.DATA_WIDTH(TDATA_WIDTH), .TO_LOG2_P(16)) gptp_ctl_mux (
@@ -6157,7 +6160,8 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
         .armed_i    (gtx_sent_w),
         .ts_valid_o (gts_valid_w),
         .ts_ns_o    (gts_ns_w),
-        .ts_seq_o   (gts_seq_w)
+        .ts_seq_o   (gts_seq_w),
+        .ts_type_o  (gts_type_w)
     );
   end else begin : g_gptp_off
     //! option off: the control lane passes straight through, the PHC

--- a/tb/verilator/gptp_plane/README.md
+++ b/tb/verilator/gptp_plane/README.md
@@ -38,9 +38,10 @@ while the input is unread.
 Scope that carefully, because the same name means two things. What is
 unread is the ENGINE port, which is what this wrapper instantiates.
 The SLICE's `timestamp_counter` wire is read by
-`KL_gptp_shadow.sv:197` and `KL_gptp_txstamp.sv:95` and IS covered:
+`KL_gptp_shadow.sv`'s `ts_arr_r <= phc_ns_i` and `KL_gptp_txstamp.sv`'s
+first-beat `ts_r <= phc_ns_i` and IS covered:
 tying both slice consumers in `tb/verilator/gptp_shadow`'s wrapper to
-`64'd0` turns that bench red, 40 checks with 31 PASS and 9 FAIL. So a
+`64'd0` turns that bench red, 59 checks with 45 PASS and 14 FAIL. So a
 mis-wire of the counter into the shipped slice is caught; only the
 engine's own port is invisible. Tracked as
 [#211](https://github.com/kebag-logic/milan-fpga/issues/211), which

--- a/tb/verilator/gptp_shadow/README.md
+++ b/tb/verilator/gptp_shadow/README.md
@@ -14,9 +14,10 @@ fabric time.
 
 | phase | claim |
 |---|---|
-| 1 | boot Pdelay_Req byte-exact through the gearbox; the boundary stamper supplies t1 by itself (its extracted sequenceId matches the frame) |
+| 1 | boot Pdelay_Req byte-exact through the gearbox; the boundary stamper supplies t1 by itself, and its extracted tags, sequenceId AND messageType, are that frame's (#214) |
 | 2, 3 | a fabric-timed exchange lands on the harness-records expectation; asCapable at the second exchange, not the first |
 | 4 | adopt; offset in range; a short closed loop locks the REAL counter against a +100 ppm master |
+| 4b | #214: a peer Pdelay_Req reusing OUR outstanding sequenceId draws our Pdelay_Resp and its Pdelay_Resp_Follow_Up, and the two returning stamps are told apart by messageType alone (0x3 and 0xA), in emission order, one stamp per frame. That collision is the systematic one on a two-board link, where both request counters start at zero and advance at 1 Hz |
 | 5 | an AVTP-ethertype frame between gPTP ones is invisible; a runt drops harmlessly and costs no drop count |
 | 6 | an OVERSIZE frame dropped inside the tap FIFO cannot skew the next sync's ingress stamp (falsifies an accept-time ts push -- the commit-pulse transport pairs stamps with DELIVERED frames only) |
 | 7 | a back-to-back burst overflows the tap FIFO: drops are COUNTED via the FIFO's overflow strobe (DROP_WHEN_FULL keeps s_ready high, so a ready-based counter is blind), and the plane keeps working afterwards |
@@ -27,7 +28,10 @@ every pdelay skewed +half the inter-frame gap), fixed in the donor as
 the per-bank eof-committed stamp; phase 2 is red under any engine
 without it. Five planted mutations (a deaf classifier lane, an
 accept-time ts push, shifted stamper sequence lanes, an eof-timed arm,
-the single-register engine revert) turn the run red.
+the single-register engine revert) turn the run red, and four more on
+the #214 type tag (dropped, read from the transportSpecific nibble
+beside it, frozen at a constant, never re-latched) each turn exactly
+the five type checks red.
 
 ```sh
 git submodule update --init gptp-processor   # once

--- a/tb/verilator/gptp_shadow/README.md
+++ b/tb/verilator/gptp_shadow/README.md
@@ -18,6 +18,7 @@ fabric time.
 | 2, 3 | a fabric-timed exchange lands on the harness-records expectation; asCapable at the second exchange, not the first |
 | 4 | adopt; offset in range; a short closed loop locks the REAL counter against a +100 ppm master |
 | 4b | #214: a peer Pdelay_Req reusing OUR outstanding sequenceId draws our Pdelay_Resp and its Pdelay_Resp_Follow_Up, and the two returning stamps are told apart by messageType alone (0x3 and 0xA), in emission order, one stamp per frame. That collision is the systematic one on a two-board link, where both request counters start at zero and advance at 1 Hz |
+| 13 | #214: with no announce refreshed the receipt timeout expires and the plane becomes grandmaster, so Announce, Sync and Follow_Up join the lane. Then every stamp of the whole run is paired with the frame it belongs to, positionally, and checked against that frame's own messageType and sequenceId, so the tag is proved for all SIX types the plane transmits rather than the three a slave-only run emits. Last in the run, because a plane that is its own grandmaster stops consuming the peer syncs the earlier phases need |
 | 5 | an AVTP-ethertype frame between gPTP ones is invisible; a runt drops harmlessly and costs no drop count |
 | 6 | an OVERSIZE frame dropped inside the tap FIFO cannot skew the next sync's ingress stamp (falsifies an accept-time ts push -- the commit-pulse transport pairs stamps with DELIVERED frames only) |
 | 7 | a back-to-back burst overflows the tap FIFO: drops are COUNTED via the FIFO's overflow strobe (DROP_WHEN_FULL keeps s_ready high, so a ready-based counter is blind), and the plane keeps working afterwards |
@@ -28,10 +29,16 @@ every pdelay skewed +half the inter-frame gap), fixed in the donor as
 the per-bank eof-committed stamp; phase 2 is red under any engine
 without it. Five planted mutations (a deaf classifier lane, an
 accept-time ts push, shifted stamper sequence lanes, an eof-timed arm,
-the single-register engine revert) turn the run red, and four more on
-the #214 type tag (dropped, read from the transportSpecific nibble
-beside it, frozen at a constant, never re-latched) each turn exactly
-the five type checks red.
+the single-register engine revert) turn the run red, and five more on
+the #214 type tag: dropped, read from the transportSpecific nibble
+beside it, frozen at a constant, and never latched at all each turn six
+checks red, while one that is correct for every type EXCEPT Announce
+turns exactly one, the whole-run pairing check, which is the reason
+that check and phase 13 exist. A sixth, re-registering the slice's
+type port instead of passing it through, turns the sample-cycle skew
+check red: the engine samples the txts face combinationally on the
+valid pulse, so a register there would hand it the previous stamp's
+type.
 
 ```sh
 git submodule update --init gptp-processor   # once

--- a/tb/verilator/gptp_shadow/gptp_shadow_wrap.sv
+++ b/tb/verilator/gptp_shadow/gptp_shadow_wrap.sv
@@ -65,10 +65,17 @@ module gptp_shadow_wrap #(
     //! window rather than of an instant. A frame the parser refuses must
     //! never move this: the refusal and the dispatch are exclusive, which
     //! is the invariant the tsn_fuzz unlisted-messageType probe rests on
-    output wire [15:0] dbg_prog_run_o
+    output wire [15:0] dbg_prog_run_o,
+    //! the stamper's messageType tag, beside the sequence tag: a returning
+    //! stamp must name the frame it belongs to by BOTH (milan-fpga #214)
+    output wire [3:0]  dbg_txts_type_o,
+    //! the same tag after the slice has held it, so the bench sees what
+    //! the engine boundary will see
+    output wire [3:0]  dbg_slice_type_o
 );
 
   logic               busy_w;
+  logic [3:0]         tst_w;
   logic signed [31:0] adj_w;
   logic               step_we_w;
   logic [63:0]        step_w;
@@ -121,6 +128,7 @@ module gptp_shadow_wrap #(
       .txts_valid_i    (tsv_w),
       .txts_ns_i       (tsn_w),
       .txts_seq_i      (tsq_w),
+      .txts_type_i     (tst_w),
       .tx_sent_o       (sent_w),
       .pub_gm_id_o     (pub_gm_id_o),
       .pub_parent_id_o (pub_parent_id_o),
@@ -136,7 +144,8 @@ module gptp_shadow_wrap #(
       .dbg_rx_ts_o     (dbg_rx_ts_o),
       .dbg_tspush_v_o  (dbg_tspush_v_o),
       .dbg_tspush_o    (dbg_tspush_o),
-      .dbg_tspop_v_o   (dbg_tspop_v_o)
+      .dbg_tspop_v_o   (dbg_tspop_v_o),
+      .dbg_txts_type_o (dbg_slice_type_o)
   );
 
   KL_gptp_txstamp #(
@@ -152,12 +161,14 @@ module gptp_shadow_wrap #(
       .armed_i    (sent_w),
       .ts_valid_o (tsv_w),
       .ts_ns_o    (tsn_w),
-      .ts_seq_o   (tsq_w)
+      .ts_seq_o   (tsq_w),
+      .ts_type_o  (tst_w)
   );
 
   assign dbg_txts_o    = tsn_w;
   assign dbg_txts_v_o  = tsv_w;
   assign dbg_txts_seq_o = tsq_w;
+  assign dbg_txts_type_o = tst_w;
 
   //! program-start counter: one per rising edge of the engine's busy line
   logic        busy_r;

--- a/tb/verilator/gptp_shadow/gptp_shadow_wrap.sv
+++ b/tb/verilator/gptp_shadow/gptp_shadow_wrap.sv
@@ -69,8 +69,9 @@ module gptp_shadow_wrap #(
     //! the stamper's messageType tag, beside the sequence tag: a returning
     //! stamp must name the frame it belongs to by BOTH (milan-fpga #214)
     output wire [3:0]  dbg_txts_type_o,
-    //! the same tag after the slice has held it, so the bench sees what
-    //! the engine boundary will see
+    //! the same tag where the engine boundary sees it: the slice PORT,
+    //! combinational, so it must equal the stamper's in the very cycle
+    //! txts_valid_i is high. A register here would lag by a leg
     output wire [3:0]  dbg_slice_type_o
 );
 

--- a/tb/verilator/gptp_shadow/sim_main.cpp
+++ b/tb/verilator/gptp_shadow/sim_main.cpp
@@ -112,7 +112,9 @@ struct Stamp { uint16_t seq; uint8_t type; uint64_t ns; };
 static std::vector<Stamp> stamps;
 //! #214: the slice port must carry the tag AT the cycle the face is valid,
 //! not one stamp later. The engine samples txts_* combinationally on the
-//! valid pulse (KL_gptp_engine.sv:278-280), so a registered mirror would
+//! valid pulse (KL_gptp_engine's `if (txts_valid_i) ... txts_pend_seq_r <=
+//! txts_seq_i`, cited by the assignment because the pin under it moves),
+//! so a registered mirror would
 //! read the PREVIOUS stamp's type there and credit one leg's egress time
 //! to another leg's claim. Every valid cycle is compared, and the count is
 //! asserted non-zero so the check cannot pass by never running.

--- a/tb/verilator/gptp_shadow/sim_main.cpp
+++ b/tb/verilator/gptp_shadow/sim_main.cpp
@@ -110,6 +110,13 @@ static uint16_t last_txts_seq = 0xFFFF;
 //! while a Pdelay_Resp echoes the peer's and the two can coincide.
 struct Stamp { uint16_t seq; uint8_t type; uint64_t ns; };
 static std::vector<Stamp> stamps;
+//! #214: the slice port must carry the tag AT the cycle the face is valid,
+//! not one stamp later. The engine samples txts_* combinationally on the
+//! valid pulse (KL_gptp_engine.sv:278-280), so a registered mirror would
+//! read the PREVIOUS stamp's type there and credit one leg's egress time
+//! to another leg's claim. Every valid cycle is compared, and the count is
+//! asserted non-zero so the check cannot pass by never running.
+static int slice_skews = 0, slice_valids = 0;
 static std::vector<std::vector<uint8_t>> txf;   // unpacked lane frames
 static std::vector<uint64_t> tx_sof_phc;        // phc at each frame's beat0
 static std::vector<uint8_t> cur;
@@ -130,6 +137,8 @@ static void tick() {
     if (dut->dbg_tspop_v_o)  g_popped.push_back(dut->dbg_rx_ts_o);
   }
   if (dut->dbg_txts_v_o) {
+    slice_valids++;
+    if (dut->dbg_slice_type_o != dut->dbg_txts_type_o) slice_skews++;
     last_txts_seq = dut->dbg_txts_seq_o;
     stamps.push_back({(uint16_t)dut->dbg_txts_seq_o,
                       (uint8_t)dut->dbg_txts_type_o, dut->dbg_txts_o});
@@ -643,6 +652,63 @@ int main(int argc, char **argv) {
     expect("mixed traffic: pops + gPTP sheds == the 60 gPTP frames sent",
            (int)g_popped.size() + (int)sheds, npair);
   }
+
+  // ---- 13: #214 -- the master role puts the other three types on the
+  // lane. Until here the run emits Pdelay_Req, Pdelay_Resp and its
+  // Follow_Up only, so the tag would be proved for three of the
+  // six types the plane transmits and a mutation correct for everything
+  // but Announce would pass. With no announce refreshed the receipt timeout
+  // expires, the plane becomes grandmaster, and Announce, Sync and
+  // Follow_Up join the lane. Last, because a plane that is its own
+  // grandmaster no longer consumes the peer syncs the earlier phases use.
+  {
+    size_t before = txf.size();        // the first Announce rides the
+    uint64_t spent = 0;                // transition itself, so mark first
+    while (!(dut->pub_flags_o & FL_AMGM) && spent < 16000000ull) {
+      run_svc(200000);
+      spent += 200000;
+    }
+    expect("quiet ride to grandmaster",
+           (dut->pub_flags_o & FL_AMGM) ? 1 : 0, 1);
+    run_svc(1400000);                  // an announce interval and then some
+    int saw_ann = 0, saw_sync = 0, saw_fu = 0;
+    for (size_t k = before; k < txf.size(); k++) {
+      if (txf[k].size() <= 14) continue;
+      int t = txf[k][14] & 0xF;
+      if (t == 0xB) saw_ann = 1;
+      if (t == 0x0) saw_sync = 1;
+      if (t == 0x8) saw_fu = 1;
+    }
+    expect("as master: an Announce reached the lane", saw_ann, 1);
+    expect("as master: a Sync reached the lane", saw_sync, 1);
+    expect("as master: its Follow_Up reached the lane", saw_fu, 1);
+  }
+
+  // #214: the tag must be right where the engine reads it, every time
+  expect("the slice port carried a tag at every stamp", slice_valids > 0, 1);
+  expect("the slice port never lags the stamper at the valid cycle",
+         slice_skews, 0);
+  // ...and every stamp must name ITS OWN frame. One stamp per transmitted
+  // frame, in order (the stamper's armed counting), so the pairing is
+  // positional and the tags are checked against the frame's own header
+  // bytes for EVERY type the run emits rather than a hard-coded few. Six
+  // is what this plane transmits: Sync 0x0, Pdelay_Req 0x2, Pdelay_Resp
+  // 0x3, Follow_Up 0x8, Pdelay_Resp_Follow_Up 0xA and Announce 0xB
+  // (802.1AS-2011 Table 11-3 and Table 10-5).
+  expect("one stamp per transmitted frame", (int)stamps.size(),
+         (int)txf.size());
+  int tag_wrong = 0, seq_wrong = 0, types_seen = 0, mask = 0;
+  for (size_t k = 0; k < stamps.size() && k < txf.size(); k++) {
+    if (txf[k].size() < 46) continue;
+    int t = txf[k][14] & 0xF;
+    if (stamps[k].type != t) tag_wrong++;
+    if (stamps[k].seq != (uint16_t)((txf[k][44] << 8) | txf[k][45]))
+      seq_wrong++;
+    if (!(mask & (1 << t))) { mask |= 1 << t; types_seen++; }
+  }
+  expect("every stamp carries its own frame's messageType", tag_wrong, 0);
+  expect("every stamp carries its own frame's sequenceId", seq_wrong, 0);
+  expect("the tag is proved for all six transmitted types", types_seen, 6);
 
   printf("%d checks: %d PASS, %d FAIL\n", checks, checks - fails, fails);
   delete dut;

--- a/tb/verilator/gptp_shadow/sim_main.cpp
+++ b/tb/verilator/gptp_shadow/sim_main.cpp
@@ -104,6 +104,12 @@ static Frame follow_up(uint16_t seq, uint64_t origin_ns) {
 static Vgptp_shadow_wrap *dut;
 static uint64_t cyc = 0;
 static uint16_t last_txts_seq = 0xFFFF;
+//! #214: every returning stamp, in arrival order, with both of its tags.
+//! A stamp names the frame it belongs to by {sequenceId, messageType}; the
+//! sequence alone cannot, because a Pdelay_Req carries our own counter
+//! while a Pdelay_Resp echoes the peer's and the two can coincide.
+struct Stamp { uint16_t seq; uint8_t type; uint64_t ns; };
+static std::vector<Stamp> stamps;
 static std::vector<std::vector<uint8_t>> txf;   // unpacked lane frames
 static std::vector<uint64_t> tx_sof_phc;        // phc at each frame's beat0
 static std::vector<uint8_t> cur;
@@ -123,7 +129,11 @@ static void tick() {
     if (dut->dbg_tspush_v_o) g_pushed.push_back(dut->dbg_tspush_o);
     if (dut->dbg_tspop_v_o)  g_popped.push_back(dut->dbg_rx_ts_o);
   }
-  if (dut->dbg_txts_v_o) last_txts_seq = dut->dbg_txts_seq_o;
+  if (dut->dbg_txts_v_o) {
+    last_txts_seq = dut->dbg_txts_seq_o;
+    stamps.push_back({(uint16_t)dut->dbg_txts_seq_o,
+                      (uint8_t)dut->dbg_txts_type_o, dut->dbg_txts_o});
+  }
   if (dut->tx_tvalid_o && dut->tx_tready_i) {
     if (tx_first) {
       cur.clear();
@@ -297,6 +307,15 @@ int main(int argc, char **argv) {
   if (!req.empty())
     expect("stamper extracted the req's seq", last_txts_seq,
            (uint16_t)((req[44] << 8) | req[45]));
+  // #214: the stamp names the frame by BOTH tags. A Pdelay_Req is
+  // messageType 0x2 (802.1AS-2011 Table 11-3), the low nibble of wire
+  // byte 14, and the tag must be that frame's, not the previous one's.
+  if (!req.empty() && !stamps.empty()) {
+    expect("the req's stamp carries messageType 0x2",
+           stamps.back().type, (uint8_t)(req[14] & 0xF));
+    expect("the slice holds the same type at the engine boundary",
+           dut->dbg_slice_type_o, (uint8_t)(req[14] & 0xF));
+  }
 
   // ---- 2: one fabric-timed exchange; not capable at one ------------------
   pd_seen = 0;                      // answer the boot request too
@@ -344,6 +363,54 @@ int main(int argc, char **argv) {
     }
     expect("closed loop locked",
            near((int32_t)dut->pub_offset_o, 0, 300), 1);
+  }
+
+  // ---- 4b: #214 -- a returning stamp names its OWN frame, by type -------
+  // The responder role puts a second transmitted type on the lane: a peer
+  // Pdelay_Req draws our Pdelay_Resp (0x3) and its Pdelay_Resp_Follow_Up
+  // (0xA). Each stamp must carry the messageType of the frame it belongs
+  // to, and the sequence tag alone cannot say which: this request reuses
+  // the sequenceId our own boot Pdelay_Req already spent, which is the
+  // collision the two-board link produces from boot (both ends count from
+  // zero at 1 Hz). Without the type tag the two stamps are
+  // indistinguishable at the engine boundary.
+  {
+    uint16_t clash = last_txts_seq;          // our own outstanding sequence
+    size_t before_n = stamps.size();
+    // 54 octets: the header plus the two ten-byte reserved fields of
+    // 802.1AS-2011 Table 11-11, which the pinned parser requires
+    Frame rq = ptp(0x2, clash, 0, 0x0000, 20, PEER_CID);
+    rq.u64(0); rq.u64(0); rq.u32(0);
+    send_wide(rq.b);
+    size_t ri = 0, fi = 0;
+    std::vector<uint8_t> rsp = wait_tx(0x3, 200000, &ri);
+    std::vector<uint8_t> rfu = wait_tx(0xA, 200000, &fi);
+    expect("responder answered the colliding request", rsp.empty() ? 0 : 1, 1);
+    expect("its Resp_Follow_Up followed", rfu.empty() ? 0 : 1, 1);
+    if (!rsp.empty() && !rfu.empty() && stamps.size() >= before_n + 2) {
+      // both carry the SAME sequenceId as our own outstanding request, so
+      // only the type separates them
+      expect("Resp echoes the colliding sequence",
+             (uint16_t)((rsp[44] << 8) | rsp[45]), clash);
+      expect("Resp_Follow_Up echoes it too",
+             (uint16_t)((rfu[44] << 8) | rfu[45]), clash);
+      int seen_resp = 0, seen_rfu = 0;
+      for (size_t k = before_n; k < stamps.size(); k++) {
+        if (stamps[k].seq != clash) continue;
+        if (stamps[k].type == 0x3) seen_resp++;
+        if (stamps[k].type == 0xA) seen_rfu++;
+      }
+      expect("a stamp carries messageType 0x3 for the Pdelay_Resp",
+             seen_resp, 1);
+      expect("a stamp carries messageType 0xA for its Follow_Up", seen_rfu, 1);
+      // the pairing is positional too: the stamps arrive in emission order,
+      // one per frame, which is what the stamper's armed counting promises
+      // for the plane's own lane
+      expect("two stamps for two frames, in order",
+             (int)(stamps.size() - before_n) >= 2 &&
+             stamps[before_n].type == 0x3 &&
+             stamps[before_n + 1].type == 0xA, 1);
+    }
   }
 
   // ---- 5: classify negatives ---------------------------------------------


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, test tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- What changed and why.
- **[The reorder claim, re-checked](#the-reorder-claim-re-checked)** -- What is guaranteed, what is not, and what a full proof needs.
- **[Authoritative references](#authoritative-references)** -- Requirements/specification clauses and docs.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout/dependency/environment commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands and expected result.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from CONTRIBUTING.md.

## Status

GREEN. Shipped RTL changes, so the full Section 3 bar including Yosys and xvlog was run at this head.

`214-txstamp-msgtype-tag` -> `dev` at exact head `e8dac76f75a43a0ccb732837c5a77f50f930e6f1` (four commits on `origin/dev` `5ee9167ac234101e206d6a544beb8688622751d2`, an ancestor after a rebase, so the head tree is the candidate merge tree): `d6d2195c` the export and its bench cover, `673aca28` the documents, `6de445f7` the review answer, `e8dac76f` the citation fix.

`tb/verilator/gptp_shadow`: **59 checks, 59 PASS** (40 on `dev`). No submodule bump: `gptp-processor` stays exactly as `dev` has it.

## Linked Issue / roles

Closes #214
Relates to Mister-M-alt/FPGA-gPTP#28 (the donor half; see below), #213

Executor: `[A1]`
Internal cleared-context reviewer: pending
External reviewer: pending

**The donor side is Mister-M-alt/FPGA-gPTP#28 and closing it needs both halves.** This PR exports the tag and proves the hardware produces it; the engine matching on it is a donor change that consumes `txts_type_i` on its own schedule. Nothing here depends on that: no submodule pin moves, and the tag waits at the engine boundary until the donor takes it.

## Description

| piece | change |
|---|---|
| `hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv` | new output `ts_type_o[3:0]`, the messageType of the stamped frame. It is the low nibble of wire byte 14 (802.1AS-2011 11.4.2.1; the high nibble is transportSpecific), which is beat-1 lane 6 -- the beat the module already stops on for the EtherType at lanes 4 and 5 -- so the byte was already in front of the module and the capture costs TWO 4-bit registers, `mtype_r` latched beside `is_gptp_r` and `ts_type_o` at the report (+9 cells hierarchically, measured below). Reported with the stamp at beat 5, reset with the rest, and the observer's `unused_w` sink narrowed from `[63:48]` to `[63:52]` so it still names exactly what is not read. |
| `hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv` | new input `txts_type_i[3:0]` beside `txts_seq_i`, passed straight to `dbg_txts_type_o` as a WIRE. Deliberately not registered: the stamper already holds `{ts_ns_o, ts_seq_o, ts_type_o}`, and the engine samples the txts face combinationally in the cycle `txts_valid_i` is high (`KL_gptp_engine.sv:278-280` latches `txts_seq_i` there), so a register would add no persistence and one cycle of lag, handing a consumer the PREVIOUS stamp's type. The comment says exactly that, because the comment is the hand-off instruction the donor will follow. |
| `hdl/milan/milan_datapath.sv` | `gts_type_w` wires stamper to slice inside `g_gptp_plane`, and the new diagnostic output is left open at the top level. |
| `tb/verilator/gptp_shadow/gptp_shadow_wrap.sv` | the tag out of the stamper (`dbg_txts_type_o`) and out of the slice (`dbg_slice_type_o`), so the bench can see both the raw tag and what the engine boundary will see. |
| `tb/verilator/gptp_shadow/sim_main.cpp` | every returning stamp is recorded with both tags in arrival order, and compared to the stamper's AT the valid cycle. Phase 1 asserts the boot Pdelay_Req's stamp carries messageType 0x2 and that the slice holds the same value. New phase 4b drives the responder role and the collision itself: a peer Pdelay_Req reusing OUR outstanding sequenceId draws our Pdelay_Resp and its Pdelay_Resp_Follow_Up, both echoing that same sequence, and the two stamps are separated by type alone (0x3 and 0xA), in emission order, one per frame. New phase 13 rides the receipt timeout to grandmaster so Announce, Sync and Follow_Up also leave the DUT, and the run closes by pairing EVERY stamp with the frame it belongs to, positionally, against that frame's own messageType and sequenceId, plus the sample-cycle equality. 19 new checks, 40 -> 59. |
| `docs/design/GPTP_PLANE.md`, `tb/verilator/gptp_shadow/README.md` | the interface is `{ts, sequenceId, messageType}` in both, with the reason the pair is needed and the note that the engine consumes one half today. |

### Why the pair, not the sequence alone

Recorded on #214 by the cold review of the donor's own fix and not re-measured here: legs that transmit without leaving a claim are still stamped, and a Pdelay_Resp_Follow_Up's stamp clearing an outstanding Pdelay_Req claim published a peer delay of 250,631 ns against a 601 ns control; in master role a Pdelay_Resp's stamp taken by a Sync claim emitted the response's egress time as a Sync `preciseOriginTimestamp` and never sent the mandatory Pdelay_Resp_Follow_Up (802.1AS-2011 11.2.14.2.3, 11.2.16). The coincidence is systematic rather than rare, because both ends of a two-board link run this implementation and both request counters start at zero and advance at 1 Hz. Two frames of the same messageType are never outstanding at once, so `{sequenceId, messageType}` separates every pair involved. Phase 4b reproduces the sequence collision deliberately rather than waiting for it.

## The reorder claim, re-checked

The banner claimed: "Frames arbitrated between the plane's lane and the boundary cannot reorder (the merge chain locks per frame downstream of the lane), so the count pairs frames exactly while the plane is the only gPTP transmitter." I could not prove that in `tb/verilator/gptp_shadow` and did not pretend to: **that bench has no arbiter between the lane and the stamper at all** -- the wrapper wires `tx_tdata_o` straight from the slice into the observer, so the DUT does not contain the thing the claim is about. What I did instead:

- **Established what is structurally true and where it is tested.** The plane's own frames leave on ONE AXI-Stream lane, so they cannot reorder against each other unless an arbiter interleaves beats; every arbiter in the merge chain is an `adp_tx_arbiter`, and `tb/verilator/adp_tx` asserts `frame not interleaved (single tag)` (`sim_main.cpp:111`; suite re-run here, 26 and 20 checks, 0 failures). The banner now says that, with the citation.
- **Said what the counting does NOT guarantee**: exclusivity. A foreign 0x88F7 frame from another stack on the same port is counted as ours. That was implicit in the old "while the plane is the only gPTP transmitter"; it is now explicit.
- **Removed the load.** With `{sequenceId, messageType}` the engine matches by tag, not by position, so the order premise stops being the thing correctness rests on. That is the real answer to the issue's "load-bearing" concern.
- **Proved the in-scope part.** Phase 4b asserts the stamper pairs back-to-back frames in emission order, one stamp per frame, each carrying its own header fields.
- **Named what a full proof needs**: `tb/verilator/milan_dp` running the gPTP lane against a contending TX source and checking the pairing survives the merge chain. The pieces exist (`sim_txgrant.cpp` already creates arbiter contention, `A_TXARB_DIAG 0x784` reports per-lane locks) but nothing ties the gPTP stamper to them today. That is written into the banner as the missing test rather than left as an assumption.

## Authoritative references

- IEEE Std 802.1AS-2011 11.4.2.1 and Table 11-3 (messageType is the low nibble of the first PTP header octet, wire byte 14 with the 14-byte Ethernet header; Sync 0x0, Pdelay_Req 0x2, Pdelay_Resp 0x3, Follow_Up 0x8, Pdelay_Resp_Follow_Up 0xA, Announce 0xB, Signaling 0xC); 11.4.2.6 sequenceId; 11.2.14.2.3 (the Follow_Up carries its associated Sync's egress timestamp) and 11.2.16 (the Pdelay_Resp_Follow_Up is mandatory), the two clauses the mis-crediting violates.
- Milan v1.2 section 4.2.6 profiles IEEE Std 802.1AS-2011 with Cor1-2013 and Cor2-2015 (the normative edition recorded on #139).
- #214 and the measurements recorded on it; Mister-M-alt/FPGA-gPTP#28; `docs/design/GPTP_PLANE.md`.

## How to get into the same state

```sh
git fetch origin 214-txstamp-msgtype-tag
git checkout --detach e8dac76f75a43a0ccb732837c5a77f50f930e6f1
git submodule update --init protocol-processor gptp-processor third_party/verilog-axis
```

## How to validate

```sh
make -C tb/verilator/gptp_shadow
make -C tb/verilator/adp_tx
suite_logs=$(mktemp -d); TSN_GEN_ROOT=~/tsn-gen scripts/run_all_suites.sh "$suite_logs"
syn/yosys/run.sh
python3 scripts/lint_rtl.py --check
XVLOG=/path/to/Vivado/bin/xvlog python3 scripts/xvlog_gate.py --check
python3 sw/builder/test_builder.py     # then --require-elaboration, NOT in parallel
python3 scripts/docs_check.py && python3 docs/traceability/gen_module_matrix.py --check
git diff --check origin/dev...HEAD
```

Expected, measured at this head:

- `tb/verilator/gptp_shadow`: **59 checks, 59 PASS, 0 FAIL** (40 on `dev`).
- `tb/verilator/adp_tx` (the citation the banner now carries): 26 and 20 checks, 0 failures.
- sweep `suites: 52 passed: 52 failed: 0 timed out: 0`, `checks: 2118496`, rc 0, 507 s, measured after the rebase: `dev`'s 2,118,477 plus this PR's 19.
- Yosys `tops: 46 pass: 46 fail: 0`, `RESULT: PASS`, `TIED-INPUT GATE: PASS (2 justified tie(s), no unjustified ones)`, `TAP-PURITY RESULT: PASS`, rc 0, 963 s, re-run after the rebase. Area, THREE tops, each measured on both trees with the same command:
  - `KL_gptp_txstamp` **211 -> 220 cells, +9, of which +8 are flops** (`$_SDFFE_PN0P_` 153 -> 161) in the hierarchical count the project's gate uses: two 4-bit registers, `mtype_r` at the capture and `ts_type_o` at the report. That figure stands whether or not the output is read. Under a boundary-crossing optimisation it does not: flattened with `ts_type_o` left OPEN, as `milan_datapath` leaves it today, both registers are pruned as dead and the module measures **212 against dev's 213**; flattened with the output actually read it is **222**. All three reproduced here (`sv2v` + `yosys synth -flatten` over a wrapper that connects or omits the port). So the tag costs +9 by the metric that gates this repo and nothing at all in the shipping build until the donor consumes it -- which is also a reminder that "unchanged cells" for an unread output proves the output is unread, not that the logic is free.
  - `KL_gptp_shadow` **186,659 cells, exactly `dev`'s**, now that the tag rides the port instead of a register. The earlier head measured 186,650 and I reported that decrease unexplained; the reviewer decomposed it as +7 real in this module and MINUS 16 of pure ABC re-mapping churn inside the untouched `KL_gptp_ucpu`, caused by the new port bumping Yosys's global `autoidx` (7,715 -> 7,725) and renumbering later objects, proven with a null-edit control and a canonicalised RTLIL diff identical over all 5,997 lines. Removing the register removes the churn with it, which is why this top is now bit-for-bit dev's count. I was right not to guess at it and the explanation is the reviewer's, reproduced here only as the final number.
  - `milan_datapath` 1,567,129 cells, unchanged -- and that is weak evidence on its own, because this top elaborates with the gPTP option OFF. The option-ON coverage is `tb/verilator/milan_dp`'s `obj_gptp` leg at `-GGPTP_PLANE_EN_P=1`, which is in the sweep and green.
- `xvlog gate: PASS (3 finding(s) == ratchet)`, 82 s. `lint_rtl.py --check` `PASS (99 <= ratchet 99, 22 waived)` -- the new ports add no violation. `sw/builder/test_builder.py` `ALL GATES PASS EXCEPT 2 NOT RUN` plain (270 s) and with `--require-elaboration` (267 s), rc 0 both, so the datapath still elaborates with the extra wire.
- `docs_check` 0 findings across 213, `check_doc_paths` OK (1131), `gen_module_matrix --check` up to date, `gen_toc --check` (152) and `--verify-anchors` (91), `check_feature_status --self-test` 18/18, `check_archive`, `check_soc_sources`, `pp_srcs --check --selftest`, `check_sweep_shape --self-test`, `ci_scope --selftest`, `check_merge_review_integrity --selftest` 18/18: all rc 0. `git diff --check origin/dev...HEAD` clean; working tree clean; no non-ASCII on any added line.

Negative controls, each applied to `hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv` alone, restored afterwards, bench back to 49/49. Every one turns EXACTLY the five type checks red and nothing else:

| # | mutation | bench | what it proves |
|---|---|---|---|
| MT1 | the tag dropped (`ts_type_o <= 4'd0`) | `59 checks: 53 PASS, 6 FAIL` | the report path |
| MT2 | the wrong nibble (`tx_tdata_i[55:52]`, transportSpecific beside it) | `53 PASS, 6 FAIL` | the capture lane |
| MT3 | the tag frozen at 0x3, so every stamp claims Pdelay_Resp | `53 PASS, 6 FAIL` | the swap the issue's acceptance asks for |
| MT4 | `mtype_r` never latched at all, so every stamp reports 0 | `53 PASS, 6 FAIL` | the capture itself; its visible effect equals MT1's, a different fault with the same symptom, which is why the gloss now says "never latched" rather than "carries the previous frame's type" |
| MT5 | the slice's type port RE-REGISTERED, the shape this round removes | `59 checks: 58 PASS, 1 FAIL` | exactly `the slice port never lags the stamper at the valid cycle`, with 3 of the 5 valids skewed. The pre-existing checks read long after the exchange settles and cannot see a lag, which is why this check is asserted at the valid cycle |
| MT6 | correct for every type EXCEPT Announce (`mtype_r == 4'hB ? 4'h0 : mtype_r`) | `59 checks: 58 PASS, 1 FAIL` | exactly the whole-run pairing check. This is the mutation the reviewer measured as passing 49/0 before phase 13 existed |

The six MT1 to MT4 kill: `the req's stamp carries messageType 0x2`, `the slice holds the same type at the engine boundary`, `a stamp carries messageType 0x3 for the Pdelay_Resp`, `a stamp carries messageType 0xA for its Follow_Up`, `two stamps for two frames, in order`, and `every stamp carries its own frame's messageType`.

## Known limitations / out of scope

- **The engine does not match on the tag yet.** That is Mister-M-alt/FPGA-gPTP#28's follow-up and needs no change here when it lands: the donor adds the port and takes `txts_type_i` directly, or equivalently the `dbg_txts_type_o` wire it drives. NO register in that path, in either direction. The engine samples the txts face combinationally in the cycle `txts_valid_i` is high, so a register would hand it the previous stamp's type and re-create the mis-crediting this ticket exists to close; the bench asserts the equality at that cycle and re-planting the register turns it red, 20 of 23 valid cycles skewed. Closing donor #28 needs both halves.
- The merge chain is still not proved end to end for the stamper; the banner now says so and names the test that would do it (see above). This PR does not add that test, because it belongs to `milan_dp` and to a ticket of its own.
- The #215 (#142) collision this body used to forecast has happened and is RESOLVED: that PR merged first, its `dbg_prog_run_o` port and `busy_w` local landed on the same two lines of `tb/verilator/gptp_shadow/gptp_shadow_wrap.sv` as this PR's `dbg_txts_type_o`, `dbg_slice_type_o` and `tst_w`, and the rebase took the union of both sides, which is additive with no semantic overlap. The wrapper now carries all three ports and both locals, and the bench is 59/59 on the rebased tree. No submodule pin moves and `tb/verilator/tsn_fuzz/fuzz_ptp.py` is untouched.
- `dbg_txts_type_o` is a diagnostic, not a CSR: nothing reads it in the shipping build, where the datapath leaves it open.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [x] Candidate merge result is validated per CONTRIBUTING.md
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done
