### PR TITLE
CI events gate: hold the full-ci-gate job's needs, step sequence and sibling-step keys, and derive the worker shard denominator

### DIFF
--- a/.github/workflows/rtl-fast.yml
+++ b/.github/workflows/rtl-fast.yml
@@ -180,17 +180,17 @@ jobs:
       - name: Require every applicable fast gate to pass
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          LINT_RESULT: ${{ needs.verilator-lint.result }}
-          BDD_RESULT: ${{ needs.bdd-conformance.result }}
-          YOSYS_RESULT: ${{ needs.yosys-elaboration.result }}
+          VERILATOR_LINT_RESULT: ${{ needs.verilator-lint.result }}
+          BDD_CONFORMANCE_RESULT: ${{ needs.bdd-conformance.result }}
+          YOSYS_ELABORATION_RESULT: ${{ needs.yosys-elaboration.result }}
         run: |
           set -euo pipefail
           bad=0
           for pair in \
             "changes:$CHANGES_RESULT" \
-            "verilator-lint:$LINT_RESULT" \
-            "bdd-conformance:$BDD_RESULT" \
-            "yosys-elaboration:$YOSYS_RESULT"; do
+            "verilator-lint:$VERILATOR_LINT_RESULT" \
+            "bdd-conformance:$BDD_CONFORMANCE_RESULT" \
+            "yosys-elaboration:$YOSYS_ELABORATION_RESULT"; do
             name="${pair%%:*}"
             result="${pair#*:}"
             printf '%-24s %s\n' "$name" "$result"

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -116,8 +116,15 @@ jobs:
   # The exhaustive inventory remains four-way and fail-closed. Specialized
   # setup is installed only on the stable shard that owns the relevant suite;
   # scripts/suite_shards.py self-tests those ownership assumptions.
+  #
+  # The shard COUNT is stated once, by the matrix below. Every denominator is
+  # `${{ strategy.job-total }}`, the size of that matrix, so growing the list
+  # moves the split with it; a restated `/4` beside a matrix of three leaves
+  # shard 3/4's suites unproduced while every static count still agrees
+  # (#209). scripts/ci_events.py refuses a denominator that is neither the
+  # derived form nor this matrix's size.
   verilator-shards:
-    name: Verilator shard ${{ matrix.shard }}/4
+    name: Verilator shard ${{ matrix.shard }}/${{ strategy.job-total }}
     needs: full-ci-gate
     if: ${{ needs.full-ci-gate.outputs.run_full == 'true' }}
     runs-on: ubuntu-latest
@@ -179,10 +186,11 @@ jobs:
       - name: Prove specialized suite ownership
         env:
           SHARD: ${{ matrix.shard }}
+          SHARDS: ${{ strategy.job-total }}
         run: |
           set -euo pipefail
           python3 scripts/suite_shards.py --selftest
-          scripts/run_all_suites.sh --shard "$SHARD/4" --list \
+          scripts/run_all_suites.sh --shard "$SHARD/$SHARDS" --list \
             > "$RUNNER_TEMP/owned-suites"
           echo "Shard $SHARD owns:"
           sed 's/^/  /' "$RUNNER_TEMP/owned-suites"
@@ -229,7 +237,7 @@ jobs:
       - name: Run this exhaustive suite shard
         run: |
           scripts/run_all_suites.sh "$RUNNER_TEMP/suite-logs" \
-            --shard "${{ matrix.shard }}/4"
+            --shard "${{ matrix.shard }}/${{ strategy.job-total }}"
 
       - name: Upload this shard's suite logs
         if: ${{ always() }}
@@ -303,7 +311,7 @@ jobs:
   # Weighted longest-processing-time assignment isolates the two dominant
   # tops and balances the remaining 44 without changing the local serial gate.
   yosys-shards:
-    name: Yosys shard ${{ matrix.shard }}/4
+    name: Yosys shard ${{ matrix.shard }}/${{ strategy.job-total }}
     needs: full-ci-gate
     if: ${{ needs.full-ci-gate.outputs.run_full == 'true' }}
     runs-on: ubuntu-latest
@@ -350,7 +358,7 @@ jobs:
           sv2v --version
       - name: Run this weighted portability shard
         run: |
-          syn/yosys/run.sh --shard "${{ matrix.shard }}/4" \
+          syn/yosys/run.sh --shard "${{ matrix.shard }}/${{ strategy.job-total }}" \
             --results "$RUNNER_TEMP/yosys-results"
       - name: Upload per-top and structural evidence
         if: ${{ always() }}

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -149,7 +149,10 @@ those runs are about the tree, not the setting, and a contributor's PR must
 not go red for a repository setting it cannot change. A drift is therefore
 visible on every run and fatal on the first run it would misdirect, instead
 of surfacing as a nightly that silently stopped. `ci_events.py --check` holds
-the assertion in its fail-closed shape, which is exactly these four things:
+the assertion in its fail-closed shape. That shape is not only what the step
+says: a check that reads a step's contents and nothing about the conditions
+under which it runs holds the wrong perimeter, which is what #209 found. So it
+is exactly these six things:
 
 1. **The script text.** The step's `run:` is pinned verbatim (whitespace
    aside) to three lines: `set -euo pipefail`, one unconditional
@@ -166,10 +169,38 @@ the assertion in its fail-closed shape, which is exactly these four things:
    `shell: bash -n {0}` (parsed, never executed), `continue-on-error`, a
    `working-directory`, or a `GH_HOST` / `GH_CONFIG_DIR` that points `gh`
    away from this repository. Each refusal names the key.
-3. **The job keys.** `full-ci-gate` carries no `if`, no `continue-on-error`
-   and no `defaults`, and the workflow carries no top-level `defaults` (a
-   `defaults.run.shell: bash -n {0}` parses every script and executes none).
-4. **The verifier steps.** Each aggregate's `--require-target-sha` step
+3. **The job's run conditions.** `full-ci-gate` carries no `needs`, no `if`,
+   no `continue-on-error` and no `defaults`, and the workflow carries no
+   top-level `defaults` (a `defaults.run.shell: bash -n {0}` parses every
+   script and executes none). `needs` is one of them because a job that needs
+   another job is a dependent, and a dependent of a skipped job is skipped,
+   taking every assertion inside it: a `noop` job carrying
+   `if: ${{ github.event_name != 'schedule' }}` plus a `needs: [noop]` on the
+   gate leaves every pinned character in place and stops the assertion running
+   on the one event it exists for.
+4. **The step sequence.** The gate job carries exactly four steps, in this
+   order: the checkout with `fetch-depth: 0`, the pin step (`id: target`), the
+   default-branch step, and the decision step (`id: gate`). The order is part
+   of the contract, because the assertion runs the `ci_events.py` the checkout
+   brought and the decision diffs the tree that checkout produced; the count is
+   part of it too, because a step inserted anywhere runs before everything
+   after it and can change what those steps read, and an entry appended to
+   `GITHUB_PATH` puts another `gh` ahead of the runner's. A refusal names the
+   position, what belongs there, and what it found.
+5. **The sibling steps' keys.** The pin step, the decision step and the
+   checkout are pinned to their own key sets exactly as the default-branch
+   step is, so `if: false`, an `if:` naming only some events, a `shell:`, a
+   `continue-on-error` or a `working-directory` on any of them is refused by
+   name; the decision step's `env` is exactly `EVENT_NAME`, `PR_DRAFT` and
+   `PR_BASE_SHA`, and the checkout keeps `fetch-depth: 0` (the decision step
+   diffs against the pull request's base commit, which a shallow clone does
+   not carry). `if: false` on the pin step or on the decision step leaves the
+   assert step's script canonical and publishes no `run_full` at all.
+   Additionally, neither the workflow's top-level `env` nor `full-ci-gate`'s
+   own names any `GH_*` variable: the step's `env` is pinned to exactly
+   `GH_TOKEN`, but a `GH_HOST` or `GH_CONFIG_DIR` set at either level above it
+   reaches the same `gh` without appearing anywhere in the step.
+6. **The verifier steps.** Each aggregate's `--require-target-sha` step
    carries exactly `name`, `if`, `env` and `run`; its `if` is exactly
    `${{ always() }}` (any other condition can skip the verification, and a
    skipped step passes the job); its `env` exactly `GATE_SHA`; and its
@@ -186,7 +217,14 @@ live read replaced by an echo, the event not passed, `|| true`, the decoy
 itself, a literal after the real read and after the call, `gh api` in a
 comment only, `observed` from another command, two assignments, the call
 before the read, an extra line, a missing `set` line; each key escape above
-on the step, on the job, on the workflow and on the verifier steps; a
+on the step, on the job, on the workflow and on the verifier steps; the gate
+given a `needs` on a job that skips on `schedule`; `if: false`, an event-only
+`if`, a `shell:`, a `continue-on-error`, a `working-directory` and a dropped
+env key on the pin and decision steps; the assert step moved before the
+checkout; a `GITHUB_PATH` step inserted before it; the pin step removed; the
+pin and assert steps swapped; a checkout without `fetch-depth: 0`; a `GH_HOST`
+on the job and on the workflow; a shard denominator restated below its matrix
+size, restated while the matrix grows, and stale in a worker's display name; a
 verifier that reassigns `GATE_SHA`, passes the wrong `--expect`, passes none,
 or keeps `--expect` while the matrix grows; an aggregate `if` loosened or
 dropped; a whitespace-only reformatting of both scripts that must still pass;
@@ -218,6 +256,15 @@ validates one tree. The workflow makes that explicit and machine-checked
   unknown label included, and any shard-directory count but `--expect`, so
   an aggregate cannot quietly stop proving that the gate, the run and its
   checkout agree, or tally three shards as four.
+
+The shard count is stated once, by each worker's `strategy.matrix.shard` list.
+The worker passes `--shard ${{ matrix.shard }}/${{ strategy.job-total }}` and
+names itself the same way, so growing that list moves the split with it, and
+`--check` derives the aggregate's `--expect` from the same list rather than
+reading a number written beside it. A restated denominator is refused, whether
+it appears in a script or in a job name: with a matrix of five and a literal
+`/4`, shard 4/5's suites and tops are never produced while `--expect`, the
+uploaded artifact count and the downloaded shard count all still agree.
 
 The aggregates refuse, and the check fails rather than skips:
 

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -152,7 +152,7 @@ of surfacing as a nightly that silently stopped. `ci_events.py --check` holds
 the assertion in its fail-closed shape. That shape is not only what the step
 says: a check that reads a step's contents and nothing about the conditions
 under which it runs holds the wrong perimeter, which is what #209 found. So it
-is exactly these six things:
+is exactly these eight things:
 
 1. **The script text.** The step's `run:` is pinned verbatim (whitespace
    aside) to three lines: `set -euo pipefail`, one unconditional
@@ -213,7 +213,7 @@ is exactly these six things:
    mattered: `PR_DRAFT: "true"` is valid workflow YAML that keeps all three
    names and all four keys and makes a ready RTL pull request publish
    `run_full=false`, on which both worker matrices skip, both aggregates skip
-   under the no-op exception in item 7, and the skipped required contexts
+   under the no-op exception in item 8, and the skipped required contexts
    satisfy the ruleset -- a false green, not a refusal.
    `PR_BASE_SHA: ${{ github.sha }}` (a commit diffed against itself, so
    `rtl=false`) and `EVENT_NAME: pull_request` (a push, schedule or dispatch

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -152,7 +152,7 @@ of surfacing as a nightly that silently stopped. `ci_events.py --check` holds
 the assertion in its fail-closed shape. That shape is not only what the step
 says: a check that reads a step's contents and nothing about the conditions
 under which it runs holds the wrong perimeter, which is what #209 found. So it
-is exactly these eight things:
+is exactly these ten things:
 
 1. **The script text.** The step's `run:` is pinned verbatim (whitespace
    aside) to three lines: `set -euo pipefail`, one unconditional
@@ -241,6 +241,41 @@ is exactly these eight things:
    `defaults`: they skip only when `full-ci-gate` succeeded and explicitly
    published `run_full=false`; any other selector result runs the aggregate
    into the SHA/shard refusal path.
+9. **The published outputs.** `full-ci-gate`'s `outputs` map is a
+   NAME to EXPRESSION mapping exactly as a step's `env` is, and it is held by
+   the same comparison: exactly `run_full`, `rtl` and `target_sha`, bound to
+   `${{ steps.gate.outputs.run_full }}`, `${{ steps.gate.outputs.rtl }}` and
+   `${{ steps.target.outputs.target_sha }}`, each derived from the step that
+   computes it rather than restated. This is the publication path, and it is
+   not the same object as item 7: no downstream job reads the decision step's
+   output, they read `needs.full-ci-gate.outputs.run_full`, which is this
+   map. Checking only that `target_sha` existed therefore held nothing where
+   it mattered, because `run_full: ${{ 'false' }}` is valid job-output YAML
+   that leaves every pinned step key, every env binding and every character
+   of the decision script in place while the job exports the literal `false`:
+   both worker matrices skip, both aggregates skip under the item 8 no-op
+   exception, and the skipped required contexts satisfy the ruleset. A
+   refusal names the job, the output, the expression required and the one
+   found.
+10. **The consumers of that decision.** Every job that needs `full-ci-gate`
+    carries a pinned `if`, with no residue. The workflow's aggregate is the
+    job whose display name is the public required check the merge bar reads,
+    and it carries the fail-closed `if` of item 8; every other job that needs
+    the gate is a consumer, and carries exactly
+    `${{ needs.full-ci-gate.outputs.run_full == 'true' }}` and no
+    `continue-on-error` or `defaults`. A job added later that depends on the
+    gate lands in the consumer class and is refused until it carries that
+    `if`, so this perimeter is closed under addition rather than being a
+    list of the escapes earlier rounds happened to find. Separately, no
+    expression anywhere in either RTL workflow may read
+    `needs.<job>.outputs.<name>` for an output that job does not publish, or
+    from a job it does not list in `needs`: both spellings evaluate to the
+    empty string, so every comparison against them is false and every job
+    gated on them skips. `rtl-fast.yml` publishes the same shape, from its
+    `changes` job to `verilator-lint` and `yosys-elaboration`, and is held by
+    the same check. Its aggregate counts a skipped consumer as a pass on
+    purpose, since a docs-only change legitimately runs no RTL lint, which is
+    exactly why that selector's published answer has to be pinned too.
 
 `--selftest` covers, one at a time: the step removed, the token missing, the
 live read replaced by an echo, the event not passed, `|| true`, the decoy
@@ -262,8 +297,17 @@ on the job and on the workflow; a shard denominator restated below its matrix
 size, restated while the matrix grows, and stale in a worker's display name; a
 verifier that reassigns `GATE_SHA`, passes the wrong `--expect`, passes none,
 or keeps `--expect` while the matrix grows; an aggregate `if` loosened or
-dropped; a whitespace-only reformatting of all three canonical scripts that
-must still pass; and the decision itself for every event class.
+dropped; the gate's `run_full` and `rtl` outputs each rebound to a literal
+`false`, `run_full` rebound to the scope answer, `target_sha` rebound to the
+run's own SHA, each of the three dropped, the whole map dropped and a surplus
+output added; a worker gated on an output nobody publishes, on `if: false`, on
+a value the decision never takes, made `continue-on-error`, given a
+`defaults.run.shell`, or reading the gate's output without needing the gate; a
+new job that depends on the gate and gates on nothing; in `rtl-fast.yml`, the
+`changes` selector's `rtl` output rebound to a literal and dropped, and its two
+consumers gated on a misspelt output and on `if: false`; a whitespace-only
+reformatting of all three canonical scripts that must still pass; and the
+decision itself for every event class.
 
 ## One authoritative SHA
 

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -267,15 +267,28 @@ is exactly these ten things:
     gate lands in the consumer class and is refused until it carries that
     `if`, so this perimeter is closed under addition rather than being a
     list of the escapes earlier rounds happened to find. Separately, no
-    expression anywhere in either RTL workflow may read
-    `needs.<job>.outputs.<name>` for an output that job does not publish, or
-    from a job it does not list in `needs`: both spellings evaluate to the
-    empty string, so every comparison against them is false and every job
-    gated on them skips. `rtl-fast.yml` publishes the same shape, from its
-    `changes` job to `verilator-lint` and `yosys-elaboration`, and is held by
-    the same check. Its aggregate counts a skipped consumer as a pass on
-    purpose, since a docs-only change legitimately runs no RTL lint, which is
-    exactly why that selector's published answer has to be pinned too.
+    expression anywhere in either RTL workflow may read an output a job does
+    not publish, or read it from a job it does not list in `needs`: both
+    mistakes evaluate to the empty string, so every comparison against them
+    is false and every job gated on them skips. The audit resolves GitHub's
+    dotted, bracket and mixed static spellings --
+    `needs.<job>.outputs.<name>`, `needs['job'].outputs.name` and
+    `needs['job']['outputs']['name']` -- as the same reference. A dynamic
+    `needs[...]` access is refused because the producer and output cannot be
+    proved statically.
+
+    `rtl-fast.yml` publishes the same shape, from its `changes` job to
+    `verilator-lint` and `yosys-elaboration`, and is held by the same check.
+    Its aggregate counts a skipped consumer as a pass on purpose, since a
+    docs-only change legitimately runs no RTL lint. Therefore the producer is
+    held too: `changes` carries no `needs`, `if`, `continue-on-error` or
+    `defaults`; the workflow carries no top-level `defaults`; and its exact
+    two-step sequence is `actions/checkout@v4` with full history followed by
+    the `scope` step. That step's keys and three env bindings are pinned, and
+    its normalized canonical script must self-test `ci_scope.py`, derive the
+    conservative changed-file set, read the selector answer and publish that
+    answer. An empty or forced-false publication can no longer skip both RTL
+    consumers into the accepted docs-only path.
 
 `--selftest` covers, one at a time: the step removed, the token missing, the
 live read replaced by an echo, the event not passed, `|| true`, the decoy
@@ -305,9 +318,15 @@ a value the decision never takes, made `continue-on-error`, given a
 `defaults.run.shell`, or reading the gate's output without needing the gate; a
 new job that depends on the gate and gates on nothing; in `rtl-fast.yml`, the
 `changes` selector's `rtl` output rebound to a literal and dropped, and its two
