### PR TITLE
syn/ooc: derive the pp_shadow OOC read set from run.sh so it contains its own top

### DIFF
--- a/.github/workflows/rtl-fast.yml
+++ b/.github/workflows/rtl-fast.yml
@@ -151,10 +151,11 @@ jobs:
       # were added with manual evidence only, and a refusal nothing runs is a
       # refusal that rots: deleting either left every hosted check green
       # ([R0] on PR #240). It runs in THIS job, not beside the lint, because
-      # syn/ooc/dp_srcs.py resolves the top through sv2v as well as through its
-      # own model of the directive layer, and the two must be checked against
-      # each other where the front end exists. --require-front-end makes an
-      # absent sv2v a failure rather than a quietly weaker check.
+      # syn/ooc/dp_srcs.py answers "does the read set declare the top" with the
+      # front end and with nothing else -- three models of the directive layer
+      # were each broken by a construct they did not model ([R0] rounds one to
+      # three) -- so its self-test needs the sv2v this job installs, and an
+      # absent sv2v is a refusal there is no flag to soften.
       - name: Prove the OOC read sets come from run.sh and refuse a bad one
         run: |
           set -euo pipefail
@@ -164,10 +165,8 @@ jobs:
           }
           python3 syn/ooc/dp_srcs.py --selftest
           python3 syn/ooc/ooc_tcl_selftest.py
-          python3 syn/ooc/dp_srcs.py --top milan_datapath --require-front-end \
-            > /dev/null
-          python3 syn/ooc/dp_srcs.py --top KL_pp_shadow --require-front-end \
-            > /dev/null
+          python3 syn/ooc/dp_srcs.py --top milan_datapath > /dev/null
+          python3 syn/ooc/dp_srcs.py --top KL_pp_shadow > /dev/null
 
   # This stable aggregate is the required fast verdict. Skipped RTL jobs are a
   # deliberate docs-only result; failures and cancellations remain failures.

--- a/.github/workflows/rtl-fast.yml
+++ b/.github/workflows/rtl-fast.yml
@@ -103,24 +103,6 @@ jobs:
       - name: Prove protocol-processor source lists are derived
         run: python3 scripts/pp_srcs.py --check --selftest
 
-      # The OOC instruments' refusals, in the gate rather than beside it. Both
-      # were added with manual evidence only, and a refusal nothing runs is a
-      # refusal that rots: deleting either left every hosted check green
-      # ([R0] on PR #240). The real expansions run too, so a parent source
-      # syn/yosys/run.sh names and the tree no longer has reddens here rather
-      # than in a Vivado log nobody reads.
-      - name: Prove the OOC read sets derive from run.sh and refuse a bad one
-        run: |
-          set -euo pipefail
-          command -v tclsh >/dev/null || {
-            sudo apt-get update -qq
-            sudo apt-get install -y --no-install-recommends tcl
-          }
-          python3 syn/ooc/dp_srcs.py --selftest
-          python3 syn/ooc/ooc_tcl_selftest.py
-          python3 syn/ooc/dp_srcs.py --top milan_datapath > /dev/null
-          python3 syn/ooc/dp_srcs.py --top KL_pp_shadow > /dev/null
-
   bdd-conformance:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -164,6 +146,28 @@ jobs:
             --top milan_datapath \
             --top KL_pp_shadow \
             --top KL_gptp_shadow
+
+      # The OOC instruments' refusals, in the gate rather than beside it. Both
+      # were added with manual evidence only, and a refusal nothing runs is a
+      # refusal that rots: deleting either left every hosted check green
+      # ([R0] on PR #240). It runs in THIS job, not beside the lint, because
+      # syn/ooc/dp_srcs.py resolves the top through sv2v as well as through its
+      # own model of the directive layer, and the two must be checked against
+      # each other where the front end exists. --require-front-end makes an
+      # absent sv2v a failure rather than a quietly weaker check.
+      - name: Prove the OOC read sets come from run.sh and refuse a bad one
+        run: |
+          set -euo pipefail
+          command -v tclsh >/dev/null || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends tcl
+          }
+          python3 syn/ooc/dp_srcs.py --selftest
+          python3 syn/ooc/ooc_tcl_selftest.py
+          python3 syn/ooc/dp_srcs.py --top milan_datapath --require-front-end \
+            > /dev/null
+          python3 syn/ooc/dp_srcs.py --top KL_pp_shadow --require-front-end \
+            > /dev/null
 
   # This stable aggregate is the required fast verdict. Skipped RTL jobs are a
   # deliberate docs-only result; failures and cancellations remain failures.

--- a/.github/workflows/rtl-fast.yml
+++ b/.github/workflows/rtl-fast.yml
@@ -103,6 +103,24 @@ jobs:
       - name: Prove protocol-processor source lists are derived
         run: python3 scripts/pp_srcs.py --check --selftest
 
+      # The OOC instruments' refusals, in the gate rather than beside it. Both
+      # were added with manual evidence only, and a refusal nothing runs is a
+      # refusal that rots: deleting either left every hosted check green
+      # ([R0] on PR #240). The real expansions run too, so a parent source
+      # syn/yosys/run.sh names and the tree no longer has reddens here rather
+      # than in a Vivado log nobody reads.
+      - name: Prove the OOC read sets derive from run.sh and refuse a bad one
+        run: |
+          set -euo pipefail
+          command -v tclsh >/dev/null || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends tcl
+          }
+          python3 syn/ooc/dp_srcs.py --selftest
+          python3 syn/ooc/ooc_tcl_selftest.py
+          python3 syn/ooc/dp_srcs.py --top milan_datapath > /dev/null
+          python3 syn/ooc/dp_srcs.py --top KL_pp_shadow > /dev/null
+
   bdd-conformance:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/docs/findings/PP_SHADOW_AREA_0812.md
+++ b/docs/findings/PP_SHADOW_AREA_0812.md
@@ -74,6 +74,11 @@ PP_N_IN=1 PP_N_OUT=1 vivado -mode batch -source <repo>/syn/ooc/pp_shadow_ooc.tcl
 ```
 
 Vivado 2026.1, `xc7a100t-fgg484-2`, `-mode out_of_context`, 100 MHz.
+`sv2v` must be on `PATH` as well: the read set comes from
+`syn/yosys/run.sh --emit` through `syn/ooc/dp_srcs.py`, which resolves
+`KL_pp_shadow` inside that set with `sv2v --top` and refuses to emit a
+list when nothing answers. The [tool table](../../README.md) carries the
+install line.
 
 ## Result
 
@@ -385,23 +390,35 @@ What is refused, exactly:
   filtered out silently;
 - a read set in which nothing declares `module KL_pp_shadow` (exit 2), so a
   `-top` outside its own read set is a named refusal instead of a Vivado
-  `module not found`. That question is answered the way the toolchain answers
-  it, not by searching for the text: `dp_srcs.py` models the directive layer,
-  so a commented, `ifdef`-guarded or unexpanded-macro declaration is not one,
-  and it also asks `sv2v --top` -- the front end the Yosys gate already runs
-  over this same list -- with both required to agree. On a host with no `sv2v`
-  the model still refuses on its own; the cross-check is what is lost, and
-  `--require-front-end` turns that loss into a failure for the gate that can
-  assume the tool.
+  `module not found`. That question is answered by `sv2v --top` -- the front
+  end the Yosys gate already runs over this same list -- and by nothing else.
+  `dp_srcs.py` used to carry its own model of the directive layer so a host
+  without `sv2v` still got an answer, and three shapes of that model were each
+  accepted here and then broken by a construct they did not model: a block
+  comment ([R0] on PR #240, round one), an unexpanded macro BODY (round two),
+  and a declaration passed as the actual ARGUMENT of a multiline macro
+  invocation (round three), the last of which the model read as code while
+  `sv2v` answered `Could not find top module KL_pp_shadow`. Deciding which
+  `module` keyword survives macro expansion is what a preprocessor does, so the
+  model is gone rather than patched again and **`sv2v` is required to run this
+  recipe**, exactly as it is required by `syn/yosys/run.sh`, which owns the read
+  set. Without it `dp_srcs.py` refuses and names the missing tool; there is no
+  flag that turns that back into an emission.
 
 Neither refusal is claimed further than it is gated.
-`.github/workflows/rtl-fast.yml` runs `syn/ooc/dp_srcs.py --selftest` (33 arms:
-ten on the record, thirteen on the declaration -- block-commented,
-`ifdef`-guarded, in a string, and the three unexpanded-macro spellings -- and
-ten that run mutated copies of the real `run.sh` under real bash, four of them
-the round-two counterexamples above) and `syn/ooc/ooc_tcl_selftest.py` (5 arms,
+`.github/workflows/rtl-fast.yml` runs `syn/ooc/dp_srcs.py --selftest` (35 arms:
+eleven on the record, the last of them proving a missing front end refuses;
+thirteen that put one construct each in a one-file read set and ask the REAL
+`sv2v` -- block-commented, line-commented, `ifdef`-guarded, in a string, a
+name-only mention, a prefix of the top, the three unexpanded-macro-body
+spellings and the round-three macro argument, plus a plain declaration and a
+macro-EXPANDED one that must both expand clean so the group cannot pass on a
+front end that refuses everything; and eleven that run mutated copies of the
+real `run.sh` under real bash, four of them the round-two counterexamples above
+and the last three the round-two and round-three constructs on the real read
+set, with and without a front end) and `syn/ooc/ooc_tcl_selftest.py` (5 arms,
 which drive this .tcl under `tclsh` with the Vivado commands stubbed), plus both
-expansions for real with `--require-front-end`.
+expansions for real.
 
 Figures at a later head, for scale rather than as a replacement: the same
 instrument at `dev` `04b55dad` with that read set corrected, protocol-processor

--- a/docs/findings/PP_SHADOW_AREA_0812.md
+++ b/docs/findings/PP_SHADOW_AREA_0812.md
@@ -421,12 +421,16 @@ which drive this .tcl under `tclsh` with the Vivado commands stubbed), plus both
 expansions for real.
 
 Figures at a later head, for scale rather than as a replacement: the same
-instrument at `dev` `04b55dad` with that read set corrected, protocol-processor
-pinned at `a25b5cc9`, reports 16,547 LUT / 19,473 FF / 17 BRAM / 4 DSP /
-WNS -0.486 ns at `N_STREAM_IN/OUT = 1`, and 22,817 LUT / 25,922 FF /
-24.5 BRAM / 4 DSP / WNS -7.573 ns at 8. The table under Result is the
-2026-08-12 measurement and stays that; the plane roughly doubled in between,
-most of it the AECP engine, its descriptor store and its microcoded core.
+instrument at `235-ooc-reads-its-top` `6ebbd17f` (on `dev` `cb444a09`), with
+that read set corrected and protocol-processor pinned at `3770ae02`, reads
+45 sources (44 SystemVerilog + 1 Verilog) and reports 20,945 LUT / 23,191 FF /
+17 BRAM / 4 DSP / WNS -5.466 ns with 1,651 failing endpoints at
+`N_STREAM_IN/OUT = 1`, and 27,743 LUT / 30,195 FF / 24.5 BRAM / 4 DSP /
+WNS -9.073 ns with 2,932 failing endpoints at 8. Both are post-synthesis
+out-of-context, so the WNS carries no placed-and-routed verdict. The table under
+Result is the 2026-08-12 measurement and stays that; the plane has roughly
+tripled at 1x1 since, most of it the AECP engine, its descriptor store and its
+microcoded core.
 
 ## THE SUBSTITUTION ON THE REAL BUILD — 2026-08-13
 

--- a/docs/findings/PP_SHADOW_AREA_0812.md
+++ b/docs/findings/PP_SHADOW_AREA_0812.md
@@ -361,9 +361,24 @@ same relative name, Vivado answers a missing image with a CRITICAL WARNING
 ending in "ignoring" rather than with an error, and the run completes and
 reports the area of a ROM full of X. On the 1x1 shape that omission understates
 the plane by 2,871 LUT (13,676 against 16,547) and by 5 block RAM tiles. The
-script refuses to synthesize unless both images are present, and its read set is
-derived from the `KL_pp_shadow` entry in `syn/yosys/run.sh` rather than
-assembled here, so it cannot again name a top it does not read.
+script refuses to synthesize unless both images are present.
+
+Its read set is not assembled here. Both halves come from the `KL_pp_shadow`
+entry in `syn/yosys/run.sh`: the submodule half through `scripts/pp_srcs.py`,
+which `run.sh` calls and `syn/ooc/dp_srcs.py` calls, and the parent half from
+`run.sh`'s own `PP_SRCS` composition, which `dp_srcs.py` parses rather than
+reproduces. What that buys, exactly: the generator refuses to emit a list in
+which no source declares `module KL_pp_shadow` in active code, so a top outside
+its own read set is a named refusal instead of a Vivado `module not found`, and
+a source `run.sh` names that the tree does not carry is a named refusal instead
+of a short list at exit 0. Comment text and `ifdef`-guarded text are not active
+code and do not satisfy that check.
+
+Neither refusal is claimed further than it is gated.
+`.github/workflows/rtl-fast.yml` runs `syn/ooc/dp_srcs.py --selftest` (19 arms,
+including the block-commented declaration and a `run.sh` that drops the
+wrapper) and `syn/ooc/ooc_tcl_selftest.py` (5 arms, which drive this .tcl under
+`tclsh` with the Vivado commands stubbed), plus both expansions for real.
 
 Figures at a later head, for scale rather than as a replacement: the same
 instrument at `dev` `04b55dad` with that read set corrected, protocol-processor

--- a/docs/findings/PP_SHADOW_AREA_0812.md
+++ b/docs/findings/PP_SHADOW_AREA_0812.md
@@ -363,22 +363,45 @@ reports the area of a ROM full of X. On the 1x1 shape that omission understates
 the plane by 2,871 LUT (13,676 against 16,547) and by 5 block RAM tiles. The
 script refuses to synthesize unless both images are present.
 
-Its read set is not assembled here. Both halves come from the `KL_pp_shadow`
-entry in `syn/yosys/run.sh`: the submodule half through `scripts/pp_srcs.py`,
-which `run.sh` calls and `syn/ooc/dp_srcs.py` calls, and the parent half from
-`run.sh`'s own `PP_SRCS` composition, which `dp_srcs.py` parses rather than
-reproduces. What that buys, exactly: the generator refuses to emit a list in
-which no source declares `module KL_pp_shadow` in active code, so a top outside
-its own read set is a named refusal instead of a Vivado `module not found`, and
-a source `run.sh` names that the tree does not carry is a named refusal instead
-of a short list at exit 0. Comment text and `ifdef`-guarded text are not active
-code and do not satisfy that check.
+Its read set is not assembled here, and it is not read out of `run.sh` either.
+`syn/yosys/run.sh --emit KL_pp_shadow` prints bash's own expansion of the same
+row the portability gate synthesises -- the top name, the preprocessor defines
+and include directories, the generated submodule half `scripts/pp_srcs.py`
+returned, and every source token -- and `syn/ooc/dp_srcs.py` checks that record.
+An earlier version recognised the `PP_SRCS` composition and the `tops` row as
+text, and a text recogniser accepts what bash does not: a generator path
+`run.sh` would fail to execute, a `--prefix` it never passes, a commented-out
+decoy row, a positional that is not a source. All four passed at rc=0 ([R0] on
+PR #240, round two) and all four are self-test arms now. What the shape buys is
+narrower and checkable: a `run.sh` edit moves this read set exactly as it moves
+the Yosys one, or fails both.
+
+What is refused, exactly:
+
+- a source `run.sh` names that the tree does not carry (exit 1), instead of a
+  short list at exit 0;
+- a token `run.sh` names that is not a `.sv`/`.v` source, or the same source
+  twice, or a generated half that only partly survives (exit 2) -- nothing is
+  filtered out silently;
+- a read set in which nothing declares `module KL_pp_shadow` (exit 2), so a
+  `-top` outside its own read set is a named refusal instead of a Vivado
+  `module not found`. That question is answered the way the toolchain answers
+  it, not by searching for the text: `dp_srcs.py` models the directive layer,
+  so a commented, `ifdef`-guarded or unexpanded-macro declaration is not one,
+  and it also asks `sv2v --top` -- the front end the Yosys gate already runs
+  over this same list -- with both required to agree. On a host with no `sv2v`
+  the model still refuses on its own; the cross-check is what is lost, and
+  `--require-front-end` turns that loss into a failure for the gate that can
+  assume the tool.
 
 Neither refusal is claimed further than it is gated.
-`.github/workflows/rtl-fast.yml` runs `syn/ooc/dp_srcs.py --selftest` (19 arms,
-including the block-commented declaration and a `run.sh` that drops the
-wrapper) and `syn/ooc/ooc_tcl_selftest.py` (5 arms, which drive this .tcl under
-`tclsh` with the Vivado commands stubbed), plus both expansions for real.
+`.github/workflows/rtl-fast.yml` runs `syn/ooc/dp_srcs.py --selftest` (33 arms:
+ten on the record, thirteen on the declaration -- block-commented,
+`ifdef`-guarded, in a string, and the three unexpanded-macro spellings -- and
+ten that run mutated copies of the real `run.sh` under real bash, four of them
+the round-two counterexamples above) and `syn/ooc/ooc_tcl_selftest.py` (5 arms,
+which drive this .tcl under `tclsh` with the Vivado commands stubbed), plus both
+expansions for real with `--require-front-end`.
 
 Figures at a later head, for scale rather than as a replacement: the same
 instrument at `dev` `04b55dad` with that read set corrected, protocol-processor

--- a/docs/findings/PP_SHADOW_AREA_0812.md
+++ b/docs/findings/PP_SHADOW_AREA_0812.md
@@ -69,6 +69,7 @@ anchors and to its 1,068 LUT µCPU measurement of record.
 ```sh
 cd <workdir>
 python3 <pp>/hdl/acmp/rom/gen_ltn_rom.py -o ltn_rom.hex
+python3 <pp>/hdl/aecp/ucode/gen_ucode.py -o ucode.hex
 PP_N_IN=1 PP_N_OUT=1 vivado -mode batch -source <repo>/syn/ooc/pp_shadow_ooc.tcl -nojournal
 ```
 
@@ -349,6 +350,28 @@ before anyone quotes these as vendor-neutral.
 `syn/ooc/pp_shadow_ooc.tcl` (this repo). `PP_N_IN` / `PP_N_OUT` select the
 shape and default to 8; the script prints the shape it used, because a
 utilization figure quoted without its shape is a figure that gets misapplied.
+
+Run it from an empty working directory outside the tree: both `$readmemh`
+images are generated into that directory, and the three reports land beside
+them.
+
+Both images are required, and the Instrument block above is the whole recipe.
+`ltn_rom.hex` on its own is not: the AECP microcode ROM reads `ucode.hex` by the
+same relative name, Vivado answers a missing image with a CRITICAL WARNING
+ending in "ignoring" rather than with an error, and the run completes and
+reports the area of a ROM full of X. On the 1x1 shape that omission understates
+the plane by 2,871 LUT (13,676 against 16,547) and by 5 block RAM tiles. The
+script refuses to synthesize unless both images are present, and its read set is
+derived from the `KL_pp_shadow` entry in `syn/yosys/run.sh` rather than
+assembled here, so it cannot again name a top it does not read.
+
+Figures at a later head, for scale rather than as a replacement: the same
+instrument at `dev` `04b55dad` with that read set corrected, protocol-processor
+pinned at `a25b5cc9`, reports 16,547 LUT / 19,473 FF / 17 BRAM / 4 DSP /
+WNS -0.486 ns at `N_STREAM_IN/OUT = 1`, and 22,817 LUT / 25,922 FF /
+24.5 BRAM / 4 DSP / WNS -7.573 ns at 8. The table under Result is the
+2026-08-12 measurement and stays that; the plane roughly doubled in between,
+most of it the AECP engine, its descriptor store and its microcoded core.
 
 ## THE SUBSTITUTION ON THE REAL BUILD — 2026-08-13
 

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -33,10 +33,11 @@ pull-request update and on every push to `dev`. It produces one stable
   longer carries fails here rather than inside Vivado. Those read sets are
   printed by `run.sh --emit` rather than read out of it, and nothing in the
   record is filtered: a token that is not a `.sv`/`.v` source is refused, not
-  dropped. The declaration of the top is resolved through a model of the
-  directive layer and through `sv2v --top`, which this job installs;
-  `--require-front-end` makes a missing front end a failure instead of a
-  quieter check.
+  dropped. The declaration of the top is resolved through `sv2v --top`, which
+  this job installs, and through nothing else -- three models of the directive
+  layer were each accepted and then broken by a construct they did not model
+  ([R0] on PR #240, rounds one to three), so a missing front end is a refusal
+  with no flag to soften it.
 
 A change containing only living documentation or an Issue template skips the
 Verilator and Yosys setup jobs. The aggregate still completes, so a docs-only PR

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -29,8 +29,14 @@ pull-request update and on every push to `dev`. It produces one stable
 - a Yosys/sv2v elaboration smoke for `milan_datapath`, `KL_pp_shadow`, and
   `KL_gptp_shadow` when RTL or its tooling changes;
 - the source-list checkers' own self-tests, and the two out-of-context read
-  sets expanded for real, so a parent source `syn/yosys/run.sh` names and the
-  tree no longer carries fails here rather than inside Vivado.
+  sets expanded for real, so a source `syn/yosys/run.sh` names and the tree no
+  longer carries fails here rather than inside Vivado. Those read sets are
+  printed by `run.sh --emit` rather than read out of it, and nothing in the
+  record is filtered: a token that is not a `.sv`/`.v` source is refused, not
+  dropped. The declaration of the top is resolved through a model of the
+  directive layer and through `sv2v --top`, which this job installs;
+  `--require-front-end` makes a missing front end a failure instead of a
+  quieter check.
 
 A change containing only living documentation or an Issue template skips the
 Verilator and Yosys setup jobs. The aggregate still completes, so a docs-only PR

--- a/docs/testing/CI_WORKFLOWS.md
+++ b/docs/testing/CI_WORKFLOWS.md
@@ -27,7 +27,10 @@ pull-request update and on every push to `dev`. It produces one stable
 - ratcheted whole-tree Verilator lint for RTL/tooling-relevant changes;
 - BDD conformance;
 - a Yosys/sv2v elaboration smoke for `milan_datapath`, `KL_pp_shadow`, and
-  `KL_gptp_shadow` when RTL or its tooling changes.
+  `KL_gptp_shadow` when RTL or its tooling changes;
+- the source-list checkers' own self-tests, and the two out-of-context read
+  sets expanded for real, so a parent source `syn/yosys/run.sh` names and the
+  tree no longer carries fails here rather than inside Vivado.
 
 A change containing only living documentation or an Issue template skips the
 Verilator and Yosys setup jobs. The aggregate still completes, so a docs-only PR

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -7229,12 +7229,19 @@ REGMAP_MD = os.path.join(ROOT, "docs/reference/REGISTER_MAP.md")
 #: Everything that compiles hdl/common/csr/milan_csr.sv. Since 11944cd that
 #: file `include-s gen/lwsrp_csr_defaults.svh, so each of these must carry
 #: hdl/common/csr as an include dir (gate 20a). (path, regex proving it).
+#:
+#: syn/yosys/run.sh spells its include dirs as an INCDIRS array rather than as
+#: one -I flag string, because syn/ooc/dp_srcs.py asks that script for them
+#: (`run.sh --emit`) instead of re-reading the file (PR #240). The property this
+#: row checks is unchanged - the directory must be in the list run.sh compiles
+#: with - so only the spelling of the proof moved, and dropping the entry from
+#: INCDIRS still fails here.
 CSR_INCDIR_CONSUMERS = (
     ("tb/verilator/csr/Makefile", r"\+incdir\+\$\(RTL_DIR\)/common/csr"),
     ("tb/verilator/milan_dp/Makefile", r"\+incdir\+\$\(RTL_DIR\)/common/csr"),
     ("tb/verilator/hostplane/Makefile", r"\+incdir\+\$\(RTL_DIR\)/common/csr"),
     ("sw/litex/milan_soc.py", r"\"hdl/common/csr\""),
-    ("syn/yosys/run.sh", r"-I \$R/hdl/common/csr"),
+    ("syn/yosys/run.sh", r"INCDIRS=\([^)]*\"\$R/hdl/common/csr\""),
 )
 
 #: Real build trees / sibling repo used by the optional cross-check gates.

