### PR TITLE
Clean staged deploy artifacts on every exit

### DIFF
--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -1715,6 +1715,8 @@ def test_qspi_owner_transition_completed_write_prefixes():
         qspi = os.path.join(td, "qspi.bin")
         log = os.path.join(td, "programmer.log")
         count = os.path.join(td, "programmer.count")
+        deploy_tmp = os.path.join(td, "deploy-tmp")
+        os.makedirs(deploy_tmp)
 
         fake_ofl = os.path.join(fake_bin, "openFPGALoader")
         with open(fake_ofl, "w", encoding="utf-8") as stream:
@@ -1867,6 +1869,7 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
             "CABLE": "ft232", "FPGA_PART": "xc7a100tfgg484",
             "OFL_QSPI": qspi, "OFL_LOG": log, "OFL_COUNT": count,
             "OFL_EXPECT_SERIAL": "TEST-SERIAL",
+            "TMPDIR": deploy_tmp,
         })
 
         def reset_flash(source):
@@ -1900,6 +1903,15 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
 
         deploy = os.path.join(SOC_DIR, "deploy.sh")
 
+        def invoke_deploy(argv, env):
+            result = subprocess.run(argv, cwd=SOC_DIR, env=env, text=True,
+                                    capture_output=True)
+            leaked = os.listdir(deploy_tmp)
+            assert not leaked, (
+                f"deploy transaction leaked staged artifacts after rc "
+                f"{result.returncode}: {leaked}\n{result.stdout}{result.stderr}")
+            return result
+
         def run_pair(source, target, fail_kind=None, fail_index=0,
                      reset=True, named=False, env_over=None):
             if reset:
@@ -1911,8 +1923,7 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
                 argv = [BUILD_SH, "flash", f"ax7101:{target['dir']}"]
             else:
                 argv = [deploy, "flash-pair"]
-            return subprocess.run(argv, cwd=SOC_DIR, env=env, text=True,
-                                  capture_output=True)
+            return invoke_deploy(argv, env)
 
         def writes():
             if not os.path.exists(log):
@@ -1996,9 +2007,7 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
         reset_flash(fabric)
         missing_env = env_for(fabric, fabric2)
         missing_env["AEM"] = os.path.join(td, "missing-aem.bin")
-        missing = subprocess.run([deploy, "flash-pair"], cwd=SOC_DIR,
-                                 env=missing_env, text=True,
-                                 capture_output=True)
+        missing = invoke_deploy([deploy, "flash-pair"], missing_env)
         assert missing.returncode != 0
         assert not writes(), "missing AEM artifact caused a programmer write"
         assert not os.path.exists(log), \
@@ -2006,9 +2015,8 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
 
         def refuse_before_io(label, source, target, needle):
             reset_flash(source)
-            refused = subprocess.run(
-                [deploy, "flash-pair"], cwd=SOC_DIR,
-                env=env_for(source, target), text=True, capture_output=True)
+            refused = invoke_deploy(
+                [deploy, "flash-pair"], env_for(source, target))
             output = refused.stdout + refused.stderr
             assert refused.returncode != 0, f"{label}: accepted\n{output}"
             assert needle in output, f"{label}: no {needle!r}\n{output}"
@@ -2023,6 +2031,21 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
                          "unique")
         refuse_before_io("image/reservation collision", fabric,
                          reserved_collision, "reserved")
+
+        # The two opt-in recovery primitives use the same staged custody and
+        # must clean it on a nested preflight exit too. This is the dynamic
+        # shell-scope case that a RETURN-only trap missed: do_check_images()
+        # has its own local `tmp` while refusing the malformed row set.
+        for recovery_step in ("flash", "flash-images"):
+            reset_flash(fabric)
+            recovery_env = env_for(fabric, malformed)
+            recovery_env["ALLOW_NONATOMIC_FLASH"] = "1"
+            refused = invoke_deploy([deploy, recovery_step], recovery_env)
+            assert refused.returncode != 0, (
+                f"{recovery_step}: malformed layout accepted\n"
+                f"{refused.stdout}{refused.stderr}")
+            assert not os.path.exists(log), \
+                f"{recovery_step}: malformed layout reached programmer I/O"
 
         # The compiled CPU width binds fail-closed ([R0] on PR #228): a
         # layout that does not state it, or states an impossible one, refuses