-consumers gated on a misspelt output and on `if: false`; a whitespace-only
-reformatting of all three canonical scripts that must still pass; and the
-decision itself for every event class.
+consumers gated on a misspelt output and on `if: false`; the `changes` job and
+scope step each given `if: false`, the job made `continue-on-error`, the scope
+env rebound, the scope script made to export `rtl=false` and stripped of its
+self-test, checkout/scope swapped, checkout made shallow, and a workflow
+`defaults.run.shell` inserted; dotted/bracket, all-bracket and mixed
+`needs...outputs` references to missing dependencies or outputs, plus a
+dynamic bracket reference; a whitespace-only reformatting of all four
+canonical scripts that must still pass; and the decision itself for every
+event class.
 
 ## One authoritative SHA
 

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -192,7 +192,8 @@ is exactly these six things:
    step is, so `if: false`, an `if:` naming only some events, a `shell:`, a
    `continue-on-error` or a `working-directory` on any of them is refused by
    name; the decision step's `env` is exactly `EVENT_NAME`, `PR_DRAFT` and
-   `PR_BASE_SHA`, and the checkout keeps `fetch-depth: 0` (the decision step
+   `PR_BASE_SHA`, each bound to the source expression item 6 requires, and
+   the checkout keeps `fetch-depth: 0` (the decision step
    diffs against the pull request's base commit, which a shallow clone does
    not carry). `if: false` on the pin step or on the decision step leaves the
    assert step's script canonical and publishes no `run_full` at all.
@@ -200,7 +201,36 @@ is exactly these six things:
    own names any `GH_*` variable: the step's `env` is pinned to exactly
    `GH_TOKEN`, but a `GH_HOST` or `GH_CONFIG_DIR` set at either level above it
    reaches the same `gh` without appearing anywhere in the step.
-6. **The verifier steps.** Each aggregate's `--require-target-sha` step
+6. **The env bindings.** A pinned step's `env` is held as a name *and* the
+   source expression that name is bound to, because the name is not the
+   contract. The decision step carries
+   `EVENT_NAME: ${{ github.event_name }}`,
+   `PR_DRAFT: ${{ github.event.pull_request.draft }}` and
+   `PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}`; the
+   default-branch step carries `GH_TOKEN: ${{ github.token }}`; each verifier
+   step binds `GATE_SHA` to `full-ci-gate`'s `target_sha` output, derived from
+   that job and output rather than restated. Names alone held nothing where it
+   mattered: `PR_DRAFT: "true"` is valid workflow YAML that keeps all three
+   names and all four keys and makes a ready RTL pull request publish
+   `run_full=false`, on which both worker matrices skip, both aggregates skip
+   under the no-op exception in item 7, and the skipped required contexts
+   satisfy the ruleset -- a false green, not a refusal.
+   `PR_BASE_SHA: ${{ github.sha }}` (a commit diffed against itself, so
+   `rtl=false`) and `EVENT_NAME: pull_request` (a push, schedule or dispatch
+   run taking the pull-request branch) arrive at the same place. A refusal
+   names the step, the variable, the expression required and the one found.
+7. **The decision step's script.** Pinned verbatim after whitespace
+   normalization, the way the default-branch step's is, and refused by naming
+   the first line that differs rather than dumping the script. The bindings in
+   item 6 hold what the step reads; this holds what it does with what it read,
+   because `run_full=true` rewritten to `run_full=false` changes no pinned
+   name and no pinned key and publishes the explicit no-op on every ready RTL
+   pull request. The structural reason is checked first: the selector's
+   `--selftest` runs exactly once and before the script reads the selector's
+   answer, so a selector is never trusted to decide a run without its own
+   proof. Re-indenting the script or wrapping a continuation differently is
+   the same script and still passes.
+8. **The verifier steps.** Each aggregate's `--require-target-sha` step
    carries exactly `name`, `if`, `env` and `run`; its `if` is exactly
    `${{ always() }}` (any other condition can skip the verification, and a
    skipped step passes the job); its `env` exactly `GATE_SHA`; and its
@@ -220,15 +250,20 @@ before the read, an extra line, a missing `set` line; each key escape above
 on the step, on the job, on the workflow and on the verifier steps; the gate
 given a `needs` on a job that skips on `schedule`; `if: false`, an event-only
 `if`, a `shell:`, a `continue-on-error`, a `working-directory` and a dropped
-env key on the pin and decision steps; the assert step moved before the
+env key on the pin and decision steps; `PR_DRAFT` forced to `true`,
+`PR_BASE_SHA` rebound to `${{ github.sha }}`, `EVENT_NAME` hard-coded to
+`pull_request`, `GH_TOKEN` rebound to another token and a verifier's
+`GATE_SHA` rebound to its own run; the decision script rewritten to publish
+`run_full=false` always and stripped of the selector's self-test; the assert
+step moved before the
 checkout; a `GITHUB_PATH` step inserted before it; the pin step removed; the
 pin and assert steps swapped; a checkout without `fetch-depth: 0`; a `GH_HOST`
 on the job and on the workflow; a shard denominator restated below its matrix
 size, restated while the matrix grows, and stale in a worker's display name; a
 verifier that reassigns `GATE_SHA`, passes the wrong `--expect`, passes none,
 or keeps `--expect` while the matrix grows; an aggregate `if` loosened or
-dropped; a whitespace-only reformatting of both scripts that must still pass;
-and the decision itself for every event class.
+dropped; a whitespace-only reformatting of all three canonical scripts that
+must still pass; and the decision itself for every event class.
 
 ## One authoritative SHA
 

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -266,12 +266,21 @@ is exactly these ten things:
     `continue-on-error` or `defaults`. A job added later that depends on the
     gate lands in the consumer class and is refused until it carries that
     `if`, so this perimeter is closed under addition rather than being a
-    list of the escapes earlier rounds happened to find. Separately, no
-    expression anywhere in either RTL workflow may read an output a job does
-    not publish, or read it from a job it does not list in `needs`: both
-    mistakes evaluate to the empty string, so every comparison against them
-    is false and every job gated on them skips. The audit resolves GitHub's
-    dotted, bracket and mixed static spellings --
+    list of the escapes earlier rounds happened to find. The closure runs in
+    both directions ([R2] on PR #239): every job an aggregate lists in its
+    own `needs` is classified too, as the selector, as a consumer, or as a
+    held contributor that carries no `needs`, `if`, `continue-on-error` or
+    `defaults` of its own. A job wired straight into an aggregate without
+    needing the selector, as `bdd-conformance` is, previously landed in no
+    class, so an `if: false` on it retired the specification suite with
+    every hosted context green and the aggregate accepting the skip.
+    Separately, no expression anywhere in either RTL workflow may read an
+    output a job does not publish, and no static `needs` chain of any kind,
+    `.result` as well as `.outputs.<name>`, may name a job the reader does
+    not list in `needs`: each mistake evaluates to the empty string, so
+    every comparison against it is false and every step or job gated on it
+    skips. The audit resolves GitHub's dotted, bracket and mixed static
+    spellings --
     `needs.<job>.outputs.<name>`, `needs['job'].outputs.name` and
     `needs['job']['outputs']['name']` -- as the same reference. A dynamic
     `needs[...]` access is refused because the producer and output cannot be
@@ -281,14 +290,33 @@ is exactly these ten things:
     `verilator-lint` and `yosys-elaboration`, and is held by the same check.
     Its aggregate counts a skipped consumer as a pass on purpose, since a
     docs-only change legitimately runs no RTL lint. Therefore the producer is
-    held too: `changes` carries no `needs`, `if`, `continue-on-error` or
-    `defaults`; the workflow carries no top-level `defaults`; and its exact
+    held too: `changes` carries no `needs`, `if`, `continue-on-error`,
+    `defaults` or job-level `env`; the workflow carries no top-level
+    `defaults`; and its exact
     two-step sequence is `actions/checkout@v4` with full history followed by
     the `scope` step. That step's keys and three env bindings are pinned, and
     its normalized canonical script must self-test `ci_scope.py`, derive the
     conservative changed-file set, read the selector answer and publish that
     answer. An empty or forced-false publication can no longer skip both RTL
     consumers into the accepted docs-only path.
+
+    The verdict half of the fast lane is held the same way ([R2] on PR
+    #239). Because the aggregate runs under `always() && !cancelled()`, its
+    one verdict step is the entire conversion of four job results into the
+    required `rtl-fast` context, and an `if` on that step, a result binding
+    rebound to the literal `success`, or a `case` widened to
+    `success|skipped|failure` each turned a FAILED fast job into a green
+    required context while every job key stayed canonical. So the aggregate
+    must list every other job of the workflow in its `needs`, which also
+    refuses an entry quietly dropped from the verdict; its single step
+    carries exactly `name`, `env` and `run`; its env is derived from that
+    `needs` list, one `<JOB>_RESULT` name per needed job bound to
+    `${{ needs.<job>.result }}`; and its normalized script equals the
+    canonical form derived from the same list, whose `case` accepts exactly
+    `success` and `skipped`. Each public check name (`verilator-suites`,
+    `yosys-portability`, `rtl-fast`, `elaborate`) must be carried by exactly
+    one job, so a second job renamed to a required name cannot make the
+    ruleset's binding ambiguous.
 
 `--selftest` covers, one at a time: the step removed, the token missing, the
 live read replaced by an echo, the event not passed, `|| true`, the decoy
@@ -324,7 +352,15 @@ env rebound, the scope script made to export `rtl=false` and stripped of its
 self-test, checkout/scope swapped, checkout made shallow, and a workflow
 `defaults.run.shell` inserted; dotted/bracket, all-bracket and mixed
 `needs...outputs` references to missing dependencies or outputs, plus a
-dynamic bracket reference; a whitespace-only reformatting of all four
+dynamic bracket reference; the fast verdict step given `if: false`, a
+`shell` and a `continue-on-error`, its lint result binding rebound to the
+literal `success`, and its `case` widened to accept `failure`;
+`bdd-conformance` dropped from the aggregate's `needs` and a new fast job
+left outside them; `bdd-conformance` itself given `if: false`, a
+`continue-on-error` and a `defaults.run.shell`; a `.result` read from a job
+outside `needs`, in the dotted and in the bracket spelling; `verilator-lint`
+renamed to the public name `rtl-fast`; a job-level `env` on the fast
+selector; a whitespace-only reformatting of all five
 canonical scripts that must still pass; and the decision itself for every
 event class.
 

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -51,6 +51,21 @@ those runs are about the tree, not the setting, and a contributor's PR must
 not go red for a setting it cannot change. `--check` requires the step, its
 token and its fail-closed shape (no `continue-on-error`, no `|| true`).
 
+WHETHER IT RUNS AT ALL (#209). The four items above hold what the gate job
+DOES. None of them held the conditions under which it does it, and GitHub has
+a separate lever for each of those: a `needs` on the gate makes it a dependent,
+and a dependent of a skipped job is skipped; an `if`, a `shell` or a
+`continue-on-error` on any step BESIDE the pinned one neuters that step while
+every pinned character stays put; a step inserted, removed or reordered
+changes what the steps after it read (an entry appended to GITHUB_PATH puts
+another `gh` first) or runs the assertion before the checkout has brought the
+script it calls; and an `env` on the job or on the workflow reaches the
+step's `gh` without appearing anywhere in the step. So `--check` also holds
+the gate job's `needs`, its exact step sequence, every step's key set, and
+the absence of any `GH_*` above the step. Separately, the worker shard
+denominator is derived from the matrix that produces the shards
+(`${{ strategy.job-total }}`) rather than restated beside it.
+
     scripts/ci_events.py --check        # the live tree against the contract
     scripts/ci_events.py --selftest     # mutation arms over in-memory copies
     scripts/ci_events.py --require-target-sha --sha gate=<sha> \\
@@ -147,12 +162,53 @@ ASSERT_STEP_ENV = ("GH_TOKEN",)
 VERIFY_STEP_KEYS = ("name", "if", "env", "run")
 VERIFY_STEP_IF = "${{ always() }}"
 VERIFY_STEP_ENV = ("GATE_SHA",)
-#: Job keys that stop a job, or its steps, from running as written. The
-#: gate job carries none of them; an aggregate job carries its documented
-#: fail-closed `if` and nothing else from this list; the workflow carries no top-level
+#: Job keys that decide whether a job runs at all, or runs as written, each
+#: with the reason a refusal names. Before #209 this gate held what the gate
+#: job DOES and nothing about the conditions under which it does it, so
+#: `needs` is here now: a gate that needs another job is a dependent, and a
+#: dependent of a skipped job is skipped, taking every assertion inside it.
+#: The gate job carries none of these keys. An aggregate job legitimately
+#: needs the gate to read its output and carries its documented fail-closed
+#: `if`, and nothing else from this list. The workflow carries no top-level
 #: `defaults` (a `defaults.run.shell: bash -n {0}` parses every script and
 #: executes none).
-JOB_NEUTER_KEYS = ("if", "continue-on-error", "defaults")
+JOB_NEUTER_KEYS = {
+    "needs": ("it makes the job a dependent, and a dependent of a skipped "
+              "job is skipped, taking every assertion in it"),
+    "if": "it decides whether the job runs at all",
+    "continue-on-error": "it turns the job's failure into a pass",
+    "defaults": "it decides by which interpreter every script in the job runs",
+}
+#: The gate job's steps carry these keys and no others. Pinning the assert
+#: step's keys while its siblings were unpinned held the wrong perimeter
+#: (#209): `if: false` on the pin step or on the decision step leaves the
+#: assert step's script canonical and its output empty.
+CHECKOUT_ACTION = "actions/checkout"
+CHECKOUT_STEP_KEYS = ("uses", "with")
+CHECKOUT_STEP_OPTIONAL = ("name",)
+CHECKOUT_FETCH_DEPTH = 0
+PIN_STEP_ID = "target"
+PIN_STEP_KEYS = ("name", "id", "run")
+DECIDE_STEP_ID = "gate"
+DECIDE_STEP_KEYS = ("name", "id", "env", "run")
+DECIDE_STEP_ENV = ("EVENT_NAME", "PR_DRAFT", "PR_BASE_SHA")
+#: `gh` reads its host, its token and its config directory from the process
+#: environment. The assert step's own env is pinned to exactly GH_TOKEN, but
+#: an `env` on the JOB or on the WORKFLOW reaches that `gh` without appearing
+#: anywhere in the step (#209, O11/O12), so neither level names a `GH_*`.
+GH_ENV_PREFIX = "GH_"
+#: The shard denominator a worker passes, and states in its display name. It
+#: is DERIVED from the matrix that defines it, or equal to that matrix's size:
+#: a third statement of the same number does not move when the matrix does,
+#: and the shards past it are never produced while every static count still
+#: agrees (#209, O9). `--expect` is already derived checker-side; this is the
+#: same rule on the worker side of the same number.
+DERIVED_SHARD_TOTAL = "${{ strategy.job-total }}"
+_EXPR = r"\$\{\{[^{}]*\}\}"   # one `${{ ... }}`, kept whole while scanning
+SHARD_ARG_RE = re.compile(r'--shard\s+"?((?:' + _EXPR + r'|[^\s"])+)"?')
+NAME_SHARD_RE = re.compile(r"\$\{\{\s*matrix\.shard\s*\}\}/((?:"
+                           + _EXPR + r'|[^\s"])+)')
+SHELL_VAR_RE = re.compile(r"^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$")
 #: A skipped required context satisfies a GitHub ruleset. Therefore an
 #: aggregate may skip only the gate's explicit successful no-op decision. A
 #: failed/cancelled gate or an absent/malformed output makes the aggregate run;
@@ -263,6 +319,57 @@ def step_text(step):
 def uses(step, action):
     u = step.get("uses")
     return isinstance(u, str) and (u == action or u.startswith(action + "@"))
+
+
+def step_label(step):
+    """What a finding calls a step: its name, its `uses`, or its `id`."""
+    if not isinstance(step, dict):
+        return "no step at this position"
+    for key in ("name", "uses", "id"):
+        value = step.get(key)
+        if isinstance(value, str) and value.strip():
+            return f"`{value.strip()}`"
+    return "an unnamed step"
+
+
+def _is_checkout_step(step):
+    return uses(step, CHECKOUT_ACTION)
+
+
+def _is_pin_step(step):
+    return step.get("id") == PIN_STEP_ID
+
+
+def _is_assert_step(step):
+    return DEFAULT_BRANCH_FLAG in step_text(step)
+
+
+def _is_decide_step(step):
+    return step.get("id") == DECIDE_STEP_ID
+
+
+#: (label, recognizer, what it must be, keys, env keys, optional keys) for
+#: every step of the gate job, in the order they must appear. The SEQUENCE is
+#: the point: the assertion runs the `ci_events.py` the checkout brought and
+#: the decision diffs the tree that checkout produced, so a step moved before
+#: the checkout runs without the file it needs, a step inserted anywhere runs
+#: before everything after it and can change what they read, and a step
+#: removed takes its assertion with it. None of those three touches a single
+#: character of the pinned script text.
+GATE_STEPS = (
+    ("the gate checkout step", _is_checkout_step,
+     f"`uses: {CHECKOUT_ACTION}` with `fetch-depth: {CHECKOUT_FETCH_DEPTH}`",
+     CHECKOUT_STEP_KEYS, (), CHECKOUT_STEP_OPTIONAL),
+    ("the pin step", _is_pin_step,
+     f"the step with `id: {PIN_STEP_ID}` that prints the event and exports "
+     f"`{GATE_OUTPUT}`", PIN_STEP_KEYS, (), ()),
+    ("the default-branch step", _is_assert_step,
+     f"the step that runs `ci_events.py {DEFAULT_BRANCH_FLAG}`",
+     ASSERT_STEP_KEYS, ASSERT_STEP_ENV, ()),
+    ("the decision step", _is_decide_step,
+     f"the step with `id: {DECIDE_STEP_ID}` that publishes `run_full`",
+     DECIDE_STEP_KEYS, DECIDE_STEP_ENV, ()),
+)
 
 
 def cron_time(cron):
@@ -385,7 +492,10 @@ def check_rtl_full(c, wf, policy):
         c.item(prints, path, f"job `{GATE_JOB}` must print the event name and "
                "GITHUB_SHA in one step")
         check_default_branch_step(c, path, gate)
+        check_gate_steps(c, path, gate)
         check_job_keys(c, path, GATE_JOB, gate)
+        check_no_gh_env(c, path, f"job `{GATE_JOB}`", gate.get("env"))
+    check_no_gh_env(c, path, "the workflow's top-level", wf.get("env"))
     c.item("defaults" not in wf, path, "the workflow must carry no top-level "
            f"`defaults` (found {wf.get('defaults')!r}): a `defaults.run.shell`"
            " changes how every script runs")
@@ -416,14 +526,22 @@ def check_rtl_full(c, wf, policy):
             if vsteps:
                 check_sha_sources(c, path, jid, vsteps[0])
                 check_verify_step(c, path, wf, jid, job, vsteps[0])
-            check_job_keys(c, path, jid, job, allowed_if=AGGREGATE_JOB_IF)
+            check_job_keys(c, path, jid, job, allowed_if=AGGREGATE_JOB_IF,
+                           allow_needs=True)
+
+    # A sharded worker states its shard count once, in the matrix.
+    for jid, job in jobs(wf).items():
+        check_shard_denominator(c, path, jid, job)
 
 
-def check_job_keys(c, path, jid, job, allowed_if=None):
-    """A job that must run as written carries no `if` (or exactly the one
-    documented), no `continue-on-error`, no `defaults`; each refusal names
-    the key."""
-    for key in JOB_NEUTER_KEYS:
+def check_job_keys(c, path, jid, job, allowed_if=None, allow_needs=False):
+    """A job that must run as written carries none of the keys that decide
+    whether it runs at all: no `needs`, no `if` (or exactly the one
+    documented), no `continue-on-error`, no `defaults`. Each refusal names
+    the key and what that key does."""
+    for key, reason in JOB_NEUTER_KEYS.items():
+        if key == "needs" and allow_needs:
+            continue
         if key not in job:
             continue
         if key == "if" and allowed_if is not None:
@@ -432,18 +550,17 @@ def check_job_keys(c, path, jid, job, allowed_if=None):
                    f"`{allowed_if}` (found `{got}`)")
             continue
         c.item(False, path, f"job `{jid}` must carry no `{key}` "
-               f"(found {job.get(key)!r}): it decides whether the job runs "
-               "as written")
+               f"(found {job.get(key)!r}): {reason}")
     if allowed_if is not None:
         c.item("if" in job, path, f"job `{jid}` must carry its documented "
                f"`if` `{allowed_if}`")
 
 
-def pinned_step_keys(c, path, what, step, keys, env_keys):
-    """A pinned step carries exactly `keys`, its env exactly `env_keys`;
-    every surplus or missing key is named."""
+def pinned_step_keys(c, path, what, step, keys, env_keys, optional=()):
+    """A pinned step carries exactly `keys` (plus anything in `optional`),
+    its env exactly `env_keys`; every surplus or missing key is named."""
     have = [k for k in step.keys() if isinstance(k, str)]
-    extra = sorted(set(have) - set(keys))
+    extra = sorted(set(have) - set(keys) - set(optional))
     missing = [k for k in keys if k not in have]
     for key in ("if", "shell", "continue-on-error"):
         if key in extra:
@@ -459,10 +576,115 @@ def pinned_step_keys(c, path, what, step, keys, env_keys):
     env_extra = sorted(set(env_have) - set(env_keys))
     env_missing = [k for k in env_keys if k not in env_have]
     c.item(not env_extra and not env_missing, path, f"{what} env must be "
-           f"exactly {', '.join(env_keys)}"
+           f"exactly {', '.join(env_keys) or 'empty'}"
            + (f"; surplus: {', '.join(env_extra)} (a GH_HOST or GH_CONFIG_DIR"
               " redirects gh away from this repository)" if env_extra else "")
            + (f"; missing: {', '.join(env_missing)}" if env_missing else ""))
+
+
+def check_gate_steps(c, path, gate):
+    """The gate job's steps: which ones exist, in which order, and the keys
+    each may carry. check_default_branch_step holds the assert step's script
+    TEXT; this holds everything around it, which is what decides whether that
+    script runs at all (#209)."""
+    ss = steps(gate)
+    c.item(len(ss) == len(GATE_STEPS), path,
+           f"job `{GATE_JOB}` must carry exactly {len(GATE_STEPS)} steps, "
+           + ", ".join(spec[0] for spec in GATE_STEPS)
+           + f", in that order (found {len(ss)}): a step inserted here runs "
+           "before every step after it and can change what they read (an "
+           "entry appended to GITHUB_PATH puts another `gh` first), and a "
+           "step removed takes its assertion with it")
+    for n, (label, recognizer, want, keys, env_keys, optional) in enumerate(
+            GATE_STEPS, 1):
+        found = [s for s in ss if recognizer(s)]
+        step = found[0] if found else None
+        at = ss[n - 1] if len(ss) >= n else None
+        c.item(step is not None and at is step, path,
+               f"job `{GATE_JOB}` step {n} must be {label}, {want} (found "
+               f"{step_label(at)}): the assertion runs the ci_events.py the "
+               "checkout brought and the decision diffs the tree that "
+               "checkout produced, so this order is the contract, not a "
+               "preference")
+        if step is not None:
+            pinned_step_keys(c, path, label, step, keys, env_keys, optional)
+    checkout = next((s for s in ss if _is_checkout_step(s)), None)
+    with_ = checkout.get("with") if isinstance(checkout, dict) else None
+    depth = with_.get("fetch-depth") if isinstance(with_, dict) else None
+    c.item(depth == CHECKOUT_FETCH_DEPTH, path,
+           f"{GATE_STEPS[0][0]} must set `fetch-depth: "
+           f"{CHECKOUT_FETCH_DEPTH}` (found {depth!r}): the decision step "
+           "diffs this head against the pull request's base commit, which a "
+           "shallow clone does not carry, so a shallow gate silently falls "
+           "back to the whole file list")
+
+
+def check_no_gh_env(c, path, where, env):
+    """No `GH_*` above the assert step. Its own env is pinned to exactly
+    GH_TOKEN, but a job- or workflow-level `env: GH_HOST` reaches its `gh`
+    without appearing in the step at all (#209, O11/O12)."""
+    env = env if isinstance(env, dict) else {}
+    named = sorted(str(k) for k in env if str(k).startswith(GH_ENV_PREFIX))
+    c.item(not named, path, f"{where} `env` must name no `{GH_ENV_PREFIX}*` "
+           f"variable (found {', '.join(named)}): it reaches the "
+           "default-branch step's `gh` without appearing in that step, whose "
+           f"own env is pinned to exactly {', '.join(ASSERT_STEP_ENV)}")
+
+
+def shard_denominators(text):
+    """Every denominator of a `--shard <i>/<n>` argument in one script."""
+    out = []
+    for arg in SHARD_ARG_RE.findall(text or ""):
+        if "/" in arg:
+            out.append(arg.rsplit("/", 1)[1].strip())
+    return out
+
+
+def resolve_denominator(token, env):
+    """A denominator as written -> what it stands for. A `$NAME` is followed
+    once through the step's own env, which is where a derived value enters a
+    script; anything else stands for itself."""
+    m = SHELL_VAR_RE.match(token or "")
+    if m and isinstance(env, dict) and m.group(1) in env:
+        return str(env[m.group(1)]).strip()
+    return (token or "").strip()
+
+
+def check_shard_denominator(c, path, jid, job):
+    """A sharded worker states its shard count ONCE, in the matrix that
+    produces the shards. Every `--shard <i>/<n>` it passes, and the `<n>` in
+    its own display name, derives that count or equals it. A restated
+    denominator does not move when the matrix does: with a matrix of three
+    and a literal `/4`, shard 3/4's suites and tops are never produced and
+    every static count still agrees (#209, O9)."""
+    strat = job.get("strategy") if isinstance(job, dict) else None
+    matrix = strat.get("matrix") if isinstance(strat, dict) else None
+    shard = matrix.get("shard") if isinstance(matrix, dict) else None
+    if not isinstance(shard, list) or not shard:
+        return
+    size = str(len(shard))
+    seen = []
+    name = job.get("name")
+    if isinstance(name, str):
+        seen += [(f"job `{jid}` name", d, None)
+                 for d in NAME_SHARD_RE.findall(name)]
+    for n, step in enumerate(steps(job), 1):
+        env = step.get("env") if isinstance(step.get("env"), dict) else {}
+        run = step.get("run") if isinstance(step.get("run"), str) else ""
+        seen += [(f"job `{jid}` step {n}", d, env)
+                 for d in shard_denominators(run)]
+    c.item(bool(seen), path, f"job `{jid}` carries a `strategy.matrix.shard` "
+           "list and must pass `--shard <i>/<n>` to the tool it shards: a "
+           "matrix nothing reads splits nothing")
+    for where, token, env in seen:
+        got = resolve_denominator(token, env)
+        c.item(got in (DERIVED_SHARD_TOTAL, size), path,
+               f"{where}: the shard denominator `{token}` must be "
+               f"`{DERIVED_SHARD_TOTAL}` or the size of this job's "
+               f"`strategy.matrix.shard` list, {size} (it resolves to "
+               f"`{got}`): a restated denominator does not move when the "
+               "matrix does, and the shards past it are never produced while "
+               "every static count still agrees")
 
 
 def matrix_size(wf, job):
@@ -582,8 +804,8 @@ def check_default_branch_step(c, path, gate):
         return
     step = found[0]
     text = step_text(step)
-    pinned_step_keys(c, path, "the default-branch step", step,
-                     ASSERT_STEP_KEYS, ASSERT_STEP_ENV)
+    # Its keys and its env are pinned in check_gate_steps, beside its
+    # siblings': the same key on any step of this job has the same effect.
     env = step.get("env") if isinstance(step.get("env"), dict) else {}
     token = str(env.get("GH_TOKEN", "")).strip()
     c.item(token == "${{ github.token }}", path, "the default-branch step "
@@ -946,6 +1168,93 @@ def _mutations():
     def m_db_no_set(w):
         set_db_script(w, CANONICAL_OBSERVED, CANONICAL_CALL)
 
+    # #209: the conditions under which the gate job runs at all, rather than
+    # what it does once it runs.
+    def gate_step_list(w):
+        return jobs(w[RTL_FULL])[GATE_JOB]["steps"]
+
+    def pin_step(w):
+        return next(s for s in gate_step_list(w)
+                    if s.get("id") == PIN_STEP_ID)
+
+    def decide_step(w):
+        return next(s for s in gate_step_list(w)
+                    if s.get("id") == DECIDE_STEP_ID)
+
+    def m_gate_needs_a_skippable_job(w):
+        # O1: a `noop` job that skips on schedule, and a gate that needs it.
+        jobs(w[RTL_FULL])["noop"] = {
+            "if": "${{ github.event_name != 'schedule' }}",
+            "runs-on": "ubuntu-latest",
+            "steps": [{"run": "true"}],
+        }
+        jobs(w[RTL_FULL])[GATE_JOB]["needs"] = ["noop"]
+
+    def m_assert_before_checkout(w):
+        # O14: the assertion runs before the checkout brings the script.
+        ss = gate_step_list(w)
+        i = next(i for i, s in enumerate(ss)
+                 if DEFAULT_BRANCH_FLAG in step_text(s))
+        ss.insert(0, ss.pop(i))
+
+    def m_pin_and_assert_swapped(w):
+        ss = gate_step_list(w)
+        i = next(i for i, s in enumerate(ss) if s.get("id") == PIN_STEP_ID)
+        ss[i], ss[i + 1] = ss[i + 1], ss[i]
+
+    def m_gate_extra_path_step(w):
+        # O6: a step before the assertion that puts another `gh` first.
+        ss = gate_step_list(w)
+        i = next(i for i, s in enumerate(ss)
+                 if DEFAULT_BRANCH_FLAG in step_text(s))
+        ss.insert(i, {"name": "Prepare tools",
+                      "run": 'echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"\n'})
+
+    def m_pin_step_removed(w):
+        ss = gate_step_list(w)
+        del ss[next(i for i, s in enumerate(ss)
+                    if s.get("id") == PIN_STEP_ID)]
+
+    def m_checkout_shallow(w):
+        del gate_step_list(w)[0]["with"]["fetch-depth"]
+
+    def m_gate_env_gh_host(w):
+        jobs(w[RTL_FULL])[GATE_JOB]["env"] = {"GH_HOST": "example.invalid"}
+
+    def m_workflow_env_gh_host(w):
+        w[RTL_FULL]["env"]["GH_HOST"] = "example.invalid"
+
+    def m_decide_env_missing(w):
+        del decide_step(w)["env"]["PR_BASE_SHA"]
+
+    def restate_shards(w, jid, value):
+        """Turn a derived denominator back into a literal, everywhere the job
+        states it: the display name, every script, every step env."""
+        job = jobs(w[RTL_FULL])[jid]
+        assert DERIVED_SHARD_TOTAL in job["name"], f"fixture drift: {jid} name"
+        job["name"] = job["name"].replace(DERIVED_SHARD_TOTAL, value)
+        for st in steps(job):
+            if isinstance(st.get("run"), str):
+                st["run"] = st["run"].replace(DERIVED_SHARD_TOTAL, value)
+            env = st.get("env")
+            if isinstance(env, dict):
+                for k, v in list(env.items()):
+                    if str(v).strip() == DERIVED_SHARD_TOTAL:
+                        env[k] = value
+
+    def m_shard_denominator_stale(w):
+        # O9: the matrix grows, the restated denominator does not.
+        restate_shards(w, "verilator-shards", "4")
+        jobs(w[RTL_FULL])["verilator-shards"]["strategy"]["matrix"][
+            "shard"].append(4)
+
+    def m_shard_denominator_wrong(w):
+        restate_shards(w, "yosys-shards", "3")
+
+    def m_shard_name_stale(w):
+        job = jobs(w[RTL_FULL])["verilator-shards"]
+        job["name"] = job["name"].replace(DERIVED_SHARD_TOTAL, "3")
+
     def verify_step(w, jid):
         for s in steps(jobs(w[RTL_FULL])[jid]):
             if VERIFY_FLAG in step_text(s):
@@ -1181,6 +1490,49 @@ def _mutations():
          set_job_key("yosys-portability", "defaults",
                      {"run": {"shell": "bash -n {0}"}}),
          "must carry no `defaults`"),
+        # #209: the conditions under which the gate job and its steps run.
+        ("O1 full-ci-gate needs a job that skips on schedule",
+         m_gate_needs_a_skippable_job, "must carry no `needs`"),
+        ("O10 decision step if: false",
+         set_step_key(decide_step, "if", False), "must carry no `if`"),
+        ("O10b decision step if: pull_request only",
+         set_step_key(decide_step, "if",
+                      "${{ github.event_name == 'pull_request' }}"),
+         "must carry no `if`"),
+        ("O13 pin step if: false", set_step_key(pin_step, "if", False),
+         "must carry no `if`"),
+        ("O13b pin step continue-on-error",
+         set_step_key(pin_step, "continue-on-error", True),
+         "must carry no `continue-on-error`"),
+        ("O14 assert step moved before the checkout", m_assert_before_checkout,
+         "step 1 must be the gate checkout step"),
+        ("O6 a GITHUB_PATH step inserted before the assertion",
+         m_gate_extra_path_step, "must carry exactly 4 steps"),
+        ("gate pin step removed", m_pin_step_removed,
+         "must carry exactly 4 steps"),
+        ("gate pin and assert steps swapped", m_pin_and_assert_swapped,
+         "step 2 must be the pin step"),
+        ("gate checkout without fetch-depth: 0", m_checkout_shallow,
+         "fetch-depth: 0"),
+        ("decision step shell: bash -n",
+         set_step_key(decide_step, "shell", "bash -n {0}"),
+         "must carry no `shell`"),
+        ("decision step working-directory",
+         set_step_key(decide_step, "working-directory", "/tmp"),
+         "surplus: working-directory"),
+        ("decision step loses PR_BASE_SHA", m_decide_env_missing,
+         "missing: PR_BASE_SHA"),
+        ("O11 full-ci-gate job env GH_HOST", m_gate_env_gh_host,
+         "must name no `GH_*`"),
+        ("O12 workflow-level env GH_HOST", m_workflow_env_gh_host,
+         "must name no `GH_*`"),
+        # #209 O9: the shard denominator restated instead of derived.
+        ("O9 verilator matrix grows, the denominator is a literal",
+         m_shard_denominator_stale, "shard denominator"),
+        ("O9b yosys denominator below its matrix size",
+         m_shard_denominator_wrong, "shard denominator"),
+        ("O9c a worker name restates a stale denominator", m_shard_name_stale,
+         "name: the shard denominator"),
         ("rtl public name verilator-suites renamed",
          m_rename_job(RTL_FULL, "verilator-suites"), "`verilator-suites`"),
         ("rtl public name yosys-portability renamed",

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -296,6 +296,42 @@ PUBLIC_NAMES = {
 #: The fast workflow's selector job and the step that computes its answer.
 FAST_SELECTOR_JOB = "changes"
 FAST_SCOPE_STEP_ID = "scope"
+#: The fast selector is a second run/no-run decision, not merely a producer
+#: of metadata.  Its exact inputs and body are held for the same reason as
+#: the exhaustive selector: an empty or forced-false answer skips both RTL
+#: consumers, and the aggregate deliberately accepts those skips.
+FAST_CHECKOUT_USES = f"{CHECKOUT_ACTION}@v4"
+FAST_CHECKOUT_WITH = {"fetch-depth": "0"}
+FAST_SCOPE_STEP_KEYS = ("name", "id", "env", "run")
+FAST_SCOPE_STEP_ENV = {
+    "EVENT_NAME": "${{ github.event_name }}",
+    "PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+    "PUSH_BEFORE_SHA": "${{ github.event.before }}",
+}
+CANONICAL_FAST_SCOPE_SCRIPT = (
+    "set -euo pipefail",
+    "python3 scripts/ci_scope.py --selftest",
+    'base=""',
+    'if [ "$EVENT_NAME" = pull_request ]; then',
+    'base="$PR_BASE_SHA"',
+    "else",
+    'base="$PUSH_BEFORE_SHA"',
+    "fi",
+    'if [ -n "$base" ] && [ "$base" != '
+    '0000000000000000000000000000000000000000 ] && '
+    'git cat-file -e "$base^{commit}" 2>/dev/null; then',
+    'git diff --name-only "$base" "$GITHUB_SHA" > '
+    '"$RUNNER_TEMP/changed-files"',
+    "else",
+    "# An unknown base must never turn a real change into docs-only.",
+    'git ls-files > "$RUNNER_TEMP/changed-files"',
+    "fi",
+    'echo "Changed files:"',
+    'sed \'s/^/ /\' "$RUNNER_TEMP/changed-files"',
+    'rtl="$(python3 scripts/ci_scope.py < "$RUNNER_TEMP/changed-files")"',
+    'echo "rtl=$rtl" >> "$GITHUB_OUTPUT"',
+    'echo "RTL/tooling relevant: $rtl"',
+)
 #: The fast workflow's aggregate `if`. It counts a skipped consumer as a pass
 #: deliberately (a docs-only change legitimately runs no RTL lint), which is
 #: exactly why that workflow's published answer has to be pinned by content
@@ -354,9 +390,14 @@ SELECTOR_DECISION = {RTL_FULL: RUN_FULL_OUTPUT, RTL_FAST: RTL_OUTPUT}
 #: derived, not listed again: the aggregate is the job whose display name is
 #: the public required check the merge bar reads (PUBLIC_NAMES above).
 AGGREGATE_IF = {RTL_FULL: AGGREGATE_JOB_IF, RTL_FAST: FAST_AGGREGATE_JOB_IF}
-#: One `needs.<job>.outputs.<name>` reference, wherever it sits.
-NEEDS_OUTPUT_RE = re.compile(
-    r"needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)")
+#: A `needs` context reference can use property syntax, index syntax, or mix
+#: them: `needs.changes.outputs.rtl`, `needs['changes'].outputs.rtl`, and
+#: `needs['changes']['outputs']['rtl']` are the same reference to GitHub.  A
+#: regex for only the first spelling made the second invisible to the gate.
+#: The small access-chain parser below resolves every static spelling and
+#: refuses dynamic brackets, whose producer/output cannot be audited here.
+NEEDS_WORD_RE = re.compile(r"\bneeds\b")
+CONTEXT_NAME_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 CRON_RE = re.compile(r"^\s*(\d{1,2})\s+(\d{1,2})\s+\*\s+\*\s+\*\s*$")
@@ -691,6 +732,94 @@ def needs_list(job):
     return [] if n is None else [str(n)]
 
 
+def context_bracket_end(text, start):
+    """Index of the `]` matching `text[start]`, or None.
+
+    GitHub expression strings use single quotes and escape one quote as two.
+    Accounting for them here keeps a `]` inside a dynamic expression's string
+    from ending the access early; nested brackets are handled as well.
+    """
+    depth = 0
+    quoted = False
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if quoted:
+            if ch == "'":
+                if i + 1 < len(text) and text[i + 1] == "'":
+                    i += 2
+                    continue
+                quoted = False
+        elif ch == "'":
+            quoted = True
+        elif ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def context_access_chain(text, start):
+    """Parse static `.name` / `['name']` accesses after a context word.
+
+    Returns `(parts, dynamic, end)`. A None part is a dynamic bracket. The
+    caller refuses it because no static workflow audit can prove which job or
+    output it names.
+    """
+    parts = []
+    dynamic = False
+    pos = start
+    while True:
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        if pos < len(text) and text[pos] == ".":
+            pos += 1
+            while pos < len(text) and text[pos].isspace():
+                pos += 1
+            match = CONTEXT_NAME_RE.match(text, pos)
+            if match is None:
+                dynamic = True
+                break
+            parts.append(match.group(0))
+            pos = match.end()
+            continue
+        if pos < len(text) and text[pos] == "[":
+            end = context_bracket_end(text, pos)
+            if end is None:
+                dynamic = True
+                pos = len(text)
+                break
+            inside = text[pos + 1:end].strip()
+            match = re.fullmatch(r"'([A-Za-z0-9_-]+)'", inside)
+            parts.append(match.group(1) if match else None)
+            dynamic = dynamic or match is None
+            pos = end + 1
+            continue
+        break
+    return parts, dynamic, pos
+
+
+def needs_output_references(text):
+    """Static `(producer, output)` refs and unresolved `needs[...]` chains."""
+    refs = set()
+    unresolved = set()
+    for match in NEEDS_WORD_RE.finditer(text or ""):
+        parts, dynamic, end = context_access_chain(text, match.end())
+        if dynamic:
+            shown = text[match.start():end].strip() or "needs[...]"
+            unresolved.add(shown)
+            continue
+        if len(parts) >= 2 and parts[1] == "outputs":
+            if len(parts) < 3:
+                unresolved.add(text[match.start():end].strip())
+            else:
+                refs.add((parts[0], parts[2]))
+    return refs, unresolved
+
+
 def check_publication_path(c, path, wf):
     """The whole path a selector's decision travels: the step that computes
     it, the job `outputs` map that publishes it, and the jobs that run on it.
@@ -729,9 +858,18 @@ def check_publication_path(c, path, wf):
                                    else consumer_job_if(sel, decision)))
 
     for jid, job in all_jobs.items():
-        refs = sorted({m.groups() for s in all_scalars(job)
-                       for m in NEEDS_OUTPUT_RE.finditer(s)})
-        for producer, name in refs:
+        refs = set()
+        unresolved = set()
+        for scalar in all_scalars(job):
+            found, unknown = needs_output_references(scalar)
+            refs.update(found)
+            unresolved.update(unknown)
+        for expression in sorted(unresolved):
+            c.item(False, path, f"job `{jid}` uses `{expression}`, a dynamic "
+                   "or incomplete `needs` context the gate cannot resolve "
+                   "statically: use a dotted or single-quoted static job and "
+                   "output name so publication and dependency can be proved")
+        for producer, name in sorted(refs):
             pj = all_jobs.get(producer)
             declared = pj.get("outputs") if isinstance(pj, dict) else None
             declared = declared if isinstance(declared, dict) else {}
@@ -1121,10 +1259,88 @@ def check_default_branch_step(c, path, gate):
            "no continue-on-error, no `|| true`")
 
 
+def check_fast_selector(c, wf):
+    """Hold the fast workflow's complete checkout -> scope decision.
+
+    `rtl-fast` accepts skipped RTL consumers for docs-only changes. Therefore
+    an `if: false` on this job or its scope step, a shallow/moved checkout, or
+    a scope body that publishes `rtl=false` is a false green unless the whole
+    producer is part of the contract.
+    """
+    selector = jobs(wf).get(FAST_SELECTOR_JOB)
+    c.item(isinstance(selector, dict), RTL_FAST,
+           f"job `{FAST_SELECTOR_JOB}` must exist as the fast RTL selector")
+    if not isinstance(selector, dict):
+        return
+
+    check_job_keys(c, RTL_FAST, FAST_SELECTOR_JOB, selector)
+    c.item("defaults" not in wf, RTL_FAST,
+           "the fast workflow must carry no top-level `defaults` "
+           f"(found {wf.get('defaults')!r}): a `defaults.run.shell` changes "
+           "how the selector script runs")
+
+    raw_steps = selector.get("steps")
+    ss = raw_steps if isinstance(raw_steps, list) else []
+    mappings = [s for s in ss if isinstance(s, dict)]
+    c.item(len(ss) == 2 and len(mappings) == 2, RTL_FAST,
+           f"job `{FAST_SELECTOR_JOB}` must carry exactly two mapping steps, "
+           "checkout then scope, in that order (found "
+           f"{len(ss)} step(s), {len(mappings)} mapping(s)): an inserted or "
+           "removed step changes whether and how the selector runs")
+
+    checkouts = [s for s in mappings if _is_checkout_step(s)]
+    scopes = [s for s in mappings if s.get("id") == FAST_SCOPE_STEP_ID]
+    checkout = checkouts[0] if len(checkouts) == 1 else None
+    scope = scopes[0] if len(scopes) == 1 else None
+    c.item(len(checkouts) == 1 and len(scopes) == 1
+           and len(ss) == 2 and ss[0] is checkout and ss[1] is scope,
+           RTL_FAST, f"job `{FAST_SELECTOR_JOB}` steps must be exactly "
+           f"`{FAST_CHECKOUT_USES}` then the step with "
+           f"`id: {FAST_SCOPE_STEP_ID}` (found "
+           f"{[step_label(s) for s in mappings]}): scope must inspect the "
+           "tree the checkout brought")
+
+    if checkout is not None:
+        pinned_step_keys(c, RTL_FAST, "the fast selector checkout step",
+                         checkout, CHECKOUT_STEP_KEYS, {},
+                         CHECKOUT_STEP_OPTIONAL)
+        got_uses = str(checkout.get("uses", "")).strip()
+        c.item(got_uses == FAST_CHECKOUT_USES, RTL_FAST,
+               "the fast selector checkout step must use exactly "
+               f"`{FAST_CHECKOUT_USES}` (found `{got_uses}`)")
+        with_ = checkout.get("with")
+        with_ = with_ if isinstance(with_, dict) else {}
+        pinned_bindings(c, RTL_FAST, "the fast selector checkout `with`",
+                        with_, FAST_CHECKOUT_WITH,
+                        "the scope step diffs against an earlier commit, so "
+                        "the checkout must carry full history")
+
+    if scope is not None:
+        pinned_step_keys(c, RTL_FAST, "the fast selector scope step", scope,
+                         FAST_SCOPE_STEP_KEYS, FAST_SCOPE_STEP_ENV)
+        run = scope.get("run") if isinstance(scope.get("run"), str) else ""
+        lines = normalize_script(run)
+        proofs = [i for i, line in enumerate(lines)
+                  if line == SELECTOR_SELFTEST]
+        reads = [i for i, line in enumerate(lines) if SELECTOR_READ in line]
+        c.item(len(proofs) == 1 and bool(reads)
+               and proofs[0] < min(reads), RTL_FAST,
+               f"the fast selector scope step must run `{SELECTOR_SELFTEST}` "
+               "exactly once and before it reads the selector's answer "
+               f"(self-test at {proofs}, reads at {reads})")
+        c.item(tuple(lines) == CANONICAL_FAST_SCOPE_SCRIPT, RTL_FAST,
+               "the fast selector scope script is not the canonical form: "
+               + script_difference(lines, CANONICAL_FAST_SCOPE_SCRIPT)
+               + "; this script publishes `rtl`, so an empty or false value "
+               "skips both RTL consumers into the aggregate's accepted "
+               "docs-only path")
+
+
 def check_rtl_fast(c, wf):
     check_push_and_pr(c, RTL_FAST, wf, exact_types=True)
     check_cancel_in_progress(c, RTL_FAST, wf)
     check_public_names(c, RTL_FAST, wf)
+    check_fast_selector(c, wf)
     # The same selector -> outputs -> consumer path as the exhaustive
     # workflow, and the same false green if it is left unheld: this
     # aggregate counts a skipped consumer as a pass.
@@ -1556,6 +1772,61 @@ def _mutations():
             jobs(w[path])[jid]["if"] = value
         return f
 
+    def set_job_key_at(path, jid, key, value):
+        def f(w):
+            jobs(w[path])[jid][key] = value
+        return f
+
+    def fast_scope_step(w):
+        found = [s for s in job_steps(w, RTL_FAST, FAST_SELECTOR_JOB)
+                 if isinstance(s, dict)
+                 and s.get("id") == FAST_SCOPE_STEP_ID]
+        assert len(found) == 1, "fixture drift: no unique fast scope step"
+        return found[0]
+
+    def fast_checkout_step(w):
+        found = [s for s in job_steps(w, RTL_FAST, FAST_SELECTOR_JOB)
+                 if isinstance(s, dict) and _is_checkout_step(s)]
+        assert len(found) == 1, "fixture drift: no unique fast checkout step"
+        return found[0]
+
+    def fast_bdd_run_step(w):
+        found = [s for s in job_steps(w, RTL_FAST, "bdd-conformance")
+                 if "behave --no-capture" in step_text(s)]
+        assert len(found) == 1, "fixture drift: no unique BDD run step"
+        return found[0]
+
+    def m_fast_scope_publishes_false(w):
+        # The selector still self-tests and reads the real answer, but exports
+        # a literal false. Both RTL consumers skip and the aggregate passes.
+        scope = fast_scope_step(w)
+        old = 'echo "rtl=$rtl" >> "$GITHUB_OUTPUT"'
+        assert old in scope["run"], "fixture drift: no fast rtl publication"
+        scope["run"] = scope["run"].replace(
+            old, 'echo "rtl=false" >> "$GITHUB_OUTPUT"', 1)
+
+    def m_fast_scope_unproven(w):
+        scope = fast_scope_step(w)
+        assert SELECTOR_SELFTEST in scope["run"], (
+            "fixture drift: fast scope does not self-test the selector")
+        scope["run"] = scope["run"].replace(SELECTOR_SELFTEST, "true", 1)
+
+    def m_fast_steps_swapped(w):
+        ss = job_steps(w, RTL_FAST, FAST_SELECTOR_JOB)
+        assert len(ss) == 2, "fixture drift: fast selector is not two steps"
+        ss[0], ss[1] = ss[1], ss[0]
+
+    def m_fast_checkout_shallow(w):
+        del fast_checkout_step(w)["with"]["fetch-depth"]
+
+    def m_fast_top_defaults(w):
+        w[RTL_FAST]["defaults"] = {"run": {"shell": "bash -n {0}"}}
+
+    def m_fast_bdd_needs_expression(expression):
+        def f(w):
+            fast_bdd_run_step(w)["if"] = expression
+        return f
+
     def m_worker_needs_dropped(w):
         del jobs(w[RTL_FULL])["verilator-shards"]["needs"]
 
@@ -1950,6 +2221,57 @@ def _mutations():
         ("O19d a fast consumer gates on if: false",
          set_job_if(RTL_FAST, "yosys-elaboration", False),
          "`if` must be exactly"),
+        # #209 O21: the producer of the fast answer must run and publish the
+        # value it computed. Each arm leaves the selector output map and both
+        # consumer conditions canonical while making their jobs skip.
+        ("O21 fast selector job if: false",
+         set_job_if(RTL_FAST, FAST_SELECTOR_JOB, False),
+         f"job `{FAST_SELECTOR_JOB}` must carry no `if`"),
+        ("O21b fast scope step if: false",
+         set_step_key(fast_scope_step, "if", False),
+         "fast selector scope step must carry no `if`"),
+        ("O21c fast scope publishes literal rtl=false",
+         m_fast_scope_publishes_false,
+         "fast selector scope script is not the canonical form"),
+        ("O21d fast scope drops the selector self-test",
+         m_fast_scope_unproven,
+         "before it reads the selector's answer"),
+        ("O21e fast scope EVENT_NAME rebound to pull_request",
+         set_env_key(fast_scope_step, "EVENT_NAME", "pull_request"),
+         "fast selector scope step env must bind `EVENT_NAME`"),
+        ("O21f fast selector continue-on-error",
+         set_job_key_at(RTL_FAST, FAST_SELECTOR_JOB,
+                        "continue-on-error", True),
+         f"job `{FAST_SELECTOR_JOB}` must carry no `continue-on-error`"),
+        ("O21g fast selector scope runs before checkout",
+         m_fast_steps_swapped,
+         "steps must be exactly `actions/checkout@v4`"),
+        ("O21h fast selector checkout is shallow",
+         m_fast_checkout_shallow,
+         "fast selector checkout `with` must be exactly fetch-depth"),
+        ("O21i fast workflow parses selector scripts instead of running",
+         m_fast_top_defaults,
+         "fast workflow must carry no top-level `defaults`"),
+        # #209 O22: GitHub permits index and mixed property syntax for the
+        # same needs context. These expressions sit on the otherwise
+        # independent BDD job so only the closed reference audit can catch
+        # them; the ordinary consumer-if comparison is not involved.
+        ("O22 bracket needs reference names an unpublished output",
+         m_fast_bdd_needs_expression(
+             "${{ needs['changes'].outputs.bogus == 'true' }}"),
+         "must publish"),
+        ("O22b all-bracket needs reference omits its dependency",
+         m_fast_bdd_needs_expression(
+             "${{ needs['changes']['outputs']['rtl'] == 'true' }}"),
+         "must list `changes` in its `needs`"),
+        ("O22c mixed needs reference names an unpublished output",
+         m_fast_bdd_needs_expression(
+             "${{ needs.changes['outputs'].bogus == 'true' }}"),
+         "must publish"),
+        ("O22d dynamic needs reference cannot evade static audit",
+         m_fast_bdd_needs_expression(
+             "${{ needs[format('{0}', 'changes')].outputs.rtl == 'true' }}"),
+         "cannot resolve statically"),
         # #209 O9: the shard denominator restated instead of derived.
         ("O9 verilator matrix grows, the denominator is a literal",
          m_shard_denominator_stale, "shard denominator"),
@@ -2150,6 +2472,10 @@ def selftest(root):
         if s.get("id") == DECIDE_STEP_ID:
             s["run"] = "\n".join("   " + l if l.strip() else ""
                                   for l in s["run"].splitlines()) + "\n"
+    for s in steps(jobs(world[RTL_FAST])[FAST_SELECTOR_JOB]):
+        if s.get("id") == FAST_SCOPE_STEP_ID:
+            s["run"] = "\n".join("   " + l if l.strip() else ""
+                                  for l in s["run"].splitlines()) + "\n"
     for s in steps(jobs(world[RTL_FULL])["yosys-portability"]):
         if VERIFY_FLAG in step_text(s):
             s["run"] = ("shopt   -s nullglob\n"
@@ -2166,7 +2492,7 @@ def selftest(root):
                         f"was refused: {check(world).findings}")
     else:
         print("  ok   canonical pins are whitespace-invariant (assert step, "
-              "decision step and verifier step)")
+              "decision step, fast scope step and verifier step)")
 
     # --require-default-branch arms: the decision for every event class. An
     # inverted or weakened comparison fails one of these, which is what makes

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -66,6 +66,18 @@ the absence of any `GH_*` above the step. Separately, the worker shard
 denominator is derived from the matrix that produces the shards
 (`${{ strategy.job-total }}`) rather than restated beside it.
 
+THE FAST VERDICT ([R2] on PR #239). rtl-fast.yml's aggregate accepts skipped
+consumers on purpose, so its one verdict step is the entire conversion of
+four job results into the required `rtl-fast` context, and it was outside
+the perimeter: an `if` on the step, a result binding rebound to `success`,
+or a `case` widened to accept `failure` each made a FAILED fast job a green
+required context. So the aggregate must need every other job of that
+workflow; every job an aggregate needs is the selector, a consumer, or
+itself held; the verdict step's keys, env bindings and script are derived
+from that `needs` list; each public check name is carried by exactly one
+job; and the reference audit covers every static `needs` chain, `.result`
+included, not only `.outputs.`.
+
     scripts/ci_events.py --check        # the live tree against the contract
     scripts/ci_events.py --selftest     # mutation arms over in-memory copies
     scripts/ci_events.py --require-target-sha --sha gate=<sha> \\
@@ -337,6 +349,16 @@ CANONICAL_FAST_SCOPE_SCRIPT = (
 #: exactly why that workflow's published answer has to be pinned by content
 #: too: rebind it and every consumer skips into that pass.
 FAST_AGGREGATE_JOB_IF = "${{ always() && !cancelled() }}"
+#: The fast aggregate's one verdict step. That step is the entire conversion
+#: of four job results into the required `rtl-fast` context ([R2] on PR
+#: #239): the job itself runs under `always() && !cancelled()`, so an `if` on
+#: the step, a rebound result binding, or a `case` widened to accept
+#: `failure` each leaves every job key canonical while a FAILED consumer
+#: still yields a green required context. So the step's keys are pinned, its
+#: env is derived from the aggregate's `needs` (one `<JOB>_RESULT` name per
+#: needed job, bound to `${{ needs.<job>.result }}`), and its script is the
+#: canonical form derived from the same list.
+FAST_VERDICT_STEP_KEYS = ("name", "env", "run")
 
 
 def step_output_ref(step_id, name):
@@ -347,6 +369,40 @@ def step_output_ref(step_id, name):
 def needs_output_ref(job_id, name):
     """`needs.<job>.outputs.<name>`, built rather than restated."""
     return "needs." + job_id + ".outputs." + name
+
+
+def needs_result_ref(job_id):
+    """`${{ needs.<job>.result }}`, built rather than restated."""
+    return "${{ needs." + job_id + ".result }}"
+
+
+def fast_result_env_name(job_id):
+    """The env name the fast verdict step reads one needed job's result
+    through, derived from the job id, never a second list:
+    `verilator-lint` -> `VERILATOR_LINT_RESULT`."""
+    return job_id.upper().replace("-", "_") + "_RESULT"
+
+
+def canonical_fast_verdict_script(needed):
+    """The fast verdict step's script, derived from the aggregate's `needs`:
+    one `job:$JOB_RESULT` pair per needed job, in `needs` order, and a `case`
+    that accepts exactly `success` and `skipped`."""
+    pairs = " ".join('"%s:$%s"' % (j, fast_result_env_name(j))
+                     for j in needed)
+    return (
+        "set -euo pipefail",
+        "bad=0",
+        f"for pair in {pairs}; do",
+        'name="${pair%%:*}"',
+        'result="${pair#*:}"',
+        "printf '%-24s %s\\n' \"$name\" \"$result\"",
+        'case "$result" in',
+        "success|skipped) ;;",
+        "*) bad=1 ;;",
+        "esac",
+        "done",
+        '[ "$bad" -eq 0 ]',
+    )
 
 
 def consumer_job_if(job_id, name):
@@ -602,11 +658,21 @@ def check_cancel_in_progress(c, path, wf):
 
 
 def check_public_names(c, path, wf):
-    names = {display_name(jid, j) for jid, j in jobs(wf).items()}
+    """Each public check-run name the merge bar reads is carried by exactly
+    one job. Existence alone held nothing ([R2] on PR #239): a second job
+    renamed to the aggregate's display name publishes a second check run
+    under the required name, and which of the two the ruleset binds is
+    ambiguous."""
+    all_jobs = jobs(wf)
     for want in PUBLIC_NAMES.get(path, ()):
-        c.item(want in names, path,
-               f"public check name `{want}` must exist as a job (found "
-               f"{sorted(names)})")
+        carriers = [jid for jid, j in all_jobs.items()
+                    if display_name(jid, j) == want]
+        c.item(len(carriers) == 1, path,
+               f"public check name `{want}` must be carried by exactly one "
+               f"job (carried by {carriers or 'none'}, jobs are "
+               f"{sorted(all_jobs)}): the merge bar reads this name, and two "
+               "jobs publishing it make which run the ruleset binds "
+               "ambiguous")
 
 
 def check_rtl_full(c, wf, policy):
@@ -802,9 +868,18 @@ def context_access_chain(text, start):
     return parts, dynamic, pos
 
 
-def needs_output_references(text):
-    """Static `(producer, output)` refs and unresolved `needs[...]` chains."""
+def needs_context_references(text):
+    """Static `needs` context chains in one scalar: `(producer, output)`
+    refs, every producer any static chain names, and unresolved chains.
+
+    The producer set covers every second component, `.result` included, not
+    only `.outputs.` ([R2] on PR #239): a `needs.<job>.result` read from a
+    job outside `needs` is the same empty string the `.outputs.` audit
+    exists for, so stopping at `.outputs.` left `.result` a silent skip. A
+    bare `needs` with no chain (as in `toJSON(needs)`) names no producer and
+    is not audited here."""
     refs = set()
+    producers = set()
     unresolved = set()
     for match in NEEDS_WORD_RE.finditer(text or ""):
         parts, dynamic, end = context_access_chain(text, match.end())
@@ -812,12 +887,15 @@ def needs_output_references(text):
             shown = text[match.start():end].strip() or "needs[...]"
             unresolved.add(shown)
             continue
+        if not parts:
+            continue
+        producers.add(parts[0])
         if len(parts) >= 2 and parts[1] == "outputs":
             if len(parts) < 3:
                 unresolved.add(text[match.start():end].strip())
             else:
                 refs.add((parts[0], parts[2]))
-    return refs, unresolved
+    return refs, producers, unresolved
 
 
 def check_publication_path(c, path, wf):
@@ -832,7 +910,11 @@ def check_publication_path(c, path, wf):
     class carries a pinned `if`. A job added tomorrow that depends on the
     selector lands in the consumer class and reddens until it carries that
     `if`, instead of arriving outside every contract the way both worker
-    matrices and both fast-lane consumers did (#209, [R0] rounds 1-3)."""
+    matrices and both fast-lane consumers did (#209, [R0] rounds 1-3).
+    Closure runs in both directions ([R2] on PR #239): every job an
+    aggregate needs is also classified, so a contributor wired straight into
+    the aggregate without needing the selector is held to run as written
+    rather than landing in no class."""
     sel = SELECTOR_JOB[path]
     want = SELECTOR_OUTPUTS[path]
     decision = SELECTOR_DECISION[path]
@@ -857,12 +939,33 @@ def check_publication_path(c, path, wf):
                        allowed_if=(AGGREGATE_IF[path] if aggregate
                                    else consumer_job_if(sel, decision)))
 
+    # [R2] on PR #239: a job wired straight into an aggregate's `needs`
+    # without itself needing the selector, as `bdd-conformance` is, landed in
+    # no class above, so an `if: false` on it disabled the specification
+    # suite with every hosted context green and the aggregate accepting the
+    # skip. So every job an aggregate needs is classified: the selector, a
+    # consumer (classified above), or itself held to run as written.
+    for jid, job in all_jobs.items():
+        if display_name(jid, job) not in public:
+            continue
+        for member in sorted(set(needs_list(job))):
+            mjob = all_jobs.get(member)
+            if not isinstance(mjob, dict):
+                c.item(False, path, f"job `{jid}` needs `{member}`, which "
+                       "must exist as a job in this workflow")
+                continue
+            if member == sel or sel in needs_list(mjob):
+                continue
+            check_job_keys(c, path, member, mjob)
+
     for jid, job in all_jobs.items():
         refs = set()
+        producers = set()
         unresolved = set()
         for scalar in all_scalars(job):
-            found, unknown = needs_output_references(scalar)
+            found, named, unknown = needs_context_references(scalar)
             refs.update(found)
+            producers.update(named)
             unresolved.update(unknown)
         for expression in sorted(unresolved):
             c.item(False, path, f"job `{jid}` uses `{expression}`, a dynamic "
@@ -879,11 +982,14 @@ def check_publication_path(c, path, wf):
                    f"{sorted(declared)}): an expression naming an output no "
                    "job declares is the empty string, so every comparison "
                    "against it is false and every job gated on it skips")
+        for producer in sorted(producers):
             c.item(producer in needs_list(job), path,
-                   f"job `{jid}` reads `{needs_output_ref(producer, name)}` "
-                   f"and must list `{producer}` in its `needs` (found "
+                   f"job `{jid}` reads the `needs.{producer}` context and "
+                   f"must list `{producer}` in its `needs` (found "
                    f"{needs_list(job)}): outside `needs` the expression is "
-                   "the empty string")
+                   "the empty string, so a `.result` or `.outputs` guard "
+                   "built on it is quietly false and the step or job it "
+                   "guards skips")
 
 
 def check_job_keys(c, path, jid, job, allowed_if=None, allow_needs=False):
@@ -1274,6 +1380,11 @@ def check_fast_selector(c, wf):
         return
 
     check_job_keys(c, RTL_FAST, FAST_SELECTOR_JOB, selector)
+    c.item("env" not in selector, RTL_FAST,
+           f"job `{FAST_SELECTOR_JOB}` must carry no `env` (found "
+           f"{sorted(map(str, selector.get('env') or {}))}): a job-level "
+           "value reaches the scope script without appearing in the pinned "
+           "step, whose own env is the selector's whole input contract")
     c.item("defaults" not in wf, RTL_FAST,
            "the fast workflow must carry no top-level `defaults` "
            f"(found {wf.get('defaults')!r}): a `defaults.run.shell` changes "
@@ -1336,11 +1447,69 @@ def check_fast_selector(c, wf):
                "docs-only path")
 
 
+def check_fast_aggregate(c, wf):
+    """Hold the verdict half of the fast lane ([R2] on PR #239).
+
+    The fast aggregate runs under `always() && !cancelled()`, so once its job
+    keys are canonical the ONLY thing standing between a failed consumer and
+    a green required context is its verdict step. An `if` on that step skips
+    it and the job succeeds with `verilator-lint` FAILED; a result binding
+    rebound to the literal `success` converts one named failure into a pass;
+    a `case` widened to `success|skipped|failure` accepts them all. None of
+    those touches a job key or the selector's publication path. So the
+    verdict step is held the way the exhaustive workflow's verifier steps
+    are: pinned keys, env derived from the aggregate's `needs`, script
+    derived from the same list. The `needs` list itself must name every
+    other job of the workflow, so no fast job can fail outside the required
+    context's view and none can be quietly dropped from it."""
+    all_jobs = jobs(wf)
+    public = set(PUBLIC_NAMES.get(RTL_FAST, ()))
+    for jid, job in all_jobs.items():
+        if display_name(jid, job) not in public:
+            continue
+        needed = needs_list(job)
+        others = [j for j in all_jobs if j != jid]
+        missing = [j for j in others if j not in needed]
+        surplus = [j for j in needed if j not in others]
+        c.item(not missing and not surplus, RTL_FAST,
+               f"job `{jid}` must need every other job of this workflow, "
+               f"{', '.join(others)}"
+               + (f"; missing: {', '.join(missing)}" if missing else "")
+               + (f"; surplus: {', '.join(surplus)}" if surplus else "")
+               + ": a fast job outside the aggregate's `needs` can fail "
+               "with the required context still green, and a dropped entry "
+               "silently removes that job's result from the verdict")
+        ss = steps(job)
+        c.item(len(ss) == 1, RTL_FAST,
+               f"job `{jid}` must carry exactly one step, its verdict step "
+               f"(found {len(ss)}): a step inserted beside the verdict can "
+               "change what it reads, and a removed one takes the verdict "
+               "with it")
+        if len(ss) != 1:
+            continue
+        what = f"job `{jid}` verdict step"
+        env_want = {fast_result_env_name(j): needs_result_ref(j)
+                    for j in needed}
+        pinned_step_keys(c, RTL_FAST, what, ss[0], FAST_VERDICT_STEP_KEYS,
+                         env_want)
+        run = ss[0].get("run") if isinstance(ss[0].get("run"), str) else ""
+        lines = normalize_script(run)
+        canon = canonical_fast_verdict_script(needed)
+        c.item(tuple(lines) == canon, RTL_FAST,
+               f"{what} script is not the canonical form derived from the "
+               "aggregate's `needs`: "
+               + script_difference(lines, canon)
+               + "; this script is the whole required fast verdict, so a "
+               "widened `case` or a dropped pair turns a named failure into "
+               "a pass")
+
+
 def check_rtl_fast(c, wf):
     check_push_and_pr(c, RTL_FAST, wf, exact_types=True)
     check_cancel_in_progress(c, RTL_FAST, wf)
     check_public_names(c, RTL_FAST, wf)
     check_fast_selector(c, wf)
+    check_fast_aggregate(c, wf)
     # The same selector -> outputs -> consumer path as the exhaustive
     # workflow, and the same false green if it is left unheld: this
     # aggregate counts a skipped consumer as a pass.
@@ -1795,6 +1964,49 @@ def _mutations():
                  if "behave --no-capture" in step_text(s)]
         assert len(found) == 1, "fixture drift: no unique BDD run step"
         return found[0]
+
+    def fast_aggregate_job(w):
+        return jobs(w[RTL_FAST])["rtl-fast"]
+
+    def fast_verdict_step(w):
+        ss = [s for s in fast_aggregate_job(w).get("steps", [])
+              if isinstance(s, dict)]
+        assert len(ss) == 1, "fixture drift: fast aggregate is not one step"
+        return ss[0]
+
+    def m_fast_verdict_case_widened(w):
+        s = fast_verdict_step(w)
+        assert "success|skipped)" in s["run"], (
+            "fixture drift: no accept case in the fast verdict")
+        s["run"] = s["run"].replace("success|skipped)",
+                                    "success|skipped|failure)", 1)
+
+    def m_fast_aggregate_forgets_bdd(w):
+        # The whole trace of `bdd-conformance` removed from the aggregate
+        # consistently: the `needs` entry, the env binding and the loop pair,
+        # so the derived env and script agree with the shrunk `needs` and the
+        # only refusal left is the `needs` universe itself.
+        agg = fast_aggregate_job(w)
+        assert "bdd-conformance" in agg["needs"], (
+            "fixture drift: the aggregate does not need bdd-conformance")
+        agg["needs"] = [n for n in agg["needs"] if n != "bdd-conformance"]
+        step = fast_verdict_step(w)
+        del step["env"]["BDD_CONFORMANCE_RESULT"]
+        pair = '"bdd-conformance:$BDD_CONFORMANCE_RESULT"'
+        step["run"], n = re.subn(r"\s*" + re.escape(pair) + r" \\", "",
+                                 step["run"])
+        assert n == 1, "fixture drift: no bdd pair line in the verdict loop"
+
+    def m_fast_new_unaggregated_job(w):
+        jobs(w[RTL_FAST])["extra-check"] = {
+            "runs-on": "ubuntu-latest",
+            "steps": [{"run": "true"}],
+        }
+
+    def m_fast_lint_masquerades_as_aggregate(w):
+        job = jobs(w[RTL_FAST])["verilator-lint"]
+        job["name"] = "rtl-fast"
+        job["if"] = FAST_AGGREGATE_JOB_IF
 
     def m_fast_scope_publishes_false(w):
         # The selector still self-tests and reads the real answer, but exports
@@ -2272,6 +2484,64 @@ def _mutations():
          m_fast_bdd_needs_expression(
              "${{ needs[format('{0}', 'changes')].outputs.rtl == 'true' }}"),
          "cannot resolve statically"),
+        # [R2] O23: the fast aggregate's verdict step, the one conversion of
+        # four job results into the required context. Each arm leaves every
+        # job key and the selector's whole publication path canonical.
+        ("O23 fast verdict step if: false",
+         set_step_key(fast_verdict_step, "if", False),
+         "verdict step must carry no `if`"),
+        ("O23b fast verdict lint result rebound to the literal success",
+         set_env_key(fast_verdict_step, "VERILATOR_LINT_RESULT", "success"),
+         "must bind `VERILATOR_LINT_RESULT`"),
+        ("O23c fast verdict case widened to accept failure",
+         m_fast_verdict_case_widened,
+         "verdict step script is not the canonical form"),
+        ("O23d fast verdict step continue-on-error",
+         set_step_key(fast_verdict_step, "continue-on-error", True),
+         "verdict step must carry no `continue-on-error`"),
+        ("O23e fast verdict step shell: bash -n",
+         set_step_key(fast_verdict_step, "shell", "bash -n {0}"),
+         "verdict step must carry no `shell`"),
+        # [R2] O24: the aggregate's `needs` universe. Membership in that list
+        # is what puts a fast job's result inside the verdict at all.
+        ("O24 fast aggregate drops bdd-conformance from its verdict",
+         m_fast_aggregate_forgets_bdd, "missing: bdd-conformance"),
+        ("O24b a new fast job lands outside the aggregate's needs",
+         m_fast_new_unaggregated_job, "missing: extra-check"),
+        # [R2] O25: a gate contributor that does not need the selector,
+        # exactly bdd-conformance's shape, held to run as written.
+        ("O25 bdd-conformance job if: false",
+         set_job_if(RTL_FAST, "bdd-conformance", False),
+         "job `bdd-conformance` must carry no `if`"),
+        ("O25b bdd-conformance continue-on-error",
+         set_job_key_at(RTL_FAST, "bdd-conformance",
+                        "continue-on-error", True),
+         "job `bdd-conformance` must carry no `continue-on-error`"),
+        ("O25c bdd-conformance defaults.run.shell bash -n",
+         set_job_key_at(RTL_FAST, "bdd-conformance", "defaults",
+                        {"run": {"shell": "bash -n {0}"}}),
+         "job `bdd-conformance` must carry no `defaults`"),
+        # [R2] O26: a `.result` chain read from a job outside `needs` is the
+        # same empty string O22 refuses for `.outputs.`, in the spelling the
+        # fast verdict itself uses four lines from its accept case.
+        ("O26 a .result read from a job outside needs",
+         m_fast_bdd_needs_expression(
+             "${{ needs.changes.result == 'success' }}"),
+         "must list `changes` in its `needs`"),
+        ("O26b the bracket spelling of the same .result read",
+         m_fast_bdd_needs_expression(
+             "${{ needs['changes']['result'] == 'success' }}"),
+         "must list `changes` in its `needs`"),
+        # [R2] O27: the public required name carried by a second job.
+        ("O27 verilator-lint renamed to the public name rtl-fast",
+         m_fast_lint_masquerades_as_aggregate,
+         "carried by exactly one job"),
+        # [R2] O28: a job-level env on the fast selector reaches the scope
+        # script without appearing in the pinned step.
+        ("O28 fast selector job-level env EVENT_NAME literal",
+         set_job_key_at(RTL_FAST, FAST_SELECTOR_JOB, "env",
+                        {"EVENT_NAME": "pull_request"}),
+         "must carry no `env`"),
         # #209 O9: the shard denominator restated instead of derived.
         ("O9 verilator matrix grows, the denominator is a literal",
          m_shard_denominator_stale, "shard denominator"),
@@ -2476,6 +2746,10 @@ def selftest(root):
         if s.get("id") == FAST_SCOPE_STEP_ID:
             s["run"] = "\n".join("   " + l if l.strip() else ""
                                   for l in s["run"].splitlines()) + "\n"
+    for s in steps(jobs(world[RTL_FAST])["rtl-fast"]):
+        if isinstance(s.get("run"), str):
+            s["run"] = "\n".join("   " + l if l.strip() else ""
+                                  for l in s["run"].splitlines()) + "\n"
     for s in steps(jobs(world[RTL_FULL])["yosys-portability"]):
         if VERIFY_FLAG in step_text(s):
             s["run"] = ("shopt   -s nullglob\n"
@@ -2492,7 +2766,8 @@ def selftest(root):
                         f"was refused: {check(world).findings}")
     else:
         print("  ok   canonical pins are whitespace-invariant (assert step, "
-              "decision step, fast scope step and verifier step)")
+              "decision step, fast scope step, fast verdict step and "
+              "verifier step)")
 
     # --require-default-branch arms: the decision for every event class. An
     # inverted or weakened comparison fails one of these, which is what makes

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -105,9 +105,15 @@ PR_TYPES = ("opened", "reopened", "synchronize", "ready_for_review",
 PUSH_BRANCH = "dev"
 #: The record every worker writes beside its evidence.
 RECORD = "TARGET_SHA"
-#: The gate job of the exhaustive workflow and the output it exports.
+#: The gate job of the exhaustive workflow and the outputs it exports. A job
+#: `outputs` map is a NAME -> EXPRESSION mapping exactly like a step's `env`,
+#: and these names are what the rest of this file derives its expressions and
+#: its consumer `if` conditions from, never a second literal.
 GATE_JOB = "full-ci-gate"
 GATE_OUTPUT = "target_sha"
+#: The published decision, and the scope answer behind it.
+RUN_FULL_OUTPUT = "run_full"
+RTL_OUTPUT = "rtl"
 #: How an aggregate invokes the verifier (the first token after the script).
 VERIFY_FLAG = "--require-target-sha"
 #: How the gate invokes the live default-branch assertion, and the events
@@ -278,7 +284,7 @@ SHELL_VAR_RE = re.compile(r"^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$")
 AGGREGATE_JOB_IF = (
     "${{ always() && "
     f"(needs.{GATE_JOB}.result != 'success' || "
-    f"needs.{GATE_JOB}.outputs.run_full != 'false') }}}}"
+    f"needs.{GATE_JOB}.outputs.{RUN_FULL_OUTPUT} != 'false') }}}}"
 )
 RUNNER_TEMP_PREFIX = "${{ runner.temp }}/"
 #: Public check names the merge bar reads (AGENTS.md section 7), per file.
@@ -287,6 +293,70 @@ PUBLIC_NAMES = {
     RTL_FAST: ("rtl-fast",),
     ELABORATE: ("elaborate",),
 }
+#: The fast workflow's selector job and the step that computes its answer.
+FAST_SELECTOR_JOB = "changes"
+FAST_SCOPE_STEP_ID = "scope"
+#: The fast workflow's aggregate `if`. It counts a skipped consumer as a pass
+#: deliberately (a docs-only change legitimately runs no RTL lint), which is
+#: exactly why that workflow's published answer has to be pinned by content
+#: too: rebind it and every consumer skips into that pass.
+FAST_AGGREGATE_JOB_IF = "${{ always() && !cancelled() }}"
+
+
+def step_output_ref(step_id, name):
+    """`${{ steps.<id>.outputs.<name> }}`, built rather than restated."""
+    return "${{ steps." + step_id + ".outputs." + name + " }}"
+
+
+def needs_output_ref(job_id, name):
+    """`needs.<job>.outputs.<name>`, built rather than restated."""
+    return "needs." + job_id + ".outputs." + name
+
+
+def consumer_job_if(job_id, name):
+    """The exact `if` a job gated on a selector's published decision carries."""
+    return "${{ " + needs_output_ref(job_id, name) + " == 'true' }}"
+
+
+#: THE PUBLICATION PATH, per workflow: the job that publishes the decision,
+#: its `outputs` map as NAME -> BINDING, and the output its consumers gate on.
+#:
+#: Three rounds of [R0] on PR #239 each found one more member of a perimeter
+#: nobody had enumerated: the gate's sibling steps, then those steps' env
+#: BINDINGS, then this map. Each round pinned the instance and left the
+#: perimeter an allow-list written from the last review, so the next unlisted
+#: thing was outside it again. A job's `outputs` is the same
+#: NAME -> EXPRESSION mapping a step's `env` is, and checking only that
+#: `target_sha` existed let `run_full: ${{ 'false' }}` -- valid job-output
+#: YAML, every pinned step key, env binding and script character intact --
+#: publish the no-op decision: both worker matrices skip, both aggregates
+#: skip under their documented no-op exception, and a skipped required
+#: context satisfies a GitHub ruleset. The same hole is open a second time in
+#: rtl-fast.yml, whose `changes` job gates the two RTL fast checks the same
+#: way. So the maps are pinned by content here and check_publication_path
+#: closes the path around them: every consumer of a selector carries a pinned
+#: `if`, and no `needs.<job>.outputs.<name>` expression anywhere may name an
+#: output no job publishes or a job it does not need.
+SELECTOR_JOB = {RTL_FULL: GATE_JOB, RTL_FAST: FAST_SELECTOR_JOB}
+SELECTOR_OUTPUTS = {
+    RTL_FULL: {
+        RUN_FULL_OUTPUT: step_output_ref(DECIDE_STEP_ID, RUN_FULL_OUTPUT),
+        RTL_OUTPUT: step_output_ref(DECIDE_STEP_ID, RTL_OUTPUT),
+        GATE_OUTPUT: step_output_ref(PIN_STEP_ID, GATE_OUTPUT),
+    },
+    RTL_FAST: {
+        RTL_OUTPUT: step_output_ref(FAST_SCOPE_STEP_ID, RTL_OUTPUT),
+    },
+}
+#: The output whose value decides whether the consumers run at all.
+SELECTOR_DECISION = {RTL_FULL: RUN_FULL_OUTPUT, RTL_FAST: RTL_OUTPUT}
+#: The `if` each workflow's own aggregate carries. WHICH job that is is
+#: derived, not listed again: the aggregate is the job whose display name is
+#: the public required check the merge bar reads (PUBLIC_NAMES above).
+AGGREGATE_IF = {RTL_FULL: AGGREGATE_JOB_IF, RTL_FAST: FAST_AGGREGATE_JOB_IF}
+#: One `needs.<job>.outputs.<name>` reference, wherever it sits.
+NEEDS_OUTPUT_RE = re.compile(
+    r"needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)")
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 CRON_RE = re.compile(r"^\s*(\d{1,2})\s+(\d{1,2})\s+\*\s+\*\s+\*\s*$")
@@ -546,9 +616,6 @@ def check_rtl_full(c, wf, policy):
     gate = jobs(wf).get(GATE_JOB)
     c.item(isinstance(gate, dict), path, f"job `{GATE_JOB}` must exist")
     if isinstance(gate, dict):
-        outputs = gate.get("outputs")
-        c.item(isinstance(outputs, dict) and GATE_OUTPUT in outputs, path,
-               f"job `{GATE_JOB}` must export the `{GATE_OUTPUT}` output")
         prints = any("GITHUB_EVENT_NAME" in step_text(s)
                      and "GITHUB_SHA" in step_text(s) for s in steps(gate))
         c.item(prints, path, f"job `{GATE_JOB}` must print the event name and "
@@ -589,12 +656,96 @@ def check_rtl_full(c, wf, policy):
             if vsteps:
                 check_sha_sources(c, path, jid, vsteps[0])
                 check_verify_step(c, path, wf, jid, job, vsteps[0])
-            check_job_keys(c, path, jid, job, allowed_if=AGGREGATE_JOB_IF,
-                           allow_needs=True)
 
     # A sharded worker states its shard count once, in the matrix.
     for jid, job in jobs(wf).items():
         check_shard_denominator(c, path, jid, job)
+
+    # The decision's publication path: the outputs map that carries it and
+    # every job that runs on it. check_job_keys for the aggregates lives
+    # there now, beside the same call for the workers.
+    check_publication_path(c, path, wf)
+
+
+def all_scalars(node):
+    """Every scalar in a parsed YAML subtree, as text. An expression can sit
+    in an `if`, a display `name`, a `run`, an `env` value or a `with` value,
+    so the walk is over the subtree rather than over a list of the places
+    somebody remembered to look in."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from all_scalars(k)
+            yield from all_scalars(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from all_scalars(v)
+    elif node is not None:
+        yield str(node)
+
+
+def needs_list(job):
+    """A job's `needs`, as a list whether it was written as one or not."""
+    n = job.get("needs") if isinstance(job, dict) else None
+    if isinstance(n, list):
+        return [str(x) for x in n]
+    return [] if n is None else [str(n)]
+
+
+def check_publication_path(c, path, wf):
+    """The whole path a selector's decision travels: the step that computes
+    it, the job `outputs` map that publishes it, and the jobs that run on it.
+
+    The perimeter here is CLOSED rather than listed. The selector's `outputs`
+    map is pinned by content, exactly as a pinned step's `env` is; every job
+    that needs the selector is then classified with no residue -- the
+    workflow's aggregate is the job carrying the public required check name,
+    every other such job is a consumer gated on the decision -- and each
+    class carries a pinned `if`. A job added tomorrow that depends on the
+    selector lands in the consumer class and reddens until it carries that
+    `if`, instead of arriving outside every contract the way both worker
+    matrices and both fast-lane consumers did (#209, [R0] rounds 1-3)."""
+    sel = SELECTOR_JOB[path]
+    want = SELECTOR_OUTPUTS[path]
+    decision = SELECTOR_DECISION[path]
+    all_jobs = jobs(wf)
+    selector = all_jobs.get(sel)
+    c.item(isinstance(selector, dict), path, f"job `{sel}` must exist: it "
+           "publishes the decision the rest of this workflow runs on")
+    outputs = selector.get("outputs") if isinstance(selector, dict) else None
+    pinned_bindings(c, path, f"job `{sel}` outputs",
+                    outputs if isinstance(outputs, dict) else {}, want,
+                    "a job output is what `needs.<job>.outputs.<name>` reads, "
+                    "so the decision step may write the right value and the "
+                    "job still export another one; every consumer then skips, "
+                    "and a skipped required context satisfies the ruleset")
+
+    public = set(PUBLIC_NAMES.get(path, ()))
+    for jid, job in all_jobs.items():
+        if jid == sel or sel not in needs_list(job):
+            continue
+        aggregate = display_name(jid, job) in public
+        check_job_keys(c, path, jid, job, allow_needs=True,
+                       allowed_if=(AGGREGATE_IF[path] if aggregate
+                                   else consumer_job_if(sel, decision)))
+
+    for jid, job in all_jobs.items():
+        refs = sorted({m.groups() for s in all_scalars(job)
+                       for m in NEEDS_OUTPUT_RE.finditer(s)})
+        for producer, name in refs:
+            pj = all_jobs.get(producer)
+            declared = pj.get("outputs") if isinstance(pj, dict) else None
+            declared = declared if isinstance(declared, dict) else {}
+            c.item(name in declared, path,
+                   f"job `{jid}` reads `{needs_output_ref(producer, name)}`, "
+                   f"which job `{producer}` must publish (publishes "
+                   f"{sorted(declared)}): an expression naming an output no "
+                   "job declares is the empty string, so every comparison "
+                   "against it is false and every job gated on it skips")
+            c.item(producer in needs_list(job), path,
+                   f"job `{jid}` reads `{needs_output_ref(producer, name)}` "
+                   f"and must list `{producer}` in its `needs` (found "
+                   f"{needs_list(job)}): outside `needs` the expression is "
+                   "the empty string")
 
 
 def check_job_keys(c, path, jid, job, allowed_if=None, allow_needs=False):
@@ -639,23 +790,35 @@ def pinned_step_keys(c, path, what, step, keys, env_keys, optional=()):
                                    else "")
            + (f"; missing: {', '.join(missing)}" if missing else ""))
     env = step.get("env") if isinstance(step.get("env"), dict) else {}
-    env_have = sorted(str(k) for k in env.keys())
-    env_extra = sorted(set(env_have) - set(env_keys))
-    env_missing = [k for k in env_keys if k not in env_have]
-    c.item(not env_extra and not env_missing, path, f"{what} env must be "
-           f"exactly {', '.join(env_keys) or 'empty'}"
-           + (f"; surplus: {', '.join(env_extra)} (a GH_HOST or GH_CONFIG_DIR"
-              " redirects gh away from this repository)" if env_extra else "")
-           + (f"; missing: {', '.join(env_missing)}" if env_missing else ""))
-    for name, want in env_keys.items():
-        if name not in env:
+    pinned_bindings(c, path, f"{what} env", env, env_keys,
+                    "the name is not the contract, the source expression "
+                    "behind it is, and a rebound value leaves every pinned "
+                    "name and key in place while changing what the script "
+                    "reads",
+                    surplus_note=" (a GH_HOST or GH_CONFIG_DIR redirects gh "
+                                 "away from this repository)")
+
+
+def pinned_bindings(c, path, what, mapping, want, reason, surplus_note=""):
+    """A NAME -> EXPRESSION mapping held by CONTENT: exactly these names, and
+    for each the exact source expression it is bound to. A step's `env` and a
+    job's `outputs` are the same object, and holding either by its key set
+    alone holds nothing: both escapes that reached [R0] on PR #239 kept every
+    pinned name in place and changed only what the name was bound to. So
+    there is one comparison, used by both."""
+    have = sorted(str(k) for k in mapping.keys())
+    extra = sorted(set(have) - set(want))
+    missing = [k for k in want if k not in have]
+    c.item(not extra and not missing, path, f"{what} must be exactly "
+           f"{', '.join(want) or 'empty'}"
+           + (f"; surplus: {', '.join(extra)}{surplus_note}" if extra else "")
+           + (f"; missing: {', '.join(missing)}" if missing else ""))
+    for name, expr in want.items():
+        if name not in mapping:
             continue
-        got = str(env.get(name)).strip()
-        c.item(got == want, path, f"{what} must bind `{name}` to `{want}` "
-               f"(found `{got}`): the name is not the contract, the source "
-               "expression behind it is, and a rebound value leaves every "
-               "pinned name and key in place while changing what the script "
-               "reads")
+        got = str(mapping.get(name)).strip()
+        c.item(got == expr, path, f"{what} must bind `{name}` to `{expr}` "
+               f"(found `{got}`): {reason}")
 
 
 def check_gate_steps(c, path, gate):
@@ -962,6 +1125,10 @@ def check_rtl_fast(c, wf):
     check_push_and_pr(c, RTL_FAST, wf, exact_types=True)
     check_cancel_in_progress(c, RTL_FAST, wf)
     check_public_names(c, RTL_FAST, wf)
+    # The same selector -> outputs -> consumer path as the exhaustive
+    # workflow, and the same false green if it is left unheld: this
+    # aggregate counts a skipped consumer as a pass.
+    check_publication_path(c, RTL_FAST, wf)
 
 
 def check_docs(c, wf):
@@ -1357,6 +1524,50 @@ def _mutations():
             "fixture drift: the decision step does not self-test the selector")
         s["run"] = s["run"].replace(SELECTOR_SELFTEST, "true", 1)
 
+    # #209 O17-O20: the publication path. A selector's `outputs` map is a
+    # NAME -> EXPRESSION mapping like a step's `env`, and every arm below
+    # leaves every pinned step key, env binding and script character intact.
+    def sel_outputs(w, path=RTL_FULL):
+        return jobs(w[path])[SELECTOR_JOB[path]]["outputs"]
+
+    def m_output_rebound(path, name, expr):
+        def f(w):
+            outs = sel_outputs(w, path)
+            assert name in outs, f"fixture drift: no `{name}` output"
+            outs[name] = expr
+        return f
+
+    def m_output_dropped(path, name):
+        def f(w):
+            outs = sel_outputs(w, path)
+            assert name in outs, f"fixture drift: no `{name}` output"
+            del outs[name]
+        return f
+
+    def m_output_surplus(w):
+        sel_outputs(w)["shadow"] = step_output_ref(DECIDE_STEP_ID,
+                                                   RUN_FULL_OUTPUT)
+
+    def m_outputs_map_dropped(w):
+        del jobs(w[RTL_FULL])[SELECTOR_JOB[RTL_FULL]]["outputs"]
+
+    def set_job_if(path, jid, value):
+        def f(w):
+            jobs(w[path])[jid]["if"] = value
+        return f
+
+    def m_worker_needs_dropped(w):
+        del jobs(w[RTL_FULL])["verilator-shards"]["needs"]
+
+    def m_new_consumer_job(w):
+        # The perimeter closed under addition: a job that depends on the
+        # selector and carries no gate on its decision runs on every event.
+        jobs(w[RTL_FULL])["extra-worker"] = {
+            "needs": GATE_JOB,
+            "runs-on": "ubuntu-latest",
+            "steps": [{"run": "true"}],
+        }
+
     def restate_shards(w, jid, value):
         """Turn a derived denominator back into a literal, everywhere the job
         states it: the display name, every script, every step env."""
@@ -1496,7 +1707,7 @@ def _mutations():
         ("rtl checkout ref via expression", m_checkout_ref_deep,
          "must not override `ref`"),
         ("rtl gate drops target_sha output", m_drop_gate_output,
-         f"`{GATE_OUTPUT}` output"),
+         f"missing: {GATE_OUTPUT}"),
         ("rtl gate prints nothing", m_gate_silent, "print the event name"),
         ("rtl Verilator worker records nothing", m_worker_no_record,
          f"write GITHUB_SHA into {RECORD}"),
@@ -1678,6 +1889,67 @@ def _mutations():
          "must name no `GH_*`"),
         ("O12 workflow-level env GH_HOST", m_workflow_env_gh_host,
          "must name no `GH_*`"),
+        # #209 O17: the gate's published outputs map, held by content. Each
+        # arm keeps every pinned step key, env binding and script character.
+        ("O17 gate exports run_full as the literal 'false'",
+         m_output_rebound(RTL_FULL, RUN_FULL_OUTPUT, "${{ 'false' }}"),
+         f"must bind `{RUN_FULL_OUTPUT}`"),
+        ("O17b gate stops exporting run_full at all",
+         m_output_dropped(RTL_FULL, RUN_FULL_OUTPUT),
+         f"missing: {RUN_FULL_OUTPUT}"),
+        ("O17c gate exports run_full from the scope answer instead",
+         m_output_rebound(RTL_FULL, RUN_FULL_OUTPUT,
+                          step_output_ref(DECIDE_STEP_ID, RTL_OUTPUT)),
+         f"must bind `{RUN_FULL_OUTPUT}`"),
+        ("O17d gate exports rtl as the literal 'false'",
+         m_output_rebound(RTL_FULL, RTL_OUTPUT, "${{ 'false' }}"),
+         f"must bind `{RTL_OUTPUT}`"),
+        ("O17e gate stops exporting rtl", m_output_dropped(RTL_FULL,
+                                                           RTL_OUTPUT),
+         f"missing: {RTL_OUTPUT}"),
+        ("O17f gate exports target_sha from the run instead of the pin step",
+         m_output_rebound(RTL_FULL, GATE_OUTPUT, "${{ github.sha }}"),
+         f"must bind `{GATE_OUTPUT}`"),
+        ("O17g gate exports no outputs map at all", m_outputs_map_dropped,
+         f"missing: {RUN_FULL_OUTPUT}, {RTL_OUTPUT}, {GATE_OUTPUT}"),
+        ("O17h gate exports a surplus output", m_output_surplus,
+         "surplus: shadow"),
+        # #209 O18: the consumers of that decision.
+        ("O18 a worker gates on an output nobody publishes",
+         set_job_if(RTL_FULL, "verilator-shards",
+                    "${{ needs.full-ci-gate.outputs.run_ful == 'true' }}"),
+         "must publish"),
+        ("O18b a worker gates on if: false",
+         set_job_if(RTL_FULL, "yosys-shards", False), "`if` must be exactly"),
+        ("O18c a worker compares the decision with a value it never takes",
+         set_job_if(RTL_FULL, "verilator-shards",
+                    "${{ needs.full-ci-gate.outputs.run_full == 'nope' }}"),
+         "`if` must be exactly"),
+        ("O18d a worker turns its own failure into a pass",
+         set_job_key("verilator-shards", "continue-on-error", True),
+         "must carry no `continue-on-error`"),
+        ("O18e a worker reads the decision without needing the gate",
+         m_worker_needs_dropped, f"must list `{GATE_JOB}` in its `needs`"),
+        ("O18f a worker parses every script instead of running it",
+         set_job_key("yosys-shards", "defaults",
+                     {"run": {"shell": "bash -n {0}"}}),
+         "must carry no `defaults`"),
+        ("O20 a new job depends on the gate and gates on nothing",
+         m_new_consumer_job, "documented `if`"),
+        # #209 O19: the same publication path in the fast workflow, whose
+        # aggregate counts a skipped consumer as a pass.
+        ("O19 fast selector exports rtl as the literal 'false'",
+         m_output_rebound(RTL_FAST, RTL_OUTPUT, "${{ 'false' }}"),
+         f"must bind `{RTL_OUTPUT}`"),
+        ("O19b fast selector stops exporting rtl",
+         m_output_dropped(RTL_FAST, RTL_OUTPUT), f"missing: {RTL_OUTPUT}"),
+        ("O19c a fast consumer gates on an output nobody publishes",
+         set_job_if(RTL_FAST, "verilator-lint",
+                    "${{ needs.changes.outputs.rt == 'true' }}"),
+         "must publish"),
+        ("O19d a fast consumer gates on if: false",
+         set_job_if(RTL_FAST, "yosys-elaboration", False),
+         "`if` must be exactly"),
         # #209 O9: the shard denominator restated instead of derived.
         ("O9 verilator matrix grows, the denominator is a literal",
          m_shard_denominator_stale, "shard denominator"),

--- a/scripts/ci_events.py
+++ b/scripts/ci_events.py
@@ -158,10 +158,27 @@ EXPECT_RE = re.compile(r"--expect\s+(\S+)")
 #: canonical and the assertion dead. So the key set is pinned, the env key
 #: set is pinned, and the verifier step's one permitted `if` is pinned.
 ASSERT_STEP_KEYS = ("name", "env", "run")
-ASSERT_STEP_ENV = ("GH_TOKEN",)
 VERIFY_STEP_KEYS = ("name", "if", "env", "run")
 VERIFY_STEP_IF = "${{ always() }}"
-VERIFY_STEP_ENV = ("GATE_SHA",)
+#: Every pinned step's `env`, as the BINDING each name must carry, never the
+#: name alone ([R0] on PR #239). Holding the names while leaving the
+#: expressions free held nothing where it mattered: `PR_DRAFT: "true"` is
+#: valid workflow YAML, keeps all three pinned names and all four pinned
+#: keys, and makes a ready RTL pull request publish `run_full=false`. Both
+#: worker matrices then skip, both aggregates skip under their documented
+#: no-op exception, and a skipped required context satisfies the ruleset, so
+#: the run is a false green rather than a refusal. `PR_BASE_SHA:
+#: ${{ github.sha }}` (a diff of a commit against itself, so `rtl=false`) and
+#: `EVENT_NAME: pull_request` (a push, schedule or dispatch run taking the
+#: pull-request branch) reach the same place by the same route. So the
+#: mapping is the contract and pinned_step_keys compares the value: there is
+#: no longer any way to pin an env name in this file without saying what it
+#: must be bound to. GATE_SHA is derived from the job and the output it
+#: reads, never restated.
+ASSERT_STEP_ENV = {"GH_TOKEN": "${{ github.token }}"}
+VERIFY_STEP_ENV = {
+    "GATE_SHA": f"${{{{ needs.{GATE_JOB}.outputs.{GATE_OUTPUT} }}}}",
+}
 #: Job keys that decide whether a job runs at all, or runs as written, each
 #: with the reason a refusal names. Before #209 this gate held what the gate
 #: job DOES and nothing about the conditions under which it does it, so
@@ -191,7 +208,52 @@ PIN_STEP_ID = "target"
 PIN_STEP_KEYS = ("name", "id", "run")
 DECIDE_STEP_ID = "gate"
 DECIDE_STEP_KEYS = ("name", "id", "env", "run")
-DECIDE_STEP_ENV = ("EVENT_NAME", "PR_DRAFT", "PR_BASE_SHA")
+DECIDE_STEP_ENV = {
+    "EVENT_NAME": "${{ github.event_name }}",
+    "PR_DRAFT": "${{ github.event.pull_request.draft }}",
+    "PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+}
+#: The decision step's script, pinned verbatim after whitespace
+#: normalization, exactly as the default-branch step's is. The bindings above
+#: hold what this step READS; this holds what it DOES with what it read.
+#: `run_full=true` rewritten to `run_full=false`, or the selector's
+#: `--selftest` replaced by `true`, changes no pinned name and no pinned key,
+#: and each publishes the no-op decision (or drops the selector's own proof)
+#: with every other contract item green -- both measured on a copy of the
+#: tree while answering [R0] on PR #239. The lines are the NORMALIZED form
+#: (continuations joined, runs of blanks collapsed), so a re-indentation or a
+#: differently wrapped continuation is the same script and still passes.
+CANONICAL_DECIDE_SCRIPT = (
+    "set -euo pipefail",
+    "python3 scripts/ci_scope.py --selftest",
+    'if [ "$EVENT_NAME" != pull_request ]; then',
+    'echo "rtl=true" >> "$GITHUB_OUTPUT"',
+    'echo "run_full=true" >> "$GITHUB_OUTPUT"',
+    'echo "Non-PR event: exhaustive validation required."',
+    "exit 0",
+    "fi",
+    'if [ -n "$PR_BASE_SHA" ] && git cat-file -e "$PR_BASE_SHA^{commit}" '
+    "2>/dev/null; then",
+    'git diff --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > '
+    '"$RUNNER_TEMP/changed-files"',
+    "else",
+    'git ls-files > "$RUNNER_TEMP/changed-files"',
+    "fi",
+    'echo "Changed files:"',
+    "sed 's/^/ /' \"$RUNNER_TEMP/changed-files\"",
+    'rtl="$(python3 scripts/ci_scope.py < "$RUNNER_TEMP/changed-files")"',
+    "run_full=false",
+    'if [ "$PR_DRAFT" = false ] && [ "$rtl" = true ]; then',
+    "run_full=true",
+    "fi",
+    'echo "rtl=$rtl" >> "$GITHUB_OUTPUT"',
+    'echo "run_full=$run_full" >> "$GITHUB_OUTPUT"',
+    'echo "draft=$PR_DRAFT rtl=$rtl run_full=$run_full"',
+)
+#: The selector's own proof, and the line that consumes the selector's
+#: answer: the proof runs once, and before the answer is read.
+SELECTOR_SELFTEST = "python3 scripts/ci_scope.py --selftest"
+SELECTOR_READ = "python3 scripts/ci_scope.py <"
 #: `gh` reads its host, its token and its config directory from the process
 #: environment. The assert step's own env is pinned to exactly GH_TOKEN, but
 #: an `env` on the JOB or on the WORKFLOW reaches that `gh` without appearing
@@ -359,10 +421,10 @@ def _is_decide_step(step):
 GATE_STEPS = (
     ("the gate checkout step", _is_checkout_step,
      f"`uses: {CHECKOUT_ACTION}` with `fetch-depth: {CHECKOUT_FETCH_DEPTH}`",
-     CHECKOUT_STEP_KEYS, (), CHECKOUT_STEP_OPTIONAL),
+     CHECKOUT_STEP_KEYS, {}, CHECKOUT_STEP_OPTIONAL),
     ("the pin step", _is_pin_step,
      f"the step with `id: {PIN_STEP_ID}` that prints the event and exports "
-     f"`{GATE_OUTPUT}`", PIN_STEP_KEYS, (), ()),
+     f"`{GATE_OUTPUT}`", PIN_STEP_KEYS, {}, ()),
     ("the default-branch step", _is_assert_step,
      f"the step that runs `ci_events.py {DEFAULT_BRANCH_FLAG}`",
      ASSERT_STEP_KEYS, ASSERT_STEP_ENV, ()),
@@ -492,6 +554,7 @@ def check_rtl_full(c, wf, policy):
         c.item(prints, path, f"job `{GATE_JOB}` must print the event name and "
                "GITHUB_SHA in one step")
         check_default_branch_step(c, path, gate)
+        check_decide_step(c, path, gate)
         check_gate_steps(c, path, gate)
         check_job_keys(c, path, GATE_JOB, gate)
         check_no_gh_env(c, path, f"job `{GATE_JOB}`", gate.get("env"))
@@ -558,7 +621,11 @@ def check_job_keys(c, path, jid, job, allowed_if=None, allow_needs=False):
 
 def pinned_step_keys(c, path, what, step, keys, env_keys, optional=()):
     """A pinned step carries exactly `keys` (plus anything in `optional`),
-    its env exactly `env_keys`; every surplus or missing key is named."""
+    and its env is exactly `env_keys`, a NAME -> EXPRESSION mapping: the
+    names it carries and, for each, the source it is bound to. Every surplus
+    key, missing key and rebound value is named. Holding the names alone let
+    `PR_DRAFT: "true"` pass every item in this file ([R0] on PR #239), so the
+    binding is checked here, once, for every pinned step there is."""
     have = [k for k in step.keys() if isinstance(k, str)]
     extra = sorted(set(have) - set(keys) - set(optional))
     missing = [k for k in keys if k not in have]
@@ -580,6 +647,15 @@ def pinned_step_keys(c, path, what, step, keys, env_keys, optional=()):
            + (f"; surplus: {', '.join(env_extra)} (a GH_HOST or GH_CONFIG_DIR"
               " redirects gh away from this repository)" if env_extra else "")
            + (f"; missing: {', '.join(env_missing)}" if env_missing else ""))
+    for name, want in env_keys.items():
+        if name not in env:
+            continue
+        got = str(env.get(name)).strip()
+        c.item(got == want, path, f"{what} must bind `{name}` to `{want}` "
+               f"(found `{got}`): the name is not the contract, the source "
+               "expression behind it is, and a rebound value leaves every "
+               "pinned name and key in place while changing what the script "
+               "reads")
 
 
 def check_gate_steps(c, path, gate):
@@ -617,6 +693,48 @@ def check_gate_steps(c, path, gate):
            "diffs this head against the pull request's base commit, which a "
            "shallow clone does not carry, so a shallow gate silently falls "
            "back to the whole file list")
+
+
+def script_difference(got, want):
+    """The first line where a script differs from its canonical form, named
+    rather than dumped: a whole-script listing of a twenty-line script buries
+    the one line that moved."""
+    for i in range(max(len(got), len(want))):
+        g = got[i] if i < len(got) else None
+        w = want[i] if i < len(want) else None
+        if g != w:
+            return (f"line {i + 1} must be {w!r} (found {g!r}); "
+                    f"{len(want)} line(s) expected, {len(got)} found")
+    return f"{len(want)} line(s) expected, {len(got)} found"
+
+
+def check_decide_step(c, path, gate):
+    """The decision step publishes `run_full`, the one value that decides
+    whether the exhaustive gates run at all. Its keys and its env bindings
+    are held in check_gate_steps; this holds its script, verbatim after
+    whitespace normalization, the way the default-branch step's is. Binding
+    the inputs without holding the body would leave `run_full=true` ->
+    `run_full=false` a legal edit ([R0] on PR #239)."""
+    found = [s for s in steps(gate) if _is_decide_step(s)]
+    c.item(len(found) == 1, path, f"job `{GATE_JOB}` must carry exactly one "
+           f"step with `id: {DECIDE_STEP_ID}` (found {len(found)})")
+    if len(found) != 1:
+        return
+    run = found[0].get("run") if isinstance(found[0].get("run"), str) else ""
+    lines = normalize_script(run)
+    proofs = [i for i, l in enumerate(lines) if l == SELECTOR_SELFTEST]
+    reads = [i for i, l in enumerate(lines) if SELECTOR_READ in l]
+    c.item(len(proofs) == 1 and bool(reads) and proofs[0] < min(reads), path,
+           f"the decision step must run `{SELECTOR_SELFTEST}` exactly once "
+           "and before it reads the selector's answer (self-test at "
+           f"{proofs}, reads at {reads}): a selector trusted without its own "
+           "proof decides whether this run validates anything")
+    c.item(tuple(lines) == CANONICAL_DECIDE_SCRIPT, path,
+           "the decision step script is not the canonical form: "
+           + script_difference(lines, CANONICAL_DECIDE_SCRIPT)
+           + "; this script publishes `run_full`, so a line changed here "
+           "selects the no-op path with every pinned name and key still in "
+           "place")
 
 
 def check_no_gh_env(c, path, where, env):
@@ -774,10 +892,8 @@ def check_sha_sources(c, path, jid, step):
     for label, want in REQUIRED_SHA_ARGS.items():
         c.item(want in script, path, f"job `{jid}` must pass {want} "
                f"(the {label} source in its binding form)")
-    env = step.get("env") if isinstance(step.get("env"), dict) else {}
-    gate_ref = f"${{{{ needs.{GATE_JOB}.outputs.{GATE_OUTPUT} }}}}"
-    c.item(str(env.get("GATE_SHA", "")).strip() == gate_ref, path,
-           f"job `{jid}` must bind GATE_SHA to {gate_ref} in the step env")
+    # GATE_SHA's own binding is held by VERIFY_STEP_ENV through
+    # pinned_step_keys, with every other pinned step's env.
 
 
 def normalize_script(run):
@@ -804,12 +920,10 @@ def check_default_branch_step(c, path, gate):
         return
     step = found[0]
     text = step_text(step)
-    # Its keys and its env are pinned in check_gate_steps, beside its
-    # siblings': the same key on any step of this job has the same effect.
-    env = step.get("env") if isinstance(step.get("env"), dict) else {}
-    token = str(env.get("GH_TOKEN", "")).strip()
-    c.item(token == "${{ github.token }}", path, "the default-branch step "
-           f"must carry GH_TOKEN: ${{{{ github.token }}}} (found {token!r})")
+    # Its keys, its env names and the expression each name is bound to are
+    # pinned in check_gate_steps beside its siblings': the same key on any
+    # step of this job has the same effect, and ASSERT_STEP_ENV is the one
+    # place that says GH_TOKEN must be `${{ github.token }}`.
     run = step.get("run") if isinstance(step.get("run"), str) else ""
     lines = normalize_script(run)
     code = [(i, l) for i, l in enumerate(lines) if not l.startswith("#")]
@@ -1227,6 +1341,22 @@ def _mutations():
     def m_decide_env_missing(w):
         del decide_step(w)["env"]["PR_BASE_SHA"]
 
+    def m_decide_script_no_op(w):
+        # O16: the guarded `run_full=true` becomes `run_full=false`. Every
+        # pinned key, every pinned name and every binding survives.
+        s = decide_step(w)
+        assert re.search(r"^\s*run_full=true$", s["run"], re.M), (
+            "fixture drift: no bare `run_full=true` in the decision step")
+        s["run"] = re.sub(r"^(\s*)run_full=true$", r"\1run_full=false",
+                          s["run"], count=1, flags=re.M)
+
+    def m_decide_script_unproven_selector(w):
+        # O16b: the selector decides the run without its own self-test.
+        s = decide_step(w)
+        assert SELECTOR_SELFTEST in s["run"], (
+            "fixture drift: the decision step does not self-test the selector")
+        s["run"] = s["run"].replace(SELECTOR_SELFTEST, "true", 1)
+
     def restate_shards(w, jid, value):
         """Turn a derived denominator back into a literal, everywhere the job
         states it: the display name, every script, every step env."""
@@ -1522,6 +1652,28 @@ def _mutations():
          "surplus: working-directory"),
         ("decision step loses PR_BASE_SHA", m_decide_env_missing,
          "missing: PR_BASE_SHA"),
+        # #209 O15/O16: the decision step's env bound to another source, and
+        # its script rewritten, each leaving every pinned name and key alone.
+        ("O15 decision step PR_DRAFT forced true",
+         set_env_key(decide_step, "PR_DRAFT", "true"),
+         "must bind `PR_DRAFT`"),
+        ("O15b decision step PR_BASE_SHA rebound to this run's own SHA",
+         set_env_key(decide_step, "PR_BASE_SHA", "${{ github.sha }}"),
+         "must bind `PR_BASE_SHA`"),
+        ("O15c decision step EVENT_NAME hard-coded to pull_request",
+         set_env_key(decide_step, "EVENT_NAME", "pull_request"),
+         "must bind `EVENT_NAME`"),
+        ("O15d assert step GH_TOKEN rebound to another token",
+         set_env_key(db_step, "GH_TOKEN", "${{ secrets.OTHER_TOKEN }}"),
+         "must bind `GH_TOKEN`"),
+        ("O15e verifier step GATE_SHA rebound to its own run",
+         set_env_key(va, "GATE_SHA", "${{ github.sha }}"),
+         "must bind `GATE_SHA`"),
+        ("O16 decision script publishes the no-op decision always",
+         m_decide_script_no_op, "decision step script is not the canonical"),
+        ("O16b decision script drops the selector's self-test",
+         m_decide_script_unproven_selector,
+         "before it reads the selector's answer"),
         ("O11 full-ci-gate job env GH_HOST", m_gate_env_gh_host,
          "must name no `GH_*`"),
         ("O12 workflow-level env GH_HOST", m_workflow_env_gh_host,
@@ -1722,6 +1874,10 @@ def selftest(root):
                         "    --require-default-branch \\\n"
                         '    --event "$GITHUB_EVENT_NAME" \\\n'
                         '    --observed "$observed"\n')
+    for s in steps(jobs(world[RTL_FULL])[GATE_JOB]):
+        if s.get("id") == DECIDE_STEP_ID:
+            s["run"] = "\n".join("   " + l if l.strip() else ""
+                                  for l in s["run"].splitlines()) + "\n"
     for s in steps(jobs(world[RTL_FULL])["yosys-portability"]):
         if VERIFY_FLAG in step_text(s):
             s["run"] = ("shopt   -s nullglob\n"
@@ -1737,8 +1893,8 @@ def selftest(root):
         problems.append("whitespace-only reformatting of the canonical scripts "
                         f"was refused: {check(world).findings}")
     else:
-        print("  ok   canonical pins are whitespace-invariant (assert step "
-              "and verifier step)")
+        print("  ok   canonical pins are whitespace-invariant (assert step, "
+              "decision step and verifier step)")
 
     # --require-default-branch arms: the decision for every event class. An
     # inverted or weakened comparison fails one of these, which is what makes


### PR DESCRIPTION
[A2]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, gate tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- The class, then what changed and why.
- **[Authoritative references](#authoritative-references)** -- Issue acceptance rows, the pages and the GitHub semantics relied on.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands, and the planted-mutation table with the exact refusals.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from CONTRIBUTING.md.

## Status

GREEN at `70421f5c543ce9e027159f3ce9c6f3a626e98747`. **Every figure on this
page was measured at that SHA.** The branch was **rebased onto the live
`dev` tip `a8b27a5f`** (the PR #240 merge) before this round's commit, so
merge-base equals `dev` and the candidate merge result is this head itself.
The `before` column is the head [R2] reviewed, `ede6fa64`.

`209-ci-events-gate` -> `dev`, 6 commits ahead of `a8b27a5f`, 0 behind.

| gate | at `ede6fa64` ([R2]'s head, base `cb444a09`) | at `70421f5c` (this head, base `a8b27a5f`) |
|---|---|---|
| `ci_events.py --check` | OK, 159 contract items | **OK, 171 contract items** |
| `ci_events.py --selftest` | PASS, 159 items / 172 arms | **PASS, 171 items / 186 arms** |
| `docs_check.py` | 0 findings / 213 md | 0 findings / 213 md |
| `check_doc_paths.py` | OK, 1136 cited paths | OK, **1142** cited paths (dev moved) |
| `gen_toc.py --check` | OK, 152 pages | OK, 152 pages |
| `gen_toc.py --verify-anchors` | 91 links | 91 links |
| `ci_scope.py --selftest` | PASS | PASS |
| `git diff --check` | clean | clean |

### The two mandatory local gates, and the carry-over argument, stated

`scripts/run_all_suites.sh` and `syn/yosys/run.sh` were last run in full on
this branch at `2e058497` (52/52 suites, 2,118,602 checks, 0 fail; 46/46
tops, 0 fail; recorded per shard in this page's previous revision and in the
round 3 answer). They were **not** re-run at this head. The argument is not
"the diff since then is small"; `dev` moved RTL-adjacent files
(`syn/ooc/*`, `syn/yosys/run.sh`) under this branch through the rebase. The
argument is tree identity against `dev`:

- `git diff --name-only a8b27a5f..70421f5c` is exactly
  `.github/workflows/rtl.yml`, `.github/workflows/rtl-fast.yml`,
  `scripts/ci_events.py`, `docs/testing/CI_WORKFLOWS.md`. None of these
  four is an input to either mandatory gate: `run_all_suites.sh` reads
  `tb/verilator`, `run.sh` reads `syn/yosys` and the HDL tree, and neither
  invokes `ci_events.py`.
- Every file either gate reads is therefore byte-identical at this head to
  `dev@a8b27a5f`, whose own push-triggered hosted runs all concluded
  success, the exhaustive `rtl-full` run 32813774533 included (all four
  Verilator shards, `verilator-suites`, all four Yosys shards,
  `yosys-portability`).

### Hosted contexts at this head

All four workflows ran at `70421f5c` on this PR's `synchronize` event:
`rtl-full` run 32829043519, `rtl-fast` 32829043538, `docs` 32829043469,
`elaborate` 32829043544. At post time every context that had concluded
concluded **success**, none skipped: `full-ci-gate`, `changes`,
`verilator-lint`, `bdd-conformance`, `yosys-elaboration`, `rtl-fast`,
`elaborate`, `docs-check`, `docs-check-no-git`, `wire-accountability`,
`Verilator shard 2/4`, `Yosys shard 2/4`, `Yosys shard 3/4`. Still in
progress: the five remaining exhaustive worker shards, whose aggregates
`verilator-suites` and `yosys-portability` conclude with run 32829043519;
their RTL inputs are byte-identical to `dev@a8b27a5f`, whose `rtl-full` run
32813774533 concluded success (the carry-over above).

The `rtl-fast` verdict job's log at this head prints all four results
through the renamed bindings:

```
changes                  success
verilator-lint           success
bdd-conformance          success
yosys-elaboration        success
```

which is the runtime proof that the derived `<JOB>_RESULT` map and the
canonical verdict script resolve on GitHub, not only in the checker.

## Linked Issue / roles

Closes #209
Relates to #204 (the record whose Known-limitations sentence this corrects), #181, #174

Executor: `[A1]` (rounds 1 to 4), `[A2]` (round 5, this head)
Internal cleared-context reviewer: `[R0]` NEGATIVE at `f2d4c3fa`, `52fa6add`
(twice) and `2e058497`; `[R2]` NEGATIVE at `ede6fa64`. Round 4 is answered by
reference ([R2] re-verified both round-4 findings fixed at `ede6fa64`); round
5 is answered at `70421f5c`, re-review pending.
External reviewer: pending

## Description

### The class, across the five rounds

One shape defect, found one hop further out each round: a NAME -> EXPRESSION
or run/no-run lever held by SHAPE (the thing exists) instead of by CONTENT
(what it is bound to, and whether it can be skipped), on a perimeter that was
an allow-list written from the last review.

| round | what was pinned | what was still outside the perimeter |
|---|---|---|
| 1 | the assert step's script and keys | the gate's sibling steps, the job's run conditions |
| 2 | every pinned step's key set and env NAMES | those names' BINDINGS, and the decision script |
| 3 | the decision step's env bindings and script | the job `outputs` map that PUBLISHES the decision, and every job consuming it |
| 4 | both publication paths' outputs maps and consumers | the fast SELECTOR itself (`changes` job/step/script), and bracket-spelled `needs` references |
| 5 | the fast selector, the dotted+bracket `.outputs.` audit | the fast VERDICT step, the aggregate contributor outside every class, `.result` chains, duplicate public names |

### Round 4 (commit `e016c64b`, reviewed by [R2] as `ede6fa64`)

`check_fast_selector` holds the `changes` job the way `full-ci-gate` is held
(job keys, two-step sequence, full-history checkout, scope step keys and
three env bindings, canonical scope script with its `ci_scope.py --selftest`
before the read), and the dotted-only `NEEDS_OUTPUT_RE` was replaced by an
access-chain parser that resolves dotted, bracket and mixed static spellings
and refuses dynamic brackets. Arms O21a-i and O22a-d. [R2] independently
re-verified both round-4 findings fixed at that head; the fix had shipped
without a record, which is round 5's Docs MAJOR, closed by this page and the
[A2] thread comment.

### Round 5 (this commit): the verdict half of the fast lane

[R2] measured that the fast aggregate's verdict step was the one
decision-carrying step left outside the perimeter, and that the perimeter's
classification was one-directional. Four MAJORs, one MINOR, one SUGGESTION,
each fixed here:

1. **The verdict step is held** (`check_fast_aggregate`). The aggregate runs
   under `always() && !cancelled()`, so once its job keys are canonical its
   single step is the entire conversion of four job results into the
   required `rtl-fast` context. Now: exactly one step; keys exactly `name`,
   `env`, `run` (so no `if`, `shell` or `continue-on-error`); env derived
   from the aggregate's `needs`, one `<JOB>_RESULT` name per needed job
   bound to `${{ needs.<job>.result }}`; script equal to the canonical form
   derived from the same list, whose `case` accepts exactly
   `success|skipped`. To make the env fully derivable, `rtl-fast.yml`'s
   three abbreviated names were renamed (`LINT_RESULT` ->
   `VERILATOR_LINT_RESULT`, `BDD_RESULT` -> `BDD_CONFORMANCE_RESULT`,
   `YOSYS_RESULT` -> `YOSYS_ELABORATION_RESULT`); the name rule is the job
   id uppercased with `-` -> `_` plus `_RESULT`, computed, never a second
   list.
2. **Every job the aggregate needs is classified** (`check_publication_path`).
   The old loop classified only jobs that need the selector, so
   `bdd-conformance` (no `needs`) was in no class. Now each member of an
   aggregate's `needs` must be the selector, a consumer, or itself held
   (no `needs`, `if`, `continue-on-error` or `defaults`). Additionally the
   fast aggregate's `needs` must name **every other job of the workflow**,
   which closes the other route: an entry dropped from `needs` (with its
   binding and pair dropped consistently) or a new fast job left outside
   the aggregate both redden.
3. **The reference audit covers every static `needs` chain**, `.result`
   included, not only `.outputs.`: any job a static chain names must be in
   the reader's `needs`. Both workflows' legitimate `.result` readers (the
   three aggregates, whose producers are all in their `needs`) satisfy this,
   so pristine stays green; the dynamic-bracket refusal is kept.
4. **Docs**: this page, the body you are reading and the [A2] comment are
   the public record at the exact head; `docs/testing/CI_WORKFLOWS.md` items
   10 and the fast-lane paragraphs now state the two-directional closure,
   the `.result` audit and the verdict-step pin.
5. **MINOR**: each public check name must be carried by exactly one job
   (`check_public_names` now counts carriers), so a second job renamed to
   `rtl-fast` cannot make the ruleset's binding ambiguous.
6. **SUGGESTION, implemented**: the fast selector job must carry no
   job-level `env` at all; a job-level value reaches the scope script
   without appearing in the pinned step. This is stricter than `rtl.yml`'s
   gate-job `GH_*` screen because the selector's step env is its whole
   input contract and the job carries no other env today.

Item count 159 -> 171, arms 172 -> 186 (14 new: O23 a/b/c/d/e, O24 a/b,
O25 a/b/c, O26 a/b, O27, O28). The vacuity guard covers all of them: a
checker stubbed to find nothing fails all 156 in-memory arms.

## Authoritative references

- Issue #209 acceptance rows 1 to 4 ([R2] verified all four satisfied at `ede6fa64`; unchanged here).
- The [R2] review comment on this PR (2026-08-25), findings 1 to 6, each with its mutant and required change.
- `docs/testing/CI_WORKFLOWS.md`, "Nightly and manual dispatch" items 1 to 10 and the fast-lane paragraphs.
- `CONTRIBUTING.md` sections 2 and 3, lines 209-222 for the two mandatory local gates; `AGENTS.md` sections 6 and 7.
- GitHub Actions semantics relied on: a missing needs-context member is the empty string; step-level `env` shadows job-level `env`; a skipped required context satisfies a ruleset; `always() && !cancelled()` runs the aggregate whatever its dependencies did, which is why its verdict step is the whole conversion.

## How to get into the same state

```sh
git clone git@github.com:kebag-logic/milan-fpga.git
cd milan-fpga
git checkout 209-ci-events-gate     # 70421f5c543ce9e027159f3ce9c6f3a626e98747
python3 -m pip install --quiet pyyaml
git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
```

Nothing in the diff reads a submodule; the three above are what the two
mandatory local gates read.

## How to validate

```sh
python3 scripts/ci_events.py --check       # OK, 171 contract item(s)
python3 scripts/ci_events.py --selftest    # PASS (171 contract items, 186 arms)
python3 scripts/docs_check.py              # 0 finding(s) across 213 md files
python3 scripts/check_doc_paths.py         # OK, 1142 cited paths
python3 scripts/gen_toc.py --check         # OK, 152 page(s)
python3 scripts/gen_toc.py --verify-anchors
python3 scripts/ci_scope.py --selftest
git diff --check
```

Expected result / pass criteria: every command exits 0, `--check` reports 171
contract items and `--selftest` reports 186 arms with no FAIL line.

**Every [R2] mutant, replanted on disk at this head.** Each was applied to a
disposable five-file copy of this exact head and the real
`scripts/ci_events.py --check --root <copy>` run over it (not the selftest
arms grading themselves). At `ede6fa64` the first ten each returned
`checked=159 findings=0`; at `70421f5c` every one exits 1:

| # | [R2] vector, replanted | findings | the refusal names |
|---|---|---|---|
| M1a | verdict step `if: false` | 2 | ``job `rtl-fast` verdict step must carry no `if` `` and ``keys must be exactly name, env, run; surplus: if`` |
| M1b | lint result binding -> literal `success` | 1 | ``job `rtl-fast` verdict step env must bind `VERILATOR_LINT_RESULT` to `${{ needs.verilator-lint.result }}` (found `success`)`` |
| M1c | `case` -> `success\|skipped\|failure` | 1 | ``verdict step script is not the canonical form derived from the aggregate's `needs`: line 8 must be 'success\|skipped) ;;'`` |
| M2a | `bdd-conformance` job `if: false` | 1 | ``job `bdd-conformance` must carry no `if` (found False): it decides whether the job runs at all`` |
| M2b | `bdd-conformance` `continue-on-error: true` | 1 | ``job `bdd-conformance` must carry no `continue-on-error` `` |
| M2c | `bdd-conformance` `defaults.run.shell: bash -n {0}` | 1 | ``job `bdd-conformance` must carry no `defaults` `` |
| M3a | BDD run step `if: ${{ needs.changes.result == 'success' }}` | 1 | ``job `bdd-conformance` reads the `needs.changes` context and must list `changes` in its `needs` (found [])`` |
| M3b | the same in bracket spelling `needs['changes']['result']` | 1 | same refusal, resolved through the chain parser |
| MINOR | `verilator-lint` renamed `name: rtl-fast` + aggregate `if` | 3 | ``public check name `rtl-fast` must be carried by exactly one job (carried by ['verilator-lint', 'rtl-fast'] ...)`` plus the needs-universe and one-step refusals on the impostor |
| SUGG | `env: {EVENT_NAME: pull_request}` on `changes` | 1 | ``job `changes` must carry no `env` (found ['EVENT_NAME'])`` |
| r3 O17 | on-disk sed `run_full: ${{ 'false' }}` | 1 | ``job `full-ci-gate` outputs must bind `run_full` to `${{ steps.gate.outputs.run_full }}` (found `${{ 'false' }}`)`` |
| r4 f1 | `changes` job `if: false`; scope step `if: false`; scope publishes `rtl=false` | 1, 2, 1 | ``job `changes` must carry no `if` ``; ``fast selector scope step must carry no `if` `` + surplus key; ``scope script is not the canonical form: line 18 ...`` |
| r4 f2 | BDD step `if: ${{ needs['changes'].outputs.bogus == 'true' }}` | 2 | ``which job `changes` must publish (publishes ['rtl'])`` and the missing `needs` |

The corresponding reason-pinned selftest arms are O23/O23b/O23c (M1),
O25/O25b/O25c (M2), O26/O26b (M3), O27 (MINOR), O28 (SUGG), plus O23d/O23e
(verdict `continue-on-error`/`shell`), O24 (an aggregate `needs` entry
dropped consistently with its binding and pair) and O24b (a new fast job
outside the aggregate's `needs`). The whitespace-invariance arm now
re-indents the verdict script too, so the canonical pin is provably
normalization-based for all five pinned scripts.

## Known limitations / out of scope

- **The four non-RTL required contexts sit outside this gate's perimeter.**
  The run/no-run levers of the jobs behind `docs-check`, `docs-check-no-git`,
  `wire-accountability` and `elaborate` are not held by `ci_events.py`, and
  their names are absent from the one-carrier rule; `if: false` on the
  `docs-check` job would retire the ci_events gate itself with every required
  context satisfied. The hole predates this branch (measured equally at
  `dev@a8b27a5f`) and is outside issue #209's acceptance rows; it is now
  tracked as issue #261.

- **The verdict env names are now part of the workflow contract.**
  `rtl-fast.yml`'s three abbreviated result names were renamed so the map is
  derivable from `needs`; adding a job to the fast lane means adding its
  `needs` entry, its `<JOB>_RESULT` binding and its loop pair, and the gate
  reddens until all three agree. That is the same bargain the pinned
  scripts already carry, now on the verdict.
- **Consumer steps stay unpinned, deliberately.** `verilator-lint`,
  `yosys-elaboration` and `bdd-conformance` keep freedom inside their own
  steps (PR #240 added a step to `yosys-elaboration` without touching this
  gate); the gate holds their job-level run/no-run levers and audits every
  static `needs` chain their steps carry. A step-level `if` on a consumer
  that references no `needs` context remains expressible; it can suppress
  that job's own work but its job then still reports its honest result to
  the verdict.
- **`rtl.yml`'s per-worker result steps are not pinned.** The exhaustive
  aggregates' "Require every worker to pass" steps remain outside the pin
  because those aggregates fail closed through the pinned `always()`
  verifier: a failed or skipped worker cannot produce its shard directory,
  and `--expect` refuses the count. The fast lane had no such second wall,
  which is why its verdict step is pinned and those steps are not.
- **The bindings are held as literal expression strings, not evaluated.** No
  `actionlint` on this box; the hosted runs at this head are the
  counter-evidence.
- **`elaborate.yml` and `docs.yml` have no selector job**, so
  `check_publication_path` does not run over them; neither publishes or
  consumes a job output today.
- **No RTL, test semantics, pin or accepted-warning set changes.** The
  mandatory local gates' carry-over argument is stated under
  [Status](#status).
- `scripts/check_doc_paths.py` still prints its pre-existing note that the
  `ALLOW` entry for `scripts/ci_scope.py` is stale. Untouched here, as in #204.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied (all four rows, verified independently by [R2] at `ede6fa64`, unchanged at this head)
- [x] New or changed behavior has self-checking tests (14 new arms this round; every [R2] mutant replanted against the real checker)
- [x] Required local verification bar passes (eight commands at this head; mandatory-gate carry-over argument stated under Status)
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [x] Candidate merge result is validated per CONTRIBUTING.md (merge-base is the live `dev` tip, so the candidate merge is this head)
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done