--- a/syn/ooc/dp_srcs.py
+++ b/syn/ooc/dp_srcs.py
@@ -5,16 +5,32 @@
 
 THE POINT IS THAT THERE IS NO SECOND COPY. A top's source list is the
 "<top>|..." entry in syn/yosys/run.sh -- the one the portability gate proves
-elaborates on every run -- and its submodule half comes from scripts/pp_srcs.py,
-which derives it from the tree. A hand-maintained duplicate in a Vivado .tcl
-would drift the first time a module lands, and the drift would show up as a
-synthesis result quietly missing a block. So the .tcl execs this instead.
+elaborates on every run -- and the collected `PP_SRCS` that entry references is
+read from run.sh as well: its submodule half through scripts/pp_srcs.py, the
+generator run.sh itself calls, and its parent half from run.sh's own
+composition line. A hand-maintained duplicate in a Vivado .tcl would drift the
+first time a module lands, and the drift would show up as a synthesis result
+quietly missing a block. So the .tcl execs this instead.
 
-This file scraped run.sh's `PP_SRCS="..."` textually until that assignment
-became a command substitution, whose inner quotes truncated the non-greedy
-capture: 104 sources became 62, exit 0, no diagnostic, and Vivado said only
-`module 'KL_pp_shadow' not found`. Scraping a build file is a recogniser;
-calling the generator resolves.
+Composing the parent half HERE was the same defect one level down, and it
+shipped: a `PARENT_WRAPPERS` tuple in this file happened to agree with run.sh,
+and agreement is not derivation. Two run.sh inputs differing only in their
+`PP_SRCS` definition produced identical output, and deleting
+hdl/milan/KL_pp_shadow.sv from run.sh left this flow green at rc=0 with an
+unchanged area figure ([R0] on PR #240). The tuple is gone. `_pp_srcs()` below
+parses the composition instead, and every way that parse can come back wrong is
+a hard error rather than a shorter list.
+
+Parsing a build file is what caused the earlier escape, so the parse is pinned
+rather than trusted. This file lifted the assignment with `PP_SRCS="(.*?)"`
+until it became a command substitution, whose inner quotes truncated the
+non-greedy capture: 104 sources became 62, exit 0, no diagnostic, and Vivado
+said only `module 'KL_pp_shadow' not found`. What is different now is that the
+composition line is selected by the generator reference it must contain, that
+exactly one line may match, that run.sh's generator call is asserted to be the
+one this file makes, that a `$`-prefixed token surviving expansion is an error,
+that every named file must exist, and that some emitted source must declare the
+top. A truncation fails all but the first of those.
 
 `--top` selects the entry. It defaults to `milan_datapath`, which is the only
 top this file served when it was written; `KL_pp_shadow` is the second. That
@@ -37,16 +53,107 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
 
-#: This repository's own two wrappers, which run.sh appends to the derived
-#: submodule half. They are the parent's files, not the submodule's, so the
-#: generator does not emit them; every consumer names them. Named here so the
-#: assertion below can prove they survived the expansion.
-PARENT_WRAPPERS = ("hdl/milan/KL_pp_shadow.sv", "hdl/milan/KL_pp_maap_shim.sv")
+#: The generator run.sh must call to derive the submodule half, and the one
+#: this file calls. Named once so the two calls cannot become two generators.
+GENERATOR = "scripts/pp_srcs.py"
+
+#: How many arms selftest() must run. A deleted arm is a self-test that still
+#: prints a pass, so the count is declared and checked rather than counted.
+ARMS = 19
 
 
 def _reader(path):
     with open(path) as fh:
         return fh.read()
+
+
+def active_code(text):
+    """`text` with comments, string literals and conditional regions removed.
+
+    Comments and strings are removed in ONE pass, because they nest the wrong
+    way for two passes: `//` inside a string opens no comment, and `"` inside a
+    comment opens no string. What is removed is replaced by spaces, so line
+    structure -- what the declaration pattern anchors on -- survives.
+
+    Conditional-compilation regions are dropped rather than evaluated. This
+    file cannot know the `+define+` set the consumer will pass, and the
+    question it has to answer is whether the top is CERTAINLY in the read set;
+    a declaration that depends on a define is not certainly anywhere.
+
+    Without this, the check was a text search: an injected source whose only
+    occurrence of the top was `/*` newline `module KL_pp_shadow;` newline
+    `endmodule` newline `*/` satisfied it at rc=0 with five emitted files
+    ([R0] on PR #240), so a semantically absent top still reached Vivado's
+    `module not found`.
+    """
+    out, i, n = [], 0, len(text)
+    while i < n:
+        two = text[i:i + 2]
+        if two == "//":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+        elif two == "/*":
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+        elif text[i] == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                j += 2 if text[j] == "\\" else 1
+            j = min(j + 1, n)
+        else:
+            out.append(text[i])
+            i += 1
+            continue
+        out.append(re.sub(r"[^\n]", " ", text[i:j]))
+        i = j
+
+    kept, depth = [], 0
+    for line in "".join(out).split("\n"):
+        head = line.lstrip()
+        if head.startswith(("`ifdef", "`ifndef")):
+            depth += 1
+            kept.append("")
+        elif head.startswith("`endif"):
+            depth = max(0, depth - 1)
+            kept.append("")
+        elif head.startswith(("`elsif", "`else")):
+            kept.append("")
+        else:
+            kept.append("" if depth else line)
+    return "\n".join(kept)
+
+
+def declares(text, top):
+    """True if `text` declares `module <top>` in code the front end sees."""
+    return re.search(r"^[ \t]*module\s+(?:automatic\s+|static\s+)?%s\b"
+                     % re.escape(top), active_code(text), re.M) is not None
+
+
+def _pp_srcs(run_sh, derived):
+    """run.sh's own `PP_SRCS` composition, expanded. Returns (text, problems).
+
+    Both halves come from run.sh: `$PP_DERIVED` is replaced by what the
+    generator run.sh names returned, and every other token is run.sh's, not
+    this file's.
+    """
+    gen = re.search(r"^[ \t]*PP_DERIVED=(.*)$", run_sh, re.M)
+    if not gen or GENERATOR not in gen.group(1):
+        return None, ["dp_srcs: run.sh has no PP_DERIVED assignment calling %s. "
+                      "This file calls it to derive the submodule half, so the "
+                      "two would be deriving that half from two generators."
+                      % GENERATOR]
+
+    # Selected by the reference it must contain, not by position: run.sh also
+    # assigns PP_SRCS a deliberately impossible placeholder on the `--list`
+    # path, which derives nothing.
+    defs = [d for d in re.findall(r'^[ \t]*PP_SRCS="([^"\n]*)"', run_sh, re.M)
+            if "$PP_DERIVED" in d]
+    if len(defs) != 1:
+        return None, ["dp_srcs: run.sh has %d PP_SRCS definition(s) referencing "
+                      "$PP_DERIVED, expected exactly 1. Guessing which one the "
+                      "build uses would put the OOC read set and the Yosys one "
+                      "back on two authorities." % len(defs)]
+    return defs[0].replace("$PP_DERIVED", " ".join(derived)), []
 
 
 def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
@@ -68,21 +175,14 @@ def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
     # like any other source. A name listed here that run.sh no longer defines
     # is a hard error on purpose: silently dropping it would emit a source list
     # missing a whole plane, and Vivado would only say "module not found".
-    # PP_SRCS is DERIVED, so there is nothing in run.sh to scrape. This used to
-    # lift the literal with `PP_SRCS="(.*?)"`, and when run.sh switched to a
-    # command substitution the inner quotes truncated that capture to
-    # `$(python3 ` -- 104 sources became 62, exit 0, no diagnostic, and Vivado
-    # only said `module 'KL_pp_shadow' not found`. Calling the generator cannot
-    # fail that way: it either returns the list or exits non-zero.
     if "$PP_SRCS" not in srcs:
         return [], ["dp_srcs: the %s entry in run.sh no longer references "
                     "$PP_SRCS. Expanding it now would emit a top without its "
                     "control plane, at exit 0." % top], 2
-    # run.sh's PP_SRCS is the derived submodule half PLUS this repository's own
-    # two wrappers; compose it the same way or the OOC netlist loses them and
-    # Vivado reports `module 'KL_pp_shadow' not found`.
-    srcs = srcs.replace("$PP_SRCS", " ".join(
-        derived + [os.path.join(repo, w) for w in PARENT_WRAPPERS]))
+    pp_srcs, problems = _pp_srcs(run_sh, derived)
+    if problems:
+        return [], problems, 2
+    srcs = srcs.replace("$PP_SRCS", pp_srcs)
 
     env = {
         "R": repo,
@@ -97,8 +197,22 @@ def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
         "PP": os.path.join(repo, "protocol-processor/hdl"),
     }
     # longest key first: "$PP/" must not be eaten by the "$P" rule
-    for k in sorted(env, key=len, reverse=True):
-        srcs = srcs.replace("$" + k + "/", env[k] + "/")
+    def expand(text):
+        for k in sorted(env, key=len, reverse=True):
+            text = text.replace("$" + k + "/", env[k] + "/")
+        return text
+
+    srcs, pp_srcs = expand(srcs), expand(pp_srcs)
+
+    # A shell variable this file does not know is the truncation's signature:
+    # the residue of a half-captured command substitution does not end in
+    # .sv/.v either, so the suffix filter below would drop it in silence.
+    residue = [t for t in srcs.split() if "$" in t]
+    if residue:
+        return [], ["dp_srcs: %d token(s) in the %s entry survived expansion "
+                    "still naming a shell variable:\n  %s\nThe expansion is "
+                    "incomplete, so the list below it would be short at exit 0."
+                    % (len(residue), top, "\n  ".join(residue))], 2
 
     files = [f for f in srcs.split() if f.endswith((".sv", ".v"))]
     missing = [f for f in files if not exists(f)]
@@ -113,8 +227,8 @@ def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
     # plane vanished from the netlist.
     emitted = set(files)
     lost = [f for f in derived if f not in emitted]
-    lost += [w for w in PARENT_WRAPPERS
-             if os.path.join(repo, w) not in emitted]
+    lost += [f for f in pp_srcs.split()
+             if f.endswith((".sv", ".v")) and f not in emitted]
     # ...and name the plane itself, not just a count. A generator that returned
     # a truncated list would satisfy the loop above -- everything it derived
     # survived -- while emitting a top with no processor in it. This is the
@@ -132,16 +246,17 @@ def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
     # the one module the consumer will name as `-top`: that is Issue #235,
     # where pp_shadow_ooc.tcl read its 41 sources and Vivado answered
     # `module 'KL_pp_shadow' not found`. So compare the list against the top as
-    # well, by reading the sources for the declaration rather than by matching
+    # well, by resolving the declaration in active code rather than by matching
     # a file name -- a file named after the module is a convention, and the
-    # convention is not what synthesis resolves.
-    decl = re.compile(r"^[ \t]*module[ \t]+%s\b" % re.escape(top), re.M)
-    if not any(decl.search(read(f)) for f in files):
+    # convention is not what synthesis resolves -- and not by matching raw text
+    # either, because a commented-out or `ifdef`-guarded declaration is not one.
+    if not any(declares(read(f), top) for f in files):
         return files, ["dp_srcs: none of the %d source(s) in run.sh's \"%s|...\" "
-                       "entry declares `module %s`. Synthesis would read every "
-                       "one of them and then fail with `module '%s' not found` "
-                       "(Issue #235), which reads as a missing module and is "
-                       "really a read set that never contained the top."
+                       "entry declares `module %s` in active code. Synthesis "
+                       "would read every one of them and then fail with "
+                       "`module '%s' not found` (Issue #235), which reads as a "
+                       "missing module and is really a read set that never "
+                       "contained the top."
                        % (len(files), top, top, top)], 2
 
     return files, [], 0
@@ -153,7 +268,8 @@ def selftest(top="faketop"):
     CONTRIBUTING.md section 3 states the bar for a checker in this repository:
     it carries a self-test that runs in a gate "so the tool cannot rot into a
     green that means nothing". Every arm below drives the real `build()`, so
-    stubbing it to return no problems fails this.
+    stubbing it to return no problems fails this. `.github/workflows/
+    rtl-fast.yml` runs it beside scripts/pp_srcs.py's.
 
     Planting the defect in syn/yosys/run.sh and restoring it afterwards would
     work exactly until the process is killed between the two writes, and it
@@ -164,66 +280,162 @@ def selftest(top="faketop"):
     pp = os.path.join(REPO, "protocol-processor/hdl")
     derived = [os.path.join(pp, "common/pp_pkg.sv"),
                os.path.join(pp, "top/protocol_processor_top.sv")]
-    wrappers = [os.path.join(REPO, w) for w in PARENT_WRAPPERS]
-    # what each synthetic source declares, for the top-declaration check
+    wrap_top = os.path.join(REPO, "hdl/milan/wrap_top.sv")
+    wrap_two = os.path.join(REPO, "hdl/milan/wrap_two.sv")
+    wrap_three = os.path.join(REPO, "hdl/milan/wrap_three.sv")
+    axis = os.path.join(REPO, "third_party/verilog-axis/rtl/axis_fifo.v")
+
+    # run.sh, reduced to the two lines this file reads: the generator call and
+    # the composition. The parent half is named HERE, in the injected run.sh,
+    # which is the whole point -- build() must take it from this text.
+    gen_line = ('  PP_DERIVED="$(python3 "$R/%s" --prefix "$PP")" || exit 2\n'
+                % GENERATOR)
+    comp = '  PP_SRCS="$PP_DERIVED $R/hdl/milan/wrap_top.sv $R/hdl/milan/wrap_two.sv"\n'
+    entry = '  "%s|$A/axis_fifo.v $PP_SRCS"\n' % top
+    clean = gen_line + comp + entry
+
+    # What each synthetic source contains, for the declaration check.
     text = {f: "module %s;\nendmodule\n" % os.path.basename(f)[:-3]
-            for f in derived + wrappers + [os.path.join(REPO, "a/axis_fifo.v")]}
-    text[wrappers[0]] = "module %s #(\n) ();\nendmodule\n" % top
+            for f in derived + [wrap_top, wrap_two, wrap_three, axis]}
+    # The real top: declared, and also NAMED in a comment above it, so a clean
+    # pass cannot be a pass on the comment.
+    real = "// %s: the wrapper this entry is built around\nmodule %s #(\n) ();\nendmodule\n" % (top, top)
+    text[wrap_top] = real
+
+    state = {"derived": list(derived), "gone": set()}
+    problems, ran = [], 0
 
     def run(world, tp=top):
-        return build(tp, world, derived, exists=lambda f: True,
+        return build(tp, world, state["derived"],
+                     exists=lambda f: f not in state["gone"],
                      read=lambda f: text.get(f, ""))
 
-    clean = '  "%s|$A/axis_fifo.v $PP_SRCS"\n' % top
-    problems = []
-
     def arm(name, world, want, tp=top):
+        nonlocal ran
+        ran += 1
         _files, bad, rc = run(world, tp)
         if not any(want in b for b in bad) or rc == 0:
             problems.append("SELF-TEST FAILED [%s]: expected a finding naming "
                             "%r at rc!=0, got rc=%d %s"
                             % (name, want, rc, bad or "no findings"))
 
+    def decl_arm(name, body):
+        """The top occurs in `body`, but not as a declaration the tool sees."""
+        saved, text[wrap_top] = text[wrap_top], body
+        arm(name, clean, "declares `module %s` in active code" % top)
+        text[wrap_top] = saved
+
     # Arm 0. The clean world is clean. Without this the other arms could all be
     # passing on a check that simply reports everything.
+    ran += 1
     files, bad, rc = run(clean)
-    if bad or rc or len(files) != len(derived) + len(wrappers) + 1:
+    if bad or rc or len(files) != len(derived) + 3:
         problems.append("SELF-TEST FAILED [clean]: the well-formed entry must "
                         "expand clean, got rc=%d %s, %d file(s)"
                         % (rc, bad, len(files)))
 
-    # Arm 1. The entry is gone, or the top was misspelled by its consumer.
+    # Arm 1. run.sh's PP_SRCS IS READ, not reconstructed. Two worlds differing
+    # only in that definition must differ in what comes out. This is [R0]'s
+    # experiment on PR #240 -- it produced identical output then -- kept as an
+    # arm, because a reintroduced parent-wrapper constant here would pass every
+    # other arm in this file.
+    ran += 1
+    more = clean.replace(' $R/hdl/milan/wrap_two.sv"',
+                         ' $R/hdl/milan/wrap_two.sv $R/hdl/milan/wrap_three.sv"')
+    a_files, _, a_rc = run(clean)
+    b_files, _, b_rc = run(more)
+    if a_rc or b_rc or a_files == b_files or wrap_three not in b_files:
+        problems.append("SELF-TEST FAILED [pp-srcs-is-read]: changing only "
+                        "run.sh's PP_SRCS definition left the emitted list "
+                        "unchanged (%d vs %d file(s), rc=%d/%d), so the parent "
+                        "half is not being read from run.sh"
+                        % (len(a_files), len(b_files), a_rc, b_rc))
+
+    # Arm 2. [R0]'s D2 mutation on PR #240, committed: run.sh drops the wrapper
+    # that declares the top. It stayed green at 16,547 LUT when this file
+    # composed the parent half itself.
+    arm("run-sh-drops-the-top", clean.replace("$R/hdl/milan/wrap_top.sv ", ""),
+        "declares `module %s` in active code" % top)
+
+    # Arm 3. A parent source run.sh names that is not on disk any more.
+    state["gone"].add(wrap_two)
+    arm("stale-parent-source", clean, "missing sources")
+    state["gone"].clear()
+
+    # Arm 4. run.sh no longer defines PP_SRCS from the derived half.
+    arm("no-pp-srcs-definition", gen_line + entry, "expected exactly 1")
+
+    # Arm 5. Two definitions: nothing here may pick one.
+    arm("two-pp-srcs-definitions", gen_line + comp + comp + entry,
+        "expected exactly 1")
+
+    # Arm 6. run.sh derives the submodule half from some other generator, so
+    # the two halves of "one authority" would be two again.
+    arm("generator-diverged",
+        '  PP_DERIVED="$(python3 "$R/scripts/other.py")"\n' + comp + entry,
+        "no PP_DERIVED assignment calling")
+
+    # Arm 7. A variable this file does not expand. The historical truncation
+    # left exactly this residue and nothing saw it.
+    arm("unexpanded-variable",
+        gen_line + comp.replace("$R/hdl/milan/wrap_two.sv",
+                                "$NEW/wrap_two.sv") + entry,
+        "still naming a shell variable")
+
+    # Arm 8. The entry is gone, or the top was misspelled by its consumer.
     arm("no-entry", clean, "no othertop top in run.sh", tp="othertop")
 
-    # Arm 2. The entry stops referencing the collected list.
-    arm("no-pp-srcs", '  "%s|$A/axis_fifo.v"\n' % top, "no longer references")
+    # Arm 9. The entry stops referencing the collected list.
+    arm("no-pp-srcs", gen_line + comp + '  "%s|$A/axis_fifo.v"\n' % top,
+        "no longer references")
 
-    # Arm 3. A derived source that does not survive the expansion, because
+    # Arm 10. A derived source that does not survive the expansion, because
     # the suffix filter below the substitution drops it. That filter is what
     # made the historical truncation invisible: it inspected only tokens
     # ending in .sv/.v, and what was left of the list ended in neither.
-    saved, derived = derived, derived + [os.path.join(pp, "acmp/ghost.svh")]
+    state["derived"] = derived + [os.path.join(pp, "acmp/ghost.svh")]
     arm("derived-source-lost", clean, "did not survive expansion")
-    derived = saved
+    state["derived"] = list(derived)
 
-    # Arm 4. The plane itself missing, which a count-based check cannot see.
-    saved, derived = derived, [os.path.join(pp, "common/pp_pkg.sv")]
+    # Arm 11. The plane itself missing, which a count-based check cannot see.
+    state["derived"] = [os.path.join(pp, "common/pp_pkg.sv")]
     arm("plane-lost", clean, "protocol_processor_top.sv (the control plane")
-    derived = saved
+    state["derived"] = list(derived)
 
-    # Arm 5. ISSUE #235. Every source present and correct, and not one of them
+    # Arm 12. ISSUE #235. Every source present and correct, and not one of them
     # declares the top. Vivado's answer to this list is `module not found`.
-    saved, text[wrappers[0]] = text[wrappers[0]], "module something_else;\n"
-    arm("top-not-in-read-set", clean, "declares `module %s`" % top)
-    text[wrappers[0]] = saved
+    decl_arm("top-not-in-read-set", "module something_else;\nendmodule\n")
 
-    # Arm 6. The same, one step subtler: the file is named after the top and
+    # Arm 13. The same, one step subtler: the file is named after the top and
     # does not declare it, which a file-name check would pass.
-    saved, text[wrappers[0]] = text[wrappers[0]], "// KL_pp_shadow lives here\n"
-    arm("named-not-declared", clean, "declares `module %s`" % top)
-    text[wrappers[0]] = saved
+    decl_arm("named-not-declared", "// %s lives here\n" % top)
 
-    return problems
+    # Arms 14-18. THE DECLARATION IS TEXT, NOT CODE. [R0] on PR #240 injected
+    # the block-commented form and got rc=0 with five emitted files; the rest
+    # are the same class in the other spellings a real file reaches for.
+    #
+    # Three of these five bypass a raw-text search and are what `active_code`
+    # is for: neuter it to `return text` and block-commented, inactive-
+    # conditional and declaration-inside-a-string all go green. The line-
+    # commented and prefix arms bind something else -- the pattern's own line
+    # anchor and word boundary -- and are here because a later loosening of
+    # that pattern is the obvious way to reintroduce the escape.
+    decl_arm("block-commented-declaration",
+             "/*\nmodule %s;\nendmodule\n*/\n" % top)
+    decl_arm("inactive-conditional-declaration",
+             "`ifdef SOME_DEFINE\nmodule %s;\nendmodule\n`endif\n" % top)
+    decl_arm("declaration-inside-a-string",
+             'localparam string S = "\nmodule %s;\n";\n' % top)
+    decl_arm("line-commented-declaration",
+             "// module %s;\n// endmodule\n" % top)
+    decl_arm("prefix-of-the-top-declared",
+             "module %s_shim;\nendmodule\n" % top)
+
+    if ran != ARMS:
+        problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), %s "
+                        "declares %d. An arm was deleted or added without "
+                        "moving the count." % (ran, __file__, ARMS))
+    return problems, ran
 
 
 def main() -> int:
@@ -236,18 +448,18 @@ def main() -> int:
     args = ap.parse_args()
 
     if args.selftest:
-        bad = selftest()
+        bad, ran = selftest()
         for b in bad:
             print("  -", b, file=sys.stderr)
         if bad:
             return 2