@@ -2041,8 +2064,7 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
             reset_flash(fabric)
             env = env_for(fabric, fabric2)
             env["LAYOUT"] = unbound_layout
-            refused = subprocess.run([deploy, "flash-pair"], cwd=SOC_DIR,
-                                     env=env, text=True, capture_output=True)
+            refused = invoke_deploy([deploy, "flash-pair"], env)
             output = refused.stdout + refused.stderr
             assert refused.returncode != 0, f"{label}: accepted\n{output}"
             assert "compiled CPU width" in output, f"{label}\n{output}"
@@ -2055,9 +2077,7 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
             reset_flash(fabric)
             omitted_env = env_for(fabric, fabric2)
             omitted_env.pop(omitted)
-            refused = subprocess.run([deploy, "flash-pair"], cwd=SOC_DIR,
-                                     env=omitted_env, text=True,
-                                     capture_output=True)
+            refused = invoke_deploy([deploy, "flash-pair"], omitted_env)
             assert refused.returncode != 0
             assert not os.path.exists(log), \
                 f"missing target {omitted} caused programmer I/O"
@@ -2066,9 +2086,8 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
         reset_flash(fabric)
         with open(qspi, "r+b") as flash:
             flash.write(b"\x00" * len(fabric["payload"]))
-        mismatch = subprocess.run([deploy, "flash-pair"], cwd=SOC_DIR,
-                                  env=env_for(fabric, fabric2), text=True,
-                                  capture_output=True)
+        mismatch = invoke_deploy(
+            [deploy, "flash-pair"], env_for(fabric, fabric2))
         assert mismatch.returncode != 0
         assert not writes(), "unidentified live bitstream caused a write"
 
@@ -2079,7 +2098,9 @@ os.execv({sys.executable!r}, [{sys.executable!r}] + sys.argv[1:])
           "prefixes across the fabric-baremetal refresh retain one live "
           "owner and every prefix resumes; all writes verify; a live target "
           "bit gets an AEM-only repair; a source BIT replaced after live "
-          "identification cannot replace the validated staged copy; the "
+          "identification cannot replace the validated staged copy; every "
+          "success/refusal (including both recovery primitives) cleans its "
+          "staged transaction set; the "
           "ownerless owner, malformed/collision layouts, missing artifacts, "
           "missing cpu_xlen x2 and an unidentified live bit all refuse "
           "before programmer I/O")

--- a/sw/litex/deploy.sh
+++ b/sw/litex/deploy.sh
@@ -364,7 +364,7 @@ refuse_nonatomic() {
     exit 2
 }
 
