### PR TITLE
Require the seven real CI contexts on dev

### DIFF
--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -242,7 +242,11 @@ jobs:
 
   verilator-suites:
     name: verilator-suites
-    if: ${{ always() && !cancelled() && needs.full-ci-gate.outputs.run_full == 'true' }}
+    # Skip only an EXPLICIT no-op decision from a successful selector. If the
+    # selector fails, is cancelled, or never publishes run_full, this job must
+    # run and fail on the missing gate SHA/shards; SKIPPED satisfies a required
+    # GitHub context and would otherwise turn a selector failure into a pass.
+    if: ${{ always() && (needs.full-ci-gate.result != 'success' || needs.full-ci-gate.outputs.run_full != 'false') }}
     needs: [full-ci-gate, verilator-shards]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -359,7 +363,8 @@ jobs:
 
   yosys-portability:
     name: yosys-portability
-    if: ${{ always() && !cancelled() && needs.full-ci-gate.outputs.run_full == 'true' }}
+    # Same fail-closed selector contract as verilator-suites above.
+    if: ${{ always() && (needs.full-ci-gate.result != 'success' || needs.full-ci-gate.outputs.run_full != 'false') }}
     needs: [full-ci-gate, yosys-shards]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,18 @@ The long-gate policy is machine-checked against the
 <!-- milan-feature-status:start -->
 | Feature ID | Status | Canonical value |
 |---|---|---|
-| `verification.long-gate-policy` | `implemented` | `local-required, remote-optional` |
+| `verification.long-gate-policy` | `implemented` | `local-required, remote-required` |
 <!-- milan-feature-status:end -->
+
+The active `dev merge bar` repository ruleset requires a pull request and these
+seven exact status-check contexts: `rtl-fast`, `docs-check`,
+`wire-accountability`, `docs-check-no-git`, `elaborate`, `verilator-suites`, and
+`yosys-portability`. The required-check policy is loose, so an intervening
+merge does not invalidate exact-head evidence by demanding another long Yosys
+run. It has no bypass actor; deletion and non-fast-forward updates of `dev` are
+also forbidden. A skipped conditional job satisfies its named context, but no
+required workflow may use path- or branch-level skipping that prevents the
+context from being emitted.
 
 ```mermaid
 flowchart LR
@@ -211,11 +221,12 @@ flowchart LR
      constant from one side and the microprogram's entry point from the other
      does not fail to elaborate — the µCPU executes ROM fill and answers a
      well-formed response carrying garbage.
-   - **The two long GitHub jobs are optional; their local gates are not.**
-     `verilator-suites` and `yosys-portability` are informational GitHub checks.
-     A PR may merge without waiting for them, including while GitHub reports
-     `MERGEABLE/UNSTABLE`. Before the PR is marked validated, run both equivalent
-     gates locally and record their results on the PR:
+   - **The two long GitHub aggregates and their local gates are independently
+     required.** `verilator-suites` and `yosys-portability` must both be emitted
+     on the PR head and must conclude successfully for RTL/tooling-relevant
+     work. A docs-only PR emits them as successful skipped contexts. Before the
+     PR is marked validated, run both equivalent gates locally and record their
+     results on the PR:
 
      ```bash
      suite_logs=$(mktemp -d)
@@ -223,8 +234,8 @@ flowchart LR
      syn/yosys/run.sh
      ```
 
-     The optional status applies only to the remote jobs. The local Verilator
-     sweep and Yosys portability sweep are mandatory merge evidence.
+     A hosted pass does not replace the local evidence, and a local pass does
+     not waive the ruleset's hosted contexts.
 
 Two board rules that go with it:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,9 @@ merge does not invalidate exact-head evidence by demanding another long Yosys
 run. It has no bypass actor; deletion and non-fast-forward updates of `dev` are
 also forbidden. A skipped conditional job satisfies its named context, but no
 required workflow may use path- or branch-level skipping that prevents the
-context from being emitted.
+context from being emitted. The exhaustive aggregates may skip only after
+`full-ci-gate` succeeds and explicitly selects the no-op path; a failed,
+cancelled, or output-less selector makes both aggregates run and fail closed.
 
 ```mermaid
 flowchart LR