-        print("dp_srcs self-test: 7 arm(s) passed")
+        print("dp_srcs self-test: %d arm(s) passed" % ran)
         return 0
 
     with open(os.path.join(REPO, "syn", "yosys", "run.sh")) as fh:
         run_sh = fh.read()
     pp = subprocess.run(
-        [sys.executable, os.path.join(REPO, "scripts", "pp_srcs.py"),
+        [sys.executable, os.path.join(REPO, *GENERATOR.split("/")),
          "--prefix", os.path.join(REPO, "protocol-processor", "hdl")],
         capture_output=True, text=True)
     if pp.returncode != 0:

--- a/syn/ooc/dp_srcs.py
+++ b/syn/ooc/dp_srcs.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Kebag Logic
 # SPDX-License-Identifier: CERN-OHL-W-2.0
-"""Print the milan_datapath source list, one absolute path per line.
+"""Print the source list of a top named in syn/yosys/run.sh, one path per line.
 
-THE POINT IS THAT THERE IS NO SECOND COPY. The datapath entry is the
-"milan_datapath|..." line in syn/yosys/run.sh — the one the portability gate
-proves elaborates on every run — and its submodule half comes from
-scripts/pp_srcs.py, which derives it from the tree. A hand-maintained duplicate
-in a Vivado .tcl would drift the first time a module lands, and the drift would
-show up as a synthesis result quietly missing a block. So the .tcl execs this
-instead.
+THE POINT IS THAT THERE IS NO SECOND COPY. A top's source list is the
+"<top>|..." entry in syn/yosys/run.sh -- the one the portability gate proves
+elaborates on every run -- and its submodule half comes from scripts/pp_srcs.py,
+which derives it from the tree. A hand-maintained duplicate in a Vivado .tcl
+would drift the first time a module lands, and the drift would show up as a
+synthesis result quietly missing a block. So the .tcl execs this instead.
 
 This file scraped run.sh's `PP_SRCS="..."` textually until that assignment
 became a command substitution, whose inner quotes truncated the non-greedy
@@ -17,8 +16,19 @@ capture: 104 sources became 62, exit 0, no diagnostic, and Vivado said only
 `module 'KL_pp_shadow' not found`. Scraping a build file is a recogniser;
 calling the generator resolves.
 
-Used by syn/ooc/milan_datapath_ooc.tcl.
+`--top` selects the entry. It defaults to `milan_datapath`, which is the only
+top this file served when it was written; `KL_pp_shadow` is the second. That
+script assembled its own read set instead -- the submodule half from
+scripts/pp_srcs.py plus a hand-named axis_fifo.v -- and the one file the
+assembly did not name was the module it passed to `synth_design -top`, so the
+documented plane-area recipe read 41 sources and then failed with
+`ERROR: [Synth 8-439] module 'KL_pp_shadow' not found` (Issue #235). Hence the
+last check below: this file refuses to emit a list in which nothing declares
+the top it was asked for, whatever the list was built from.
+
+Used by syn/ooc/milan_datapath_ooc.tcl and syn/ooc/pp_shadow_ooc.tcl.
 """
+import argparse
 import os
 import re
 import subprocess
@@ -34,15 +44,21 @@ REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
 PARENT_WRAPPERS = ("hdl/milan/KL_pp_shadow.sv", "hdl/milan/KL_pp_maap_shim.sv")
 
 
-def main() -> int:
-    run_sh = os.path.join(REPO, "syn", "yosys", "run.sh")
-    with open(run_sh) as fh:
-        s = fh.read()
+def _reader(path):
+    with open(path) as fh:
+        return fh.read()
 
-    m = re.search(r'"milan_datapath\|(.*?)"\n', s, re.S)
+
+def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
+    """Expand `top`'s entry in run.sh's text. Returns (files, problems, rc).
+
+    `run_sh`, `derived`, `exists` and `read` are the inputs, injected rather
+    than read, so that `selftest()` can prove every check below bites without
+    editing the repository to do it.
+    """
+    m = re.search(r'"%s\|(.*?)"\n' % re.escape(top), run_sh, re.S)
     if not m:
-        print("dp_srcs: no milan_datapath top in run.sh", file=sys.stderr)
-        return 2
+        return [], ["dp_srcs: no %s top in run.sh" % top], 2
     srcs = m.group(1)
 
     # The one collected list that entry references. It used to be three
@@ -59,45 +75,35 @@ def main() -> int:
     # only said `module 'KL_pp_shadow' not found`. Calling the generator cannot
     # fail that way: it either returns the list or exits non-zero.
     if "$PP_SRCS" not in srcs:
-        print("dp_srcs: the milan_datapath entry in run.sh no longer references "
-              "$PP_SRCS. Expanding it now would emit a datapath without its "
-              "control plane, at exit 0.", file=sys.stderr)
-        return 2
-    pp = subprocess.run(
-        [sys.executable, os.path.join(REPO, "scripts", "pp_srcs.py"),
-         "--prefix", os.path.join(REPO, "protocol-processor", "hdl")],
-        capture_output=True, text=True)
-    if pp.returncode != 0:
-        sys.stderr.write(pp.stderr)
-        return 2
-    derived = pp.stdout.split()
+        return [], ["dp_srcs: the %s entry in run.sh no longer references "
+                    "$PP_SRCS. Expanding it now would emit a top without its "
+                    "control plane, at exit 0." % top], 2
     # run.sh's PP_SRCS is the derived submodule half PLUS this repository's own
     # two wrappers; compose it the same way or the OOC netlist loses them and
     # Vivado reports `module 'KL_pp_shadow' not found`.
     srcs = srcs.replace("$PP_SRCS", " ".join(
-        derived + [os.path.join(REPO, w) for w in PARENT_WRAPPERS]))
+        derived + [os.path.join(repo, w) for w in PARENT_WRAPPERS]))
 
     env = {
-        "R": REPO,
-        "A": os.path.join(REPO, "third_party/verilog-axis/rtl"),
-        "C": os.path.join(REPO, "hdl/common"),
-        "Q": os.path.join(REPO, "hdl/ieee8021q/ts"),
-        "P": os.path.join(REPO, "hdl/ieee8021as/ptp_timestamp"),
-        "E": os.path.join(REPO, "hdl/common/eth_event_counter"),
-        "D": os.path.join(REPO, "hdl/ieee17221/adp"),
-        "F": os.path.join(REPO, "hdl/ieee8021q/filtering"),
+        "R": repo,
+        "A": os.path.join(repo, "third_party/verilog-axis/rtl"),
+        "C": os.path.join(repo, "hdl/common"),
+        "Q": os.path.join(repo, "hdl/ieee8021q/ts"),
+        "P": os.path.join(repo, "hdl/ieee8021as/ptp_timestamp"),
+        "E": os.path.join(repo, "hdl/common/eth_event_counter"),
+        "D": os.path.join(repo, "hdl/ieee17221/adp"),
+        "F": os.path.join(repo, "hdl/ieee8021q/filtering"),
         # the protocol-processor submodule root, as run.sh's PP_SRCS spells it
-        "PP": os.path.join(REPO, "protocol-processor/hdl"),
+        "PP": os.path.join(repo, "protocol-processor/hdl"),
     }
     # longest key first: "$PP/" must not be eaten by the "$P" rule
     for k in sorted(env, key=len, reverse=True):
         srcs = srcs.replace("$" + k + "/", env[k] + "/")
 
     files = [f for f in srcs.split() if f.endswith((".sv", ".v"))]
-    missing = [f for f in files if not os.path.exists(f)]
+    missing = [f for f in files if not exists(f)]
     if missing:
-        print("dp_srcs: missing sources:\n  " + "\n  ".join(missing), file=sys.stderr)
-        return 1
+        return files, ["dp_srcs: missing sources:\n  " + "\n  ".join(missing)], 1
 
     # A SHORT LIST AT EXIT 0 IS THE FAILURE THIS FILE CAUSED ONCE ALREADY, so
     # assert what the output must contain rather than trusting the expansion.
@@ -108,20 +114,150 @@ def main() -> int:
     emitted = set(files)
     lost = [f for f in derived if f not in emitted]
     lost += [w for w in PARENT_WRAPPERS
-             if os.path.join(REPO, w) not in emitted]
+             if os.path.join(repo, w) not in emitted]
     # ...and name the plane itself, not just a count. A generator that returned
     # a truncated list would satisfy the loop above -- everything it derived
-    # survived -- while emitting a datapath with no processor in it. This is
-    # the module milan_datapath.sv instantiates through KL_pp_shadow, so its
+    # survived -- while emitting a top with no processor in it. This is the
+    # module milan_datapath.sv and KL_pp_shadow.sv both instantiate, so its
     # absence is not a stale list, it is a netlist that cannot elaborate.
     if not any(os.path.basename(f) == "protocol_processor_top.sv" for f in files):
         lost.append("protocol_processor_top.sv (the control plane itself)")
     if lost:
-        print("dp_srcs: %d source(s) were derived but did not survive expansion "
-              "into the milan_datapath entry:\n  %s"
-              % (len(lost), "\n  ".join(lost)), file=sys.stderr)
-        return 2
+        return files, ["dp_srcs: %d source(s) were derived but did not survive "
+                       "expansion into the %s entry:\n  %s"
+                       % (len(lost), top, "\n  ".join(lost))], 2
 
+    # THE TOP ITSELF. Every check above compares the list against what went
+    # into it, and all of them pass on a list that contains everything except
+    # the one module the consumer will name as `-top`: that is Issue #235,
+    # where pp_shadow_ooc.tcl read its 41 sources and Vivado answered
+    # `module 'KL_pp_shadow' not found`. So compare the list against the top as
+    # well, by reading the sources for the declaration rather than by matching
+    # a file name -- a file named after the module is a convention, and the
+    # convention is not what synthesis resolves.
+    decl = re.compile(r"^[ \t]*module[ \t]+%s\b" % re.escape(top), re.M)
+    if not any(decl.search(read(f)) for f in files):
+        return files, ["dp_srcs: none of the %d source(s) in run.sh's \"%s|...\" "
+                       "entry declares `module %s`. Synthesis would read every "
+                       "one of them and then fail with `module '%s' not found` "
+                       "(Issue #235), which reads as a missing module and is "
+                       "really a read set that never contained the top."
+                       % (len(files), top, top, top)], 2
+
+    return files, [], 0
+
+
+def selftest(top="faketop"):
+    """Prove every check bites, on synthetic inputs, without editing the tree.
+
+    CONTRIBUTING.md section 3 states the bar for a checker in this repository:
+    it carries a self-test that runs in a gate "so the tool cannot rot into a
+    green that means nothing". Every arm below drives the real `build()`, so
+    stubbing it to return no problems fails this.
+
+    Planting the defect in syn/yosys/run.sh and restoring it afterwards would
+    work exactly until the process is killed between the two writes, and it
+    cannot run on a read-only checkout. Injecting the inputs instead exercises
+    the same function and touches nothing. scripts/pp_srcs.py:selftest makes
+    the same argument for the same reason.
+    """
+    pp = os.path.join(REPO, "protocol-processor/hdl")
+    derived = [os.path.join(pp, "common/pp_pkg.sv"),
+               os.path.join(pp, "top/protocol_processor_top.sv")]
+    wrappers = [os.path.join(REPO, w) for w in PARENT_WRAPPERS]
+    # what each synthetic source declares, for the top-declaration check
+    text = {f: "module %s;\nendmodule\n" % os.path.basename(f)[:-3]
+            for f in derived + wrappers + [os.path.join(REPO, "a/axis_fifo.v")]}
+    text[wrappers[0]] = "module %s #(\n) ();\nendmodule\n" % top
+
+    def run(world, tp=top):
+        return build(tp, world, derived, exists=lambda f: True,
+                     read=lambda f: text.get(f, ""))
+
+    clean = '  "%s|$A/axis_fifo.v $PP_SRCS"\n' % top
+    problems = []
+
+    def arm(name, world, want, tp=top):
+        _files, bad, rc = run(world, tp)
+        if not any(want in b for b in bad) or rc == 0:
+            problems.append("SELF-TEST FAILED [%s]: expected a finding naming "
+                            "%r at rc!=0, got rc=%d %s"
+                            % (name, want, rc, bad or "no findings"))
+
+    # Arm 0. The clean world is clean. Without this the other arms could all be
+    # passing on a check that simply reports everything.
+    files, bad, rc = run(clean)
+    if bad or rc or len(files) != len(derived) + len(wrappers) + 1:
+        problems.append("SELF-TEST FAILED [clean]: the well-formed entry must "
+                        "expand clean, got rc=%d %s, %d file(s)"
+                        % (rc, bad, len(files)))
+
+    # Arm 1. The entry is gone, or the top was misspelled by its consumer.
+    arm("no-entry", clean, "no othertop top in run.sh", tp="othertop")
+
+    # Arm 2. The entry stops referencing the collected list.
+    arm("no-pp-srcs", '  "%s|$A/axis_fifo.v"\n' % top, "no longer references")
+
+    # Arm 3. A derived source that does not survive the expansion, because
+    # the suffix filter below the substitution drops it. That filter is what
+    # made the historical truncation invisible: it inspected only tokens
+    # ending in .sv/.v, and what was left of the list ended in neither.
+    saved, derived = derived, derived + [os.path.join(pp, "acmp/ghost.svh")]
+    arm("derived-source-lost", clean, "did not survive expansion")
+    derived = saved
+
+    # Arm 4. The plane itself missing, which a count-based check cannot see.
+    saved, derived = derived, [os.path.join(pp, "common/pp_pkg.sv")]
+    arm("plane-lost", clean, "protocol_processor_top.sv (the control plane")
+    derived = saved
+
+    # Arm 5. ISSUE #235. Every source present and correct, and not one of them
+    # declares the top. Vivado's answer to this list is `module not found`.
+    saved, text[wrappers[0]] = text[wrappers[0]], "module something_else;\n"
+    arm("top-not-in-read-set", clean, "declares `module %s`" % top)
+    text[wrappers[0]] = saved
+
+    # Arm 6. The same, one step subtler: the file is named after the top and
+    # does not declare it, which a file-name check would pass.
+    saved, text[wrappers[0]] = text[wrappers[0]], "// KL_pp_shadow lives here\n"
+    arm("named-not-declared", clean, "declares `module %s`" % top)
+    text[wrappers[0]] = saved
+
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--top", default="milan_datapath",
+                    help="the run.sh entry to expand (default: milan_datapath)")
+    ap.add_argument("--selftest", action="store_true",
+                    help="prove each check fails on a planted defect")
+    args = ap.parse_args()
+
+    if args.selftest:
+        bad = selftest()
+        for b in bad:
+            print("  -", b, file=sys.stderr)
+        if bad:
+            return 2
+        print("dp_srcs self-test: 7 arm(s) passed")
+        return 0
+
+    with open(os.path.join(REPO, "syn", "yosys", "run.sh")) as fh:
+        run_sh = fh.read()
+    pp = subprocess.run(
+        [sys.executable, os.path.join(REPO, "scripts", "pp_srcs.py"),
+         "--prefix", os.path.join(REPO, "protocol-processor", "hdl")],
+        capture_output=True, text=True)
+    if pp.returncode != 0:
+        sys.stderr.write(pp.stderr)
+        return 2
+    files, problems, rc = build(args.top, run_sh, pp.stdout.split())
+    for p in problems:
+        print(p, file=sys.stderr)
+    if rc:
+        return rc
     print("\n".join(files))
     return 0
 

--- a/syn/ooc/dp_srcs.py
+++ b/syn/ooc/dp_srcs.py
@@ -35,22 +35,36 @@ silently filtering an input is exactly how the fourth escape worked. A mutation
 of run.sh now either moves this consumer the same way it moves Yosys, or fails
 both.
 
-THE TOP MUST RESOLVE, NOT MERELY APPEAR. The other half of Issue #235 is a read
-set that contains every source except the module the consumer passes to
-`synth_design -top`: pp_shadow_ooc.tcl read 41 sources and Vivado answered
-`ERROR: [Synth 8-439] module 'KL_pp_shadow' not found`. Checking for the text
-`module <top>` is not that check. A block comment satisfied it ([R0], round
-one), and after comments were stripped an unexpanded macro body still did: the
-three lines `` `define UNUSED `` / `module KL_pp_shadow;` / `endmodule`, joined
-by trailing backslashes, returned rc=0 with 43 files while sv2v answered
-`Could not find top module KL_pp_shadow` and Yosys `Module 'KL_pp_shadow' not
-found` ([R0], round two). Both answers are the preprocessor's, not the text's.
-So `declares()` runs `preprocess()` -- a model of the directive layer that
-consumes a `define` and everything its backslashes carry, drops conditional
-regions unevaluated, and drops every other directive line -- and
-`sv2v_verdict()` asks the front end the gate itself uses. Both must say yes.
-Neither alone is trusted: the model runs where no front end is installed, and
-the front end catches a model that has drifted from the language.
+THE TOP MUST RESOLVE, NOT MERELY APPEAR, AND ONLY A FRONT END SAYS SO. The other
+half of Issue #235 is a read set that contains every source except the module
+the consumer passes to `synth_design -top`: pp_shadow_ooc.tcl read 41 sources
+and Vivado answered `ERROR: [Synth 8-439] module 'KL_pp_shadow' not found`.
+Whether a `module` keyword is code is decided by the directive layer, and three
+successive MODELS of that layer were each accepted here and then broken, all in
+the same direction, all by [R0] on PR #240:
+
+1. round one -- a text search for `module <top>`. A block comment satisfied it.
+2. round two -- comments and strings stripped first. An unexpanded macro body
+   still satisfied it: `` `define UNUSED `` / `module KL_pp_shadow;` /
+   `endmodule`, joined by trailing backslashes, returned rc=0 while sv2v
+   answered `Could not find top module KL_pp_shadow` and Yosys `Module
+   'KL_pp_shadow' not found`.
+3. round three -- `define` bodies consumed and directive lines dropped. A
+   multiline macro INVOCATION still satisfied it: `` `define DISCARD(x) ``,
+   then `` `DISCARD( `` / the declaration / `)`. The model dropped the
+   invocation line and read its ARGUMENT text as code; sv2v again answered
+   `Could not find top module KL_pp_shadow`.
+
+Three rounds, three spellings, one question: which of these `module` keywords
+survives macro expansion. Answering that completely is a preprocessor, and a
+preprocessor is the front end -- so the model is GONE rather than patched a
+fourth time. `sv2v_verdict()`, the front end syn/yosys/run.sh already runs over
+these same lists, is now the ONLY answerer. No front end therefore means no
+answer, and no answer is a refusal: there is no mode in which this file
+approximates top resolution, because an approximation that disagrees with the
+toolchain is exactly what all three rounds measured. That costs no new tool --
+`sv2v` is already required by syn/yosys/run.sh, the authority that defines this
+read set, and listed in README.md's tool table.
 
 `--top` selects the entry; it defaults to `milan_datapath`.
 Used by syn/ooc/milan_datapath_ooc.tcl and syn/ooc/pp_shadow_ooc.tcl.
@@ -95,7 +109,7 @@ LINKED = ("hdl", "scripts", "protocol-processor", "gptp-processor",
 
 #: How many arms selftest() must run. A deleted arm is a self-test that still
 #: prints a pass, so the count is declared and checked rather than counted.
-ARMS = 33
+ARMS = 35
 
 
 def _reader(path):
@@ -158,84 +172,7 @@ def parse_record(text, top, run_sh=RUN_SH):
 
 
 # --------------------------------------------------------------------------
-# does the read set declare the top
-
-
-DIRECTIVE = re.compile(r"^[ \t]*`(\w+)")
-
-
-def preprocess(text):
-    """`text` reduced to what the directive layer would hand the parser.
-
-    Comments and string literals go first, in ONE pass, because they nest the
-    wrong way for two: `//` inside a string opens no comment, and `"` inside a
-    comment opens no string. What is removed becomes spaces, so line structure
-    -- what the declaration pattern anchors on -- survives.
-
-    Then the directive layer, line by line:
-
-    * a `define` line, and every line a trailing backslash carries after it, is
-      MACRO TEXT. It is not code until something expands the macro, and nothing
-      here does. This is the escape that reopened after round one: three lines
-      of unexpanded macro body read as a module declaration to any text search
-      and to no front end.
-    * `ifdef`/`ifndef`/`elsif`/`else`/`endif` regions are dropped rather than
-      evaluated. This file cannot know the `+define+` set the consumer passes,
-      and the question is whether the top is CERTAINLY in the read set.
-    * every other directive line -- `include`, `timescale`, `undef`, a bare
-      macro invocation -- is dropped with its continuations for the same
-      reason: what it brings in is not visible from here.
-
-    The bias is deliberate. A declaration this model cannot see is reported as
-    absent even when a front end would find it; that is a refusal to emit, not
-    a silent pass, and `sv2v_verdict()` below distinguishes the two cases.
-    """
-    out, i, n = [], 0, len(text)
-    while i < n:
-        two = text[i:i + 2]
-        if two == "//":
-            j = text.find("\n", i)
-            j = n if j < 0 else j
-        elif two == "/*":
-            j = text.find("*/", i + 2)
-            j = n if j < 0 else j + 2
-        elif text[i] == '"':
-            j = i + 1
-            while j < n and text[j] != '"':
-                j += 2 if text[j] == "\\" else 1
-            j = min(j + 1, n)
-        else:
-            out.append(text[i])
-            i += 1
-            continue
-        out.append(re.sub(r"[^\n]", " ", text[i:j]))
-        i = j
-
-    kept, depth, carried = [], 0, False
-    for line in "".join(out).split("\n"):
-        continues = line.rstrip().endswith("\\")
-        if carried:
-            kept.append("")
-            carried = continues
-            continue
-        directive = DIRECTIVE.match(line)
-        if directive:
-            name = directive.group(1)
-            if name in ("ifdef", "ifndef"):
-                depth += 1
-            elif name == "endif":
-                depth = max(0, depth - 1)
-            kept.append("")
-            carried = continues
-            continue
-        kept.append("" if depth else line)
-    return "\n".join(kept)
-
-
-def declares(text, top):
-    """True if `text` declares `module <top>` where the parser would see it."""
-    return re.search(r"^[ \t]*module\s+(?:automatic\s+|static\s+)?%s\b"
-                     % re.escape(top), preprocess(text), re.M) is not None
+# does the read set declare the top -- asked of the front end, of nothing else
 
 
 def sv2v_verdict(files, top, incdirs, defines,
@@ -244,8 +181,9 @@ def sv2v_verdict(files, top, incdirs, defines,
 
     Returns (verdict, note): True, False, or None when the front end gave no
     top-resolution answer -- absent, or failed for some other reason. None is
-    never treated as a pass; it is reported, and `--require-front-end` turns it
-    into a refusal so a gate cannot lose this oracle without saying so.
+    not a weaker pass, and there is no flag that makes it one: `build()` refuses
+    on it. The alternative is this file answering from its own model of the
+    language, and that is the escape of all three [R0] rounds.
 
     The invocation is the one syn/yosys/run.sh already makes for the same list.
     """
@@ -274,8 +212,7 @@ def sv2v_verdict(files, top, incdirs, defines,
 # the checks
 
 
-def build(top, rec, exists=os.path.exists, read=_reader,
-          front_end=sv2v_verdict, require_front_end=False):
+def build(top, rec, exists=os.path.exists, front_end=sv2v_verdict):
     """Check the authority's record for `top`. Returns (files, problems, rc)."""
     files = rec["src"]
 
@@ -327,40 +264,32 @@ def build(top, rec, exists=os.path.exists, read=_reader,
 
     # 3. THE TOP ITSELF -- ISSUE #235. Every check above compares the list
     # against what went into it, and all of them pass on a list that contains
-    # everything except the one module the consumer names as `-top`. Resolve it
-    # the way the toolchain does: through the directive layer, and through the
-    # front end the gate runs. Both must agree, in both directions.
-    modelled = any(declares(read(f), top) for f in files)
+    # everything except the one module the consumer names as `-top`. Only the
+    # front end answers this. Whether a `module` keyword is code is a question
+    # about macro expansion, three models of the directive layer were each
+    # broken here by a construct they did not model (module docstring), and a
+    # fourth model would be a fourth round -- so no front end is a REFUSAL, not
+    # a quietly weaker check, and this file has no tool-absent mode at all.
     verdict, note = front_end(files, top, rec["incdir"], rec["define"])
 
+    if verdict is None:
+        return files, ["dp_srcs: no front end resolved `module %s` in the %d "
+                       "source(s) run.sh names for %s: %s. This flow does not "
+                       "answer that question itself: three text/directive "
+                       "models of it were each accepted and then broken by a "
+                       "construct they did not model ([R0] on PR #240, rounds "
+                       "one to three), so an unanswered question is a refusal "
+                       "and not an emission. Install %s -- README.md's tool "
+                       "table has it, and syn/yosys/run.sh, which owns this "
+                       "read set, already requires it."
+                       % (top, len(files), top, note, FRONT_END)], 2
     if verdict is False:
         return files, ["dp_srcs: %s does not resolve `%s` in the %d source(s) "
                        "run.sh names for it:\n  %s\nSynthesis reads every one "
                        "of them and then fails with `module '%s' not found` "
                        "(Issue #235), which reads as a missing module and is "
-                       "really a read set that never declared the top.%s"
-                       % (FRONT_END, top, len(files), note, top,
-                          "" if not modelled else
-                          "\n  This file's own model DID see a declaration, so "
-                          "the model is wrong about the language here and must "
-                          "be fixed, not relaxed.")], 2
-    if not modelled:
-        return files, ["dp_srcs: none of the %d source(s) run.sh names for %s "
-                       "declares `module %s` where the directive layer leaves "
-                       "it: a commented, `ifdef`-guarded or unexpanded-macro "
-                       "declaration is not one. Synthesis would read every "
-                       "source and fail with `module '%s' not found` "
-                       "(Issue #235).%s"
-                       % (len(files), top, top, top,
-                          ("\n  %s resolved it, so the declaration is "
-                           "reachable only through expansion this file will "
-                           "not perform; declare the module plainly."
-                           % FRONT_END) if verdict is True else "")], 2
-    if verdict is None and require_front_end:
-        return files, ["dp_srcs: --require-front-end was given and no front end "
-                       "confirmed `module %s`: %s. A gate that silently loses "
-                       "this oracle is a gate that stops testing the escape it "
-                       "was added for." % (top, note)], 2
+                       "really a read set that never declared the top."
+                       % (FRONT_END, top, len(files), note, top)], 2
     return files, [], 0
 
 
@@ -397,14 +326,21 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
     Every arm drives the real `build()`, `parse_record()` or `ask_authority()`,
     so stubbing any of them to return no problems fails this.
 
-    Three groups. The record arms inject a synthetic record, so they need no
-    tree. The declaration arms inject synthetic text and a stub front end. The
-    authority arms run REAL BASH over a mutated copy of the real
-    syn/yosys/run.sh from a link farm, and the last of them runs the real front
-    end over the real read set: those need the protocol-processor and
-    verilog-axis submodules and sv2v, and they refuse rather than skip when
-    either is absent, because every escape of round two lived exactly in the gap
-    between what a parser modelled and what bash and the front end do.
+    Three groups, and the middle one CHANGED SHAPE in round three. The record
+    arms inject a synthetic record and stub the front end, because they are
+    about the record. The front-end arms used to assert what a model of the
+    directive layer believed about a construct; they now put each construct in a
+    one-file read set and ask the REAL `sv2v`, so what is asserted is the
+    toolchain's answer and not a belief about the language. Two of them run the
+    other way -- a plain declaration and a macro-EXPANDED one must both expand
+    clean -- so this group cannot be passing on a front end that refuses
+    everything. The authority arms run REAL BASH over a mutated copy of the real
+    syn/yosys/run.sh from a link farm.
+
+    The front-end and authority arms need `sv2v` and the protocol-processor and
+    verilog-axis submodules, and they refuse rather than skip when either is
+    absent: every escape this file has had lived in the gap between something
+    modelled here and what bash and the front end actually do.
     """
     problems, ran = [], 0
     src = ["/r/a.sv", "/r/b.sv", "/r/" + PLANE, "/r/top.sv"]
@@ -416,39 +352,26 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
         rec.update(over)
         return rec
 
-    text = {f: "module %s;\nendmodule\n" % os.path.basename(f)[:-3] for f in src}
-    # The real top: declared, and ALSO named in a comment above it, so a clean
-    # pass cannot be a pass on the comment.
-    text["/r/top.sv"] = ("// %s: the wrapper this entry is built around\n"
-                         "module %s #(\n) ();\nendmodule\n" % (top, top))
     gone = set()
 
     def stub_front_end(verdict, note=""):
         return lambda *a, **k: (verdict, note)
 
-    def run(rec, fe=None, require=False):
+    def run(rec, fe=None):
         return build(top, rec, exists=lambda f: f not in gone,
-                     read=lambda f: text.get(f, ""),
-                     front_end=fe or stub_front_end(True),
-                     require_front_end=require)
+                     front_end=fe or stub_front_end(True))
 
-    def arm(name, want, rec=None, fe=None, require=False, call=None):
+    def arm(name, want, rec=None, fe=None, call=None):
         nonlocal ran
         ran += 1
         if call:
             _rec, bad, rc = call()
         else:
-            _files, bad, rc = run(rec, fe, require)
+            _files, bad, rc = run(rec, fe)
         if not any(want in b for b in bad) or rc == 0:
             problems.append("SELF-TEST FAILED [%s]: expected a finding naming "
                             "%r at rc!=0, got rc=%d %s"
                             % (name, want, rc, bad or "no findings"))
-
-    def decl_arm(name, body, fe=None, want=None):
-        saved, text["/r/top.sv"] = text["/r/top.sv"], body
-        arm(name, want or "declares `module %s` where the directive layer" % top,
-            record(), fe)
-        text["/r/top.sv"] = saved
 
     # ---- record arms -----------------------------------------------------
     # Arm 0. ANTI-VACUITY: the well-formed record expands clean. Without it
@@ -502,75 +425,121 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
     arm("plane-lost", "(the control plane itself)",
         record(src=["/r/a.sv", "/r/top.sv"], derived=["/r/a.sv"]))
 
-    # ---- declaration arms ------------------------------------------------
-    # Arm 10. ISSUE #235: every source present and correct, none declares the
-    # top. Vivado's answer to this list is `module not found`.
-    decl_arm("top-not-in-read-set", "module something_else;\nendmodule\n")
+    # Arm 10. THE CONTRACT: no front end, no answer, no emission. The record is
+    # well-formed and its sources are on disk; nothing answered whether the top
+    # resolves, and that alone is the refusal. Deleting the `verdict is None`
+    # arm of build() is what this bites, and that deletion is the whole of what
+    # the tool-absent mode used to be.
+    arm("no-front-end-is-a-refusal", "no front end resolved",
+        record(), stub_front_end(None, "sv2v is not on PATH"))
 
-    # Arm 11. One step subtler: the file is NAMED after the top and does not
-    # declare it, which a file-name check would pass.
-    decl_arm("named-not-declared", "// %s lives here\n" % top)
-
-    # Arms 12-16. THE DECLARATION IS TEXT, NOT CODE ([R0] round one).
-    decl_arm("block-commented-declaration",
-             "/*\nmodule %s;\nendmodule\n*/\n" % top)
-    decl_arm("inactive-conditional-declaration",
-             "`ifdef SOME_DEFINE\nmodule %s;\nendmodule\n`endif\n" % top)
-    decl_arm("declaration-inside-a-string",
-             'localparam string S = "\nmodule %s;\n";\n' % top)
-    decl_arm("line-commented-declaration",
-             "// module %s;\n// endmodule\n" % top)
-    decl_arm("prefix-of-the-top-declared", "module %s_shim;\nendmodule\n" % top)
-
-    # Arms 17-19. THE DECLARATION IS TEXT, NOT PREPROCESSED CODE ([R0] round
-    # two). An unexpanded macro body is not a declaration; arm 17 is the exact
-    # three-line construct the reviewer drove the real `build()` with.
-    decl_arm("macro-body-declaration",
-             "`define UNUSED \\\nmodule %s; \\\nendmodule\n" % top)
-    decl_arm("macro-body-one-line",
-             "`define UNUSED module %s; endmodule\n" % top)
-    decl_arm("macro-body-after-a-comment",
-             "`define UNUSED /* keep */ \\\nmodule %s; \\\nendmodule\n" % top)
-
-    # Arm 20. The front end resolves no such top and the model saw one. The
-    # front end wins, and the finding says the model must be fixed.
-    arm("front-end-refuses-what-the-model-saw", "does not resolve",
-        record(), stub_front_end(False, "Could not find top module"))
-
-    # Arm 21. The other direction: the front end resolves it and the model
-    # cannot. Also a refusal -- an emitted list must be provable from here too.
-    decl_arm("front-end-only", "module something_else;\nendmodule\n",
-             stub_front_end(True),
-             want="reachable only through expansion")
-
-    # Arm 22. No front end, and a caller that said it required one.
-    arm("front-end-required-and-absent", "--require-front-end was given",
-        record(), stub_front_end(None, "sv2v is not on PATH"), require=True)
-
-    # ---- authority arms --------------------------------------------------
-    # These run REAL BASH over a mutated real run.sh, and the reviewer's four
-    # round-two counterexamples are four of them. A tree without submodules
-    # cannot answer them, and a skip here is the false green they exist to
-    # close, so their absence is reported as a failure.
+    # ---- front-end arms --------------------------------------------------
+    # From here the REAL front end runs, so its absence is a failure and not a
+    # skip: these arms ARE the top-resolution check now.
     if not (os.path.exists(RUN_SH) and shutil.which("bash")
             and os.path.exists(os.path.join(REPO, "protocol-processor", "hdl"))
             and os.path.exists(os.path.join(REPO, "third_party",
                                             "verilog-axis", "rtl"))):
-        problems.append("SELF-TEST FAILED [authority-arms]: syn/yosys/run.sh, "
-                        "bash and the protocol-processor and verilog-axis "
-                        "submodules are all required. The round-two escapes "
-                        "were all disagreements between a parser and bash, so "
-                        "skipping these arms is skipping the finding.")
+        problems.append("SELF-TEST FAILED [front-end-and-authority-arms]: "
+                        "syn/yosys/run.sh, bash and the protocol-processor and "
+                        "verilog-axis submodules are all required. The "
+                        "round-two escapes were all disagreements between a "
+                        "parser and bash, so skipping these arms is skipping "
+                        "the finding.")
         return problems, ran
     if shutil.which(FRONT_END) is None:
-        problems.append("SELF-TEST FAILED [authority-arms]: %s is not on PATH. "
-                        "It is the oracle for the macro-body escape, and the "
-                        "Yosys gate already requires it." % FRONT_END)
+        problems.append("SELF-TEST FAILED [front-end-and-authority-arms]: %s is "
+                        "not on PATH. It is the only answerer for the "
+                        "declaration question, and the Yosys gate already "
+                        "requires it." % FRONT_END)
         return problems, ran
 
     real = _reader(RUN_SH)
     tmp = tempfile.mkdtemp(prefix="dp-srcs-selftest-")
     try:
+        def one_file(name, body, want="does not resolve", clean=False):
+            """One synthetic source, the real front end, nothing in between.
+
+            `clean=True` is the other direction: the front end resolves the top
+            and the flow must emit. Two arms use it, because a group of arms
+            that only ever expects a refusal passes on a front end that refuses
+            everything.
+            """
+            nonlocal ran
+            ran += 1
+            path = os.path.join(tmp, name + ".sv")
+            with open(path, "w") as fh:
+                fh.write(body)
+            _files, bad, rc = build(top, {"top": [top], "define": [],
+                                          "incdir": [], "derived": [],
+                                          "src": [path]})
+            if clean:
+                if rc or bad:
+                    problems.append("SELF-TEST FAILED [%s]: %s resolves this "
+                                    "declaration, so the list must expand "
+                                    "clean; got rc=%d %s"
+                                    % (name, FRONT_END, rc, bad))
+                return
+            if rc == 0 or not any(want in b for b in bad):
+                problems.append("SELF-TEST FAILED [%s]: expected a finding "
+                                "naming %r at rc!=0, got rc=%d %s"
+                                % (name, want, rc, bad or "no findings"))
+
+        # Arm 11. ANTI-VACUITY for this group: a plain declaration expands
+        # clean through the real front end.
+        one_file("plain-declaration", "module %s;\nendmodule\n" % top,
+                 clean=True)
+
+        # Arm 12. ISSUE #235 itself: sources present and correct, none of them
+        # declaring the top. This is the list Vivado answers `module not found`.
+        one_file("top-not-in-read-set", "module something_else;\nendmodule\n")
+
+        # Arm 13. One step subtler: a file NAMED after the top that does not
+        # declare it, which a file-name check would pass.
+        one_file("named-not-declared", "// %s lives here\n" % top)
+
+        # Arms 14-18. THE DECLARATION IS TEXT, NOT CODE ([R0] round one).
+        one_file("block-commented-declaration",
+                 "/*\nmodule %s;\nendmodule\n*/\n" % top)
+        one_file("line-commented-declaration",
+                 "// module %s;\n// endmodule\n" % top)
+        one_file("inactive-conditional-declaration",
+                 "`ifdef SOME_DEFINE\nmodule %s;\nendmodule\n`endif\n" % top)
+        one_file("declaration-inside-a-string",
+                 'module other;\n'
+                 '  localparam string S = "module %s; endmodule";\n'
+                 'endmodule\n' % top)
+        one_file("prefix-of-the-top-declared",
+                 "module %s_shim;\nendmodule\n" % top)
+
+        # Arms 19-21. THE DECLARATION IS TEXT, NOT PREPROCESSED CODE ([R0]
+        # round two): an unexpanded macro BODY, in its three spellings.
+        one_file("macro-body-declaration",
+                 "`define UNUSED \\\nmodule %s; \\\nendmodule\n" % top)
+        one_file("macro-body-one-line",
+                 "`define UNUSED module %s; endmodule\n" % top)
+        one_file("macro-body-after-a-comment",
+                 "`define UNUSED /* keep */ \\\nmodule %s; \\\nendmodule\n"
+                 % top)
+
+        # Arm 22. [R0] ROUND THREE, the construct that closed the model: the
+        # declaration is the ACTUAL ARGUMENT of a multiline macro invocation,
+        # so it is argument text the expansion discards. The round-two model
+        # dropped the invocation line and read the argument as code.
+        one_file("macro-argument-declaration",
+                 "`define DISCARD(x)\n`DISCARD(\nmodule %s;\nendmodule\n)\n"
+                 % top)
+
+        # Arm 23. The OTHER direction, and the reason a model cannot stand in
+        # for the front end even conservatively: here the text carries no
+        # declaration at all and the expansion produces one. The front end
+        # resolves it, so the flow must emit -- the deleted model refused this.
+        one_file("macro-expanded-declaration",
+                 "`define D module %s; endmodule\n`D\n" % top, clean=True)
+
+        # ---- authority arms ----------------------------------------------
+        # These run REAL BASH over a mutated real run.sh, and the reviewer's
+        # four round-two counterexamples are four of them.
         def relative(root, rec):
             """The record's sources as the authority's own tree spells them.
             Each arm gets its own shadow root, so absolute paths differ by
@@ -597,20 +566,20 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
                                 "naming %r at rc!=0, got rc=%d %s"
                                 % (name, want, rc, bad or "no findings"))
 
-        # Arm 23. ANTI-VACUITY over the REAL authority: the untouched run.sh
+        # Arm 24. ANTI-VACUITY over the REAL authority: the untouched run.sh
         # expands clean through real bash and the real front end.
         ran += 1
         base_root, base_path = _shadow(real, tmp)
         base, bad, rc = ask_authority(real_top, base_path)
         base_src = relative(base_root, base) if rc == 0 else []
         if rc == 0:
-            _f, bad, rc = build(real_top, base, require_front_end=True)
+            _f, bad, rc = build(real_top, base)
         if rc or bad or len(base_src) < 2:
             problems.append("SELF-TEST FAILED [real-authority-clean]: the "
                             "untouched run.sh must expand clean, got rc=%d %s, "
                             "%d source(s)" % (rc, bad, len(base_src)))
 
-        # Arm 24. [R0] round two, mutation 1: the generator token is suffixed.
+        # Arm 25. [R0] round two, mutation 1: the generator token is suffixed.
         # The old recogniser accepted the expected path as a SUBSTRING and
         # returned rc=0 with 43 files; bash executes a nonexistent file and
         # takes run.sh's own `|| exit 2`.
@@ -619,7 +588,7 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
                                       '"$R/scripts/pp_srcs.py.broken"'),
                   "so there is no read set to emit")
 