-do_flash() {
+do_flash() (
     refuse_nonatomic flash
     echo "[deploy] WARNING: non-atomic recovery bitstream write requested" >&2
     [ -n "$BIT" ] && [ -f "$BIT" ] || {
@@ -372,9 +372,10 @@ do_flash() {
     [ -n "$LAYOUT" ] && [ -f "$LAYOUT" ] || {
         echo "[deploy] flash REFUSED: no flashboot_layout.json owner contract." >&2
         exit 2; }
-    local tmp target layout bit aem
+    local tmp target layout bit aem deploy_transaction_tmp
     tmp="$(mktemp -d)"; target="$tmp/target"
-    trap 'rm -rf -- "$tmp"' RETURN
+    deploy_transaction_tmp="$tmp"
+    trap 'rm -rf -- "$deploy_transaction_tmp"' EXIT
     aem="${AEM:-$(dirname "$LAYOUT")/aem_desc.bin}"
     stage_artifact_pair "$target" "$LAYOUT" "$BIT" "$aem" || exit 2
     layout="$target/flashboot_layout.json"
@@ -387,14 +388,15 @@ do_flash() {
             exit 2
         }
     write_target_bit "$bit"
-}
+)
 
-do_flash_images() {
+do_flash_images() (
     refuse_nonatomic flash-images
     echo "[deploy] WARNING: non-atomic recovery image writes requested" >&2
-    local tmp rows target layout bit aem
+    local tmp rows target layout bit aem deploy_transaction_tmp
     tmp="$(mktemp -d)"; rows="$tmp/images.tsv"; target="$tmp/target"
-    trap 'rm -rf -- "$tmp"' RETURN
+    deploy_transaction_tmp="$tmp"
+    trap 'rm -rf -- "$deploy_transaction_tmp"' EXIT
     aem="${AEM:-$(dirname "$LAYOUT")/aem_desc.bin}"
     stage_artifact_pair "$target" "$LAYOUT" "$BIT" "$aem" || exit 2
     layout="$target/flashboot_layout.json"
@@ -402,9 +404,9 @@ do_flash_images() {
     aem="$target/aem_desc.bin"
     prepare_images "$tmp" "$rows" "$layout" "$bit" "$aem"
     write_prepared_images "$rows"
-}
+)
 
-do_flash_pair() {
+do_flash_pair() (
     [ -n "$BIT_EXPLICIT" ] && [ -n "$BIT" ] && [ -f "$BIT" ] || {
         echo "[deploy] flash-pair REFUSED: set BIT=<target .bit>" >&2; exit 2; }
     [ -n "$LAYOUT_EXPLICIT" ] && [ -n "$LAYOUT" ] && [ -f "$LAYOUT" ] || {
@@ -416,10 +418,11 @@ do_flash_pair() {
 
     local tmp rows live state target_stage installed_stage
     local target_layout target_bit target_aem installed_layout installed_bit
-    local aem_src
+    local aem_src deploy_transaction_tmp
     tmp="$(mktemp -d)"; rows="$tmp/images.tsv"; live="$tmp/qspi-offset-zero.bin"
     target_stage="$tmp/target"; installed_stage="$tmp/installed"
-    trap 'rm -rf -- "$tmp"' RETURN
+    deploy_transaction_tmp="$tmp"
+    trap 'rm -rf -- "$deploy_transaction_tmp"' EXIT
     aem_src="${AEM:-$(dirname "$LAYOUT")/aem_desc.bin}"
     stage_artifact_pair "$installed_stage" "$INSTALLED_LAYOUT" \
         "$INSTALLED_BIT" || exit 2
@@ -468,7 +471,7 @@ do_flash_pair() {
         write_target_bit "$target_bit"
     fi
     echo "[deploy] flash-pair done. Power-cycle to boot the verified owner set."
-}
+)
 do_console(){ echo "[deploy] console $CONSOLE @ $BAUD  (picocom; exit: Ctrl-a Ctrl-x)"; exec picocom -b "$BAUD" "$CONSOLE"; }
 
 case "$STEP" in


### PR DESCRIPTION
## Summary

This is the standalone follow-up to #266. It keeps only the deploy cleanup fix that remains after the bare-metal product baseline is merged.

Deployment transactions previously installed `RETURN` traps inside shell functions. Those traps did not run when `exit` or `set -e` terminated the function, so staged temporary artifacts could leak after a failed flash operation.

## Fix

- run `do_flash`, `do_flash_images`, and `do_flash_pair` in subshells;
- keep one stable transaction temporary path and remove it from an `EXIT` trap;
- exercise success, refusal, and recovery paths under a controlled `TMPDIR`, requiring zero staged leftovers after every invocation.

## Validation

- full builder suite with `--require-elaboration` passed against the pinned LiteX environment;
- deploy gate proves cleanup after successful operations, refusals, and recovery primitives;
- bare-metal-only policy: 0 findings across 782 files; self-test: 40/40;
- docs check: 0 findings across 181 files;
- feature-status gate, shell syntax, Python compilation, and `git diff --check` passed.

The only local skip is the pre-existing optional Vivado utilization-report check because that external report is not present in the test environment.