--- a/docs/reference/MILAN_FEATURE_STATUS.md
+++ b/docs/reference/MILAN_FEATURE_STATUS.md
@@ -35,7 +35,7 @@ served on the wire while still having a known behavioral defect.
 | `notifications.controller-liveness` | `missing` | - |
 | `soc.baremetal-profile` | `implemented` | - |
 | `host.sound-card-option` | `implemented` | - |
-| `verification.long-gate-policy` | `implemented` | `local-required, remote-optional` |
+| `verification.long-gate-policy` | `implemented` | `local-required, remote-required` |
 <!-- milan-feature-status:end -->
 
 ## Exact command inventories

--- a/docs/reference/milan_feature_status.json
+++ b/docs/reference/milan_feature_status.json
@@ -319,8 +319,8 @@
     {
       "id": "verification.long-gate-policy",
       "status": "implemented",
-      "value": "local-required, remote-optional",
-      "summary": "Local Verilator and Yosys sweeps are mandatory; their long remote copies are optional.",
+      "value": "local-required, remote-required",
+      "summary": "Local Verilator and Yosys sweeps remain mandatory, and the dev ruleset also requires their stable hosted contexts.",
       "documents": [
         "CONTRIBUTING.md",
         "docs/reference/MILAN_FEATURE_STATUS.md",

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -166,7 +166,10 @@ the assertion in its fail-closed shape, which is exactly these four things:
    script equals a canonical form derived from the job's own download step
    and the worker matrix, so `--expect` is the shard count and no line can
    reassign a source before the call. The aggregate jobs keep their
-   documented `if` verbatim and carry no `continue-on-error` or `defaults`.
+   documented fail-closed `if` verbatim and carry no `continue-on-error` or
+   `defaults`: they skip only when `full-ci-gate` succeeded and explicitly
+   published `run_full=false`; any other selector result runs the aggregate
+   into the SHA/shard refusal path.
 
 `--selftest` covers, one at a time: the step removed, the token missing, the
 live read replaced by an echo, the event not passed, `|| true`, the decoy
@@ -208,6 +211,9 @@ validates one tree. The workflow makes that explicit and machine-checked
 
 The aggregates refuse, and the check fails rather than skips:
 
+- `full-ci-gate` fails, is cancelled, or does not publish an explicit
+  `run_full` result (only a successful `run_full=false` decision may skip an
+  aggregate);
 - a shard directory without a `TARGET_SHA` record, including the empty
   placeholder the aggregate creates when the download produced nothing;
 - a record that is not a 40-digit hexadecimal commit id;
@@ -308,12 +314,15 @@ merge validation under [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 Conditional job skipping is part of the contract. A documentation-only PR
 must emit the two exhaustive aggregate checks as skipped and must complete the
-fast aggregate and `elaborate` check after their expensive steps skip. Do not
-add workflow-level `paths`, `paths-ignore`, or branch filtering to any required
-context: a workflow that never starts leaves its required name pending. The
-three documentation jobs are independent required siblings, so a failure in
-`wire-accountability` or `docs-check-no-git` blocks the PR even when
-`docs-check` itself succeeds.
+fast aggregate and `elaborate` check after their expensive steps skip. That is
+permitted only when `full-ci-gate` itself succeeds and explicitly publishes
+`run_full=false`; a gate failure, cancellation, or missing output makes both
+aggregates run and fail on absent evidence, because a skipped required job
+would otherwise satisfy the ruleset. Do not add workflow-level `paths`,
+`paths-ignore`, or branch filtering to any required context: a workflow that
+never starts leaves its required name pending. The three documentation jobs
+are independent required siblings, so a failure in `wire-accountability` or
+`docs-check-no-git` blocks the PR even when `docs-check` itself succeeds.
 
 ## Issue closing on merge
 

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -12,6 +12,7 @@ reduce the local verification bar in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 - **[One authoritative SHA](#one-authoritative-sha)** -- How every job of a run is pinned to one tree, what the workers record, what the aggregates refuse, and the gate that holds the files to this page.
 - **[Elaboration](#elaboration)** -- The one job that installs LiteX and observes what elaboration hands the datapath Instance, and what makes it red.
 - **[Pull-request state](#pull-request-state)** -- How draft and ready states control hosted long jobs without changing local responsibilities.
+- **[Protected merge bar](#protected-merge-bar)** -- The active `dev` ruleset, its seven exact required contexts, and why its update policy is loose.
 - **[Issue closing on merge](#issue-closing-on-merge)** -- What `Closes #N` does now that `dev` is the default branch, and what still waits for containment.
 - **[Local commands](#local-commands)** -- The serial commands that remain the authoritative developer-side gates.
 - **[Failure and cancellation semantics](#failure-and-cancellation-semantics)** -- How missing artifacts, superseded commits, and resumed work are handled.
@@ -62,7 +63,9 @@ the default was `main`, which carried neither trigger, and no scheduled or
 dispatched run had ever occurred; the first scheduled run is recorded on #174.
 
 The workflow keeps the public aggregate names `verilator-suites` and
-`yosys-portability`.
+`yosys-portability`. Both are required contexts on `dev`: an RTL/tooling-
+relevant PR must run them successfully, while a docs-only PR emits them as
+explicit successful skipped results.
 
 Verilator runs the complete suite inventory on four workers. The aggregate
 rejects missing, unexpected, or duplicate suite logs before it trusts the
@@ -218,8 +221,8 @@ to the trigger contract above: no `actions/checkout` step in `rtl.yml`
 overrides `ref`, every job that uploads an artifact records the SHA first,
 every job that downloads artifacts verifies it, the gate carries the
 default-branch assertion in its fail-closed shape, the trigger lists, the
-`cancel-in-progress` rule and the public check names `rtl-fast`,
-`verilator-suites`, `yosys-portability` and `elaborate` are what this page
+`cancel-in-progress` rule and the public aggregate names `rtl-fast`,
+`verilator-suites`, `yosys-portability`, and `elaborate` are what this page
 says, and the cron time string on this page matches the YAML. Its
 `--selftest` removes or alters each item on in-memory copies and requires
 the check to catch every one, and fails if the checker is stubbed to find
@@ -282,7 +285,35 @@ draft that needs the exhaustive gates once is dispatched by hand (see
 flipped ready and back.
 
 A docs-only ready PR remains cheap: the long workflow starts, classifies the
-diff, and skips its RTL workers with explicit skipped results.
+diff, and skips its RTL workers with explicit skipped results. The two stable
+aggregate contexts are still emitted, so the ruleset never waits for a check
+name that the pull request cannot produce.
+
+## Protected merge bar
+
+The active repository ruleset named `dev merge bar` applies only to
+`refs/heads/dev`. It has no bypass actor and enforces four rules:
+
+- changes arrive through pull requests;
+- branch deletion is forbidden;
+- non-fast-forward updates are forbidden;
+- these seven exact status-check contexts are required: `rtl-fast`,
+  `docs-check`, `wire-accountability`, `docs-check-no-git`, `elaborate`,
+  `verilator-suites`, and `yosys-portability`.
+
+Required checks use the loose policy: an intervening merge to `dev` does not
+force the PR to rerun the 23--26 minute `milan_datapath` Yosys job merely to
+become current with the base. Reviewers still own exact-head and candidate-
+merge validation under [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+Conditional job skipping is part of the contract. A documentation-only PR
+must emit the two exhaustive aggregate checks as skipped and must complete the
+fast aggregate and `elaborate` check after their expensive steps skip. Do not
+add workflow-level `paths`, `paths-ignore`, or branch filtering to any required
+context: a workflow that never starts leaves its required name pending. The
+three documentation jobs are independent required siblings, so a failure in
+`wire-accountability` or `docs-check-no-git` blocks the PR even when
+`docs-check` itself succeeds.
 
 ## Issue closing on merge
 

--- a/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
+++ b/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
@@ -41,7 +41,7 @@ Machine-checked status rows are defined by the
 | `state.nonvolatile-persistence` | `missing` | - |
 | `notifications.change-events` | `partial` | - |
 | `notifications.controller-liveness` | `missing` | - |
-| `verification.long-gate-policy` | `implemented` | `local-required, remote-optional` |
+| `verification.long-gate-policy` | `implemented` | `local-required, remote-required` |
 <!-- milan-feature-status:end -->
 
 ## Current verification record
@@ -68,8 +68,8 @@ The official controller decoder result is reproducible from the tracked DUT
 capture without relying on the audit prose. Run:
 
 The full local Verilator and Yosys portability sweeps are required validation
-evidence. Their long remote copies are optional and need not delay review after
-the local equivalents pass.
+evidence. The `dev merge bar` ruleset separately requires their stable remote
+aggregate contexts, so neither result substitutes for the other.
 
 ```console
 scripts/verify_la_avdecc_counters.sh

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -74,13 +74,13 @@ Machine-checked status rows are defined by the
 | `crf.media-clock-consumption` | `missing` | - |
 | `state.nonvolatile-persistence` | `missing` | - |
 | `notifications.change-events` | `partial` | - |
-| `verification.long-gate-policy` | `implemented` | `local-required, remote-optional` |
+| `verification.long-gate-policy` | `implemented` | `local-required, remote-required` |
 <!-- milan-feature-status:end -->
 
 The local full Verilator and Yosys portability sweeps are mandatory validation
-evidence. Their long GitHub copies are optional and do not block review when
-the local equivalents pass. Issue #97 owns the response-boundary and stopped
-CRF observation gaps that keep START/STOP partial.
+evidence. The `dev merge bar` ruleset also requires their stable GitHub
+aggregate contexts; neither copy substitutes for the other. Issue #97 owns the
+response-boundary and stopped CRF observation gaps that keep START/STOP partial.
 
 ## Contents
 

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -32,10 +32,13 @@ exhaustive workflow makes that explicit: the gate job prints event, ref and SHA
 and exports `target_sha`; every worker writes GITHUB_SHA into a TARGET_SHA file
 beside its evidence; both aggregates run `--require-target-sha` over the
 downloaded shards and refuse a missing record, a record naming another tree, or
-a gate/run/checkout SHA that is not one value. A missing record is a failure,
-never a skip. `--check` refuses any `actions/checkout` step in rtl.yml that
-overrides `ref`, requires every artifact-uploading job to record the SHA and
-every artifact-downloading job to verify it.
+a gate/run/checkout SHA that is not one value. An aggregate skips only when the
+gate succeeded and explicitly published `run_full=false`; a gate failure,
+cancellation or missing output makes the aggregate run into that refusal path.
+A missing record is a failure, never a skip. `--check` refuses any
+`actions/checkout` step in rtl.yml that overrides `ref`, requires every
+artifact-uploading job to record the SHA and every artifact-downloading job to
+verify it.
 
 THE DEFAULT-BRANCH ASSERTION ([R1] on PR #204). The cron was inert because of
 a repository SETTING, and a gate that reads files cannot see a setting. So the
@@ -146,12 +149,19 @@ VERIFY_STEP_IF = "${{ always() }}"
 VERIFY_STEP_ENV = ("GATE_SHA",)
 #: Job keys that stop a job, or its steps, from running as written. The
 #: gate job carries none of them; an aggregate job carries its documented
-#: `if` and nothing else from this list; the workflow carries no top-level
+#: fail-closed `if` and nothing else from this list; the workflow carries no top-level
 #: `defaults` (a `defaults.run.shell: bash -n {0}` parses every script and
 #: executes none).
 JOB_NEUTER_KEYS = ("if", "continue-on-error", "defaults")
-AGGREGATE_JOB_IF = ("${{ always() && !cancelled() && "
-                    f"needs.{GATE_JOB}.outputs.run_full == 'true' }}}}")
+#: A skipped required context satisfies a GitHub ruleset. Therefore an
+#: aggregate may skip only the gate's explicit successful no-op decision. A
+#: failed/cancelled gate or an absent/malformed output makes the aggregate run;
+#: its target-SHA and shard reconciliation then fail closed.
+AGGREGATE_JOB_IF = (
+    "${{ always() && "
+    f"(needs.{GATE_JOB}.result != 'success' || "
+    f"needs.{GATE_JOB}.outputs.run_full != 'false') }}}}"
+)
 RUNNER_TEMP_PREFIX = "${{ runner.temp }}/"
 #: Public check names the merge bar reads (AGENTS.md section 7), per file.
 PUBLIC_NAMES = {
@@ -997,6 +1007,12 @@ def _mutations():
     def m_aggregate_if_dropped(w):
         del jobs(w[RTL_FULL])["yosys-portability"]["if"]
 
+    def m_aggregate_fail_open(w):
+        jobs(w[RTL_FULL])["verilator-suites"]["if"] = (
+            "${{ always() && !cancelled() && "
+            "needs.full-ci-gate.outputs.run_full == 'true' }}"
+        )
+
     va = lambda w: verify_step(w, "verilator-suites")  # noqa: E731
     ya = lambda w: verify_step(w, "yosys-portability")  # noqa: E731
 
@@ -1156,6 +1172,8 @@ def _mutations():
          "`if` must be exactly"),
         ("aggregate job if dropped", m_aggregate_if_dropped,
          "documented `if`"),
+        ("aggregate skips when its selector fails", m_aggregate_fail_open,
+         "`if` must be exactly"),
         ("aggregate job continue-on-error",
          set_job_key("verilator-suites", "continue-on-error", True),
          "must carry no `continue-on-error`"),


### PR DESCRIPTION
[A0]

## Contents

- **[Status](#status)** — Exact-head implementation gates are green; review and latest-`dev` candidate validation remain; `220-dev-merge-bar` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** — Public task and review ownership.
- **[Description](#description)** — The documented `dev` merge bar and seven exact check contexts.
- **[Authoritative references](#authoritative-references)** — Repository workflow and policy contracts.
- **[How to get into the same state](#how-to-get-into-the-same-state)** — Exact checkout commands.
- **[How to validate](#how-to-validate)** — Documentation, event-contract, and exhaustive gates.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** — Review, merge, and post-merge containment remain.
- **[Definition of Done](#definition-of-done)** — The repository merge bar.

## Status

Review ready — fail-closed fix at `56a3f1035f3d12d110a6a91c8eecb1cd12a8b3b5`; exact-head local gates and all seven hosted required contexts are green. Review and full validation of the synthetic merge candidate against current `dev` remain — `220-dev-merge-bar` -> `dev`.

## Linked Issue / roles

Closes #220
Relates to #174, #209

Executor: `[A0]`
Internal cleared-context reviewer: `[R1]` in progress on the exact head
External reviewer: required before merge

## Description

- Document the active `dev merge bar` ruleset and its no-bypass pull-request, deletion, and non-fast-forward policy.
- Name the seven real required status contexts: `rtl-fast`, `docs-check`, `wire-accountability`, `docs-check-no-git`, `elaborate`, `verilator-suites`, and `yosys-portability`.
- Record loose required-check semantics and the contract that documentation-only changes still emit every required context.
- Make both exhaustive aggregate jobs fail closed: they skip only after a successful selector emits the exact `false` decision; selector failure, cancellation, or missing/malformed output runs the aggregates and fails their existing integrity checks.
- Change the canonical long-gate feature value from `local-required, remote-optional` to `local-required, remote-required`.

## Authoritative references

- Issue #220 acceptance criteria and proposed ruleset
- `CONTRIBUTING.md`
- `.github/workflows/docs.yml`, `.github/workflows/elaborate.yml`, `.github/workflows/rtl-fast.yml`, and `.github/workflows/rtl.yml`
- `docs/testing/CI_WORKFLOWS.md`

## How to get into the same state

```sh
gh pr checkout 220-dev-merge-bar
git submodule update --init --recursive
```

## How to validate

```sh
python3 scripts/check_feature_status.py --self-test
python3 scripts/ci_events.py --check
python3 scripts/ci_events.py --selftest
python3 scripts/docs_check.py
python3 scripts/gen_toc.py --verify-anchors
python3 scripts/gen_toc.py --check
python3 scripts/check_doc_paths.py
python3 sw/builder/test_builder.py
scripts/run_all_suites.sh "$(mktemp -d)"
syn/yosys/run.sh
```

Expected result / pass criteria: every listed command passes; the pull request emits all seven exact hosted contexts; the rules API reports the issue's four rule types with no bypass actor and loose status checks.

## Known limitations / out of scope

- Repository ruleset `21236073` is active and its effective `dev` rules have been verified through the API. This functional exact head exercises both exhaustive contexts; documentation-only changes emit skipped aggregate contexts only after the selector succeeds with the exact `false` decision.
- PR #225 merged normally through ruleset `21236073` at merge commit `d9212d240c67adb308e0a8c544fd9846fe5ecfd3`, proving the active no-bypass `dev` path with an independently reviewed PR. No speculative direct-push refusal was used as the first enforcement probe.

## Definition of Done

- [ ] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done