-        # Arm 25. Mutation 2: the generator's --prefix points at a tree that
+        # Arm 26. Mutation 2: the generator's --prefix points at a tree that
         # does not exist. The old recogniser ignored the invocation it claimed
         # to validate and ran its own; bash hands sv2v paths that are not there.
         authority("generator-prefix-diverted",
@@ -627,7 +596,7 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
                                       '--prefix "$PP/not-the-tree"'),
                   "missing sources")
 
-        # Arm 26. Mutation 3: a valid shell COMMENT above the live row, spelt
+        # Arm 27. Mutation 3: a valid shell COMMENT above the live row, spelt
         # so a text selector prefers it. The old recogniser emitted 42 files and
         # dropped axis_fifo.v; bash ignores the line entirely, so the correct
         # answer is the unchanged read set -- which is the property that proves
@@ -639,71 +608,89 @@ def selftest(top="faketop", real_top="KL_pp_shadow"):
                       '  "KL_pp_shadow|$A/axis_fifo.v $PP_SRCS"\n'),
                   None, expect_src=base_src)
 
-        # Arm 27. Mutation 4: a positional that is not a source. The old
+        # Arm 28. Mutation 4: a positional that is not a source. The old
         # recogniser filtered it out before the missing-source check.
         authority("unaccounted-positional",
                   lambda t: t.replace('PP_SRCS="$PP_DERIVED ',
                                       'PP_SRCS="$PP_DERIVED $PP/ghost.svh '),
                   "are not .sv/.v sources")
 
-        # Arm 28. The same positional spelt as a source that is not on disk.
+        # Arm 29. The same positional spelt as a source that is not on disk.
         authority("missing-positional",
                   lambda t: t.replace('PP_SRCS="$PP_DERIVED ',
                                       'PP_SRCS="$PP_DERIVED $PP/ghost.sv '),
                   "missing sources")
 
-        # Arm 29. [R0] round one, mutation D2, now through real bash: run.sh
+        # Arm 30. [R0] round one, mutation D2, now through real bash: run.sh
         # drops the wrapper that declares the top. It stayed green at
         # 16,547 LUT when this file composed the parent half itself.
         authority("run-sh-drops-the-top",
                   lambda t: t.replace(" $R/hdl/milan/KL_pp_shadow.sv", ""),
                   "does not resolve `%s`" % real_top)
 
-        # Arm 30. A top no row defines. run.sh answers, this flow reports it.
+        # Arm 31. A top no row defines. run.sh answers, this flow reports it.
         ran += 1
         _rec, bad, rc = ask_authority("othertop", _shadow(real, tmp)[1])
         if rc == 0 or not any("unknown top: othertop" in b for b in bad):
             problems.append("SELF-TEST FAILED [unknown-top]: expected the "
                             "authority's own refusal, got rc=%d %s" % (rc, bad))
 
-        # Arm 31. THE ROUND-TWO BLOCKER, END TO END. The real read set, with the
-        # file that declares the top replaced on disk by the reviewer's exact
-        # unexpanded macro body, driven through real bash and the REAL front
-        # end. `sv2v --top` answers `Could not find top module`; so must this.
-        ran += 1
-        shadow_src = os.path.join(tmp, "KL_pp_shadow.sv")
-        with open(shadow_src, "w") as fh:
-            fh.write("`define UNUSED \\\nmodule %s; \\\nendmodule\n" % real_top)
-        macro_root, macro_path = _shadow(
-            real.replace("$R/hdl/milan/KL_pp_shadow.sv", shadow_src), tmp)
-        rec, bad, rc = ask_authority(real_top, macro_path)
-        if rc == 0:
-            _f, bad, rc = build(real_top, rec, require_front_end=True)
-        if rc == 0 or not any("does not resolve" in b for b in bad):
-            problems.append("SELF-TEST FAILED [macro-body-real-front-end]: the "
-                            "real read set with an unexpanded macro body in "
-                            "place of the top must be refused by %s; got rc=%d "
-                            "%s" % (FRONT_END, rc, bad))
-        if len(relative(macro_root, rec)) != len(base_src):
-            problems.append("SELF-TEST FAILED [macro-body-real-front-end]: the "
-                            "mutation must change only the top's TEXT, and it "
-                            "changed the read set (%d vs %d source(s))"
-                            % (len(relative(macro_root, rec)), len(base_src)))
+        # Arms 32-34. THE TWO REOPENED ESCAPES, END TO END, ON THE REAL READ
+        # SET. The file that declares the top is replaced on disk by the
+        # round-two construct and then by the round-three one, and the whole
+        # real record is driven through real bash. Only the top's TEXT moves,
+        # which each arm asserts by comparing the source count with arm 24's.
+        def real_set_with(name, body):
+            path = os.path.join(tmp, name + ".sv")
+            with open(path, "w") as fh:
+                fh.write(body)
+            return _shadow(
+                real.replace("$R/hdl/milan/KL_pp_shadow.sv", path), tmp)
 
-        # Arm 32. THE SAME SET WITH NO FRONT END AT ALL. A Vivado host need not
-        # carry sv2v, so the directive-layer model has to close this escape on
-        # its own; this arm is what stops a later change from leaning on the
-        # oracle and leaving that host with the round-two behaviour.
-        ran += 1
-        rec, bad, rc = ask_authority(real_top, macro_path)
-        if rc == 0:
-            _f, bad, rc = build(real_top, rec,
-                                front_end=lambda *a, **k: (None, "no front end"))
-        want = "declares `module %s` where the directive layer" % real_top
-        if rc == 0 or not any(want in b for b in bad):
-            problems.append("SELF-TEST FAILED [macro-body-model-alone]: with no "
-                            "front end the model must still refuse the macro "
-                            "body; got rc=%d %s" % (rc, bad))
+        def real_text_arm(name, root, path, fe, want):
+            nonlocal ran
+            ran += 1
+            rec, bad, rc = ask_authority(real_top, path)
+            if rc == 0:
+                _f, bad, rc = build(real_top, rec, front_end=fe)
+            if rc == 0 or not any(want in b for b in bad):
+                problems.append("SELF-TEST FAILED [%s]: expected a finding "
+                                "naming %r at rc!=0, got rc=%d %s"
+                                % (name, want, rc, bad or "no findings"))
+            if len(relative(root, rec)) != len(base_src):
+                problems.append("SELF-TEST FAILED [%s]: the mutation must "
+                                "change only the top's TEXT, and it changed "
+                                "the read set (%d vs %d source(s))"
+                                % (name, len(relative(root, rec)),
+                                   len(base_src)))
+
+        macro_root, macro_path = real_set_with(
+            "round2_body", "`define UNUSED \\\nmodule %s; \\\nendmodule\n"
+            % real_top)
+        arg_root, arg_path = real_set_with(
+            "round3_argument",
+            "`define DISCARD(x)\n`DISCARD(\nmodule %s;\nendmodule\n)\n"
+            % real_top)
+
+        # Arm 32. Round two's unexpanded macro body, real front end.
+        real_text_arm("macro-body-real-front-end", macro_root, macro_path,
+                      sv2v_verdict, "does not resolve")
+
+        # Arm 33. ROUND THREE's macro argument, real front end. At the previous
+        # head this same input reached `build()` and the front end refused it
+        # there too; what had to change is the arm below.
+        real_text_arm("macro-argument-real-front-end", arg_root, arg_path,
+                      sv2v_verdict, "does not resolve")
+
+        # Arm 34. ROUND THREE with NO FRONT END -- the path a Vivado host that
+        # has not installed sv2v takes. At the previous head this returned rc=0
+        # with no findings, because a model of the directive layer answered in
+        # the front end's place; there is no such model now, so the answer is a
+        # refusal naming the missing tool. Restoring the `verdict is None` pass
+        # is what reddens here.
+        real_text_arm("macro-argument-no-front-end", arg_root, arg_path,
+                      lambda *a, **k: (None, "no front end"),
+                      "no front end resolved")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 
@@ -722,9 +709,6 @@ def main() -> int:
                     help="the run.sh entry to expand (default: milan_datapath)")
     ap.add_argument("--selftest", action="store_true",
                     help="prove each check fails on a planted defect")
