### PR TITLE
Declare every identifier before its first use in milan_csr and milan_datapath, emptying the xvlog ratchet

### DIFF
--- a/hdl/common/csr/milan_csr.sv
+++ b/hdl/common/csr/milan_csr.sv
@@ -891,6 +891,31 @@ module milan_csr #(
   logic         sweep_busy;              //! defaults -> shadow copy after reset
   logic [9:0]   sweep_cnt;
 
+  //! ------------------------------------------------------------------------
+  //! Declared EARLY (#193): the decode-stage wires below (wr_fire, rd_fire,
+  //! rd_is_slow_w, rds_valid_w, rds_done_w) read these registers, and
+  //! Vivado's front-end rejects an identifier used before its declaration
+  //! (VRFC 10-3380), which Verilator and sv2v accept. Each register is
+  //! driven by its own machine further down, where its documentation lives;
+  //! only the declarations moved.
+  //! ------------------------------------------------------------------------
+  logic        strm_dir_r;               //! A_STRM_SEL[8]: 0=listener, 1=talker
+  logic [3:0]  strm_idx_r;               //! A_STRM_SEL[3:0]: stream index
+  logic        lctx_wr_p_r;              //! LCTX CFG-word write pulse
+  logic [7:0]  lctx_wr_addr_r;
+  logic [31:0] lctx_wr_data_r;
+  logic        tctx_wr_p_r;              //! TCTX CFG-word write pulse
+  logic [6:0]  tctx_wr_addr_r;
+  logic [31:0] tctx_wr_data_r;
+  logic        snap_busy_r;              //! SNAP burst in flight
+  logic        rds_busy_r;               //! slow engine-window read in flight
+  logic        rds_dir_r;
+  logic [1:0]  rds_cyc_r;
+  //! P11 window selection range gate: out-of-range idx reads 0, writes are
+  //! ignored, SNAP latches zeros (the defined out-of-range behaviour)
+  wire win_in_range_w = strm_dir_r ? (32'(strm_idx_r) < N_TALKERS_P)
+                                   : (32'(strm_idx_r) < N_LISTENERS_P);
+
   //! wr_fire additionally holds off while a P11 engine CFG-word write
   //! request is pending (held until i_*_wr_rdy): a second AXI write landing
   //! mid-request would clobber the held addr/data. The engine accepts
@@ -1189,7 +1214,7 @@ module milan_csr #(
   localparam logic [31:0] ADP_LIST_C = {ADP_LISTENER_CAPS_C,
                                         16'(ADP_LISTENER_SINK_C)};
 
-  logic        strm_dir_r;               //! A_STRM_SEL[8]: 0=listener, 1=talker
+  //! strm_dir_r is declared with the early block above wr_fire (#193)
   logic        strm_lsn0_r;             //! A_STRM_SEL[9]: select the DEDICATED
                                         //! listener-0 lwSRP row. Its own bit, not
                                         //! {dir=0, idx=0}: that pattern is the
@@ -1198,7 +1223,7 @@ module milan_csr #(
                                         //! turned the idle window into a
                                         //! continuous row poll (milan_dp's qkill
                                         //! sweep caught the arbitration shift)
-  logic [3:0]  strm_idx_r;               //! A_STRM_SEL[3:0]: stream index
+  //! strm_idx_r is declared with the early block above wr_fire (#193)
   logic [31:0] stg_sid_lo_r, stg_sid_hi_r;   //! window write staging: stream_id
   logic [31:0] stg_dmac_lo_r, stg_dmac_hi_r; //! window write staging: DMAC
   //! WHICH {dir, idx} THE STAGING SET BELONGS TO (2026-07-30). The four
@@ -1216,12 +1241,8 @@ module milan_csr #(
   //! the other three words rather than mixing two streams' halves.
   logic [4:0]  stg_sel_r;
   logic        stg_vld_r;
-  logic        lctx_wr_p_r;              //! LCTX CFG-word write pulse
-  logic [7:0]  lctx_wr_addr_r;
-  logic [31:0] lctx_wr_data_r;
-  logic        tctx_wr_p_r;              //! TCTX CFG-word write pulse
-  logic [6:0]  tctx_wr_addr_r;
-  logic [31:0] tctx_wr_data_r;
+  //! the LCTX/TCTX CFG-word write request registers are declared with the
+  //! early block above wr_fire (#193)
   //! SRP ctx master: one pending provisioning write + continuous status poll
   logic        srp_wr_pend_r;            //! a row write awaits its grant
   logic        srp_wr_valid_r;           //! record valid (CTRL.en at commit)
@@ -1264,7 +1285,7 @@ module milan_csr #(
   //! SNAP shadow: the ONE permitted window shadow ([M-5.4.2.25] coherent
   //! counter block): [0] STATE, [1..10] CNT0..9, [11] PDUS
   logic [31:0] snap_shadow_r [0:11];
-  logic        snap_busy_r;
+  //! snap_busy_r is declared with the early block above wr_fire (#193)
   logic [2:0]  snap_st_r;                //! 0 idle,1 done-pulse,2 wait-free,3 arm,4 fetch
   logic        snap_dir_r;
   logic [3:0]  snap_idx_r;
@@ -1274,10 +1295,9 @@ module milan_csr #(
   logic        snap_req_r;               //! o_*_snap_req (dir-steered)
   logic        snap_rden_r;              //! o_*_rd_en during the burst
   logic [31:0] snap_m8_r;                //! LCTX w8 hold (STATE compose)
-  //! slow read: engine port-B backed window words (4-cycle fetch)
-  logic        rds_busy_r;
-  logic        rds_dir_r;
-  logic [1:0]  rds_cyc_r;
+  //! slow read: engine port-B backed window words (4-cycle fetch);
+  //! rds_busy_r, rds_dir_r and rds_cyc_r are declared with the early block
+  //! above wr_fire (#193)
   logic [4:0]  rds_word_r;
   logic [2:0]  rds_idx_r;               //! stream index latched at the fetch
 
@@ -1322,10 +1342,12 @@ module milan_csr #(
   end : mac_reinit_edge
   wire mac_reinit_rel_w = mac_reinit_q && !i_mac_reinit;
 
-  //! P11 window selection range gate: out-of-range idx reads 0, writes are
-  //! ignored, SNAP latches zeros (the defined out-of-range behaviour)
-  wire win_in_range_w = strm_dir_r ? (32'(strm_idx_r) < N_TALKERS_P)
-                                   : (32'(strm_idx_r) < N_LISTENERS_P);
+  //! The staging set belongs to the CURRENT {dir, idx} selection (the
+  //! ownership rule is documented with the lwSRP ctx master below, which
+  //! commits it). Declared here ahead of the write path, its first reader
+  //! (#193).
+  wire       stg_hit_w     = stg_vld_r && (stg_sel_r == {strm_dir_r,
+                                                         strm_idx_r});
 
   //! Register file write path: synchronous reset defaults, hardware event
   //! latching (before W1C), AXI-Lite register writes, W1C on IRQ_STATUS, and
@@ -2090,6 +2112,10 @@ module milan_csr #(
   //  plain-RW config register reads from the shadow BRAM.
   // ==========================================================================
   logic [31:0] live_mux;
+  //! Reset-epoch canary (documented with epoch_cnt below, which drives it):
+  //! a flop WITHOUT a reset clause, bitstream-initialised. Declared here
+  //! ahead of read_mux, its first reader (#193).
+  reg [7:0] rst_epoch_r = 8'd0;
   logic        live_hit;
 
   always_comb begin : read_mux
@@ -2243,6 +2269,12 @@ module milan_csr #(
   wire [47:0] mac_wire_w = {mac_alo[7:0], mac_alo[15:8], mac_alo[23:16],
                             mac_alo[31:24], mac_ahi[7:0], mac_ahi[15:8]};
   logic [31:0] strm_mux;
+  //! listener idx 0 addresses the DEDICATED sink-0 row when this build has
+  //! one (SRP_LSN0_ROW_P != 0) - the row-0 legacy pair keeps the talker-0
+  //! side, so talker-dir idx 0 stays excluded (flat CSRs serve it).
+  //! Declared here ahead of strm_read_mux, its first reader (#193); the
+  //! lwSRP ctx master that consumes it alongside is further down.
+  wire       srp_idx0_ls_w = strm_lsn0_r && (SRP_LSN0_ROW_P != 0);
   logic        strm_hit;
   always_comb begin : strm_read_mux
     logic [ADDR_WIDTH-1:0] coff;         //! CNT word offset
@@ -2518,7 +2550,7 @@ module milan_csr #(
   //! reset clause (bitstream-init 0, survive axis resets). Software compares
   //! epochs to detect hidden fabric resets that the config shadow masks
   //! (the 2026-07-19 link-bounce forensics: CSR reads lied after a reset).
-  reg [7:0] rst_epoch_r = 8'd0;
+  //! rst_epoch_r is declared above read_mux, its first reader (#193)
   reg       rstn_seen_r = 1'b0;
   always @(posedge aclk) begin : epoch_cnt
     rstn_seen_r <= aresetn;
@@ -2785,10 +2817,8 @@ module milan_csr #(
 
   //! lwSRP ctx master: continuous status poll of the selected extra row +
   //! one-deep provisioning write queue (committed by a window CTRL write)
-  //! listener idx 0 addresses the DEDICATED sink-0 row when this build has
-  //! one (SRP_LSN0_ROW_P != 0) - the row-0 legacy pair keeps the talker-0
-  //! side, so talker-dir idx 0 stays excluded (flat CSRs serve it).
-  wire       srp_idx0_ls_w = strm_lsn0_r && (SRP_LSN0_ROW_P != 0);
+  //! (srp_idx0_ls_w, the listener idx-0 dedicated-row select, is declared
+  //! above strm_read_mux, its first reader, #193)
   wire       srp_poll_w    = win_in_range_w &&
                              ((strm_idx_r != 4'd0) || srp_idx0_ls_w);
   wire [4:0] srp_sel_row_w = strm_dir_r
@@ -2805,8 +2835,8 @@ module milan_csr #(
   //! Ownership is by SELECTION, not spent by the commit: repeated CTRL writes
   //! at the index a sid was staged for keep that sid, so a re-enable cannot
   //! change a running stream's declared identity underneath it.
-  wire       stg_hit_w     = stg_vld_r && (stg_sel_r == {strm_dir_r,
-                                                         strm_idx_r});
+  //! (stg_hit_w, the staging-set ownership compare, is declared above the
+  //! register-file write path, its first reader, #193)
 
   always_ff @(posedge aclk) begin : strm_srp_master_S
     if (!aresetn) begin

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -668,6 +668,10 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! cfg_mac_addr is the platform LSB-first convention (the driver packs
   //! MAC_ADDR_LO/HI that way and the RX filter consumes it that way), and
   //! every protocol engine here wants the other one. Byte-reversed ONCE.
+  //! cfg_mac_addr belongs to the CSR <-> datapath block below; it is
+  //! declared here because this is its first reader and Vivado's front-end
+  //! rejects a use before the declaration (#193).
+  wire [47:0] cfg_mac_addr;
   wire [47:0] station_mac_be_w = {cfg_mac_addr[7:0],   cfg_mac_addr[15:8],
                                   cfg_mac_addr[23:16], cfg_mac_addr[31:24],
                                   cfg_mac_addr[39:32], cfg_mac_addr[47:40]};
@@ -1329,12 +1333,22 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! writer or boot seeder. The declared front-end routing stays selected
   //! after reset. Software writes the map through the CSR window and then
   //! uses CHMAP_CTRL[0] to select that crossbar in place of the front end.
+  //! cfg_chmap_enable (CHMAP_CTRL[0], documented with the chmap 0x900 fabric
+  //! below) is declared here ahead of its first reader (#193).
+  wire        cfg_chmap_enable;
   wire        cap_xbar_live_w = aecp_odmap_dyn_w | cfg_chmap_enable;
   wire        pkt_pv_w   = cap_xbar_live_w ? cmap_pv_w   : zf_pv_w;
   wire [4:0]  pkt_slot_w = cap_xbar_live_w ? cmap_slot_w : zf_slot_w;
   wire [23:0] pkt_l_w    = cap_xbar_live_w ? cmap_l_w    : zf_l_w;
   wire [23:0] pkt_r_w    = cap_xbar_live_w ? cmap_r_w    : zf_r_w;
 
+  //! lwsrp_adopt_valid/lwsrp_op_prio/lwsrp_op_vid: the Domain adoption
+  //! pair the AAF C-TAG muxes read, declared ahead of aaf_packetizer,
+  //! their first reader (#193); documented with the LWSRP_DOM 0x788
+  //! block below.
+  wire        lwsrp_adopt_valid;
+  wire [7:0]  lwsrp_op_prio;
+  wire [11:0] lwsrp_op_vid;
   KL_aaf_packetizer #(.N_TALKERS_P(N_STREAMS),
                       .WIRE_CHANS_P(TALKER_WIRE_CHANS_P)) aaf_packetizer (
     .clk_i (axis_clk), .rst_n (axis_resetn),
@@ -1409,7 +1423,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   // ==========================================================================
   wire        cfg_mac_tx_en, cfg_mac_rx_en, cfg_mac_promisc, cfg_mac_allmulti, cfg_mac_is_1g;
   wire [7:0]  cfg_mac_ifg;
-  wire [47:0] cfg_mac_addr;
+  //! cfg_mac_addr is declared above station_mac_be_w (its first reader)
   wire [63:0] cfg_mc_hash;
   wire        cfg_phy_reset_n;
 
@@ -1609,9 +1623,8 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! OPERATIONAL {priority, VID} every declaration serializes; when
   //! adopt_valid the AAF/CRF C-TAG muxes below take the same pair, so the
   //! reservation and the frames can never diverge. LWSRP_DOM 0x788.
-  wire        lwsrp_adopt_valid;
-  wire [7:0]  lwsrp_op_prio;
-  wire [11:0] lwsrp_op_vid;
+  //! (lwsrp_adopt_valid, lwsrp_op_prio and lwsrp_op_vid are declared above
+  //! aaf_packetizer, their first reader, #193)
   wire        lwsrp_tfail_valid;
   wire [7:0]  lwsrp_tfail_code, lwsrp_rx_drops;
   wire [15:0] lwsrp_tx_count, lwsrp_rx_pdus;
@@ -1625,6 +1638,10 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   wire        acmpl1_bound;
   wire [63:0] acmpl1_sid;
   wire [31:0] aecp_bdbg0_w, aecp_bdbg1_w, aecp_bdbg2_w;
+  //! pp_cd_acmp_bound_vlan_w belongs to the protocol processor class-D
+  //! face below; it is declared here because acmpl_vlan_w is its first
+  //! reader (#193).
+  wire [ACMP_SINKS_C*12-1:0] pp_cd_acmp_bound_vlan_w;
   //! the bound stream's VLAN, kept only for the 0x6A4 status word's field
   wire [11:0] acmpl_vlan_w = pp_cd_acmp_bound_vlan_w[11:0];
   //! ACMP listener bind record, republished from the protocol processor's
@@ -1680,8 +1697,8 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! chmap 0x900 fabric (docs/CHANNEL_MAP_64.md §6): CSR map-RAM write port +
   //! bypass arm. Default (cfg_chmap_enable=0) leaves the compliance audio path
   //! bit-identical (render/capture crossbars are muxed OUT of both the
-  //! packetizer feed and the i2s_playback feed).
-  wire        cfg_chmap_enable;
+  //! packetizer feed and the i2s_playback feed). cfg_chmap_enable itself is
+  //! declared above cap_xbar_live_w, its first reader.
   //! Render-side AECP map-write leg. Accepted input transactions project
   //! backed model clusters here; the CSR 0x900 window shares the writer.
   wire        aecp_dmap_wr_p_w;
@@ -1996,8 +2013,9 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   assign o_mac_addr     = cfg_mac_addr;
   assign o_mc_hash      = cfg_mc_hash;
   assign o_phy_reset_n  = cfg_phy_reset_n;
-  assign o_irq_csr      = csr_irq;
+  //! csr_irq: declared ahead of the o_irq_csr assign, its first reader (#193)
   wire   csr_irq;
+  assign o_irq_csr      = csr_irq;
 
   //! Synchronise the MAC speed[] indication (i_mac_speed, gtx_clk-domain) into
   //! axis_clk before it is used by the CSR readback and link-change detector.
@@ -2185,7 +2203,8 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   wire [ACMP_SINKS_C*64-1:0] pp_cd_acmp_bound_eid_w;
   wire [ACMP_SINKS_C*64-1:0] pp_cd_acmp_bound_sid_w;
   wire [ACMP_SINKS_C*48-1:0] pp_cd_acmp_bound_dmac_w;
-  wire [ACMP_SINKS_C*12-1:0] pp_cd_acmp_bound_vlan_w;
+  //! (pp_cd_acmp_bound_vlan_w is declared above acmpl_vlan_w, its first
+  //! reader, #193)
   wire [31:0]                pp_cd_adp_avail_index_w /* verilator public_flat_rd */;
 
   //! ---- the shadow plane's maap request face, and the shim's answers ----
@@ -3105,6 +3124,16 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   assign aecp_resp_count = 16'd0;
   assign aecp_ctlr_diag = 32'd0;
   assign aemp_stat_w = 32'd0;  //! no AEM patch ingest
+  //! pp_aecp_pt_offset_*/pp_aecp_fmt_in_*/pp_aecp_fmt_out_*: the
+  //! processor per-row settings faces, declared ahead of the
+  //! aecp_in0_fmt fold, their first reader (#193); documented with the
+  //! KL_pp_shadow block below.
+  logic [ACMP_SRC_C*32-1:0]   pp_aecp_pt_offset_w;
+  logic [ACMP_SRC_C-1:0]      pp_aecp_pt_offset_v_w;
+  logic [ACMP_SINKS_C*64-1:0] pp_aecp_fmt_in_w;
+  logic [ACMP_SINKS_C-1:0]    pp_aecp_fmt_in_v_w;
+  logic [ACMP_SRC_C*64-1:0]   pp_aecp_fmt_out_w;
+  logic [ACMP_SRC_C-1:0]      pp_aecp_fmt_out_v_w;
   //! STREAM_INPUT[0]'s stream_format. NOT ZERO: KL_avtp_rx_monitor_ctx
   //! accepts frames against this value, so 0 rejects every conformant AAF
   //! PDU and stream 0 accepts NOTHING. The DEFAULT is the AEM ROM's old
@@ -3501,6 +3530,27 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   logic [7:0]  amap_seen_r;
   logic [15:0] amap_cnt_r;
   logic [63:0] amap_rec_r2;
+  //! amap_in_ent_w: the stage-A render-map entry, declared ahead of the
+  //! amap_answer_srv pipeline, its first reader (#193); driven by
+  //! amap_page_slot below.
+  logic [7:0] amap_in_ent_w;
+  //! amap_out_ent_w/amap_out_owner_v_w/amap_out_owner_w/amap_out_cluster_w:
+  //! the stage-A capture-map entry terms, declared ahead of
+  //! amap_answer_srv, their first reader (#193); driven by amap_out_slot
+  //! below.
+  logic [12:0] amap_out_ent_w;
+  logic        amap_out_owner_v_w;
+  logic [15:0] amap_out_owner_w;
+  logic [15:0] amap_out_cluster_w;
+  //! amap_slot_hit_w/amap_slot_rec_w: the direction select the sequential
+  //! accumulator consumes, declared ahead of amap_answer_srv, their first
+  //! reader (#193); the expressions stay below, past the terms they read.
+  wire        amap_slot_hit_w;
+  wire [63:0] amap_slot_rec_w;
+  //! amap_spo_w: the STREAM_PORT_OUTPUT selector, declared ahead of
+  //! amap_answer_srv, its first reader (#193); the expression stays below
+  //! with the OUTPUT-half constants it reads.
+  wire amap_spo_w;
   always_ff @(posedge axis_clk or negedge axis_resetn) begin : amap_answer_srv
     if (!axis_resetn) begin
       amapq_type_r <= 16'd0; amapq_index_r <= 16'd0; amapq_map_r <= 16'd0;
@@ -3597,7 +3647,8 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! stage A of the slot pipeline: the ADDRESS MATH and the 512-bit
   //! indexed read, nothing else - the result registers into
   //! amap_in_ent_q_r and stage B consumes it a cycle later
-  logic [7:0] amap_in_ent_w;
+  //! (amap_in_ent_w is declared above amap_answer_srv, its first
+  //! reader, #193)
   always_comb begin : amap_page_slot
     int unsigned off_c, g_c;
     off_c = (amap_page_ok_w ? 32'(amapq_map_r) : 32'd0)
@@ -3630,6 +3681,16 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     end
   end : amap_page_fmt
 
+  //! Output mappings need one fixed subset because a Stream Output has at
+  //! most eight audio channels (the OUTPUT half of the answer is below);
+  //! declared ahead of amap_answer, its first reader, because Vivado's
+  //! front-end rejects a constant used before its declaration (#193).
+  localparam int AMAP_OUT_NMAPS_C = 1;
+
+  //! amap_opage_ok_w belongs to the OUTPUT half below; it is declared
+  //! here because amap_answer is its first reader (#193).
+  wire amap_opage_ok_w = amap_spo_w
+                      && (amapq_map_r == 16'd0);
   always_comb begin : amap_answer
     unique case (amapq_sel_r)
       2'd0:    amap_ans_raw_w = {48'd0,
@@ -3654,15 +3715,14 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! the same role pools as the descriptor image. Output mappings need one
   //! fixed subset because a Stream Output has at most eight audio channels.
   localparam int AMAP_OUT_PORTS_C = ADP_DMAP_OUT_NPORTS_C;
-  localparam int AMAP_OUT_NMAPS_C = 1;
   localparam logic [15:0] DESC_STREAM_PORT_OUT_C = 16'h000F;
 
-  wire amap_spo_w = (amapq_type_r == DESC_STREAM_PORT_OUT_C)
-                 && (32'(amapq_index_r) < AMAP_OUT_PORTS_C)
-                 && (amapq_index_r < 16'd64)
-                 && ADP_DMAP_OUT_MASK_C[amapq_index_r[5:0]];
-  wire amap_opage_ok_w = amap_spo_w
-                      && (amapq_map_r == 16'd0);
+  //! (amap_spo_w is declared above amap_answer_srv, its first reader, #193)
+  assign amap_spo_w = (amapq_type_r == DESC_STREAM_PORT_OUT_C)
+                   && (32'(amapq_index_r) < AMAP_OUT_PORTS_C)
+                   && (amapq_index_r < 16'd64)
+                   && ADP_DMAP_OUT_MASK_C[amapq_index_r[5:0]];
+  //! (amap_opage_ok_w is declared above amap_answer, its first reader, #193)
 
   //! Resolve a vendor CSR write back into the addressed output port's AEM
   //! cluster coordinate. Transactional AECP writes already carry that
@@ -3694,10 +3754,9 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! falls inside the queried page - 7.4.44.2.1 read back off live routing
   //! per-slot terms of the OUTPUT walk, same sequential form
   //! stage A, output side: the 13-bit indexed read only
-  logic [12:0] amap_out_ent_w;
-  logic        amap_out_owner_v_w;
-  logic [15:0] amap_out_owner_w;
-  logic [15:0] amap_out_cluster_w;
+  //! (amap_out_ent_w, amap_out_owner_v_w, amap_out_owner_w and
+  //! amap_out_cluster_w are declared above amap_answer_srv, their first
+  //! reader, #193)
   always_comb begin : amap_out_slot
     amap_out_ent_w = (amap_opage_ok_w
              && (32'(amap_walk_j_r) < AMAP_OUT_KEYS_C))
@@ -3743,9 +3802,10 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   end : amap_out_fmt
 
   //! the direction select the sequential accumulator consumes
-  wire        amap_slot_hit_w = amap_spi_w ? amap_in_hit_w
+  //! (both nets are declared above amap_answer_srv, their first reader, #193)
+  assign      amap_slot_hit_w = amap_spi_w ? amap_in_hit_w
                               : amap_spo_w ? amap_out_hit_w : 1'b0;
-  wire [63:0] amap_slot_rec_w = amap_spi_w ? amap_in_rec_w : amap_out_rec_w;
+  assign      amap_slot_rec_w = amap_spi_w ? amap_in_rec_w : amap_out_rec_w;
 
   //! HOLD, not a ready - combinational flops again, never held
   assign pp_amap_data_w = amap_data_r;
@@ -4275,6 +4335,9 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
 
   //! Milan Tables 5.9/5.11 flags + Tables 5.10/5.12 flags_ex, per direction
   logic [31:0] gsi_flags_w, gsi_flags_ex_w;
+  //! pp_aecp_strm_started_w belongs to the KL_pp_shadow face below; it
+  //! is declared here because gsi_flag_law is its first reader (#193).
+  logic [ACMP_SINKS_C-1:0]  pp_aecp_strm_started_w;
   always_comb begin : gsi_flag_law
     gsi_flags_w    = 32'd0;
     gsi_flags_ex_w = 32'd0;
@@ -4383,6 +4446,12 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     : gsi_out_w     ? (sfv_base_ok_w
                        && (sfv_ch_w == sfv_decl_w[31:22]))
                     : 1'b0;
+  //! sfv_need_in_r belongs to the INPUT-side reduction below; it is
+  //! declared here because sfv_need_w is its first reader (#193).
+  logic [3:0] sfv_need_in_r [N_STREAMS];
+  //! sfv_need_out_w belongs to the OUTPUT-side reduction below; it is
+  //! declared here because sfv_need_w is its first reader (#193).
+  logic [ACMP_SRC_C*4-1:0] sfv_need_out_w;
   //! SURVIVES: the per-stream channels-required reductions below, judged
   //! against the proposal's channel count. The CRF rows carry no audio
   //! mappings, so they survive by construction.
@@ -4407,7 +4476,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   localparam int SFV_KW_C = (SFV_KEYS_C <= 2) ? 1 : $clog2(SFV_KEYS_C);
   logic [SFV_KW_C-1:0] sfv_cur_r;
   logic [3:0] sfv_acc_r     [N_STREAMS];
-  logic [3:0] sfv_need_in_r [N_STREAMS];
+  //! (sfv_need_in_r is declared above sfv_need_w, its first reader, #193)
   logic [3:0] sfv_nxt_w     [N_STREAMS];
   wire  [7:0] sfv_ent_w = amap_in_store_r[32'(sfv_cur_r)*8 +: 8];
   wire  [3:0] sfv_ent_need_w = {1'b0, sfv_ent_w[2:0]} + 4'd1;
@@ -4442,7 +4511,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! (key = stream*8 + channel), so the requirement is a per-stream
   //! priority over eight enable bits - combinational, no sweep. The CRF
   //! row's nibble stays zero: no audio mapping can reference it.
-  logic [ACMP_SRC_C*4-1:0] sfv_need_out_w;
+  //! (sfv_need_out_w is declared above sfv_need_w, its first reader, #193)
   always_comb begin : sfv_out_need
     sfv_need_out_w = '0;
     for (int s = 0; s < N_STREAMS; s++)
@@ -6474,17 +6543,15 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! shape (see the .N_STREAM_IN_P connection below), which is deliberately
   //! wider than N_STREAMS — a bare N_STREAMS-wide array would have truncated
   //! the started vector and silently dropped the top sinks' state.
-  logic [ACMP_SINKS_C-1:0]  pp_aecp_strm_started_w;
+  //! (pp_aecp_strm_started_w is declared above gsi_flag_law, its first
+  //! reader, #193)
   //! the per-row settings faces (issue #67): value beside valid bit, sized
   //! at the processor's ACMP shape so the CRF rows ride along (the CRF
   //! output's offset row IS its transit entry's source below). A value
   //! whose valid bit is clear is a reset zero - every consumer here FOLDS.
-  logic [ACMP_SRC_C*32-1:0]   pp_aecp_pt_offset_w;
-  logic [ACMP_SRC_C-1:0]      pp_aecp_pt_offset_v_w;
-  logic [ACMP_SINKS_C*64-1:0] pp_aecp_fmt_in_w;
-  logic [ACMP_SINKS_C-1:0]    pp_aecp_fmt_in_v_w;
-  logic [ACMP_SRC_C*64-1:0]   pp_aecp_fmt_out_w;
-  logic [ACMP_SRC_C-1:0]      pp_aecp_fmt_out_v_w;
+  //! (pp_aecp_pt_offset_w, pp_aecp_pt_offset_v_w, pp_aecp_fmt_in_w,
+  //! pp_aecp_fmt_in_v_w, pp_aecp_fmt_out_w and pp_aecp_fmt_out_v_w are
+  //! declared above the aecp_in0_fmt fold, their first reader, #193)
   logic                     pp_aecp_dyn_dirty_w;
 
   KL_pp_shadow #(

--- a/scripts/xvlog.budget
+++ b/scripts/xvlog.budget
@@ -5,13 +5,13 @@
 # longer occurs (bank the fix). Keyed on identity, not a count, so a
 # compensating swap cannot hide (issue #150's lesson).
 #
-# These are use-before-declaration defects real on dev and invisible to the
-# Verilator/sv2v bar; fixing them (moving each declaration above first use)
-# is issue #193, not this gate's lane. Lowering an entry is a normal commit:
+# An entry is a construct Vivado's front-end REJECTS that the
+# Verilator/sv2v bar cannot see - use-before-declaration is the first
+# such class found (#132). Fixing one means changing the source, not
+# this file; banking the fix is a normal commit:
 #     scripts/xvlog_gate.py && git add scripts/xvlog.budget
+# An EMPTY list is the goal state, reached for the whole hdl/ tree by
+# #193: the gate then fails on the first NEW finding rather than on a
+# count, and no entry can be traded away against a fix.
 #
-# total 3 finding(s)
-
-hdl/common/csr/milan_csr.sv|VRFC 10-3380|lctx_wr_p_r  # line(s) 900
-hdl/milan/milan_datapath.sv|VRFC 10-3380|AMAP_OUT_NMAPS_C  # line(s) 3637,3641
-hdl/milan/milan_datapath.sv|VRFC 10-3380|cfg_mac_addr  # line(s) 671
+# total 0 finding(s)

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -126,8 +126,19 @@ class Finding:
         # behind the banked key. So an identifier-less finding is discriminated
         # by a short hash of its message - stable across line moves, unlike the
         # line number, and distinct per defect ([R1] on PR #194).
-        ident = self.identifier or (
-            "#" + hashlib.sha1(self.message.encode("utf-8",
+        # The discriminator is prefixed `~`, NOT `#`: the budget's trailing
+        # `# line(s) N` comment is stripped at the first `#`, so a `#`-keyed
+        # finding wrote one key and read back a different, truncated one --
+        # it could never be banked, only re-reported forever ([R0] on
+        # PR #222 proved it end to end). `~` cannot appear in a path, a
+        # VRFC code or an identifier.
+        # An ESCAPED SystemVerilog identifier is terminated by whitespace,
+        # which is a delimiter and not part of the name. It must not reach
+        # the key: the budget is line-based, so a trailing space would be
+        # invisible, would make `git diff --check` refuse the generated
+        # file, and would not survive the reader's strip.
+        ident = (self.identifier or "").strip() or (
+            "~" + hashlib.sha1(self.message.encode("utf-8",
                                                    "replace")).hexdigest()[:8])
         return f"{self.path}|{self.code}|{ident}"
 
@@ -252,33 +263,57 @@ _BUDGET_HEADER = [
     "# longer occurs (bank the fix). Keyed on identity, not a count, so a",
     "# compensating swap cannot hide (issue #150's lesson).",
     "#",
-    "# These are use-before-declaration defects real on dev and invisible to the",
-    "# Verilator/sv2v bar; fixing them (moving each declaration above first use)",
-    "# is issue #193, not this gate's lane. Lowering an entry is a normal commit:",
+    "# An entry is a construct Vivado's front-end REJECTS that the",
+    "# Verilator/sv2v bar cannot see - use-before-declaration is the first",
+    "# such class found (#132). Fixing one means changing the source, not",
+    "# this file; banking the fix is a normal commit:",
     "#     scripts/xvlog_gate.py && git add scripts/xvlog.budget",
+    "# An EMPTY list is the goal state, reached for the whole hdl/ tree by",
+    "# #193: the gate then fails on the first NEW finding rather than on a",
+    "# count, and no entry can be traded away against a fix.",
 ]
 
 
-def read_budget():
-    """The grandfathered finding keys, or None if the file is absent."""
-    if not BUDGET.exists():
+_LOC_COMMENT_RE = re.compile(r"\s+# line\(s\) [\d,]+\s*$")
+
+
+def read_budget(path=None):
+    """The grandfathered finding keys, or None if the file is absent.
+
+    The trailing `  # line(s) N` note is stripped by its OWN shape, not by
+    cutting at the first `#`: a key may legitimately contain that character
+    (an escaped SystemVerilog identifier such as ``\\hash#in~side``), and a
+    reader that cuts at it returns a key the writer never wrote, so the
+    finding can be reported forever and never banked ([R0] on PR #222 found
+    the `#`-prefixed discriminator case; this is the same defect's general
+    form). A whole-line `#` comment is still a comment.
+    """
+    path = path or BUDGET
+    if not path.exists():
         return None
     keys = set()
-    for line in BUDGET.read_text().splitlines():
-        line = line.split("#", 1)[0].strip()
+    for line in path.read_text().splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        line = _LOC_COMMENT_RE.sub("", line).strip()
         if line:
             keys.add(line)
     return keys
 
 
-def write_budget(findings):
+def write_budget(findings, path=None):
     lines = list(_BUDGET_HEADER)
     lines.append(f"#\n# total {len(findings)} finding(s)")
-    lines.append("")
+    # the blank separator belongs to the LIST, not to the header: with an
+    # empty ratchet (every finding fixed, #193) an unconditional one is a
+    # trailing blank line at EOF, which `git diff --check` refuses and the
+    # merge bar runs
+    if findings:
+        lines.append("")
     for f in sorted(findings, key=lambda x: x.key):
         loc = f"  # line(s) {','.join(f.lines)}" if f.lines else ""
         lines.append(f"{f.key}{loc}")
-    BUDGET.write_text("\n".join(lines) + "\n")
+    (path or BUDGET).write_text("\n".join(lines) + "\n")
 
 
 def _print_census(findings):
@@ -406,6 +441,56 @@ def _selftest_logic():
     if a.key != c.key:
         problems.append("empty-identifier: identical messages got different "
                         f"keys {a.key} vs {c.key}")
+    if "#" in a.key:
+        problems.append(f"empty-identifier: key {a.key} contains the budget's "
+                        "comment character, so read_budget would truncate it")
+
+    # ...and the budget must SERIALIZE and ROUND-TRIP in both its goal state
+    # (empty) and populated states. A populated list has one blank separator
+    # before its entries; an empty list ends at the total instead, because a
+    # trailing blank line fails `git diff --check`. A key the writer emits and
+    # the reader cannot parse makes the finding unbankable, which is the only
+    # escape hatch --check offers once the ratchet is empty (#193).
+    # The tracked ratchet is NEVER touched by this: the round-trip runs
+    # against a scratch file. run_all_suites.sh runs --selftest at the start
+    # of every sweep, so an arm that wrote scripts/xvlog.budget in place
+    # would leave synthetic entries in a tracked file if the process were
+    # killed mid-call, and SIGTERM/SIGKILL cannot be caught ([R0] on #222).
+    scratch = pathlib.Path(tempfile.mkdtemp(prefix="xvlog-budget-")) / "b"
+    try:
+        for case in ([], [a], [a, b],
+                     [a, Finding("m.sv", "VRFC 10-3380", "x", "3", "m")]):
+            write_budget(case, scratch)
+            rendered = scratch.read_text()
+            total = f"# total {len(case)} finding(s)"
+            if case and f"{total}\n\n" not in rendered:
+                problems.append("budget serialization: populated budget has "
+                                "no blank separator before its entries")
+            if not case and not rendered.endswith(f"{total}\n"):
+                problems.append("budget serialization: empty budget does not "
+                                "end at its total line")
+            back = read_budget(scratch)
+            want = {f.key for f in case}
+            if back != want:
+                problems.append(f"budget round-trip: wrote {sorted(want)}, "
+                                f"read back {sorted(back or [])}")
+            new_k, gone_k = _diff(want, back or set())
+            if new_k or gone_k:
+                problems.append(f"budget round-trip: --check would report "
+                                f"new={new_k} gone={gone_k} against its own "
+                                f"freshly written budget")
+        # a key carrying the comment character must survive too: the reader
+        # strips the location note by shape, not by cutting at the first `#`
+        esc = Finding("m.sv", "VRFC 10-3380", "\\hash#in~side ", "7", "m")
+        if esc.key.endswith(" ") or "\n" in esc.key:
+            problems.append(f"key {esc.key!r} carries trailing whitespace, "
+                            "which the budget format cannot represent")
+        write_budget([esc], scratch)
+        if read_budget(scratch) != {esc.key}:
+            problems.append("budget round-trip: a key containing '#' (an "
+                            "escaped identifier) did not survive the reader")
+    finally:
+        shutil.rmtree(scratch.parent, ignore_errors=True)
     return problems
 
 


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, test tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- What changed and why.
- **[What the Issue got wrong, measured](#what-the-issue-got-wrong-measured)** -- Three findings were the front of a chain.
- **[Beyond the ticket](#beyond-the-ticket)** -- One scoped exception, argued.
- **[Authoritative references](#authoritative-references)** -- Requirements/specification clauses and docs.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout/dependency/environment commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands and expected result.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from CONTRIBUTING.md.

## Status

GREEN. No submodule moves.

`193-fix-xvlog-use-before-declarations` -> `dev` at exact head `411685a2` (one commit on `origin/dev` `457d140c`, an ancestor, so the head tree is the candidate merge tree).

`scripts/xvlog.budget` goes from **3 grandfathered findings to 0**: every `hdl/` module now analyses under Vivado's front-end with nothing ratcheted.

## Linked Issue / roles

Closes #193
Relates to #132 (the gate this empties, PR #194)

Executor: `[A1]`
Internal cleared-context reviewer: `[R1]`, pending
External reviewer: `[R0]`, pending

## Description

Declaration-order edits only, in two files, so that no identifier is used before its declaration and Vivado's front-end (`VRFC 10-3380`) accepts both modules.

| file | what moved |
|---|---|
| `hdl/common/csr/milan_csr.sv` | one **"declared early" block** above the decode-stage wires, holding `strm_dir_r`, `strm_idx_r`, the six `lctx_wr_*` / `tctx_wr_*` CFG-word request registers, `snap_busy_r`, `rds_busy_r`, `rds_dir_r`, `rds_cyc_r` and `win_in_range_w` (read by `wr_fire`, `rd_fire`, `rd_is_slow_w`, `rds_valid_w`, `rds_done_w`); plus `rst_epoch_r` above `read_mux`, `srp_idx0_ls_w` above `strm_read_mux`, and `stg_hit_w` above the register-file write path. |
| `hdl/milan/milan_datapath.sv` | eleven groups: `cfg_mac_addr` above `station_mac_be_w`; `cfg_chmap_enable` and `AMAP_OUT_NMAPS_C` above their first readers; the `lwsrp_adopt_valid` / `lwsrp_op_prio` / `lwsrp_op_vid` trio above the AAF packetizer instance; `pp_cd_acmp_bound_vlan_w` above `acmpl_vlan_w`; `csr_irq` above `assign o_irq_csr`; the six `pp_aecp_*` vectors above their first reader; `amap_in_ent_w`, the four `amap_out_*` wires, `amap_slot_hit_w`, `amap_slot_rec_w`, `amap_spo_w` and `amap_opage_ok_w` above the AMAP query pipeline; `pp_aecp_strm_started_w` above `gsi_flag_law`; `sfv_need_in_r` and `sfv_need_out_w` above `sfv_need_w`. |
| `scripts/xvlog.budget` | 3 entries -> 0, regenerated in the same commit. |

Three of the moves could not be plain moves, because their initialiser expressions read signals produced further down: `amap_spo_w`, `amap_slot_hit_w` and `amap_slot_rec_w` become `wire NAME;` early plus `assign NAME = EXPR;` **left exactly where the original line was**, with the expression text byte-identical. Everything else is a declaration line relocated verbatim, comment and all.

**Nothing else changed.** Measured rather than asserted, two ways:

- Every declaration line removed by this diff appears added, byte-identical (comments and trailing whitespace normalised), except exactly the three split wires above: `git diff origin/dev...HEAD -- <file> | grep -E '^[-+] *(wire|logic|reg|localparam)\b'`, sorted, each text appearing twice.
- A statement-level comparison (comments and strings blanked, whitespace collapsed, split on `;`) of each file against `origin/dev` returns the same multiset of statements apart from the three documented `wire = expr` -> `wire;` + `assign` splits; the CSR file has 1243 statements before and after.

The CSR `VERSION` word is untouched (`milan_csr.sv:110`, `32'h0002_0054`); no `git diff` hunk in either file touches a `VERSION`, an address constant or a reset value.

## What the Issue got wrong, measured

The Issue names three findings and calls them "the three use-before-declaration defects". They are the visible front of a chain: `xvlog` reports at most one `VRFC 10-3380` per statement and abandons that statement, so fixing one exposes the next identifier behind it. Fixing the three named ones took **twelve** further rounds.

The rule was established with planted modules rather than guessed, and **corrected after the `[R1]` round measured two of its rows and found them wrong** (each probe is a two-module compile under `default_nettype none`, Vivado 2026.1):

| use of a later-declared identifier | `xvlog -sv` |
|---|---|
| continuous assignment, or a `wire x = ...` initialiser | rejected |
| procedural read or write (`always_comb`, `always_ff`) | rejected |
| a later `localparam` used as a constant | rejected |
| a port connection: bare `.p(sig)` | **accepted** |
| a port connection: an operator expression `.p(a && b)`, `.p(!a)`, `.p(a == 1'b1)`, `.p(a \| b)`, `.p(\|v)` | **accepted** |
| a port connection: a part-select `.p(v[3:0])` or a concatenation `.p({v[2:0], 1'b0})` | **accepted** |
| a port connection: the later identifier in a ternary BRANCH, `.p(c ? late : 0)` | **accepted** |
| a port connection: the later identifier as the ternary CONDITION, `.p(late ? a : b)` | **rejected** |

Round 1 of this body claimed the operator and part-select rows were rejected. They are not; the probe that produced that claim put a later-declared net in a ternary condition AND in a part-select in the same module, and `xvlog` stops at the first error, so the part-select was never independently tested. Corrected here, and confirmed against the real tree rather than a toy: returning the lwSRP trio to its `dev` position reddens `hdl/milan/milan_datapath.sv` at `.vlan_vid_i (lwsrp_adopt_valid ? lwsrp_op_vid : cfg_aaf_vid)` -- a ternary condition, which is the shape that actually occurs here. The error did not reach the change: the `[R1]` round measured that all 38 relocations are individually necessary (moving any one back reddens the gate naming that identifier), so nothing was moved that did not have to be.

That is why the bare port connections of later-declared nets in `milan_datapath.sv` are left untouched: they are legal, and moving them would be churn. An occurrence scan counts 51 such sites at this head and 52 on `dev`, the one that left being `lwsrp_adopt_valid`, which moved because it is ALSO a ternary condition at `:1367` (an earlier revision of this body said 41, from a scan that collapsed repeated names). A static scan for the rejected shapes over-reports for the same reason (38 candidates against 11 real groups), so `xvlog` itself was the authority for every round: the loop was "run the gate on one module, fix the identifier it names, repeat", 5 s per round.

## Beyond the ticket

Two changes outside the declaration-order scope, both in `scripts/xvlog_gate.py`, argued because the Issue explicitly puts the gate out of scope:

`scripts/xvlog_gate.py:274-281` writes the budget as header, `# total N finding(s)`, a blank separator, then the findings. With **N = 0** that separator becomes a trailing blank line at EOF, and `git diff --check` -- which CONTRIBUTING section 3 puts in the merge bar -- refuses it. This PR is the first change ever to empty that file, so the case has not been reachable before. Hand-editing the artifact is not an option: the gate rewrites it on every normal run, so the blank line would return on the next lane's `xvlog_gate.py && git add scripts/xvlog.budget`. The fix is one condition (`if findings: lines.append("")`) and it changes nothing the gate detects; `--check` and `--selftest` both pass unchanged, and the self-test still reddens on a planted use-before-declaration and stays clean on the donor.

Second, the generated ratchet's header paragraph described a specific backlog ("These are use-before-declaration defects real on `dev` ... is issue #193, not this gate's lane") and this PR empties that backlog, so the committed artifact would have contradicted itself directly above `# total 0 finding(s)` and pointed a cold reader at pending work that is this PR. It now describes the mechanism and names the empty list as the goal state. Found by the `[R1]` round; text only, no behaviour, and the committed `scripts/xvlog.budget` remains byte-identical to what `write_budget([])` regenerates.

Third, **an identifier-less finding could not round-trip the budget at all**, so it could never be banked -- found by the `[R0]` round and reproduced here end to end. `Finding.key` discriminates a finding whose message names no identifier by a short message hash prefixed `#`, and `read_budget` strips each line at its first `#` to drop the trailing `# line(s) N` comment: the writer emitted `path|CODE|#c9ef638e` and the reader parsed `path|CODE|`, so `--check` reported that same finding as BOTH a regression and a bankable fix, forever. The discriminator is now `~`, **and the reader was fixed too**, which is where the truncation actually lived: it strips the trailing `  # line(s) N` note by that note's own shape instead of cutting at the first `#`, so a key legitimately containing `#` survives. That case is real rather than theoretical -- an escaped SystemVerilog identifier may contain one -- and probing it turned up a second defect: an escaped identifier is terminated by whitespace, which was reaching the key, and a trailing space in a line-based generated file is both invisible and refused by `git diff --check`. `Finding.key` now strips it. This PR is where it costs nothing to change: the ratchet is empty, so no existing key migrates. It is in scope for the same reason the header is -- #193 empties the list, and with an empty list banking is the only alternative to fixing, so a broken banking path is a broken escape hatch rather than a latent one. The round-trip self-test runs against a scratch file rather than the tracked ratchet: `run_all_suites.sh` runs `--selftest` at the start of every sweep, and an arm that wrote `scripts/xvlog.budget` in place would leave synthetic entries in a tracked file if the process were killed mid-call (SIGTERM and SIGKILL cannot be caught). The committed budget's md5 is unchanged across a self-test run.

Proven both ways: the new `--selftest` round-trip arm reddens under the old `#` prefix (`wrote ['m.sv|VRFC 10-2989|#949b9dc5'], read back ['m.sv|VRFC 10-2989|']`) and passes under `~`; and end to end, planting an undeclared reference in `hdl/common/cdc_pulse.sv`, running the gate to bank it, then `--check` immediately after now returns `PASS (1 finding(s) == ratchet)` rc 0, where before it returned rc 1 naming the same finding twice. The two later arms are anti-vacuity-checked the same way: restoring the reader's cut-at-first-`#` reddens the escaped-identifier arm, and restoring the unstripped identifier reddens the trailing-whitespace arm.

The self-test's empty-budget case and its blank-separator assertions came from the `[R0]` round, which pushed them to the branch during its review; they are folded into this single commit rather than left as a second one, and credited here.

## Authoritative references

- Issue #193 (this task) and Issue #132 / PR #194 (the `xvlog` front-end gate, `scripts/xvlog_gate.py`, `scripts/xvlog.budget`).
- `CONTRIBUTING.md` sections 2 and 3 (the lane and the verification bar, including `git diff --check` and the xvlog ratchet).
- Vivado 2026.1 `xvlog` diagnostics `VRFC 10-3380` (identifier used before its declaration) and `VRFC 10-8530` (module ignored due to previous errors); Vivado `synth_design` only warns (`Synth 8-6901`), which is why a bitstream still built.
- IEEE 1800-2017 6.10 / 23.2.2: an implicit net and an out-of-order reference are the constructs at issue; `default_nettype none` is already in force in both files.

## How to get into the same state

```sh
git fetch origin 193-fix-xvlog-use-before-declarations
git checkout --detach 411685a2
git submodule update --init protocol-processor gptp-processor third_party/verilog-axis
# an aborted submodule init leaves an EMPTY checkout and then the gates lie:
# lint prints "LINT SETUP: REFUSED" and the datapath bench cannot find verilog-axis
```
`xvlog` needs a bench box with Vivado 2026.1: `export XVLOG=/home/alex/Xilinx/2026.1/Vivado/bin/xvlog`.

## How to validate

```sh
XVLOG=... python3 scripts/xvlog_gate.py --check      # expect PASS (0 finding(s) == ratchet)
XVLOG=... python3 scripts/xvlog_gate.py --selftest
python3 scripts/lint_rtl.py --check
make -C tb/verilator/milan_dp                        # the datapath regression bench
suite_logs=$(mktemp -d); TSN_GEN_ROOT=... scripts/run_all_suites.sh "$suite_logs" --wait
syn/yosys/run.sh
python3 sw/builder/test_builder.py                   # then --require-elaboration, NOT in parallel
git diff --check origin/dev...HEAD
```

Expected, all measured at this head:

- `xvlog gate: PASS (0 finding(s) == ratchet)`, and the ratchet file is empty of entries; selftest `PASS`.
- `lint_rtl.py --check` `PASS (99 violation(s) <= ratchet 99; 22 waived, 0 justified lint_off)`.
- `tb/verilator/milan_dp` **11240 checks, 0 failures**, rc 0, 152 s -- the figure `scripts/suite_tally.py` reads from that log, and the one the sweep's per-suite table shows. (An earlier revision of this body said 748: that is the sum of the five `<name>: N checks` lines only, and the bench also emits six `checks: N failures: 0` lines in the other shape. `suite_tally.py` exists because of exactly that mis-read and names this bench in its docstring.)
- sweep `suites: 52 passed: 52 failed: 0 timed out: 0`, **`checks: 2118523`**, 0 in-suite failures, rc 0, 308 s.
- Yosys `tops: 46 pass: 46 fail: 0`, `RESULT: PASS`, `TIED-INPUT GATE: PASS (2 justified tie(s), no unjustified ones)`, `TAP-PURITY RESULT: PASS`, rc 0, 973 s.
- `sw/builder/test_builder.py` `ALL GATES PASS EXCEPT 2 NOT RUN` (gates 11 and 19b, pre-existing: no mf48 build tree on disk) plain (275 s) and with `--require-elaboration` (266 s), rc 0 both, run one after the other.
- `git diff --check origin/dev...HEAD` clean; working tree clean.

### Why this is behaviour-preserving, as evidence rather than assertion

- **The sweep check count does not move, to the digit.** This head measures `checks: 2118523` across 52 suites; `dev` `457d140c` measures `checks: 2118523` too -- that is not my arithmetic but the `verilator-suites` aggregate of the `dev` push run for `457d140c` (run 32622596879, `target-sha: OK, 4 record(s)`, `checks: 2118496`+27 = 2,118,523). That is the control that matters: a declaration move that changed a net's meaning would change what some suite computes, and 52 suites recompute it.
- **The datapath regression bench passes at this head**: 11240 checks, 0 failures across 12 tallies, including three `milan_datapath` elaborations at different parameter sets and the divergent and prune shapes. A declaration move that changed a net's meaning would have to survive all of those AND leave the sweep total unchanged.
- **Yosys synthesises all 46 tops**, so the two edited modules still elaborate through sv2v and Yosys, and the tied-input and tap-purity structural gates are unmoved.
- **`xvlog` is the positive control for the defect itself**: on `dev` it reports 3 findings and both modules are `ignored due to previous errors`; at this head it reports none.

A note on how the sweep and Yosys figures were obtained, so a reviewer meeting a stale log is not misled. The first attempt at each failed for a reason that was NOT this diff: `/tmp` on the bench box is a shared tmpfs and it ran out while several lanes gated at once. That surfaces as `make: write error: stdout` and NOCOUNT accounting failures in the sweep (`suites: 52 passed: 47 failed: 5`, five suites "printed no tally line at all", one log empty), and in Yosys as `tops: 46 pass: 12 fail: 34` whose one readable cause is `ERROR: Can't open ABC output file /tmp/yosys-abc-...` -- ABC writes into `TMPDIR` -- naming tops this diff never touches. Re-run serially with `TMPDIR` on `$HOME`, both gates are the figures recorded above. `df` and `quota` look healthy afterwards, so checking them later proves nothing; the tell is that the failure's evidence is a write error rather than a check.

## Known limitations / out of scope

- Only the two modules the Issue names are touched. Other `hdl/` modules were already clean under `xvlog` (the ratchet listed exactly these three findings), so the empty budget is the whole tree's result, not these two files'.
- The bare port connections of later-declared nets in `milan_datapath.sv` (51 sites at this head, 52 on `dev`) are legal and deliberately left alone.
- No functional RTL change, no CSR or address-map change, no new waiver, no unrelated lint cleanup.

## Definition of Done

- [ ] Linked Issue acceptance criteria are satisfied
- [ ] New or changed behavior has self-checking tests
- [ ] Required local verification bar passes
- [ ] Self-test evidence is posted in a PR comment
- [ ] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per CONTRIBUTING.md
- [ ] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done