-    ap.add_argument("--require-front-end", action="store_true",
-                    help="refuse unless %s confirms the top resolves"
-                         % FRONT_END)
     args = ap.parse_args()
 
     if args.selftest:
@@ -739,8 +723,7 @@ def main() -> int:
     files, problems, rc = [], [], 0
     rec, problems, rc = ask_authority(args.top)
     if rc == 0:
-        files, problems, rc = build(args.top, rec,
-                                    require_front_end=args.require_front_end)
+        files, problems, rc = build(args.top, rec)
     for p in problems:
         print(p, file=sys.stderr)
     if rc:

--- a/syn/ooc/dp_srcs.py
+++ b/syn/ooc/dp_srcs.py
@@ -3,63 +3,99 @@
 # SPDX-License-Identifier: CERN-OHL-W-2.0
 """Print the source list of a top named in syn/yosys/run.sh, one path per line.
 
-THE POINT IS THAT THERE IS NO SECOND COPY. A top's source list is the
-"<top>|..." entry in syn/yosys/run.sh -- the one the portability gate proves
-elaborates on every run -- and the collected `PP_SRCS` that entry references is
-read from run.sh as well: its submodule half through scripts/pp_srcs.py, the
-generator run.sh itself calls, and its parent half from run.sh's own
-composition line. A hand-maintained duplicate in a Vivado .tcl would drift the
-first time a module lands, and the drift would show up as a synthesis result
-quietly missing a block. So the .tcl execs this instead.
+THE POINT IS THAT THERE IS NO SECOND COPY, AND NO SECOND READER. A top's source
+list is the "<top>|..." entry in syn/yosys/run.sh -- the one the portability
+gate proves elaborates on every run -- and this file does not read that entry.
+It asks run.sh for it: `syn/yosys/run.sh --emit <top>` prints bash's own
+expansion of the row the gate is about to synthesize, as `top=` / `define=` /
+`incdir=` / `derived=` / `src=` lines, and everything below is that record.
 
-Composing the parent half HERE was the same defect one level down, and it
-shipped: a `PARENT_WRAPPERS` tuple in this file happened to agree with run.sh,
-and agreement is not derivation. Two run.sh inputs differing only in their
-`PP_SRCS` definition produced identical output, and deleting
-hdl/milan/KL_pp_shadow.sv from run.sh left this flow green at rc=0 with an
-unchanged area figure ([R0] on PR #240). The tuple is gone. `_pp_srcs()` below
-parses the composition instead, and every way that parse can come back wrong is
-a hard error rather than a shorter list.
+Two earlier shapes of this file both failed, in the same direction, and the
+second failure is why the shape changed rather than the spelling:
 
-Parsing a build file is what caused the earlier escape, so the parse is pinned
-rather than trusted. This file lifted the assignment with `PP_SRCS="(.*?)"`
-until it became a command substitution, whose inner quotes truncated the
-non-greedy capture: 104 sources became 62, exit 0, no diagnostic, and Vivado
-said only `module 'KL_pp_shadow' not found`. What is different now is that the
-composition line is selected by the generator reference it must contain, that
-exactly one line may match, that run.sh's generator call is asserted to be the
-one this file makes, that a `$`-prefixed token surviving expansion is an error,
-that every named file must exist, and that some emitted source must declare the
-top. A truncation fails all but the first of those.
+1. A `PARENT_WRAPPERS` tuple here happened to agree with run.sh, and agreement
+   is not derivation. Deleting hdl/milan/KL_pp_shadow.sv from run.sh left this
+   flow green at rc=0 with an unchanged area figure ([R0] on PR #240).
+2. Parsing run.sh instead of duplicating it moved the defect one level down. A
+   recogniser accepts what it has modelled, and bash accepts something else. At
+   the previous head, suffixing the generator to `scripts/pp_srcs.py.broken`
+   still gave rc=0 with 43 files, because the check accepted the expected path
+   as a substring while run.sh would have executed a nonexistent file and taken
+   its `|| exit 2`. Pointing the generator's `--prefix` at a tree that does not
+   exist gave rc=0 with 43 files. Prepending the shell comment
+   `# "KL_pp_shadow|$PP_SRCS"` -- which bash ignores entirely -- made the
+   selector pick the comment and emit 42 files, silently dropping axis_fifo.v.
+   Adding a positional `ghost.svh` gave rc=0 with 43 files, because the suffix
+   filter dropped the token before the missing-source check could see it. All
+   four are [R0] on PR #240, round two, and all four are arms below.
 
-`--top` selects the entry. It defaults to `milan_datapath`, which is the only
-top this file served when it was written; `KL_pp_shadow` is the second. That
-script assembled its own read set instead -- the submodule half from
-scripts/pp_srcs.py plus a hand-named axis_fifo.v -- and the one file the
-assembly did not name was the module it passed to `synth_design -top`, so the
-documented plane-area recipe read 41 sources and then failed with
-`ERROR: [Synth 8-439] module 'KL_pp_shadow' not found` (Issue #235). Hence the
-last check below: this file refuses to emit a list in which nothing declares
-the top it was asked for, whatever the list was built from.
+So the recogniser is gone. `ask_authority()` executes run.sh; `parse_record()`
+models the whole record and refuses any line it has not modelled, because
+silently filtering an input is exactly how the fourth escape worked. A mutation
+of run.sh now either moves this consumer the same way it moves Yosys, or fails
+both.
 
+THE TOP MUST RESOLVE, NOT MERELY APPEAR. The other half of Issue #235 is a read
+set that contains every source except the module the consumer passes to
+`synth_design -top`: pp_shadow_ooc.tcl read 41 sources and Vivado answered
+`ERROR: [Synth 8-439] module 'KL_pp_shadow' not found`. Checking for the text
+`module <top>` is not that check. A block comment satisfied it ([R0], round
+one), and after comments were stripped an unexpanded macro body still did: the
+three lines `` `define UNUSED `` / `module KL_pp_shadow;` / `endmodule`, joined
+by trailing backslashes, returned rc=0 with 43 files while sv2v answered
+`Could not find top module KL_pp_shadow` and Yosys `Module 'KL_pp_shadow' not
+found` ([R0], round two). Both answers are the preprocessor's, not the text's.
+So `declares()` runs `preprocess()` -- a model of the directive layer that
+consumes a `define` and everything its backslashes carry, drops conditional
+regions unevaluated, and drops every other directive line -- and
+`sv2v_verdict()` asks the front end the gate itself uses. Both must say yes.
+Neither alone is trusted: the model runs where no front end is installed, and
+the front end catches a model that has drifted from the language.
+
+`--top` selects the entry; it defaults to `milan_datapath`.
 Used by syn/ooc/milan_datapath_ooc.tcl and syn/ooc/pp_shadow_ooc.tcl.
 """
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
 
-#: The generator run.sh must call to derive the submodule half, and the one
-#: this file calls. Named once so the two calls cannot become two generators.
-GENERATOR = "scripts/pp_srcs.py"
+#: The authority, and the flag that makes it hand over one top's record. Named
+#: once: a second spelling of either is a second authority.
+RUN_SH = os.path.join(REPO, "syn", "yosys", "run.sh")
+EMIT = "--emit"
+
+#: Every key the record may carry. A line whose key is not here is a hard error
+#: rather than a skipped line -- see escape 4 in the module docstring.
+KEYS = ("top", "define", "incdir", "derived", "src")
+
+#: What a consumer of this list can hand to `read_verilog`. A token that is not
+#: one of these is not filtered out, it is refused.
+SOURCE_SUFFIXES = (".sv", ".v")
+
+#: The module that IS the control plane. Named rather than counted: a generator
+#: that returned a truncated list would satisfy a count.
+PLANE = "protocol_processor_top.sv"
+
+#: The front end the mandatory Yosys gate already runs over these same source
+#: lists (syn/yosys/run.sh calls `sv2v --top=<top> <inc> <srcs>`), so asking it
+#: here adds no tool the gate does not already require.
+FRONT_END = "sv2v"
+
+#: Repository entries the authority resolves paths against. Only used by the
+#: self-test, which runs mutated copies of run.sh from a shadow root of links.
+LINKED = ("hdl", "scripts", "protocol-processor", "gptp-processor",
+          "third_party", "configs", "tb")
 
 #: How many arms selftest() must run. A deleted arm is a self-test that still
 #: prints a pass, so the count is declared and checked rather than counted.
-ARMS = 19
+ARMS = 33
 
 
 def _reader(path):
@@ -67,24 +103,92 @@ def _reader(path):
         return fh.read()
 
 
-def active_code(text):
-    """`text` with comments, string literals and conditional regions removed.
+# --------------------------------------------------------------------------
+# the authority
 
-    Comments and strings are removed in ONE pass, because they nest the wrong
-    way for two passes: `//` inside a string opens no comment, and `"` inside a
-    comment opens no string. What is removed is replaced by spaces, so line
-    structure -- what the declaration pattern anchors on -- survives.
 
-    Conditional-compilation regions are dropped rather than evaluated. This
-    file cannot know the `+define+` set the consumer will pass, and the
-    question it has to answer is whether the top is CERTAINLY in the read set;
-    a declaration that depends on a define is not certainly anywhere.
+def ask_authority(top, run_sh=RUN_SH, runner=subprocess.run):
+    """Run `run_sh --emit <top>` and parse its record. Returns (rec, bad, rc).
 
-    Without this, the check was a text search: an injected source whose only
-    occurrence of the top was `/*` newline `module KL_pp_shadow;` newline
-    `endmodule` newline `*/` satisfied it at rc=0 with five emitted files
-    ([R0] on PR #240), so a semantically absent top still reached Vivado's
-    `module not found`.
+    `bash` explicitly, not the executable bit: a checkout that lost the mode
+    bit would otherwise turn one authority back into none.
+    """
+    out = runner(["bash", run_sh, EMIT, top], capture_output=True, text=True)
+    if out.returncode != 0:
+        err = (out.stderr or out.stdout or "").strip() or "(no diagnostic)"
+        return None, ["dp_srcs: %s %s %s exited %d, so there is no read set to "
+                      "emit. That script is the authority for what this top is "
+                      "built from; its refusal is this flow's refusal.\n  %s"
+                      % (os.path.relpath(run_sh, REPO), EMIT, top,
+                         out.returncode, err.replace("\n", "\n  "))], 2
+    return parse_record(out.stdout, top, run_sh)
+
+
+def parse_record(text, top, run_sh=RUN_SH):
+    """The `--emit` record, fully modelled. Returns (rec, problems, rc).
+
+    NOTHING IS SKIPPED. The escape this replaces filtered every token it did
+    not recognise, so a source the authority named and this file could not
+    handle became invisible instead of fatal.
+    """
+    rec = {k: [] for k in KEYS}
+    for n, line in enumerate(text.split("\n"), 1):
+        if not line.strip():
+            continue
+        key, sep, value = line.partition("=")
+        if not sep or key not in KEYS or not value:
+            return None, ["dp_srcs: line %d of the %s %s record is not one of "
+                          "the modelled %s lines:\n  %r\nIt is refused rather "
+                          "than skipped: skipping an input the authority named "
+                          "is how a source list goes short at exit 0."
+                          % (n, os.path.relpath(run_sh, REPO), EMIT,
+                             "/".join(KEYS), line)], 2
+        rec[key].append(value)
+
+    if rec["top"] != [top]:
+        return None, ["dp_srcs: asked %s for %r and the record names %r. The "
+                      "list and the module a consumer passes to -top would be "
+                      "about two different entries."
+                      % (EMIT, top, rec["top"])], 2
+    if not rec["src"]:
+        return None, ["dp_srcs: the %s record for %s names no source. An empty "
+                      "read set elaborates nothing and reports no error."
+                      % (EMIT, top)], 2
+    return rec, [], 0
+
+
+# --------------------------------------------------------------------------
+# does the read set declare the top
+
+
+DIRECTIVE = re.compile(r"^[ \t]*`(\w+)")
+
+
+def preprocess(text):
+    """`text` reduced to what the directive layer would hand the parser.
+
+    Comments and string literals go first, in ONE pass, because they nest the
+    wrong way for two: `//` inside a string opens no comment, and `"` inside a
+    comment opens no string. What is removed becomes spaces, so line structure
+    -- what the declaration pattern anchors on -- survives.
+
+    Then the directive layer, line by line:
+
+    * a `define` line, and every line a trailing backslash carries after it, is
+      MACRO TEXT. It is not code until something expands the macro, and nothing
+      here does. This is the escape that reopened after round one: three lines
+      of unexpanded macro body read as a module declaration to any text search
+      and to no front end.
+    * `ifdef`/`ifndef`/`elsif`/`else`/`endif` regions are dropped rather than
+      evaluated. This file cannot know the `+define+` set the consumer passes,
+      and the question is whether the top is CERTAINLY in the read set.
+    * every other directive line -- `include`, `timescale`, `undef`, a bare
+      macro invocation -- is dropped with its continuations for the same
+      reason: what it brings in is not visible from here.
+
+    The bias is deliberate. A declaration this model cannot see is reported as
+    absent even when a front end would find it; that is a refusal to emit, not
+    a silent pass, and `sv2v_verdict()` below distinguishes the two cases.
     """
     out, i, n = [], 0, len(text)
     while i < n:
@@ -107,319 +211,307 @@ def active_code(text):
         out.append(re.sub(r"[^\n]", " ", text[i:j]))
         i = j
 
-    kept, depth = [], 0
+    kept, depth, carried = [], 0, False
     for line in "".join(out).split("\n"):
-        head = line.lstrip()
-        if head.startswith(("`ifdef", "`ifndef")):
-            depth += 1
+        continues = line.rstrip().endswith("\\")
+        if carried:
             kept.append("")
-        elif head.startswith("`endif"):
-            depth = max(0, depth - 1)
+            carried = continues
+            continue
+        directive = DIRECTIVE.match(line)
+        if directive:
+            name = directive.group(1)
+            if name in ("ifdef", "ifndef"):
+                depth += 1
+            elif name == "endif":
+                depth = max(0, depth - 1)
             kept.append("")
-        elif head.startswith(("`elsif", "`else")):
-            kept.append("")
-        else:
-            kept.append("" if depth else line)
+            carried = continues
+            continue
+        kept.append("" if depth else line)
     return "\n".join(kept)
 
 
 def declares(text, top):
-    """True if `text` declares `module <top>` in code the front end sees."""
+    """True if `text` declares `module <top>` where the parser would see it."""
     return re.search(r"^[ \t]*module\s+(?:automatic\s+|static\s+)?%s\b"
-                     % re.escape(top), active_code(text), re.M) is not None
+                     % re.escape(top), preprocess(text), re.M) is not None
 
 
-def _pp_srcs(run_sh, derived):
-    """run.sh's own `PP_SRCS` composition, expanded. Returns (text, problems).
+def sv2v_verdict(files, top, incdirs, defines,
+                 which=shutil.which, runner=subprocess.run):
+    """Ask the front end whether it resolves `top` in `files`.
 
-    Both halves come from run.sh: `$PP_DERIVED` is replaced by what the
-    generator run.sh names returned, and every other token is run.sh's, not
-    this file's.
+    Returns (verdict, note): True, False, or None when the front end gave no
+    top-resolution answer -- absent, or failed for some other reason. None is
+    never treated as a pass; it is reported, and `--require-front-end` turns it
+    into a refusal so a gate cannot lose this oracle without saying so.
+
+    The invocation is the one syn/yosys/run.sh already makes for the same list.
     """
-    gen = re.search(r"^[ \t]*PP_DERIVED=(.*)$", run_sh, re.M)
-    if not gen or GENERATOR not in gen.group(1):
-        return None, ["dp_srcs: run.sh has no PP_DERIVED assignment calling %s. "
-                      "This file calls it to derive the submodule half, so the "
-                      "two would be deriving that half from two generators."
-                      % GENERATOR]
+    exe = which(FRONT_END)
+    if exe is None:
+        return None, ("%s is not on PATH, so no front end confirmed the "
+                      "declaration" % FRONT_END)
+    argv = [exe, "--top=" + top]
+    argv += ["-D" + d for d in defines]
+    for d in incdirs:
+        argv += ["-I", d]
+    argv += list(files)
+    out = runner(argv, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                 text=True)
+    err = (out.stderr or "").strip()
+    if out.returncode == 0:
+        return True, ""
+    if re.search(r"find top module\s+%s\b" % re.escape(top), err):
+        return False, err.split("\n")[0]
+    return None, ("%s exited %d without a top-resolution verdict: %s"
+                  % (FRONT_END, out.returncode,
+                     err.split("\n")[0] if err else "(no diagnostic)"))
 
-    # Selected by the reference it must contain, not by position: run.sh also
-    # assigns PP_SRCS a deliberately impossible placeholder on the `--list`
-    # path, which derives nothing.
-    defs = [d for d in re.findall(r'^[ \t]*PP_SRCS="([^"\n]*)"', run_sh, re.M)
-            if "$PP_DERIVED" in d]
-    if len(defs) != 1:
-        return None, ["dp_srcs: run.sh has %d PP_SRCS definition(s) referencing "
-                      "$PP_DERIVED, expected exactly 1. Guessing which one the "
-                      "build uses would put the OOC read set and the Yosys one "
-                      "back on two authorities." % len(defs)]
-    return defs[0].replace("$PP_DERIVED", " ".join(derived)), []
+
+# --------------------------------------------------------------------------
+# the checks
 
 
-def build(top, run_sh, derived, repo=REPO, exists=os.path.exists, read=_reader):
-    """Expand `top`'s entry in run.sh's text. Returns (files, problems, rc).
+def build(top, rec, exists=os.path.exists, read=_reader,
+          front_end=sv2v_verdict, require_front_end=False):
+    """Check the authority's record for `top`. Returns (files, problems, rc)."""
+    files = rec["src"]
 
-    `run_sh`, `derived`, `exists` and `read` are the inputs, injected rather
-    than read, so that `selftest()` can prove every check below bites without
-    editing the repository to do it.
-    """
-    m = re.search(r'"%s\|(.*?)"\n' % re.escape(top), run_sh, re.S)
-    if not m:
-        return [], ["dp_srcs: no %s top in run.sh" % top], 2
-    srcs = m.group(1)
+    # 1. EVERY TOKEN IS A SOURCE. The previous shape kept only tokens ending in
+    # .sv/.v and dropped the rest without a word, so a positional `ghost.svh`
+    # in run.sh's PP_SRCS never reached the missing-source check ([R0]).
+    unaccounted = [f for f in files if not f.endswith(SOURCE_SUFFIXES)]
+    if unaccounted:
+        return files, ["dp_srcs: the authority named %d token(s) for %s that "
+                       "are not %s sources:\n  %s\nrun.sh passes them to sv2v "
+                       "and this flow would pass them to read_verilog. Dropping "
+                       "them here is what made a bad entry look clean."
+                       % (len(unaccounted), top, "/".join(SOURCE_SUFFIXES),
+                          "\n  ".join(unaccounted))], 2
 
-    # The one collected list that entry references. It used to be three
-    # (AECP_SRCS / LWSRP_SRCS / PP_SRCS): the first two named the 1722.1 and
-    # SRP planes, which are deleted, and PP_SRCS - the protocol processor that
-    # replaced them - is no longer optional, so the datapath entry expands it
-    # like any other source. A name listed here that run.sh no longer defines
-    # is a hard error on purpose: silently dropping it would emit a source list
-    # missing a whole plane, and Vivado would only say "module not found".
-    if "$PP_SRCS" not in srcs:
-        return [], ["dp_srcs: the %s entry in run.sh no longer references "
-                    "$PP_SRCS. Expanding it now would emit a top without its "
-                    "control plane, at exit 0." % top], 2
-    pp_srcs, problems = _pp_srcs(run_sh, derived)
-    if problems:
-        return [], problems, 2
-    srcs = srcs.replace("$PP_SRCS", pp_srcs)
+    seen, duplicate = set(), []
+    for f in files:
+        if f in seen:
+            duplicate.append(f)
+        else:
+            seen.add(f)
+    if duplicate:
+        return files, ["dp_srcs: the %s entry names %d source(s) twice:\n  %s\n"
+                       "read_verilog would redeclare their modules."
+                       % (top, len(duplicate),
+                          "\n  ".join(sorted(set(duplicate))))], 2
 
-    env = {
-        "R": repo,
-        "A": os.path.join(repo, "third_party/verilog-axis/rtl"),
-        "C": os.path.join(repo, "hdl/common"),
-        "Q": os.path.join(repo, "hdl/ieee8021q/ts"),
-        "P": os.path.join(repo, "hdl/ieee8021as/ptp_timestamp"),
-        "E": os.path.join(repo, "hdl/common/eth_event_counter"),
-        "D": os.path.join(repo, "hdl/ieee17221/adp"),
-        "F": os.path.join(repo, "hdl/ieee8021q/filtering"),
-        # the protocol-processor submodule root, as run.sh's PP_SRCS spells it
-        "PP": os.path.join(repo, "protocol-processor/hdl"),
-    }
-    # longest key first: "$PP/" must not be eaten by the "$P" rule
-    def expand(text):
-        for k in sorted(env, key=len, reverse=True):
-            text = text.replace("$" + k + "/", env[k] + "/")
-        return text
-
-    srcs, pp_srcs = expand(srcs), expand(pp_srcs)
-
-    # A shell variable this file does not know is the truncation's signature:
-    # the residue of a half-captured command substitution does not end in
-    # .sv/.v either, so the suffix filter below would drop it in silence.
-    residue = [t for t in srcs.split() if "$" in t]
-    if residue:
-        return [], ["dp_srcs: %d token(s) in the %s entry survived expansion "
-                    "still naming a shell variable:\n  %s\nThe expansion is "
-                    "incomplete, so the list below it would be short at exit 0."
-                    % (len(residue), top, "\n  ".join(residue))], 2
-
-    files = [f for f in srcs.split() if f.endswith((".sv", ".v"))]
     missing = [f for f in files if not exists(f)]
     if missing:
         return files, ["dp_srcs: missing sources:\n  " + "\n  ".join(missing)], 1
 
-    # A SHORT LIST AT EXIT 0 IS THE FAILURE THIS FILE CAUSED ONCE ALREADY, so
-    # assert what the output must contain rather than trusting the expansion.
-    # The old guards could not see it: one only checked that the variable NAME
-    # was present, the other only inspected tokens ending in .sv/.v, and the
-    # truncation residue ended in neither. Both stayed silent while the control
-    # plane vanished from the netlist.
-    emitted = set(files)
-    lost = [f for f in derived if f not in emitted]
-    lost += [f for f in pp_srcs.split()
-             if f.endswith((".sv", ".v")) and f not in emitted]
-    # ...and name the plane itself, not just a count. A generator that returned
-    # a truncated list would satisfy the loop above -- everything it derived
-    # survived -- while emitting a top with no processor in it. This is the
-    # module milan_datapath.sv and KL_pp_shadow.sv both instantiate, so its
-    # absence is not a stale list, it is a netlist that cannot elaborate.
-    if not any(os.path.basename(f) == "protocol_processor_top.sv" for f in files):
-        lost.append("protocol_processor_top.sv (the control plane itself)")
-    if lost:
-        return files, ["dp_srcs: %d source(s) were derived but did not survive "
-                       "expansion into the %s entry:\n  %s"
-                       % (len(lost), top, "\n  ".join(lost))], 2
+    # 2. THE GENERATED HALF SURVIVES WHOLE OR NOT AT ALL. `derived=` is what
+    # scripts/pp_srcs.py returned to run.sh. A top that pulls in part of it is
+    # a netlist missing part of a plane, which Vivado reports as a module it
+    # cannot find rather than as a list it was not given.
+    kept = [f for f in rec["derived"] if f in seen]
+    if kept:
+        lost = [f for f in rec["derived"] if f not in seen]
+        if lost:
+            return files, ["dp_srcs: the %s entry takes %d of the %d generated "
+                           "source(s) run.sh derived, not all of them. Missing:"
+                           "\n  %s" % (top, len(kept), len(rec["derived"]),
+                                       "\n  ".join(lost))], 2
+        if not any(os.path.basename(f) == PLANE for f in files):
+            return files, ["dp_srcs: the %s entry carries the generated half "
+                           "but not %s (the control plane itself), so the "
+                           "generator returned a truncated list."
+                           % (top, PLANE)], 2
 
-    # THE TOP ITSELF. Every check above compares the list against what went
-    # into it, and all of them pass on a list that contains everything except
-    # the one module the consumer will name as `-top`: that is Issue #235,
-    # where pp_shadow_ooc.tcl read its 41 sources and Vivado answered
-    # `module 'KL_pp_shadow' not found`. So compare the list against the top as
-    # well, by resolving the declaration in active code rather than by matching
-    # a file name -- a file named after the module is a convention, and the
-    # convention is not what synthesis resolves -- and not by matching raw text
-    # either, because a commented-out or `ifdef`-guarded declaration is not one.
-    if not any(declares(read(f), top) for f in files):
-        return files, ["dp_srcs: none of the %d source(s) in run.sh's \"%s|...\" "
-                       "entry declares `module %s` in active code. Synthesis "
-                       "would read every one of them and then fail with "
-                       "`module '%s' not found` (Issue #235), which reads as a "
-                       "missing module and is really a read set that never "
-                       "contained the top."
-                       % (len(files), top, top, top)], 2
+    # 3. THE TOP ITSELF -- ISSUE #235. Every check above compares the list
+    # against what went into it, and all of them pass on a list that contains
+    # everything except the one module the consumer names as `-top`. Resolve it
+    # the way the toolchain does: through the directive layer, and through the
+    # front end the gate runs. Both must agree, in both directions.
+    modelled = any(declares(read(f), top) for f in files)
+    verdict, note = front_end(files, top, rec["incdir"], rec["define"])
 
+    if verdict is False:
+        return files, ["dp_srcs: %s does not resolve `%s` in the %d source(s) "
+                       "run.sh names for it:\n  %s\nSynthesis reads every one "
+                       "of them and then fails with `module '%s' not found` "
+                       "(Issue #235), which reads as a missing module and is "
+                       "really a read set that never declared the top.%s"
+                       % (FRONT_END, top, len(files), note, top,
+                          "" if not modelled else
+                          "\n  This file's own model DID see a declaration, so "
+                          "the model is wrong about the language here and must "
+                          "be fixed, not relaxed.")], 2
+    if not modelled:
+        return files, ["dp_srcs: none of the %d source(s) run.sh names for %s "
+                       "declares `module %s` where the directive layer leaves "
+                       "it: a commented, `ifdef`-guarded or unexpanded-macro "
+                       "declaration is not one. Synthesis would read every "
+                       "source and fail with `module '%s' not found` "
+                       "(Issue #235).%s"
+                       % (len(files), top, top, top,
+                          ("\n  %s resolved it, so the declaration is "
+                           "reachable only through expansion this file will "
+                           "not perform; declare the module plainly."
+                           % FRONT_END) if verdict is True else "")], 2
+    if verdict is None and require_front_end:
+        return files, ["dp_srcs: --require-front-end was given and no front end "
+                       "confirmed `module %s`: %s. A gate that silently loses "
+                       "this oracle is a gate that stops testing the escape it "
+                       "was added for." % (top, note)], 2
     return files, [], 0
 
 
-def selftest(top="faketop"):
-    """Prove every check bites, on synthetic inputs, without editing the tree.
+# --------------------------------------------------------------------------
+# self-test
 
-    CONTRIBUTING.md section 3 states the bar for a checker in this repository:
-    it carries a self-test that runs in a gate "so the tool cannot rot into a
-    green that means nothing". Every arm below drives the real `build()`, so
-    stubbing it to return no problems fails this. `.github/workflows/
-    rtl-fast.yml` runs it beside scripts/pp_srcs.py's.
 
-    Planting the defect in syn/yosys/run.sh and restoring it afterwards would
-    work exactly until the process is killed between the two writes, and it
-    cannot run on a read-only checkout. Injecting the inputs instead exercises
-    the same function and touches nothing. scripts/pp_srcs.py:selftest makes
-    the same argument for the same reason.
+def _shadow(text, tmp):
+    """A repository root whose syn/yosys/run.sh is `text` and whose every other
+    entry links to this one.
+
+    Lets an arm run a MUTATED REAL AUTHORITY under real bash without writing
+    into the checkout. The previous shape could not do this at all: it injected
+    run.sh's text into a parser, so the parser's disagreement with bash was
+    invisible by construction, which is what round two of [R0] measured.
     """
-    pp = os.path.join(REPO, "protocol-processor/hdl")
-    derived = [os.path.join(pp, "common/pp_pkg.sv"),
-               os.path.join(pp, "top/protocol_processor_top.sv")]
-    wrap_top = os.path.join(REPO, "hdl/milan/wrap_top.sv")
-    wrap_two = os.path.join(REPO, "hdl/milan/wrap_two.sv")
-    wrap_three = os.path.join(REPO, "hdl/milan/wrap_three.sv")
-    axis = os.path.join(REPO, "third_party/verilog-axis/rtl/axis_fifo.v")
+    root = tempfile.mkdtemp(dir=tmp, prefix="authority-")
+    os.makedirs(os.path.join(root, "syn", "yosys"))
+    for name in LINKED:
+        target = os.path.join(REPO, name)
+        if os.path.exists(target):
+            os.symlink(target, os.path.join(root, name))
+    path = os.path.join(root, "syn", "yosys", "run.sh")
+    with open(path, "w") as fh:
+        fh.write(text)
+    return root, path
 
-    # run.sh, reduced to the two lines this file reads: the generator call and
-    # the composition. The parent half is named HERE, in the injected run.sh,
-    # which is the whole point -- build() must take it from this text.
-    gen_line = ('  PP_DERIVED="$(python3 "$R/%s" --prefix "$PP")" || exit 2\n'
-                % GENERATOR)
-    comp = '  PP_SRCS="$PP_DERIVED $R/hdl/milan/wrap_top.sv $R/hdl/milan/wrap_two.sv"\n'
-    entry = '  "%s|$A/axis_fifo.v $PP_SRCS"\n' % top
-    clean = gen_line + comp + entry
 
-    # What each synthetic source contains, for the declaration check.
-    text = {f: "module %s;\nendmodule\n" % os.path.basename(f)[:-3]
-            for f in derived + [wrap_top, wrap_two, wrap_three, axis]}
-    # The real top: declared, and also NAMED in a comment above it, so a clean
-    # pass cannot be a pass on the comment.
-    real = "// %s: the wrapper this entry is built around\nmodule %s #(\n) ();\nendmodule\n" % (top, top)
-    text[wrap_top] = real
+def selftest(top="faketop", real_top="KL_pp_shadow"):
+    """Prove every check bites. Returns (problems, arms run).
 
-    state = {"derived": list(derived), "gone": set()}
+    CONTRIBUTING.md section 3 states the bar: a checker carries a self-test that
+    runs in a gate "so the tool cannot rot into a green that means nothing".
+    Every arm drives the real `build()`, `parse_record()` or `ask_authority()`,
+    so stubbing any of them to return no problems fails this.
+
+    Three groups. The record arms inject a synthetic record, so they need no
+    tree. The declaration arms inject synthetic text and a stub front end. The
+    authority arms run REAL BASH over a mutated copy of the real
+    syn/yosys/run.sh from a link farm, and the last of them runs the real front
+    end over the real read set: those need the protocol-processor and
+    verilog-axis submodules and sv2v, and they refuse rather than skip when
+    either is absent, because every escape of round two lived exactly in the gap
+    between what a parser modelled and what bash and the front end do.
+    """
     problems, ran = [], 0
+    src = ["/r/a.sv", "/r/b.sv", "/r/" + PLANE, "/r/top.sv"]
+    derived = ["/r/a.sv", "/r/" + PLANE]
 
-    def run(world, tp=top):
-        return build(tp, world, state["derived"],
-                     exists=lambda f: f not in state["gone"],
-                     read=lambda f: text.get(f, ""))
+    def record(**over):
+        rec = {"top": [top], "define": ["SYNTHESIS"], "incdir": ["/r/inc"],
+               "derived": list(derived), "src": list(src)}
+        rec.update(over)
+        return rec
 
-    def arm(name, world, want, tp=top):
+    text = {f: "module %s;\nendmodule\n" % os.path.basename(f)[:-3] for f in src}
+    # The real top: declared, and ALSO named in a comment above it, so a clean
+    # pass cannot be a pass on the comment.
+    text["/r/top.sv"] = ("// %s: the wrapper this entry is built around\n"
+                         "module %s #(\n) ();\nendmodule\n" % (top, top))
+    gone = set()
+
+    def stub_front_end(verdict, note=""):
+        return lambda *a, **k: (verdict, note)
+
+    def run(rec, fe=None, require=False):
+        return build(top, rec, exists=lambda f: f not in gone,
+                     read=lambda f: text.get(f, ""),
+                     front_end=fe or stub_front_end(True),
+                     require_front_end=require)
+
+    def arm(name, want, rec=None, fe=None, require=False, call=None):
         nonlocal ran
         ran += 1
-        _files, bad, rc = run(world, tp)
+        if call:
+            _rec, bad, rc = call()
+        else:
+            _files, bad, rc = run(rec, fe, require)
         if not any(want in b for b in bad) or rc == 0:
             problems.append("SELF-TEST FAILED [%s]: expected a finding naming "
                             "%r at rc!=0, got rc=%d %s"
                             % (name, want, rc, bad or "no findings"))
 
-    def decl_arm(name, body):
-        """The top occurs in `body`, but not as a declaration the tool sees."""
-        saved, text[wrap_top] = text[wrap_top], body
-        arm(name, clean, "declares `module %s` in active code" % top)
-        text[wrap_top] = saved
+    def decl_arm(name, body, fe=None, want=None):
+        saved, text["/r/top.sv"] = text["/r/top.sv"], body
+        arm(name, want or "declares `module %s` where the directive layer" % top,
+            record(), fe)
+        text["/r/top.sv"] = saved
 
-    # Arm 0. The clean world is clean. Without this the other arms could all be
-    # passing on a check that simply reports everything.
+    # ---- record arms -----------------------------------------------------
+    # Arm 0. ANTI-VACUITY: the well-formed record expands clean. Without it
+    # every other arm could be passing on a check that reports everything.
     ran += 1
-    files, bad, rc = run(clean)
-    if bad or rc or len(files) != len(derived) + 3:
-        problems.append("SELF-TEST FAILED [clean]: the well-formed entry must "
+    files, bad, rc = run(record())
+    if bad or rc or files != src:
+        problems.append("SELF-TEST FAILED [clean]: a well-formed record must "
                         "expand clean, got rc=%d %s, %d file(s)"
                         % (rc, bad, len(files)))
 
-    # Arm 1. run.sh's PP_SRCS IS READ, not reconstructed. Two worlds differing
-    # only in that definition must differ in what comes out. This is [R0]'s
-    # experiment on PR #240 -- it produced identical output then -- kept as an
-    # arm, because a reintroduced parent-wrapper constant here would pass every
-    # other arm in this file.
-    ran += 1
-    more = clean.replace(' $R/hdl/milan/wrap_two.sv"',
-                         ' $R/hdl/milan/wrap_two.sv $R/hdl/milan/wrap_three.sv"')
-    a_files, _, a_rc = run(clean)
-    b_files, _, b_rc = run(more)
-    if a_rc or b_rc or a_files == b_files or wrap_three not in b_files:
-        problems.append("SELF-TEST FAILED [pp-srcs-is-read]: changing only "
-                        "run.sh's PP_SRCS definition left the emitted list "
-                        "unchanged (%d vs %d file(s), rc=%d/%d), so the parent "
-                        "half is not being read from run.sh"
-                        % (len(a_files), len(b_files), a_rc, b_rc))
+    # Arm 1. The authority refuses. Its exit status is this flow's exit status.
+    class _Refused(object):
+        returncode, stdout, stderr = 2, "", "planted authority refusal\n"
 
-    # Arm 2. [R0]'s D2 mutation on PR #240, committed: run.sh drops the wrapper
-    # that declares the top. It stayed green at 16,547 LUT when this file
-    # composed the parent half itself.
-    arm("run-sh-drops-the-top", clean.replace("$R/hdl/milan/wrap_top.sv ", ""),
-        "declares `module %s` in active code" % top)
+    arm("authority-refuses", "so there is no read set to emit",
+        call=lambda: ask_authority(top, "/r/run.sh", lambda *a, **k: _Refused))
 
-    # Arm 3. A parent source run.sh names that is not on disk any more.
-    state["gone"].add(wrap_two)
-    arm("stale-parent-source", clean, "missing sources")
-    state["gone"].clear()
+    # Arm 2. A line the record model does not know. Refused, NOT skipped: the
+    # skip is how a positional ghost.svh stayed invisible ([R0] round two).
+    arm("unmodelled-record-line", "is not one of the modelled",
+        call=lambda: parse_record("top=%s\nsrc=/r/a.sv\nwat=1\n" % top, top))
 
-    # Arm 4. run.sh no longer defines PP_SRCS from the derived half.
-    arm("no-pp-srcs-definition", gen_line + entry, "expected exactly 1")
+    # Arm 3. The record answers about a different top.
+    arm("record-names-another-top", "the record names",
+        call=lambda: parse_record("top=other\nsrc=/r/a.sv\n", top))
 
-    # Arm 5. Two definitions: nothing here may pick one.
-    arm("two-pp-srcs-definitions", gen_line + comp + comp + entry,
-        "expected exactly 1")
+    # Arm 4. A record with no source at all.
+    arm("record-has-no-source", "names no source",
+        call=lambda: parse_record("top=%s\n" % top, top))
 
-    # Arm 6. run.sh derives the submodule half from some other generator, so
-    # the two halves of "one authority" would be two again.
-    arm("generator-diverged",
-        '  PP_DERIVED="$(python3 "$R/scripts/other.py")"\n' + comp + entry,
-        "no PP_DERIVED assignment calling")
+    # Arm 5. A token that is not a source. This is [R0]'s ghost.svh, at the
+    # level where it is decided: nothing may be filtered out.
+    arm("unaccounted-token", "are not .sv/.v sources",
+        record(src=src + ["/r/ghost.svh"]))
 
-    # Arm 7. A variable this file does not expand. The historical truncation
-    # left exactly this residue and nothing saw it.
-    arm("unexpanded-variable",
-        gen_line + comp.replace("$R/hdl/milan/wrap_two.sv",
-                                "$NEW/wrap_two.sv") + entry,
-        "still naming a shell variable")
+    # Arm 6. The same source twice.
+    arm("duplicate-source", "twice", record(src=src + ["/r/a.sv"]))
 
-    # Arm 8. The entry is gone, or the top was misspelled by its consumer.
-    arm("no-entry", clean, "no othertop top in run.sh", tp="othertop")
+    # Arm 7. A source the authority names and the tree does not carry.
+    gone.add("/r/b.sv")
+    arm("stale-source", "missing sources", record())
+    gone.clear()
 
-    # Arm 9. The entry stops referencing the collected list.
-    arm("no-pp-srcs", gen_line + comp + '  "%s|$A/axis_fifo.v"\n' % top,
-        "no longer references")
+    # Arm 8. Part of the generated half in the entry, part not.
+    arm("generated-half-split", "not all of them",
+        record(derived=derived + ["/r/missing_from_entry.sv"]))
 
-    # Arm 10. A derived source that does not survive the expansion, because
-    # the suffix filter below the substitution drops it. That filter is what
-    # made the historical truncation invisible: it inspected only tokens
-    # ending in .sv/.v, and what was left of the list ended in neither.
-    state["derived"] = derived + [os.path.join(pp, "acmp/ghost.svh")]
-    arm("derived-source-lost", clean, "did not survive expansion")
-    state["derived"] = list(derived)
+    # Arm 9. The generated half present and the plane itself not, which no
+    # count-based check can see.
+    arm("plane-lost", "(the control plane itself)",
+        record(src=["/r/a.sv", "/r/top.sv"], derived=["/r/a.sv"]))
 
-    # Arm 11. The plane itself missing, which a count-based check cannot see.
-    state["derived"] = [os.path.join(pp, "common/pp_pkg.sv")]
-    arm("plane-lost", clean, "protocol_processor_top.sv (the control plane")
-    state["derived"] = list(derived)
-
-    # Arm 12. ISSUE #235. Every source present and correct, and not one of them
-    # declares the top. Vivado's answer to this list is `module not found`.
+    # ---- declaration arms ------------------------------------------------
+    # Arm 10. ISSUE #235: every source present and correct, none declares the
+    # top. Vivado's answer to this list is `module not found`.
     decl_arm("top-not-in-read-set", "module something_else;\nendmodule\n")
 
-    # Arm 13. The same, one step subtler: the file is named after the top and
-    # does not declare it, which a file-name check would pass.
+    # Arm 11. One step subtler: the file is NAMED after the top and does not
+    # declare it, which a file-name check would pass.
     decl_arm("named-not-declared", "// %s lives here\n" % top)
 
-    # Arms 14-18. THE DECLARATION IS TEXT, NOT CODE. [R0] on PR #240 injected
-    # the block-commented form and got rc=0 with five emitted files; the rest
-    # are the same class in the other spellings a real file reaches for.
-    #
-    # Three of these five bypass a raw-text search and are what `active_code`
-    # is for: neuter it to `return text` and block-commented, inactive-
-    # conditional and declaration-inside-a-string all go green. The line-
-    # commented and prefix arms bind something else -- the pattern's own line
-    # anchor and word boundary -- and are here because a later loosening of
-    # that pattern is the obvious way to reintroduce the escape.
+    # Arms 12-16. THE DECLARATION IS TEXT, NOT CODE ([R0] round one).
     decl_arm("block-commented-declaration",
              "/*\nmodule %s;\nendmodule\n*/\n" % top)
     decl_arm("inactive-conditional-declaration",
@@ -428,8 +520,192 @@ def selftest(top="faketop"):
              'localparam string S = "\nmodule %s;\n";\n' % top)
     decl_arm("line-commented-declaration",
              "// module %s;\n// endmodule\n" % top)
-    decl_arm("prefix-of-the-top-declared",
-             "module %s_shim;\nendmodule\n" % top)
+    decl_arm("prefix-of-the-top-declared", "module %s_shim;\nendmodule\n" % top)
+
+    # Arms 17-19. THE DECLARATION IS TEXT, NOT PREPROCESSED CODE ([R0] round
+    # two). An unexpanded macro body is not a declaration; arm 17 is the exact
+    # three-line construct the reviewer drove the real `build()` with.
+    decl_arm("macro-body-declaration",
+             "`define UNUSED \\\nmodule %s; \\\nendmodule\n" % top)
+    decl_arm("macro-body-one-line",
+             "`define UNUSED module %s; endmodule\n" % top)
+    decl_arm("macro-body-after-a-comment",
+             "`define UNUSED /* keep */ \\\nmodule %s; \\\nendmodule\n" % top)
+
+    # Arm 20. The front end resolves no such top and the model saw one. The
+    # front end wins, and the finding says the model must be fixed.
+    arm("front-end-refuses-what-the-model-saw", "does not resolve",
+        record(), stub_front_end(False, "Could not find top module"))
+
+    # Arm 21. The other direction: the front end resolves it and the model
+    # cannot. Also a refusal -- an emitted list must be provable from here too.
+    decl_arm("front-end-only", "module something_else;\nendmodule\n",
+             stub_front_end(True),
+             want="reachable only through expansion")
+
+    # Arm 22. No front end, and a caller that said it required one.
+    arm("front-end-required-and-absent", "--require-front-end was given",
+        record(), stub_front_end(None, "sv2v is not on PATH"), require=True)
+
+    # ---- authority arms --------------------------------------------------
+    # These run REAL BASH over a mutated real run.sh, and the reviewer's four
+    # round-two counterexamples are four of them. A tree without submodules
+    # cannot answer them, and a skip here is the false green they exist to
+    # close, so their absence is reported as a failure.
+    if not (os.path.exists(RUN_SH) and shutil.which("bash")
+            and os.path.exists(os.path.join(REPO, "protocol-processor", "hdl"))
+            and os.path.exists(os.path.join(REPO, "third_party",
+                                            "verilog-axis", "rtl"))):
+        problems.append("SELF-TEST FAILED [authority-arms]: syn/yosys/run.sh, "
+                        "bash and the protocol-processor and verilog-axis "
+                        "submodules are all required. The round-two escapes "
+                        "were all disagreements between a parser and bash, so "
+                        "skipping these arms is skipping the finding.")
+        return problems, ran
+    if shutil.which(FRONT_END) is None:
+        problems.append("SELF-TEST FAILED [authority-arms]: %s is not on PATH. "
+                        "It is the oracle for the macro-body escape, and the "
+                        "Yosys gate already requires it." % FRONT_END)
+        return problems, ran
+
+    real = _reader(RUN_SH)
+    tmp = tempfile.mkdtemp(prefix="dp-srcs-selftest-")
+    try:
+        def relative(root, rec):
+            """The record's sources as the authority's own tree spells them.
+            Each arm gets its own shadow root, so absolute paths differ by
+            construction and only the tree-relative set is comparable."""
+            return [] if rec is None else [os.path.relpath(f, root)
+                                           for f in rec["src"]]
+
+        def authority(name, mutate, want, expect_src=None):
+            nonlocal ran
+            ran += 1
+            root, path = _shadow(mutate(real), tmp)
+            rec, bad, rc = ask_authority(real_top, path)
+            if rc == 0:
+                _files, bad, rc = build(real_top, rec)
+            if expect_src is not None:
+                if rc != 0 or relative(root, rec) != expect_src:
+                    problems.append("SELF-TEST FAILED [%s]: bash ignores this "
+                                    "mutation, so the read set must be "
+                                    "unchanged; got rc=%d, %d source(s) %s"
+                                    % (name, rc, len(relative(root, rec)), bad))
+                return
+            if rc == 0 or not any(want in b for b in bad):
+                problems.append("SELF-TEST FAILED [%s]: expected a finding "
+                                "naming %r at rc!=0, got rc=%d %s"
+                                % (name, want, rc, bad or "no findings"))
+
+        # Arm 23. ANTI-VACUITY over the REAL authority: the untouched run.sh
+        # expands clean through real bash and the real front end.
+        ran += 1
+        base_root, base_path = _shadow(real, tmp)
+        base, bad, rc = ask_authority(real_top, base_path)
+        base_src = relative(base_root, base) if rc == 0 else []
+        if rc == 0:
+            _f, bad, rc = build(real_top, base, require_front_end=True)
+        if rc or bad or len(base_src) < 2:
+            problems.append("SELF-TEST FAILED [real-authority-clean]: the "
+                            "untouched run.sh must expand clean, got rc=%d %s, "
+                            "%d source(s)" % (rc, bad, len(base_src)))
+
+        # Arm 24. [R0] round two, mutation 1: the generator token is suffixed.
+        # The old recogniser accepted the expected path as a SUBSTRING and
+        # returned rc=0 with 43 files; bash executes a nonexistent file and
+        # takes run.sh's own `|| exit 2`.
+        authority("generator-token-suffixed",
+                  lambda t: t.replace('"$R/scripts/pp_srcs.py"',
+                                      '"$R/scripts/pp_srcs.py.broken"'),
+                  "so there is no read set to emit")
+
+        # Arm 25. Mutation 2: the generator's --prefix points at a tree that
+        # does not exist. The old recogniser ignored the invocation it claimed
+        # to validate and ran its own; bash hands sv2v paths that are not there.
+        authority("generator-prefix-diverted",
+                  lambda t: t.replace('--prefix "$PP"',
+                                      '--prefix "$PP/not-the-tree"'),
+                  "missing sources")
+
+        # Arm 26. Mutation 3: a valid shell COMMENT above the live row, spelt
+        # so a text selector prefers it. The old recogniser emitted 42 files and
+        # dropped axis_fifo.v; bash ignores the line entirely, so the correct
+        # answer is the unchanged read set -- which is the property that proves
+        # this consumer follows bash rather than the text.
+        authority("commented-decoy-row",
+                  lambda t: t.replace(
+                      '  "KL_pp_shadow|$A/axis_fifo.v $PP_SRCS"\n',
+                      '  # "KL_pp_shadow|$PP_SRCS"\n'
+                      '  "KL_pp_shadow|$A/axis_fifo.v $PP_SRCS"\n'),
+                  None, expect_src=base_src)
+
+        # Arm 27. Mutation 4: a positional that is not a source. The old
+        # recogniser filtered it out before the missing-source check.
+        authority("unaccounted-positional",
+                  lambda t: t.replace('PP_SRCS="$PP_DERIVED ',
+                                      'PP_SRCS="$PP_DERIVED $PP/ghost.svh '),
+                  "are not .sv/.v sources")
+
+        # Arm 28. The same positional spelt as a source that is not on disk.
+        authority("missing-positional",
+                  lambda t: t.replace('PP_SRCS="$PP_DERIVED ',
+                                      'PP_SRCS="$PP_DERIVED $PP/ghost.sv '),
+                  "missing sources")
+
+        # Arm 29. [R0] round one, mutation D2, now through real bash: run.sh
+        # drops the wrapper that declares the top. It stayed green at
+        # 16,547 LUT when this file composed the parent half itself.
+        authority("run-sh-drops-the-top",
+                  lambda t: t.replace(" $R/hdl/milan/KL_pp_shadow.sv", ""),
+                  "does not resolve `%s`" % real_top)
+
+        # Arm 30. A top no row defines. run.sh answers, this flow reports it.
+        ran += 1
+        _rec, bad, rc = ask_authority("othertop", _shadow(real, tmp)[1])
+        if rc == 0 or not any("unknown top: othertop" in b for b in bad):
+            problems.append("SELF-TEST FAILED [unknown-top]: expected the "
+                            "authority's own refusal, got rc=%d %s" % (rc, bad))
+
+        # Arm 31. THE ROUND-TWO BLOCKER, END TO END. The real read set, with the
+        # file that declares the top replaced on disk by the reviewer's exact
+        # unexpanded macro body, driven through real bash and the REAL front
+        # end. `sv2v --top` answers `Could not find top module`; so must this.
+        ran += 1
+        shadow_src = os.path.join(tmp, "KL_pp_shadow.sv")
+        with open(shadow_src, "w") as fh:
+            fh.write("`define UNUSED \\\nmodule %s; \\\nendmodule\n" % real_top)
+        macro_root, macro_path = _shadow(
+            real.replace("$R/hdl/milan/KL_pp_shadow.sv", shadow_src), tmp)
+        rec, bad, rc = ask_authority(real_top, macro_path)
+        if rc == 0:
+            _f, bad, rc = build(real_top, rec, require_front_end=True)
+        if rc == 0 or not any("does not resolve" in b for b in bad):
+            problems.append("SELF-TEST FAILED [macro-body-real-front-end]: the "
+                            "real read set with an unexpanded macro body in "
+                            "place of the top must be refused by %s; got rc=%d "
+                            "%s" % (FRONT_END, rc, bad))
+        if len(relative(macro_root, rec)) != len(base_src):
+            problems.append("SELF-TEST FAILED [macro-body-real-front-end]: the "
+                            "mutation must change only the top's TEXT, and it "
+                            "changed the read set (%d vs %d source(s))"
+                            % (len(relative(macro_root, rec)), len(base_src)))
+
+        # Arm 32. THE SAME SET WITH NO FRONT END AT ALL. A Vivado host need not
+        # carry sv2v, so the directive-layer model has to close this escape on
+        # its own; this arm is what stops a later change from leaning on the
+        # oracle and leaving that host with the round-two behaviour.
+        ran += 1
+        rec, bad, rc = ask_authority(real_top, macro_path)
+        if rc == 0:
+            _f, bad, rc = build(real_top, rec,
+                                front_end=lambda *a, **k: (None, "no front end"))
+        want = "declares `module %s` where the directive layer" % real_top
+        if rc == 0 or not any(want in b for b in bad):
+            problems.append("SELF-TEST FAILED [macro-body-model-alone]: with no "
+                            "front end the model must still refuse the macro "
+                            "body; got rc=%d %s" % (rc, bad))
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
     if ran != ARMS:
         problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), %s "
@@ -439,12 +715,16 @@ def selftest(top="faketop"):
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--top", default="milan_datapath",
                     help="the run.sh entry to expand (default: milan_datapath)")
     ap.add_argument("--selftest", action="store_true",
                     help="prove each check fails on a planted defect")
+    ap.add_argument("--require-front-end", action="store_true",
+                    help="refuse unless %s confirms the top resolves"
+                         % FRONT_END)
     args = ap.parse_args()
 
     if args.selftest:
@@ -456,16 +736,11 @@ def main() -> int:
         print("dp_srcs self-test: %d arm(s) passed" % ran)
         return 0
 
-    with open(os.path.join(REPO, "syn", "yosys", "run.sh")) as fh:
-        run_sh = fh.read()
-    pp = subprocess.run(
-        [sys.executable, os.path.join(REPO, *GENERATOR.split("/")),
-         "--prefix", os.path.join(REPO, "protocol-processor", "hdl")],
-        capture_output=True, text=True)
-    if pp.returncode != 0:
-        sys.stderr.write(pp.stderr)
-        return 2
-    files, problems, rc = build(args.top, run_sh, pp.stdout.split())
+    files, problems, rc = [], [], 0
+    rec, problems, rc = ask_authority(args.top)
+    if rc == 0:
+        files, problems, rc = build(args.top, rec,
+                                    require_front_end=args.require_front_end)
     for p in problems:
         print(p, file=sys.stderr)
     if rc:

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -28,10 +28,11 @@ set REPO [file normalize [file dirname [info script]]/../..]
 set TAG  [expr {[info exists ::env(TAG)] ? $::env(TAG) : "base"}]
 puts "milan_datapath OOC: tag=$TAG"
 
-# The source list comes from syn/yosys/run.sh via dp_srcs.py — the ONE list
-# the portability gate proves elaborates. A copy of it here would drift, and
-# since the processor's files are part of that list now, a copy would drift a
-# whole control plane. Nothing is read outside it.
+# The source list is printed by syn/yosys/run.sh itself (`--emit`) and relayed
+# by dp_srcs.py -- the ONE list the portability gate proves elaborates. A copy
+# here would drift, and since the processor's files are part of that list now, a
+# copy would drift a whole control plane. Nothing is read outside it, and
+# nothing re-reads run.sh: dp_srcs.py checks the record run.sh hands it.
 set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py]] "\n"]
 set SV {}
 set V  {}

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -32,7 +32,9 @@ puts "milan_datapath OOC: tag=$TAG"
 # by dp_srcs.py -- the ONE list the portability gate proves elaborates. A copy
 # here would drift, and since the processor's files are part of that list now, a
 # copy would drift a whole control plane. Nothing is read outside it, and
-# nothing re-reads run.sh: dp_srcs.py checks the record run.sh hands it.
+# nothing re-reads run.sh: dp_srcs.py checks the record run.sh hands it, and
+# resolves $TOP in it through `sv2v --top`, so sv2v is required to run this
+# script as well as the Yosys gate (README.md's tool table).
 set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py]] "\n"]
 set SV {}
 set V  {}

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Drive syn/ooc/pp_shadow_ooc.tcl's two pre-synthesis refusals, automatically.
+
+That script refuses to synthesize when a `$readmemh` image is missing or empty,
+and it takes the source generator's exit status. Both refusals had manual
+evidence and no test ([R0] on PR #240): deleting either one left every hosted
+check green, which is the definition of a defense that rots.
+
+WHAT IT RUNS IS THE REAL .TCL, not a copy of its logic. `tclsh` sources the
+tracked file with the Vivado-only commands stubbed, and `read_verilog` -- the
+first command after both refusals -- prints a sentinel and exits 0. So an arm
+that expects a refusal fails if the sentinel appears, and the positive arm fails
+if it does not: removing the guard from the .tcl reddens this, and so does a
+guard that fires on a well-formed directory.
+
+`tclsh` is the interpreter Vivado embeds, so the guard is exercised by the
+language it is written in rather than reimplemented in Python.
+
+    python3 syn/ooc/ooc_tcl_selftest.py
+
+Runs in .github/workflows/rtl-fast.yml beside syn/ooc/dp_srcs.py --selftest.
+Needs the protocol-processor and verilog-axis submodules, because the .tcl
+derives its read set before it reaches either refusal.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+TCL = os.path.join(HERE, "pp_shadow_ooc.tcl")
+SENTINEL = "OOC-GUARD-PASSED"
+
+#: The Vivado commands pp_shadow_ooc.tcl calls after its refusals. `read_verilog`
+#: is the first of them, so reaching it means every refusal let the run through.
+STUBS = """
+proc read_verilog args { puts "%s"; exit 0 }
+proc synth_design args {}
+proc create_clock args {}
+proc get_ports args { return {} }
+proc report_utilization args {}
+proc report_timing_summary args {}
+source {%s}
+""" % (SENTINEL, TCL)
+
+#: How many arms run. A deleted arm is a self-test that still prints a pass.
+ARMS = 5
+
+
+def _run(workdir, env=None):
+    e = dict(os.environ)
+    e.update(env or {})
+    # A driver FILE, not tclsh's stdin: reading a script from stdin makes an
+    # uncaught error a printed message at exit 0, which would make every arm
+    # below agree with a guard that does not exist.
+    fd, driver = tempfile.mkstemp(suffix=".tcl", prefix="ooc-driver-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(STUBS)
+        out = subprocess.run(["tclsh", driver], cwd=workdir, env=e,
+                             capture_output=True, text=True)
+    finally:
+        os.unlink(driver)
+    return out.returncode, out.stdout + out.stderr
+
+
+def _write(workdir, name, content):
+    with open(os.path.join(workdir, name), "w") as fh:
+        fh.write(content)
+
+
+def selftest():
+    problems, ran = [], 0
+    if not shutil.which("tclsh"):
+        # NOT a skip. A skip here is the false green this file exists to close;
+        # the workflow installs tclsh for exactly this reason.
+        return ["tclsh is not on PATH, so %s cannot be exercised. Install tcl "
+                "(the interpreter Vivado embeds) rather than skipping: an "
+                "unexercised refusal is the defect this file tests for."
+                % os.path.relpath(TCL, REPO)], 0
+
+    def arm(name, want, expect_rc0, setup=None, env=None):
+        nonlocal ran
+        ran += 1
+        with tempfile.TemporaryDirectory() as d:
+            if setup:
+                setup(d)
+            rc, log = _run(d, env)
+        reached = SENTINEL in log
+        if expect_rc0:
+            if rc != 0 or not reached:
+                problems.append("SELF-TEST FAILED [%s]: a well-formed run must "
+                                "reach synthesis, got rc=%d, sentinel=%s\n%s"
+                                % (name, rc, reached, log.strip()))
+            return
+        if rc == 0 or reached or want not in log:
+            problems.append("SELF-TEST FAILED [%s]: expected a refusal naming "
+                            "%r before synthesis, got rc=%d, sentinel=%s\n%s"
+                            % (name, want, rc, reached, log.strip()))
+
+    def images(*names):
+        def setup(d):
+            for n in names:
+                _write(d, n, "" if n.endswith("!") else "00\n")
+            for n in names:
+                if n.endswith("!"):
+                    os.rename(os.path.join(d, n), os.path.join(d, n[:-1]))
+        return setup
+
+    # Arm 1. Neither image. The first one named is the one reported.
+    arm("no-images", "ltn_rom.hex is missing or empty", False)
+
+    # Arm 2. The image the finding document used to name on its own. The AECP
+    # microcode ROM is the one it did not, and its absence is a CRITICAL
+    # WARNING ending in "ignoring" plus a utilization number 17 % low.
+    arm("ucode-missing", "ucode.hex is missing or empty", False,
+        images("ltn_rom.hex"))
+
+    # Arm 3. Present and zero bytes: `file exists` alone would pass this, and
+    # Vivado reads an empty image exactly as it reads an absent one.
+    arm("ucode-empty", "ucode.hex is missing or empty", False,
+        images("ltn_rom.hex", "ucode.hex!"))
+
+    # Arm 4. ANTI-VACUITY. Both images present and non-empty must reach
+    # synthesis. Without this arm a guard that always fires passes arms 1-3.
+    arm("both-images-present", None, True, images("ltn_rom.hex", "ucode.hex"))
+
+    # Arm 5. The .tcl must take the generator's exit status. A consumer that
+    # discards it synthesizes whatever a broken generator printed, and an empty
+    # source list builds cleanly while proving nothing (CONTRIBUTING.md 3).
+    stub = tempfile.mkdtemp(prefix="dp-srcs-fails-")
+    with open(os.path.join(stub, "python3"), "w") as fh:
+        fh.write("#!/bin/sh\necho 'dp_srcs: planted generator failure' >&2\n"
+                 "exit 2\n")
+    os.chmod(os.path.join(stub, "python3"), 0o755)
+    arm("generator-failure-propagates", "planted generator failure", False,
+        images("ltn_rom.hex", "ucode.hex"),
+        env={"PATH": stub + os.pathsep + os.environ.get("PATH", "")})
+    shutil.rmtree(stub, ignore_errors=True)
+
+    if ran != ARMS:
+        problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this file "
+                        "declares %d." % (ran, ARMS))
+    return problems, ran
+
+
+def main() -> int:
+    bad, ran = selftest()
+    for b in bad:
+        print("  -", b, file=sys.stderr)
+    if bad:
+        return 2
+    print("pp_shadow OOC refusal self-test: %d arm(s) passed" % ran)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/syn/ooc/pp_shadow_ooc.tcl
+++ b/syn/ooc/pp_shadow_ooc.tcl
@@ -50,12 +50,14 @@ set TOP KL_pp_shadow
 # one, and the one was $TOP itself, so the documented plane-area recipe read 41
 # sources and stopped at `ERROR: [Synth 8-439] module 'KL_pp_shadow' not found`
 # (Issue #235). What replaces it is not a tidier spelling of the same list:
-# dp_srcs.py refuses to emit a list unless the top RESOLVES in it -- its model of
-# the directive layer must see the declaration (a commented, `ifdef`-guarded or
-# unexpanded-macro one is not one), and sv2v, when installed, must resolve it
-# too. On a host without sv2v the model alone still refuses; only the
-# cross-check is lost, and `--require-front-end` (which CI passes and this file
-# does not) turns that loss into a failure.
+# dp_srcs.py refuses to emit a list unless the top RESOLVES in it, and it asks
+# `sv2v --top` -- the front end syn/yosys/run.sh already runs over this same
+# list -- because that is the only thing that answers the question. It used to
+# carry a model of the directive layer for hosts without sv2v; three shapes of
+# that model were each broken by a construct they did not model ([R0] on PR
+# #240, rounds one to three), so the model is gone and sv2v is REQUIRED here.
+# Without it this script stops before Vivado starts, naming the missing tool,
+# rather than emitting a list whose top may not be in it.
 set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py --top $TOP]] "\n"]
 set SV {}
 set V  {}

--- a/syn/ooc/pp_shadow_ooc.tcl
+++ b/syn/ooc/pp_shadow_ooc.tcl
@@ -37,17 +37,25 @@ set REPO [file normalize [file dirname [info script]]/../..]
 # it reads cannot be two different strings.
 set TOP KL_pp_shadow
 
-# The read set is DERIVED from the "KL_pp_shadow|..." entry in syn/yosys/run.sh
-# -- the same list the portability gate elaborates on every run -- exactly as
-# syn/ooc/milan_datapath_ooc.tcl derives the datapath's, and through the same
-# generator. This file used to assemble its own instead: scripts/pp_srcs.py for
-# the submodule half plus a hand-named axis_fifo.v. That covered every source
-# except one, and the one was $TOP itself, so the documented plane-area recipe
-# read 41 sources and stopped at `ERROR: [Synth 8-439] module 'KL_pp_shadow'
-# not found` (Issue #235). Deriving is not a tidier spelling of the same list:
-# dp_srcs.py refuses to emit a list in which nothing declares the top it was
-# asked for, so a -top outside its own read set is now a failure of the
-# generator rather than a Vivado error nobody can read.
+# The read set is what syn/yosys/run.sh ITSELF PRINTS for the "KL_pp_shadow|..."
+# entry -- the same list the portability gate elaborates on every run. dp_srcs.py
+# runs `run.sh --emit KL_pp_shadow` and checks the record; it does not read the
+# script, because a reader of a build file accepts what it has modelled and bash
+# accepts something else, and four such disagreements were measured on the
+# reading version ([R0] on PR #240, round two). Now a run.sh edit either moves
+# this read set exactly as it moves the Yosys one, or fails both.
+#
+# This file used to assemble its own list instead: scripts/pp_srcs.py for the
+# submodule half plus a hand-named axis_fifo.v. That covered every source except
+# one, and the one was $TOP itself, so the documented plane-area recipe read 41
+# sources and stopped at `ERROR: [Synth 8-439] module 'KL_pp_shadow' not found`
+# (Issue #235). What replaces it is not a tidier spelling of the same list:
+# dp_srcs.py refuses to emit a list unless the top RESOLVES in it -- its model of
+# the directive layer must see the declaration (a commented, `ifdef`-guarded or
+# unexpanded-macro one is not one), and sv2v, when installed, must resolve it
+# too. On a host without sv2v the model alone still refuses; only the
+# cross-check is lost, and `--require-front-end` (which CI passes and this file
+# does not) turns that loss into a failure.
 set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py --top $TOP]] "\n"]
 set SV {}
 set V  {}

--- a/syn/ooc/pp_shadow_ooc.tcl
+++ b/syn/ooc/pp_shadow_ooc.tcl
@@ -27,23 +27,56 @@
 # full of X. ucode.hex became necessary when this file stopped naming a subset
 # of the plane by hand: the AECP uCPU was one of the eight sources the old
 # literal had gone stale by. syn/yosys/run.sh generates both, for this reason.
+# The check below refuses to synthesize without them, because that CRITICAL
+# WARNING is the one failure of this instrument that still returns a number.
 
 set REPO [file normalize [file dirname [info script]]/../..]
-set PP   $REPO/protocol-processor/hdl
-set AXIS $REPO/third_party/verilog-axis/rtl
 
-# The submodule sources are DERIVED (scripts/pp_srcs.py), not listed here. This
-# file used to carry a sixth hand-written copy of that list and it was stale by
-# eight sources, the whole AECP engine among them, which Vivado reports only as
-# `module not found`. Packages come first because a package must be declared
-# before its importers; the generator guarantees that ordering.
-set PP_SRCS [exec python3 $REPO/scripts/pp_srcs.py --prefix $PP]
-read_verilog -sv {*}$PP_SRCS
+# The top is named ONCE. It reaches synth_design and the source-list generator
+# from the same variable, so the module this script synthesizes and the module
+# it reads cannot be two different strings.
+set TOP KL_pp_shadow
 
-# the Forencich frame FIFO is plain Verilog-2001
-read_verilog $AXIS/axis_fifo.v
+# The read set is DERIVED from the "KL_pp_shadow|..." entry in syn/yosys/run.sh
+# -- the same list the portability gate elaborates on every run -- exactly as
+# syn/ooc/milan_datapath_ooc.tcl derives the datapath's, and through the same
+# generator. This file used to assemble its own instead: scripts/pp_srcs.py for
+# the submodule half plus a hand-named axis_fifo.v. That covered every source
+# except one, and the one was $TOP itself, so the documented plane-area recipe
+# read 41 sources and stopped at `ERROR: [Synth 8-439] module 'KL_pp_shadow'
+# not found` (Issue #235). Deriving is not a tidier spelling of the same list:
+# dp_srcs.py refuses to emit a list in which nothing declares the top it was
+# asked for, so a -top outside its own read set is now a failure of the
+# generator rather than a Vivado error nobody can read.
+set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py --top $TOP]] "\n"]
+set SV {}
+set V  {}
+foreach f $SRC_LINES {
+  if {[string match "*.sv" $f]} { lappend SV $f } else { lappend V $f }
+}
+puts "pp_shadow OOC: [llength $SV] SystemVerilog + [llength $V] Verilog sources"
 
-# Shape. Defaults to the wrapper's own 8/8 — the FULL-shape, pessimistic,
+# Both $readmemh images, BEFORE anything slow. Vivado resolves the relative
+# name against the working directory, so this check has to ask the same
+# question the same way: from here, by relative name. An absent or empty image
+# is a CRITICAL WARNING and a completed run whose utilization figure is for a
+# ROM of X -- the only way this script returns a wrong number instead of no
+# number, which is the worse half of the pair Issue #235 is the other half of.
+foreach {img gen} [list \
+    ltn_rom.hex "protocol-processor/hdl/acmp/rom/gen_ltn_rom.py (KL_pp_acmp_listener's F05.3 transition ROM)" \
+    ucode.hex   "protocol-processor/hdl/aecp/ucode/gen_ucode.py (KL_aecp_ucpu's microcode)"] {
+  if {![file exists $img] || [file size $img] == 0} {
+    error "pp_shadow OOC: $img is missing or empty in [pwd]. Generate it here\
+with $gen before running this script. Vivado would report the missing\
+\$readmemh image as a CRITICAL WARNING ending in \"ignoring\", synthesize a ROM\
+full of X and print a utilization number for it."
+  }
+}
+
+read_verilog -sv $SV
+read_verilog $V
+
+# Shape. Defaults to the wrapper's own 8/8 - the FULL-shape, pessimistic,
 # decision-relevant end. Override for the shape a given board actually flashes:
 #   PP_N_IN=1 PP_N_OUT=1 vivado -mode batch -source .../pp_shadow_ooc.tcl
 # The two numbers are read ONCE here and printed with the result, because a
@@ -52,7 +85,7 @@ set N_IN  [expr {[info exists ::env(PP_N_IN)]  ? $::env(PP_N_IN)  : 8}]
 set N_OUT [expr {[info exists ::env(PP_N_OUT)] ? $::env(PP_N_OUT) : 8}]
 puts "pp_shadow OOC shape: N_STREAM_IN_P=$N_IN N_STREAM_OUT_P=$N_OUT"
 
-synth_design -mode out_of_context -top KL_pp_shadow -part xc7a100tfgg484-2 \
+synth_design -mode out_of_context -top $TOP -part xc7a100tfgg484-2 \
   -generic N_STREAM_IN_P=$N_IN -generic N_STREAM_OUT_P=$N_OUT
 
 create_clock -period 10.000 -name clk [get_ports clk_i]

--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -71,6 +71,15 @@ the array.
   targets — `make ecp5` maps e.g. `tcam`→~1.7 k `TRELLIS_FF`, `milan_csr`→~2.2 k.
 - `axis_fifo`'s large cell count is its default `DEPTH=4096` RAM; instances in the
   design set a small depth.
+- `run.sh --emit NAME` prints one top's inventory record (`top=` / `define=` /
+  `incdir=` / `derived=` / `src=` lines) and exits. It exists so a second
+  consumer does not have to read this script: the Vivado out-of-context flow
+  (`syn/ooc/dp_srcs.py`) asks for the record instead of recognising the
+  `tops=()` row and the `PP_SRCS` composition as text. A recogniser accepts
+  what it has modelled and bash accepts something else, and four such
+  disagreements were measured on the recognising version (PR #240). Anything
+  printed is bash's own expansion of the row this script is about to
+  synthesise, so an edit here moves both consumers or fails both.
 
 ## `ooc.sh` — AREA measurement (a different question from `run.sh`)
 

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -7,6 +7,7 @@
 #
 #   ./run.sh                                  # full serial gate, every top
 #   ./run.sh --list                           # print the authoritative inventory
+#   ./run.sh --emit KL_pp_shadow              # one top's record, for a consumer
 #   ./run.sh --shard 0/4 --results out/       # one weighted CI worker
 #   ./run.sh --mode elaborate --top TOP       # fast hierarchy/process smoke
 #   YOSYS_SYNTH=synth_ecp5 ./run.sh           # target a real device
@@ -24,6 +25,8 @@ usage: syn/yosys/run.sh [options]
   --top NAME             select one explicit top; may be repeated
   --list                 print selected top names; python3 only, no sv2v,
                          yosys or submodule checkout
+  --emit NAME            print one top's machine-readable inventory record
+                         (top=/define=/incdir=/derived=/src= lines) and exit
   --mode full|elaborate  full synthesis or fast hierarchy/process smoke
   --results DIRECTORY    write one machine-readable result per top/gate
   --no-structural        do not run the tied-input and tap-purity checks
@@ -34,6 +37,7 @@ EOF
 SHARD="0/1"
 MODE="full"
 LIST=0
+EMIT=""
 RESULTS=""
 NO_STRUCTURAL=0
 REQUESTED_TOPS=()
@@ -56,6 +60,10 @@ while [ "$#" -gt 0 ]; do
       RESULTS="$2"; shift 2 ;;
     --results=*) RESULTS="${1#--results=}"; shift ;;
     --list) LIST=1; shift ;;
+    --emit)
+      [ "$#" -ge 2 ] || { echo "--emit needs a top NAME" >&2; exit 2; }
+      EMIT="$2"; shift 2 ;;
+    --emit=*) EMIT="${1#--emit=}"; shift ;;
     --no-structural) NO_STRUCTURAL=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -69,6 +77,13 @@ if [ "${#REQUESTED_TOPS[@]}" -gt 0 ] && [ "$SHARD" != "0/1" ]; then
   echo "--top and a non-default --shard are mutually exclusive" >&2
   exit 2
 fi
+# --list deliberately derives NO sources; --emit is a source record. Answering
+# both at once would have to emit the "@pp-srcs-not-derived-for---list@"
+# placeholder as if it were a file.
+if [ -n "$EMIT" ] && [ "$LIST" -eq 1 ]; then
+  echo "--emit and --list are mutually exclusive" >&2
+  exit 2
+fi
 
 export PATH="$HOME/.local/bin:$PATH"
 R="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -76,7 +91,27 @@ A="$R/third_party/verilog-axis/rtl"
 C="$R/hdl/common"; Q="$R/hdl/ieee8021q/ts"; P="$R/hdl/ieee8021as/ptp_timestamp"
 E="$R/hdl/common/eth_event_counter"; D="$R/hdl/ieee17221/adp"
 F="$R/hdl/ieee8021q/filtering"
-INC="-DSYNTHESIS -I $R/hdl/common -I $R/hdl/common/csr -I $Q -I $E -I $D -I $P"
+# PREPROCESSOR INPUTS AS LISTS, NOT AS ONE FLAG STRING. syn/ooc/dp_srcs.py asks
+# this script for them (`--emit`) and hands them to the same front end; a flag
+# string would have to be re-split by that consumer, and a consumer that re-reads
+# this file rather than being handed its contents is the defect class of #235.
+DEFINES=(SYNTHESIS)
+INCDIRS=("$R/hdl/common" "$R/hdl/common/csr" "$Q" "$E" "$D" "$P")
+
+# milan_datapath and nothing else `include's the elaboration-shape header. Named
+# once here so the flags the gate passes and the record `--emit` prints are the
+# same list.
+incdirs_for() {
+  case "$1" in
+    milan_datapath) printf '%s\n' "$R/configs/generated/endstation_arty_current" ;;
+  esac
+  printf '%s\n' "${INCDIRS[@]}"
+}
+inc_flags_for() {
+  local d
+  for d in "${DEFINES[@]}"; do printf -- '-D%s ' "$d"; done
+  while IFS= read -r d; do printf -- '-I %s ' "$d"; done < <(incdirs_for "$1")
+}
 SYNTH="${YOSYS_SYNTH:-synth}"
 
 # THE PROTOCOL PROCESSOR IS THE CONTROL PLANE (scenario B, 2026-08-13).
@@ -177,6 +212,32 @@ for spec in "${tops[@]}"; do
   all_names+=("$name")
   spec_by_name[$name]="$spec"
 done
+
+# `--emit NAME` HANDS ONE TOP'S RECORD TO A SECOND CONSUMER instead of letting
+# it read this file. syn/ooc/dp_srcs.py, which feeds the Vivado out-of-context
+# scripts, used to recognise the PP_SRCS composition and the `tops` row as text,
+# and a text recogniser accepts what bash does not: a generator path this script
+# would fail to execute, an argument it never passes, a commented-out row, a
+# positional that is not a source ([R0] on PR #240). Everything printed below is
+# bash's own expansion of the array the gate synthesises, so a mutation of this
+# file either moves both consumers or fails both.
+if [ -n "$EMIT" ]; then
+  [ "${spec_by_name[$EMIT]+set}" = set ] || {
+    echo "unknown top: $EMIT" >&2
+    exit 2
+  }
+  emit_spec="${spec_by_name[$EMIT]}"
+  printf 'top=%s\n' "$EMIT"
+  for emit_d in "${DEFINES[@]}"; do printf 'define=%s\n' "$emit_d"; done
+  while IFS= read -r emit_d; do printf 'incdir=%s\n' "$emit_d"; done \
+    < <(incdirs_for "$EMIT")
+  # The generated half, named so the consumer can assert it survived whole.
+  for emit_f in ${PP_DERIVED:-}; do printf 'derived=%s\n' "$emit_f"; done
+  # UNQUOTED on purpose: this is the same word splitting that builds sv2v's
+  # argument list below, so the record cannot hold a token the gate would not.
+  for emit_f in ${emit_spec#*|}; do printf 'src=%s\n' "$emit_f"; done
+  exit 0
+fi
 
 python3 "$R/scripts/yosys_shards.py" --selftest >/dev/null || {
   echo "Yosys shard selector fails its own self-test" >&2
@@ -279,9 +340,7 @@ for name in "${selected_names[@]}"; do
   spec="${spec_by_name[$name]}"
   top="${spec%%|*}"
   srcs="${spec#*|}"
-  inc="$INC"
-  [ "$top" = "milan_datapath" ] && \
-    inc="-I $R/configs/generated/endstation_arty_current $INC"
+  inc="$(inc_flags_for "$top")"
 
   if ! sv2v --top="$top" $inc $srcs > "$TMP/$top.v" 2> "$TMP/$top.sv2v.err"; then
     printf "  [FAIL] %-22s sv2v: %s\n" "$top" "$(head -1 "$TMP/$top.sv2v.err")"


### PR DESCRIPTION
[A1]

## Contents

- **[Status](#status)**
- **[Linked Issue / roles](#linked-issue--roles)**
- **[Description](#description)**
- **[Authoritative references](#authoritative-references)**
- **[How to get into the same state](#how-to-get-into-the-same-state)**
- **[How to validate](#how-to-validate)**
- **[Known limitations / out of scope](#known-limitations--out-of-scope)**
- **[Definition of Done](#definition-of-done)**

## Status

GREEN at head `64d2fae8`, answering [R0] round three's blocker on `d4e004bd`.

**Every figure in this body was measured at `64d2fae8`.** Nothing is carried over from
`d4e004bd`, `cf991e51`, `add9f717` or `bafd29f3`, and no figure from an earlier round
survives: `dev` moved under the review (PR #227 merged at `cb444a09`, carrying the AS_PATH
trigger split and re-pinning `protocol-processor` to `3770ae02`), this branch was rebased
onto it, and the read set and both area figures changed as a result. The two Vivado runs
were taken at `6ebbd17f`, the parent of `64d2fae8`; `64d2fae8` edits only the page they are
recorded on and touches nothing either run reads.

`235-ooc-reads-its-top` -> `dev`.

## Linked Issue / roles

Closes #235
Relates to #231

Executor: `[A1]`
Internal cleared-context reviewer: `[R<n>]`
External reviewer: `[R<n>]`

## Description

The script named `KL_pp_shadow` as `-top` and read 41 sources that did not include it.
Three review rounds have been spent on the two halves of that: where the read set comes
from, and how "the top is in it" is decided. The first half is settled -- `syn/yosys/run.sh`
emits its own read set and `syn/ooc/dp_srcs.py` consumes the emission. **This round changes
the second half**, because the same finding came back three times.

| Round | The construct that escaped | What was changed |
|---|---|---|
| one | a block comment around `module KL_pp_shadow` | strip comments and strings first |
| two | `` `define UNUSED `` / `module KL_pp_shadow;` / `endmodule`, joined by backslashes | consume a `define` and everything its continuations carry |
| three | `` `define DISCARD(x) `` then `` `DISCARD( `` / the declaration / `)` | **the model is deleted** |

Round three's construct is legal input, and at `d4e004bd` `declares()` returned `True` and
`build(..., front_end=(None, "no front end"))` returned `rc=0` with no findings, while the
front end the gate runs answered `sv2v: Could not find top module KL_pp_shadow`. Both
reproduced verbatim; see the [A1] comment.

**Which of the two contracts the review offered, and why.** The review allowed either
"make the no-front-end model conservatively refuse" or "require a semantic front end on
every path that claims top resolution". **I chose the second: the tool-absent mode does not
exist any more.**

The reason is the table above. All three escapes are one class -- *the model answers a
question that only the directive layer can answer* -- and each fix changed the model's
spelling, not its shape. Deciding which `module` keyword survives macro expansion is what a
preprocessor does; a complete model of the directive layer **is** a front end, so a fourth
spelling would buy a fourth round. The conservative variant does not escape that: its
refusal condition is itself an enumeration ("no macro invocation may precede the match, no
`pragma protect` envelope, no include that could leave an argument list open, ..."), and the
enumeration is the thing that has been wrong every time it was tested. A model that abstains
correctly needs the same knowledge as a model that answers correctly. So `preprocess()` and
`declares()` are gone, `sv2v_verdict()` is the only answerer, and a `None` verdict -- front
end absent, or no top-resolution answer -- is a refusal with no flag to soften it.

**What it costs, measured.** `sv2v` becomes required to run the two OOC `.tcl` scripts. That
is not a new tool in the tree: `syn/yosys/run.sh`, the authority these scripts get their read
set from, requires `sv2v` (its header, and its `for tool in sv2v yosys` check), and
`README.md`'s tool table already carries the install line. A Vivado host that cannot run
`sv2v` cannot run the gate that defines the list it is consuming. What such a host loses is
the preflight, and it gets a named refusal that says which tool to install rather than a
`module 'KL_pp_shadow' not found` from Vivado 41 sources later.

| File | Change |
|---|---|
| `syn/ooc/dp_srcs.py` | `DIRECTIVE`, `preprocess()` and `declares()` **deleted** (-63 lines of model). `build()` loses its `read=` and `require_front_end=` parameters; `verdict is None` is now a hard refusal naming the missing tool. `--require-front-end` removed from the CLI: it is the only behaviour. The module docstring records all three rounds and why the shape changed. `--selftest` is **35 arms**: the declaration group no longer asserts what a model believed, it puts one construct per one-file read set and asks the REAL `sv2v` |
| `syn/ooc/pp_shadow_ooc.tcl` | commentary corrected: `sv2v` is required here, and why the model that used to stand in for it is gone |
| `syn/ooc/milan_datapath_ooc.tcl` | same one-authority comment, plus the `sv2v` requirement |
| `.github/workflows/rtl-fast.yml` | the two real expansions drop `--require-front-end` (the flag no longer exists); the step comment says what the job now proves |
| `docs/findings/PP_SHADOW_AREA_0812.md` | the refusal bullet rewritten to the new contract with all three escapes named; the Instrument recipe states the `sv2v` prerequisite; the arm inventory is 35; **both area figures re-measured at this head** |
| `docs/testing/CI_WORKFLOWS.md` | the fast workflow bullet says the declaration is resolved through `sv2v` and through nothing else |
| `syn/yosys/run.sh`, `syn/yosys/README.md`, `syn/ooc/ooc_tcl_selftest.py`, `sw/builder/test_builder.py` | unchanged this round (they carry the round-two emission work) |

**Why the self-test changed shape too.** Thirteen arms used to encode what the model believed
about thirteen constructs. Those beliefs were the defect, so asserting them was asserting the
defect. Each construct is now a one-file read set handed to the real `sv2v`, and two arms run
the other way -- a plain declaration and a **macro-EXPANDED** one must both expand clean --
so the group cannot pass on a front end that refuses everything. The macro-expanded arm also
fixes a false refusal the deleted model caused: `` `define D module faketop; endmodule `` /
`` `D `` carries no declaration in text, `sv2v` resolves it, and the old model refused it.

## Authoritative references

- Issue #235 (acceptance criteria, including the deliberate missing-top refusal), Issue #231
  (the area baseline this unblocks), Issue #170 (derived source lists).
- `CONTRIBUTING.md` section 3: a build input derives the protocol-processor sources and takes
  the exit status; a checker carries a self-test that runs in a gate so the tool cannot rot
  into a green that means nothing.
- `CONTRIBUTING.md` lines 209-222: `scripts/run_all_suites.sh` and `syn/yosys/run.sh` are
  independently required local merge evidence. Both were run at `64d2fae8`, sharded, and
  every shard is recorded below.
- `AGENTS.md` section 6 for the review lenses.
- `syn/yosys/run.sh` is the authority for every read set (`--emit`), and the front end it
  requires is the authority for whether a read set declares its top.
- `README.md` tool table: the `sv2v` prerequisite this PR makes binding for the OOC flow.

## How to get into the same state

```sh
git clone git@github.com:kebag-logic/milan-fpga.git && cd milan-fpga
git checkout 235-ooc-reads-its-top          # 64d2fae8, on dev cb444a09
git submodule update --init protocol-processor third_party/verilog-axis gptp-processor
export PATH=<vivado-2026.1>/bin:$PATH       # for the two shapes only
# sv2v (README.md tool table) and yosys as in syn/yosys/README.md; tclsh for the .tcl self-test
export TMPDIR=$HOME/tmp                     # /tmp on this box has a per-user quota
```

## How to validate

```sh
REPO=$PWD

# 1. the authority emits, and the consumer agrees byte for byte
diff <(bash syn/yosys/run.sh --emit KL_pp_shadow | sed -n 's/^src=//p') \
     <(python3 syn/ooc/dp_srcs.py --top KL_pp_shadow)        # empty
python3 syn/ooc/dp_srcs.py --top KL_pp_shadow | wc -l        # 45
python3 syn/ooc/dp_srcs.py | wc -l                           # 106 (milan_datapath)

# 2. the checks rtl-fast runs
python3 syn/ooc/dp_srcs.py --selftest                        # 35 arm(s) passed
python3 syn/ooc/ooc_tcl_selftest.py                          # 5 arm(s) passed (tclsh)

# 3. round three's construct, both ways (the [A1] comment quotes the output)
python3 - <<'EOF'
import sys, tempfile, os
sys.path.insert(0, "syn/ooc"); import dp_srcs
d = tempfile.mkdtemp(); p = os.path.join(d, "KL_pp_shadow.sv")
open(p, "w").write("`define DISCARD(x)\n`DISCARD(\nmodule KL_pp_shadow;\nendmodule\n)\n")
rec = {"top": ["KL_pp_shadow"], "define": [], "incdir": [], "derived": [], "src": [p]}
for fe in (lambda *a, **k: (None, "no front end"), dp_srcs.sv2v_verdict):
    print(dp_srcs.build("KL_pp_shadow", rec, front_end=fe)[2])   # 2 and 2
EOF

# 4. the rest of the local bar
python3 scripts/pp_srcs.py --check --selftest
bash syn/yosys/check_list_hermetic.sh
python3 scripts/lint_rtl.py --check --self-test
python3 sw/builder/test_builder.py
python3 scripts/docs_check.py && python3 scripts/check_doc_paths.py \
  && python3 scripts/gen_toc.py --check
git diff --check

# 5. both mandatory local gates, sharded
for i in 0 1 2 3 4 5; do scripts/run_all_suites.sh "$(mktemp -d)" --shard $i/6; done
for i in 0 1 2 3;     do syn/yosys/run.sh --shard $i/4; done

# 6. the two shapes, each in its own empty directory OUTSIDE the tree, one at a time
for shape in 1 8; do
  d=$(mktemp -d); cd $d
  python3 $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py -o ltn_rom.hex
  python3 $REPO/protocol-processor/hdl/aecp/ucode/gen_ucode.py -o ucode.hex
  PP_N_IN=$shape PP_N_OUT=$shape vivado -mode batch \
      -source $REPO/syn/ooc/pp_shadow_ooc.tcl -nojournal -log ooc.log
  grep -E "^\| Slice LUTs" util.rpt; cd $REPO
done
```

Expected result / pass criteria, all measured at `64d2fae8`:

- `dp_srcs.py --selftest` prints `35 arm(s) passed`; `ooc_tcl_selftest.py` prints
  `5 arm(s) passed`; `check_list_hermetic.sh` prints `OK` with 46 tops;
  `pp_srcs.py --check --selftest` derives 42 tracked sources at rc=0.
- `dp_srcs.py --top KL_pp_shadow` prints **45** lines and the default top prints **106**.
  Both counts moved with `dev`'s `protocol-processor` re-pin (43 and 104 at `d4e004bd`); the
  `--emit`/`dp_srcs.py` diff is empty for both tops.
- `scripts/run_all_suites.sh`, shards 0..5 of 6: **52 suites, 52 passed, 0 failed, 0 timed
  out, 2,119,350 checks, 0 in-suite failures.** Per shard: 0/6 4 suites 284 checks; 1/6 10
  suites 15,076; 2/6 6 suites 1,721,855; 3/6 14 suites 37,520; 4/6 8 suites 213,379; 5/6 10
  suites 131,236. Shard 1/6 was run twice: once without `TSN_GEN_ROOT` (14,328 checks, the
  four `tsn_fuzz` campaign arms declaring a skip) and once with it pointed at the local
  tsn-gen checkout (15,076); the higher figure is the one recorded.
- `syn/yosys/run.sh`, shards 0..3 of 4: **46 tops, 46 pass, 0 fail, `RESULT: PASS` in every
  shard.** `milan_datapath` 1,597,718 cells (shard 0/4); `KL_pp_shadow` 1,133,318 cells
  (shard 1/4, 253 s); shard 2/4 22 tops (99 s); shard 3/4 22 tops (60 s). Shard 0/4 also runs
  the structural gates: `TIED-INPUT GATE: PASS` (26 tied, 2 justified, 0 unjustified, 0
  stale) and `TAP-PURITY RESULT: PASS` (24 stream-net bindings, 0 violations). The 48 result
  records under `--results` are all `status=PASS`.
- Both Vivado runs exit 0, read `44 SystemVerilog + 1 Verilog sources`, emit no
  `CRITICAL WARNING`, and write `util.rpt`, `util_hier.rpt`, `timing.rpt`:

  | Shape | Slice LUTs | Slice Registers | Block RAM Tile | DSPs | WNS | Failing endpoints |
  |---|---|---|---|---|---|---|
  | `N_STREAM_IN/OUT = 1` | 20,945 | 23,191 | 17 | 4 | -5.466 ns | 1,651 |
  | `N_STREAM_IN/OUT = 8` | 27,743 | 30,195 | 24.5 | 4 | -9.073 ns | 2,932 |

  Both are larger than the `d4e004bd` figures (16,547 and 22,817 LUT) because `dev` re-pinned
  `protocol-processor` from `a25b5cc9` to `3770ae02`. No change in this PR moves them.
- `python3 scripts/lint_rtl.py --check --self-test`: `LINT GATE: PASS (99 violation(s) <=
  ratchet 99; 22 waived, 0 justified lint_off)`; `python3 sw/builder/test_builder.py`:
  `ALL GATES PASS EXCEPT 2 NOT RUN` (gate 11 and gate 19b need build trees that are not on
  this box; unrelated to this PR).
- the three doc gates exit 0 and `git diff --check` is clean. `git status --short` is empty in
  the parent and in every submodule after every run above.

## Known limitations / out of scope

- **`sv2v` is now a hard prerequisite of the two OOC `.tcl` scripts.** This is the deliberate
  contract of this round, not an oversight: the alternative was a second answerer that
  disagrees with the toolchain, which is what the three [R0] rounds measured. A host without
  `sv2v` gets a refusal naming the tool. `README.md`'s tool table and the finding's Instrument
  block both state it.
- **A declaration this flow refuses may still be legal SystemVerilog.** `sv2v` is the oracle,
  and if `sv2v` and Vivado ever disagree about top resolution, this flow follows `sv2v`. That
  is a narrower claim than "Vivado will find the top", and it is the claim the code makes.
- **`syn/ooc/milan_datapath_ooc.tcl` does not require `ucode.hex`** and generates only
  `ltn_rom.hex`. `milan_datapath` instantiates `KL_pp_shadow`, so the datapath OOC figure
  carries the same understated-ROM exposure this PR closes for the plane flow. Not changed
  here: adding the requirement without the generation step would break a documented recipe,
  and the datapath baseline belongs to #231.
- **A separate false green in `syn/yosys/ooc.sh`** (it prints a missing-`ucode.hex` error and
  exits 0) is filed as #245 by another lane. Different file, different issue.
- **`scripts/run_all_suites.sh` does not carry the two OOC self-tests.** They run in the
  hosted required gate (`rtl-fast` / `yosys-elaboration`), which is where the review asked for
  them and where `sv2v` and `tclsh` are installed.
- **No RTL changed.** No file under `hdl/`, `tb/` or any submodule is touched by this PR's
  commits, and no submodule pin moves relative to `dev` `cb444a09`. Both mandatory local gates
  were nonetheless run in full at `64d2fae8` and are recorded above.
- **CI cannot run the two shapes**: there is no Vivado in the workflows. They were run
  locally, one at a time, each in its own directory under `$HOME` outside the tree, because
  concurrent Vivado aborts with JVM errors on this box.
- **The figures are post-synthesis out-of-context**, on `xc7a100tfgg484-2`, with the 100 MHz
  clock created after `synth_design`. They are not post-place-and-route and carry no closure
  verdict. The WNS is reported because the run produces it, not as a timing sign-off.
- **Observed but not fixed, and not attributable to this PR**: `scripts/check_doc_paths.py`
  prints `note: ALLOW entry 'scripts/ci_scope.py' is stale - the path exists now`. That entry
  is on `dev` at `cb444a09` and this PR does not touch `scripts/check_doc_paths.py`; the gate
  still exits 0. Left for the lane that owns it.
- **The environment was degraded during this round.** `/tmp` is at its per-user tmpfs quota,
  and the harness's own command capture failed repeatedly (`exit 1` with no output, including
  for `true`). Every gate above was therefore run with its output redirected to a file under
  `$HOME` and read back; the one gate this affected in substance is the Yosys `0/4` shard,
  whose wrapper was killed at a 10-minute cap **after** its log was written in full
  (`RESULT: PASS`, both structural gates, 46-record results directory). Nothing was rerun to
  produce a nicer number.
- The 2026-08-12 area tables in the finding are left as the dated measurement they are. The
  current baseline belongs to #231.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done
