### PR TITLE
xvlog gate: analyse the tracked .v and the pinned processors, refuse instead of under-counting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,8 @@ Two board rules that go with it:
   [`scripts/lint_rtl.py`](scripts/lint_rtl.py) read, and are exactly what CI
   initialises. Two of them, the processor pair, are also what
   [`scripts/xvlog_gate.py`](scripts/xvlog_gate.py) analyses, and it refuses the
-  same way when one is missing. Lint now REFUSES (exit 2, not the
+  same way -- but against the **gitlink**, so a standalone clone dropped at the
+  path or a checkout moved off the pin is refused too, not counted. Lint now REFUSES (exit 2, not the
   ratchet-tighten exit 1) rather
   than under-count when one is absent (#186): a count over an incomplete
   resolution set drops findings and would invite a tighten to a number the real
@@ -310,13 +311,18 @@ Two board rules that go with it:
   when no Vivado is present, so it is inert in CI and never a false green. Its
   `--selftest` runs in [`scripts/run_all_suites.sh`](scripts/run_all_suites.sh)
   next to the others. Two things to know before you run it (#224, #236):
-  - With a processor submodule absent or empty it **REFUSES** (exit 2, naming
-    the tree and the init command) instead of reporting a smaller clean set,
-    the same shape and the same #186 reason as the lint refusal above. The
-    budget carries the two populations in **separate sections**, so donor debt
-    is never traded against `hdl/` debt; a processor key is spelled
-    `<submodule>:<path>` so this generated file is not read as a hand-written
-    copy of the submodule source list.
+  - **The processor population is the superproject's gitlink, or the gate
+    REFUSES** (exit 2, before it enumerates anything, naming the state, the
+    expected and actual revisions and the remediation). Absent, empty,
+    uninitialised, a standalone clone sitting at the path, a registered
+    submodule at another revision, or one with local modifications to tracked
+    files: each of those is a population the pin does not stand behind, and a
+    default run would rewrite the ratchet from it. Same shape and same #186
+    reason as the lint refusal above. Check with `git submodule status` -- a
+    `-` or `+` prefix is a refusal. The budget carries the two populations in
+    **separate sections**, so donor debt is never traded against `hdl/` debt;
+    a processor key is spelled `<submodule>:<path>` so this generated file is
+    not read as a hand-written copy of the submodule source list.
   - It **analyses; it does not elaborate**, and one real class lives only in
     elaboration. Splitting a declaration-with-initialiser (`reg [7:0] r =
     8'd0;`) into a bare declaration plus a continuous `assign` is not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,7 +261,9 @@ Two board rules that go with it:
   `git submodule update --init third_party/verilog-axis protocol-processor gptp-processor`.
   These three are what the Verilator suites, the Yosys gate and
   [`scripts/lint_rtl.py`](scripts/lint_rtl.py) read, and are exactly what CI
-  initialises. Lint now REFUSES (exit 2, not the ratchet-tighten exit 1) rather
+  initialises. Two of them, the processor pair, are also what
+  [`scripts/xvlog_gate.py`](scripts/xvlog_gate.py) analyses, and it refuses the
+  same way when one is missing. Lint now REFUSES (exit 2, not the ratchet-tighten exit 1) rather
   than under-count when one is absent (#186): a count over an incomplete
   resolution set drops findings and would invite a tighten to a number the real
   tree cannot meet. The `external` submodule is SSH-only and no sim, lint or
@@ -300,12 +302,28 @@ Two board rules that go with it:
   sweep and the Yosys gate all lower SystemVerilog through Verilator/sv2v, so a
   construct Vivado is stricter about (use-before-declaration is the first one
   found) is invisible to the whole bar (#132). The gate runs `xvlog -sv` over
-  every `hdl/` module, ratchets today's findings in
-  [`scripts/xvlog.budget`](scripts/xvlog.budget) keyed on identity so a
-  compensating swap cannot hide, and SKIPS cleanly with a visible marker when no
-  Vivado is present, so it is inert in CI and never a false green. Its
+  every tracked `.sv` **and** `.v` under `hdl/` and over the pinned control
+  plane (`protocol-processor/hdl`, `gptp-processor/hdl`), ratchets today's
+  findings in [`scripts/xvlog.budget`](scripts/xvlog.budget) keyed on identity
+  so a compensating swap cannot hide, and SKIPS cleanly with a visible marker
+  when no Vivado is present, so it is inert in CI and never a false green. Its
   `--selftest` runs in [`scripts/run_all_suites.sh`](scripts/run_all_suites.sh)
-  next to the others.
+  next to the others. Two things to know before you run it (#224, #236):
+  - With a processor submodule absent or empty it **REFUSES** (exit 2, naming
+    the tree and the init command) instead of reporting a smaller clean set,
+    the same shape and the same #186 reason as the lint refusal above. The
+    budget carries the two populations in **separate sections**, so donor debt
+    is never traded against `hdl/` debt; a processor key is spelled
+    `<submodule>:<path>` so this generated file is not read as a hand-written
+    copy of the submodule source list.
+  - It **analyses; it does not elaborate**, and one real class lives only in
+    elaboration. Splitting a declaration-with-initialiser (`reg [7:0] r =
+    8'd0;`) into a bare declaration plus a continuous `assign` is not
+    equivalent, and `xvlog`, Verilator 5.050 under `-Wall`, `sv2v` and Yosys
+    all accept the broken form silently. Only `xelab` rejects it
+    (`VRFC 10-9171`), and no gate in this repository runs `xelab`. If your
+    change moves declarations around, that construct has **no gate** -- check
+    it by hand and say so in the PR.
 - **A build input never lists the protocol-processor sources, it derives
   them**: [`scripts/pp_srcs.py`](scripts/pp_srcs.py) reads the submodule tree
   and emits the list, packages first (detected by reading each file for a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,16 +313,23 @@ Two board rules that go with it:
   next to the others. Two things to know before you run it (#224, #236):
   - **The processor population is the superproject's gitlink, or the gate
     REFUSES** (exit 2, before it enumerates anything, naming the state, the
-    expected and actual revisions and the remediation). Absent, empty,
-    uninitialised, a standalone clone sitting at the path, a registered
-    submodule at another revision, or one with local modifications to tracked
-    files: each of those is a population the pin does not stand behind, and a
-    default run would rewrite the ratchet from it. Same shape and same #186
-    reason as the lint refusal above. Check with `git submodule status` -- a
-    `-` or `+` prefix is a refusal. The budget carries the two populations in
-    **separate sections**, so donor debt is never traded against `hdl/` debt;
-    a processor key is spelled `<submodule>:<path>` so this generated file is
-    not read as a hand-written copy of the submodule source list.
+    expected and actual revisions and the remediation). The pin it accepts is
+    exactly one index record at the path, mode `160000`, stage `0`. An
+    unmerged gitlink is not one, whatever single SHA survives: any record at
+    stage 1, 2 or 3, a `160000` stage beside a file or symlink stage, or a
+    one-sided stage with nothing to merge it against. Nor is a path tracked as
+    an ordinary file or symlink, nor contents committed as ordinary files
+    under it. Nor, on the checkout side, is absent, empty, a file or a symlink
+    where the checkout must be, uninitialised, a standalone clone sitting at
+    the path, a registered submodule at another revision, or one with local
+    modifications to tracked files. Each of those is a population the pin does
+    not stand behind, and a default run would rewrite the ratchet from it.
+    Same shape and same #186 reason as the lint refusal above. Check with
+    `git submodule status` -- a `-`, `+` or `U` prefix is a refusal. The
+    budget carries the two populations in **separate sections**, so donor debt
+    is never traded against `hdl/` debt; a processor key is spelled
+    `<submodule>:<path>` so this generated file is not read as a hand-written
+    copy of the submodule source list.
   - It **analyses; it does not elaborate**, and one real class lives only in
     elaboration. Splitting a declaration-with-initialiser (`reg [7:0] r =
     8'd0;`) into a bare declaration plus a continuous `assign` is not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,8 +263,10 @@ Two board rules that go with it:
   [`scripts/lint_rtl.py`](scripts/lint_rtl.py) read, and are exactly what CI
   initialises. Two of them, the processor pair, are also what
   [`scripts/xvlog_gate.py`](scripts/xvlog_gate.py) analyses, and it refuses the
-  same way -- but against the **gitlink**, so a standalone clone dropped at the
-  path or a checkout moved off the pin is refused too, not counted. Lint now REFUSES (exit 2, not the
+  same way -- but against the **gitlink** and then against the pinned **bytes**,
+  so a standalone clone dropped at the path, a checkout moved off the pin, and a
+  local edit the index has been told to keep quiet about are all refused, not
+  counted. Lint now REFUSES (exit 2, not the
   ratchet-tighten exit 1) rather
   than under-count when one is absent (#186): a count over an incomplete
   resolution set drops findings and would invite a tighten to a number the real
@@ -311,8 +313,9 @@ Two board rules that go with it:
   when no Vivado is present, so it is inert in CI and never a false green. Its
   `--selftest` runs in [`scripts/run_all_suites.sh`](scripts/run_all_suites.sh)
   next to the others. Two things to know before you run it (#224, #236):
-  - **The processor population is the superproject's gitlink, or the gate
-    REFUSES** (exit 2, before it enumerates anything, naming the state, the
+  - **The processor population is the superproject's gitlink, proved byte by
+    byte, or the gate REFUSES** (exit 2, before it enumerates anything, before
+    the census and before the budget is read or written, naming the state, the
     expected and actual revisions and the remediation). The pin it accepts is
     exactly one index record at the path, mode `160000`, stage `0`. An
     unmerged gitlink is not one, whatever single SHA survives: any record at
@@ -321,15 +324,30 @@ Two board rules that go with it:
     an ordinary file or symlink, nor contents committed as ordinary files
     under it. Nor, on the checkout side, is absent, empty, a file or a symlink
     where the checkout must be, uninitialised, a standalone clone sitting at
-    the path, a registered submodule at another revision, or one with local
-    modifications to tracked files. Each of those is a population the pin does
-    not stand behind, and a default run would rewrite the ratchet from it.
+    the path, or a registered submodule at another revision.
     Same shape and same #186 reason as the lint refusal above. Check with
     `git submodule status` -- a `-`, `+` or `U` prefix is a refusal. The
     budget carries the two populations in **separate sections**, so donor debt
     is never traded against `hdl/` debt; a processor key is spelled
     `<submodule>:<path>` so this generated file is not read as a hand-written
     copy of the submodule source list.
+  - **Once the revision matches, the SOURCES themselves are proved, not asked
+    about.** The population is read from the pinned commit's own tree
+    (`git ls-tree -r <pin>`), and every file in it must hash to the blob id the
+    pin records, over the exact bytes `xvlog` opens. `git status`,
+    `git diff` and `git ls-files` are not consulted at all, because those
+    answers are computed through the index and the index can be told to stay
+    quiet: `git update-index --assume-unchanged` and `--skip-worktree` both
+    hide a changed or deleted file from every one of them (`git -C <sub>
+    ls-files -v` prints `h` and `S` for the two). So a hidden edit, a sparse or
+    skip-worktree checkout, a dropped index record, and a symlink standing in
+    for a pinned file are all refused -- not because each is enumerated, but
+    because acceptance is a per-file hash equality none of them can produce.
+    A checkout that is not the pinned bytes is a population the pin does not
+    stand behind, and a default run would rewrite the ratchet from it (#236).
+    The repository's own `hdl/` is deliberately NOT proved this way: it is the
+    tree you are gating, so its bytes on disk are the population by
+    definition.
   - It **analyses; it does not elaborate**, and one real class lives only in
     elaboration. Splitting a declaration-with-initialiser (`reg [7:0] r =
     8'd0;`) into a bare declaration plus a continuous `assign` is not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,13 @@ Two board rules that go with it:
   - **Once the revision matches, the SOURCES themselves are proved, not asked
     about.** The population is read from the pinned commit's own tree
     (`git ls-tree -r <pin>`), and every file in it must hash to the blob id the
-    pin records, over the exact bytes `xvlog` opens. `git status`,
+    pin records, over the exact bytes `xvlog` opens. Every Git call contributing
+    to that decision explicitly sets `GIT_NO_REPLACE_OBJECTS=1`: a mutable
+    `refs/replace/<pin>` must not make `git ls-tree <pin>` read a different
+    commit while `HEAD` still prints the pinned id. The real-Git self-test
+    installs that substitution with its altered bytes on disk and requires a
+    `modified` setup refusal in both modes, before census or budget write.
+    `git status`,
     `git diff` and `git ls-files` are not consulted at all, because those
     answers are computed through the index and the index can be told to stay
     quiet: `git update-index --assume-unchanged` and `--skip-worktree` both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,8 @@ Two board rules that go with it:
   [`scripts/lint_rtl.py`](scripts/lint_rtl.py) read, and are exactly what CI
   initialises. Two of them, the processor pair, are also what
   [`scripts/xvlog_gate.py`](scripts/xvlog_gate.py) analyses, and it refuses the
-  same way when one is missing. Lint now REFUSES (exit 2, not the ratchet-tighten exit 1) rather
+  same way when one is missing. Lint now REFUSES (exit 2, not the
+  ratchet-tighten exit 1) rather
   than under-count when one is absent (#186): a count over an incomplete
   resolution set drops findings and would invite a tighten to a number the real
   tree cannot meet. The `external` submodule is SSH-only and no sim, lint or

--- a/scripts/xvlog.budget
+++ b/scripts/xvlog.budget
@@ -14,4 +14,23 @@
 # #193: the gate then fails on the first NEW finding rather than on a
 # count, and no entry can be traded away against a fix.
 #
-# total 0 finding(s)
+# TWO SECTIONS, and a key cannot move between them (#236). The `hdl`
+# section is this repository's own RTL; `submodules` is the pinned
+# processor control plane, whose keys are spelled `<submodule>:<path>`
+# so that scripts/pp_srcs.py --check does not read this generated file
+# as a hand-written copy of the submodule source list. A section is
+# DERIVED from each key's path when this file is read, so grandfathering
+# donor debt cannot bank an hdl/ finding and vice versa, and the empty
+# hdl section #193 reached stays visible as its own zero.
+#
+# xvlog stops at the FIRST error in a module, so one entry can stand for
+# many occurrences of the same class in that file. Fixing the first one
+# raises the next: --check then reports one vanished and one new key, and
+# both are re-banked in the same deliberate commit.
+#
+# --- section hdl: 0 finding(s) (hdl/) ---
+#
+# --- section submodules: 3 finding(s) (pinned processors) ---
+gptp-processor:hdl/top/KL_gptp_engine.sv|VRFC 10-3380|evq_full_w  # line(s) 157
+protocol-processor:hdl/packet_engine/KL_pp_rx_validator.sv|VRFC 10-3380|vd_push_w  # line(s) 364
+protocol-processor:hdl/top/protocol_processor_top.sv|VRFC 10-3380|srp_class_a_prio_w  # line(s) 746

--- a/scripts/xvlog.budget
+++ b/scripts/xvlog.budget
@@ -30,7 +30,9 @@
 #
 # --- section hdl: 0 finding(s) (hdl/) ---
 #
-# --- section submodules: 3 finding(s) (pinned processors) ---
-gptp-processor:hdl/top/KL_gptp_engine.sv|VRFC 10-3380|evq_full_w  # line(s) 157
+# --- section submodules: 5 finding(s) (pinned processors) ---
+gptp-processor:hdl/top/KL_gptp_engine.sv|VRFC 10-3380|evq_full_w  # line(s) 184
+protocol-processor:hdl/aecp/KL_aecp_notify.sv|VRFC 10-3380|pd_ix_w  # line(s) 502
+protocol-processor:hdl/packet_engine/KL_pp_originator.sv|VRFC 10-3380|cancel_hit_w  # line(s) 194
 protocol-processor:hdl/packet_engine/KL_pp_rx_validator.sv|VRFC 10-3380|vd_push_w  # line(s) 364
-protocol-processor:hdl/top/protocol_processor_top.sv|VRFC 10-3380|srp_class_a_prio_w  # line(s) 746
+protocol-processor:hdl/top/protocol_processor_top.sv|VRFC 10-3380|srp_class_a_prio_w  # line(s) 759

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -29,11 +29,56 @@ independently is load-bearing: xvlog stops analysing a compilation unit at the
 first module error, so a single bad file in a shared compile masks every file
 after it. One module per invocation enumerates them all, which a ratchet needs.
 
+WHAT IT ANALYSES, exactly (widened by #224 and #236 - read the next paragraph
+before narrowing it again): every TRACKED `.sv` AND `.v` under hdl/, and every
+tracked design source under protocol-processor/hdl and gptp-processor/hdl. Those
+two are not third-party leaf IP - they are the control plane milan_datapath
+elaborates on every build, and the same sources scripts/pp_srcs.py hands the
+Verilator sweep, the Yosys portability gate and both Vivado OOC flows, so #132's
+argument applies to them exactly as it applies to hdl/. third_party/ and
+external/ are NOT analysed: leaf IP this repository neither owns nor edits, which
+scripts/lint_rtl.py already treats as resolution-only, never linted. The census
+prints that scope in full every run, because the defect both issues reported was
+a census claiming more than the measurement covered - "every hdl/ module" over a
+set that excluded one tracked `.v` and every processor source.
+
+THE #186 INVARIANT IS KEPT BY REFUSING, NOT BY NARROWING. This banner used to say
+the gate reads only hdl/, so that an uninitialised submodule cannot make the tree
+look cleaner than it is. That reason stands and is not weakened here; the
+conclusion drawn from it does not, because its price was that the very class this
+gate exists to catch had live occurrences in the pinned processors with no gate
+at all (#236 measured 37 at the pin on dev, 51 at the pin PR #227 proposes). So
+the scope widens and the invariant is enforced directly instead: with a processor
+tree absent, empty, or not a checked-out submodule, the gate REFUSES - exit 2,
+naming the tree and the init command - rather than reporting a smaller clean set.
+That is scripts/lint_rtl.py's shape, which #186 forced on the lint ratchet for
+this same reason.
+
+ONE FINDING PER MODULE, NOT ONE PER OCCURRENCE. xvlog stops at the first error in
+a compilation unit and prints only the 10-8530 cascade after it, so a module with
+many use-before-declaration occurrences yields ONE finding, naming the first
+identifier. Measured 2026-08-24 on the processor top that `synth_design` reports
+with 35 `Synth 8-6901` warnings: xvlog prints exactly one 10-3380 plus the
+cascade, and `xvlog --help` in 2026.1 offers no continue-on-error switch. Fixing
+that first occurrence banks one key and raises the next, so --check fails in both
+directions at once and the new front is re-banked deliberately. That is the
+ratchet working, not churn: the finding set changed, and it said so.
+
+WHAT IT STILL CANNOT SEE: elaboration. Splitting a declaration-with-initialiser
+(`reg [7:0] r = 8'd0;`) into a declaration plus a continuous `assign` is NOT
+equivalent - an initialiser runs once at time zero, a continuous assign drives
+forever - and xvlog, Verilator 5.050 under -Wall, sv2v and Yosys all accept the
+broken form silently (#224). Only `xelab` rejects it, with VRFC 10-9171, and
+`xelab` appears nowhere in this repository: the required `elaborate` context is
+the LiteX/Verilator elaboration in sw/builder/test_builder.py. #224 leaves that
+arm deliberately open; a lane doing declaration-order work has no gate for it.
+
 TOOL ABSENCE IS A SKIP, NEVER A FALSE GREEN. With no xvlog on the box (CI has
 none) the gate prints a visible SKIP marker and exits 0, the tsn-gen precedent.
-It reads only hdl/ and include dirs under hdl/, so an uninitialised submodule
-cannot make the tree look cleaner than it is (the #186 trap): the finding set
-does not depend on submodule checkout.
+The skip is decided BEFORE the missing-tree refusal, on purpose: with no tool
+nothing can be measured at all, so refusing there would turn a gate CONTRIBUTING
+section 3 calls inert in CI into a red one, and a skip already reads as not a
+pass.
 
 THE RATCHET keys on the finding IDENTITY `path|CODE|identifier`, not on a count.
 A count ratchet cannot see a compensating swap - one finding fixed while another
@@ -43,12 +88,29 @@ vanished (bank the improvement deliberately), so neither direction is silent.
 Today's backlog is grandfathered in scripts/xvlog.budget and printed in full;
 the underlying defects are their own ticket, not this gate's to fix.
 
+THE BUDGET HAS TWO SECTIONS, hdl/ and the pinned processors, and a key cannot
+move between them: a finding's section is DERIVED from its own path and a budget
+filing a key under the other section is rejected as malformed. Donor debt can
+therefore never be traded against hdl/ debt, and the empty hdl/ section #193
+reached stays visibly empty instead of being absorbed into a joint total.
+
+A PROCESSOR KEY IS SPELLED `<submodule>:<path>`, never `<submodule>/<path>`.
+scripts/pp_srcs.py --check - a required `rtl-fast` context - fails any tracked
+file outside its PROSE_OK table that names a submodule source literally, and this
+ratchet is a tracked file whose whole job is to name them. Measured 2026-08-24
+against pp_srcs.check(): the `/` spelling fails it, the `:` spelling does not.
+Widening PROSE_OK instead would put a hand-maintained list of submodule sources
+back in the tree, which is the defect pp_srcs.py exists to prevent. The colon
+also carries the population inside the key, which is what the two sections above
+are checked against.
+
     scripts/xvlog_gate.py            # analyse, print the census, LOWER the ratchet
     scripts/xvlog_gate.py --check    # gate: fail on a NEW or a vanished finding
     scripts/xvlog_gate.py --selftest # prove the gate reddens on a planted fault
 
 Exit 0 = at the ratchet (or skipped), 1 = regression / vanished finding / a
-package that will not analyse, 2 = usage or setup error.
+package that will not analyse, 2 = usage or setup error, including a processor
+tree that is not checked out and a malformed budget.
 """
 
 import argparse
@@ -78,6 +140,25 @@ INCLUDE_DIRS = [
 ]
 DEFINES = ["SYNTHESIS"]
 
+#: The pinned processor trees analysed alongside hdl/, each with the reason its
+#: sources belong in a gate about THIS repository's front-end risk, printed by
+#: the refusal when it is not checked out. Nothing here is resolved or
+#: elaborated - xvlog analyses one file at a time - so unlike lint_rtl.py's
+#: REQUIRED_TREES this list deliberately omits third_party/verilog-axis (leaf IP,
+#: resolution only) and external/ (SSH-only; CONTRIBUTING 2.2 keeps it out of the
+#: documented local-bar init, so requiring it would refuse on every lane).
+SUBMODULE_TREES = [
+    ("protocol-processor", "protocol-processor/hdl",
+     "the ATDECC/SRP control plane milan_datapath elaborates via KL_pp_shadow"),
+    ("gptp-processor", "gptp-processor/hdl",
+     "the 802.1AS engine milan_datapath elaborates via KL_gptp_shadow"),
+]
+
+#: Budget/census sections, in print order, with the words the census uses for
+#: each. A finding belongs to exactly one, derived from its path.
+SECTIONS = ["hdl", "submodules"]
+SECTION_LABEL = {"hdl": "hdl/", "submodules": "pinned processors"}
+
 #: Where a bench install puts Vivado (docs/reference: 2026.1). $XVLOG wins, then
 #: these, then PATH. Read, not restated in three places.
 XVLOG_CANDIDATES = [
@@ -94,6 +175,38 @@ _PACKAGE_RE = re.compile(r"^\s*package\s+\w+\s*;", re.M)
 _CODE_RE = re.compile(r"\[(VRFC \d+-\d+)\]")
 _IDENT_RE = re.compile(r"identifier '([^']+)'")
 _LOC_RE = re.compile(r"\[([^\]\s]+):(\d+)\]\s*$")
+
+
+def display_path(rel):
+    """The path a finding is KEYED on: `<submodule>:<path>` inside a processor.
+
+    A processor source is spelled with a colon rather than a slash because
+    scripts/pp_srcs.py --check fails any tracked file outside its PROSE_OK table
+    that names a submodule source literally, and scripts/xvlog.budget is a
+    tracked file that must name exactly those sources (see the module docstring
+    for the measurement). Everything else is unchanged, so an hdl/ key reads
+    today as it read before, and an absolute path - the self-test's planted
+    temp file - passes straight through.
+    """
+    for label, _tree, _why in SUBMODULE_TREES:
+        if rel.startswith(label + "/"):
+            return label + ":" + rel[len(label) + 1:]
+    return rel
+
+
+def section_of(key_or_path):
+    """Which budget section a finding key (or its path) belongs to.
+
+    Derived from the path, never stored alongside it: a section a writer could
+    choose independently of the finding is a section a hand edit can move a key
+    into, which is exactly the trade between donor and hdl/ debt the two
+    sections exist to prevent.
+    """
+    head = key_or_path.split("|", 1)[0]
+    for label, _tree, _why in SUBMODULE_TREES:
+        if head.startswith(label + ":"):
+            return "submodules"
+    return "hdl"
 
 
 class Finding:
@@ -159,22 +272,114 @@ def find_xvlog():
     return shutil.which("xvlog")
 
 
-def hdl_sources():
-    """Tracked hdl/ SystemVerilog, packages first then the rest, both sorted.
+def _split_packages(files):
+    """(packages, modules) - a package is a file that DECLARES one, read.
 
-    Tracked only (git ls-files): analysing an untracked stray .sv is a build no
-    other checkout can reproduce - the same rule pp_srcs.py keeps.
+    Keying on a `_pkg.sv` suffix is a naming convention; a package in a file
+    named otherwise would sort after its importers and fail to analyse. Same
+    rule, same reason, as scripts/pp_srcs.py.
     """
-    out = subprocess.run(["git", "ls-files", "hdl/**/*.sv", "hdl/*.sv"],
-                         cwd=ROOT, capture_output=True, text=True)
-    if out.returncode:
-        raise SystemExit(f"git ls-files failed: {out.stderr.strip()}")
-    files = sorted(out.stdout.split())
-    if not files:
-        raise SystemExit("no tracked hdl/*.sv files found")
     pkgs = [f for f in files if _PACKAGE_RE.search((ROOT / f).read_text())]
     rest = [f for f in files if f not in set(pkgs)]
     return pkgs, rest
+
+
+def hdl_sources():
+    """Tracked hdl/ design sources, packages first then the rest, both sorted.
+
+    Tracked only (git ls-files): analysing an untracked stray source is a build
+    no other checkout can reproduce - the same rule pp_srcs.py keeps.
+
+    BOTH `.sv` AND `.v`. The glob was `*.sv` alone and silently excluded
+    hdl/milan/milan_dma_wrapper.v, the one tracked Verilog-2001 module under
+    hdl/, while the census claimed every hdl/ module (#224). It is a real
+    module - bd/build.tcl ships it and scripts/lint_rtl.py carries a named
+    LINT_EXCLUDE waiver for it - and being outside the fabric build is a reason
+    not to LINT it, not a reason to leave it out of a parse census that says
+    "every". `.svh` is not matched: an include header is analysed through the
+    file that includes it, and compiling one alone is not a compilation unit.
+    """
+    out = subprocess.run(["git", "ls-files",
+                          "hdl/**/*.sv", "hdl/*.sv", "hdl/**/*.v", "hdl/*.v"],
+                         cwd=ROOT, capture_output=True, text=True)
+    if out.returncode:
+        raise SystemExit(f"git ls-files failed: {out.stderr.strip()}")
+    files = sorted(set(out.stdout.split()))
+    if not files:
+        raise SystemExit("no tracked hdl/ .sv or .v files found")
+    return _split_packages(files)
+
+
+def submodule_sources(label, tree):
+    """Tracked design sources under one processor tree, or None if unusable.
+
+    None means REFUSE, and it covers three states that all look like a smaller
+    clean finding set: the tree is missing, the tree is present but holds no
+    tracked source, and the directory exists without being a checked-out
+    submodule.
+
+    The third is why this resolves the repository boundary before listing
+    anything. `git -C <dir>` WALKS UP when <dir> is not a repository, so an
+    empty submodule directory - what an aborted `submodule update` leaves
+    behind - would answer with the SUPERPROJECT's file list, and the gate would
+    happily analyse hdl/ twice and call the processors covered. Requiring the
+    submodule's own top-level to BE the submodule directory rules that out.
+    """
+    root = ROOT / tree
+    if not root.is_dir():
+        return None
+    top = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                         cwd=ROOT / label, capture_output=True, text=True)
+    if top.returncode:
+        return None
+    if pathlib.Path(top.stdout.strip()).resolve() != (ROOT / label).resolve():
+        return None
+    out = subprocess.run(["git", "ls-files", "*.sv", "*.v"], cwd=root,
+                         capture_output=True, text=True)
+    if out.returncode:
+        return None
+    files = sorted(set(out.stdout.split()))
+    if not files:
+        return None
+    return [f"{tree}/{f}" for f in files]
+
+
+def missing_submodule_trees(sources=None):
+    """(label, why) for every processor tree the gate cannot analyse.
+
+    `sources` overrides the lookup so the self-test can drive both arms on any
+    box, with no submodule present or absent - lint_rtl.py's shape.
+    """
+    sources = sources or submodule_sources
+    return [(label, why) for label, tree, why in SUBMODULE_TREES
+            if not sources(label, tree)]
+
+
+def source_plan():
+    """(packages, modules, {section: tracked file count}) for the whole scope.
+
+    Every package in the scope is analysed into the one work library before any
+    module, hdl/ first and then each processor tree in SUBMODULE_TREES order.
+    Within a tree the order is the sorted one pp_srcs.py emits, which is what
+    the Yosys and Verilator consumers already build with; a cross-package
+    dependency the order got wrong would surface as a package error, and the
+    gate refuses to grade any module when a package will not analyse.
+
+    Callers must have cleared missing_submodule_trees() first: this function
+    silently omits a tree it cannot read, which is precisely the under-report
+    the refusal exists to prevent.
+    """
+    pkgs, mods = hdl_sources()
+    counts = {"hdl": len(pkgs) + len(mods), "submodules": 0}
+    for label, tree, _why in SUBMODULE_TREES:
+        files = submodule_sources(label, tree)
+        if not files:
+            continue
+        sub_pkgs, sub_mods = _split_packages(files)
+        pkgs += sub_pkgs
+        mods += sub_mods
+        counts["submodules"] += len(sub_pkgs) + len(sub_mods)
+    return pkgs, mods, counts
 
 
 def _xvlog_cmd(xvlog, path):
@@ -229,9 +434,11 @@ def analyse(xvlog, extra_modules=None, workdir=None):
 
     `extra_modules` replaces the module list (the self-test passes a planted
     file); `workdir` overrides the scratch dir. Packages always come from the
-    tree, because a planted module may import one.
+    tree, because a planted module may import one - including the processor
+    packages, so a planted PROCESSOR file analyses in the same library the real
+    ones do and the self-test cannot pass on a world the gate never builds.
     """
-    pkgs, rest = hdl_sources()
+    pkgs, rest, _counts = source_plan()
     modules = rest if extra_modules is None else extra_modules
     findings, pkg_errors = [], []
     made = workdir is None
@@ -241,14 +448,14 @@ def analyse(xvlog, extra_modules=None, workdir=None):
             r = subprocess.run(_xvlog_cmd(xvlog, p), cwd=workdir,
                                capture_output=True, text=True)
             if r.returncode:
-                pkg_errors += _parse(p, r.stdout + r.stderr)
+                pkg_errors += _parse(display_path(p), r.stdout + r.stderr)
         if pkg_errors:
             return findings, pkg_errors
         for m in modules:
             r = subprocess.run(_xvlog_cmd(xvlog, m), cwd=workdir,
                                capture_output=True, text=True)
             if r.returncode:
-                findings += _parse(m, r.stdout + r.stderr)
+                findings += _parse(display_path(m), r.stdout + r.stderr)
     finally:
         if made:
             shutil.rmtree(workdir, ignore_errors=True)
@@ -271,14 +478,33 @@ _BUDGET_HEADER = [
     "# An EMPTY list is the goal state, reached for the whole hdl/ tree by",
     "# #193: the gate then fails on the first NEW finding rather than on a",
     "# count, and no entry can be traded away against a fix.",
+    "#",
+    "# TWO SECTIONS, and a key cannot move between them (#236). The `hdl`",
+    "# section is this repository's own RTL; `submodules` is the pinned",
+    "# processor control plane, whose keys are spelled `<submodule>:<path>`",
+    "# so that scripts/pp_srcs.py --check does not read this generated file",
+    "# as a hand-written copy of the submodule source list. A section is",
+    "# DERIVED from each key's path when this file is read, so grandfathering",
+    "# donor debt cannot bank an hdl/ finding and vice versa, and the empty",
+    "# hdl section #193 reached stays visible as its own zero.",
+    "#",
+    "# xvlog stops at the FIRST error in a module, so one entry can stand for",
+    "# many occurrences of the same class in that file. Fixing the first one",
+    "# raises the next: --check then reports one vanished and one new key, and",
+    "# both are re-banked in the same deliberate commit.",
 ]
 
 
 _LOC_COMMENT_RE = re.compile(r"\s+# line\(s\) [\d,]+\s*$")
+_SECTION_RE = re.compile(r"^#\s*---\s*section (\w+):")
+
+
+class BudgetError(Exception):
+    """The budget file cannot be read as written - a setup error, not a finding."""
 
 
 def read_budget(path=None):
-    """The grandfathered finding keys, or None if the file is absent.
+    """{section: {key}} for the grandfathered findings, or None if absent.
 
     The trailing `  # line(s) N` note is stripped by its OWN shape, not by
     cutting at the first `#`: a key may legitimately contain that character
@@ -286,45 +512,102 @@ def read_budget(path=None):
     reader that cuts at it returns a key the writer never wrote, so the
     finding can be reported forever and never banked ([R0] on PR #222 found
     the `#`-prefixed discriminator case; this is the same defect's general
-    form). A whole-line `#` comment is still a comment.
+    form). A whole-line `#` comment is still a comment - except the section
+    marker, which is a comment the reader parses.
+
+    A key filed under a section its own path does not derive raises
+    BudgetError rather than being silently re-filed. Silently re-filing is
+    the trade the sections exist to stop, and accepting it would make the
+    file's own section headers decorative.
     """
     path = path or BUDGET
     if not path.exists():
         return None
-    keys = set()
+    sections = {name: set() for name in SECTIONS}
+    # Keys before the first marker belong to `hdl`: that is the shape of every
+    # budget written before #236 added sections, and those keys are hdl/ paths.
+    current = SECTIONS[0]
     for line in path.read_text().splitlines():
+        marker = _SECTION_RE.match(line)
+        if marker:
+            current = marker.group(1)
+            if current not in sections:
+                raise BudgetError(f"unknown section {current!r} in {path}")
+            continue
         if line.lstrip().startswith("#"):
             continue
         line = _LOC_COMMENT_RE.sub("", line).strip()
-        if line:
-            keys.add(line)
-    return keys
+        if not line:
+            continue
+        derived = section_of(line)
+        if derived != current:
+            raise BudgetError(
+                f"{path}: key {line!r} is filed under section {current!r} but "
+                f"its path derives {derived!r}. A key does not move between "
+                "sections; fix the file rather than the finding.")
+        sections[current].add(line)
+    return sections
 
 
 def write_budget(findings, path=None):
+    """Rewrite the ratchet: one block per section, in SECTIONS order.
+
+    No blank lines anywhere, deliberately. The previous format carried a blank
+    separator that had to be suppressed for an empty list, because a trailing
+    blank line at EOF is what `git diff --check` refuses and the merge bar runs
+    that check; with a section per population the same conditional would have
+    to be right in four combinations instead of two. A comment line before each
+    block reads the same and cannot end the file wrong.
+    """
+    by_section = {name: [] for name in SECTIONS}
+    for f in findings:
+        by_section[section_of(f.key)].append(f)
     lines = list(_BUDGET_HEADER)
-    lines.append(f"#\n# total {len(findings)} finding(s)")
-    # the blank separator belongs to the LIST, not to the header: with an
-    # empty ratchet (every finding fixed, #193) an unconditional one is a
-    # trailing blank line at EOF, which `git diff --check` refuses and the
-    # merge bar runs
-    if findings:
-        lines.append("")
-    for f in sorted(findings, key=lambda x: x.key):
-        loc = f"  # line(s) {','.join(f.lines)}" if f.lines else ""
-        lines.append(f"{f.key}{loc}")
+    for name in SECTIONS:
+        entries = sorted(by_section[name], key=lambda x: x.key)
+        lines.append("#")
+        lines.append(f"# --- section {name}: {len(entries)} finding(s) "
+                     f"({SECTION_LABEL[name]}) ---")
+        for f in entries:
+            loc = f"  # line(s) {','.join(f.lines)}" if f.lines else ""
+            lines.append(f"{f.key}{loc}")
     (path or BUDGET).write_text("\n".join(lines) + "\n")
 
 
-def _print_census(findings):
-    if not findings:
-        print("xvlog gate: 0 findings - every hdl/ module analyses under "
-              "Vivado's front-end")
-        return
-    print(f"xvlog gate: {len(findings)} finding(s) across "
-          f"{len({f.path for f in findings})} module(s):")
-    for f in sorted(findings, key=lambda x: x.key):
-        print(f"  {f.detail()}")
+def _scope_lines(counts):
+    """The census's coverage claim, printed EVERY run, findings or not.
+
+    The claim and the measurement are the same sentence on purpose. Both #224
+    and #236 are the same defect - a census line reading "every hdl/ module"
+    over a set that excluded one tracked `.v` and every processor source - so
+    the counts here are computed from the list actually analysed, and what is
+    NOT analysed is named rather than left to be inferred from a green line.
+    """
+    trees = ", ".join(tree for _label, tree, _why in SUBMODULE_TREES)
+    return [
+        f"  analysed: {counts['hdl']} tracked .sv/.v file(s) under hdl/ and "
+        f"{counts['submodules']} under the pinned processors ({trees})",
+        "  NOT analysed: third_party/ and external/ (leaf IP this repo neither "
+        "owns nor edits), and",
+        "                any defect only ELABORATION rejects - xvlog analyses; "
+        "the split-initialiser",
+        "                class needs xelab, which nothing in this repo runs "
+        "(#224)",
+    ]
+
+
+def _print_census(findings, counts):
+    total = len(findings)
+    print(f"xvlog gate: {total} finding(s) across "
+          f"{len({f.path for f in findings})} module(s)")
+    for line in _scope_lines(counts):
+        print(line)
+    for name in SECTIONS:
+        here = sorted((f for f in findings if section_of(f.key) == name),
+                      key=lambda x: x.key)
+        print(f"  {SECTION_LABEL[name]}: {len(here)} finding(s)")
+        for f in here:
+            print(f"    {f.detail()}")
 
 
 def cmd_selftest(xvlog):
@@ -393,6 +676,30 @@ def _diff(keys, budget):
     return sorted(keys - budget), sorted(budget - keys)
 
 
+def _refuse_missing(missing):
+    """Print the missing-tree refusal and return its exit code.
+
+    Exit 2, a setup refusal, deliberately NOT the exit-1 regression path: a
+    finding set measured over an incomplete scope proves nothing, must not read
+    as a pass, and must not invite anyone to bank a smaller ratchet from it.
+    Same shape and same reasoning as scripts/lint_rtl.py's LINT SETUP refusal.
+    """
+    print("XVLOG SETUP: REFUSED - a source tree this gate analyses is not "
+          "checked out, so the finding set would be under-reported:",
+          file=sys.stderr)
+    for label, why in missing:
+        print(f"  missing: {label:<22} ({why})", file=sys.stderr)
+    print("  A fresh clone or `git worktree add` inherits no submodules. "
+          "Initialise them:", file=sys.stderr)
+    print("    git submodule update --init "
+          + " ".join(label for label, _ in missing), file=sys.stderr)
+    print("  Refused rather than counted: with a processor tree absent the "
+          "gate would print a SMALLER clean set than the tree really carries, "
+          "which is the #186 trap the hdl/-only scope used to avoid by "
+          "narrowing.", file=sys.stderr)
+    return 2
+
+
 def _selftest_logic():
     """Arms that need no xvlog: the parser, the dedup, the ratchet diff.
 
@@ -456,29 +763,35 @@ def _selftest_logic():
     # of every sweep, so an arm that wrote scripts/xvlog.budget in place
     # would leave synthetic entries in a tracked file if the process were
     # killed mid-call, and SIGTERM/SIGKILL cannot be caught ([R0] on #222).
+    sub_label = SUBMODULE_TREES[0][0]
+    sub = Finding(f"{sub_label}:hdl/top/t.sv", "VRFC 10-3380", "late_w", "5", "m")
     scratch = pathlib.Path(tempfile.mkdtemp(prefix="xvlog-budget-")) / "b"
     try:
-        for case in ([], [a], [a, b],
-                     [a, Finding("m.sv", "VRFC 10-3380", "x", "3", "m")]):
+        for case in ([], [a], [a, b], [sub], [a, sub],
+                     [a, Finding("m.sv", "VRFC 10-3380", "x", "3", "m"), sub]):
             write_budget(case, scratch)
             rendered = scratch.read_text()
-            total = f"# total {len(case)} finding(s)"
-            if case and f"{total}\n\n" not in rendered:
-                problems.append("budget serialization: populated budget has "
-                                "no blank separator before its entries")
-            if not case and not rendered.endswith(f"{total}\n"):
-                problems.append("budget serialization: empty budget does not "
-                                "end at its total line")
+            for name in SECTIONS:
+                n = len([f for f in case if section_of(f.key) == name])
+                if f"# --- section {name}: {n} finding(s)" not in rendered:
+                    problems.append(f"budget serialization: no section header "
+                                    f"for {name} with {n} finding(s)")
+            if "\n\n" in rendered:
+                problems.append("budget serialization: blank line in the file "
+                                "- `git diff --check` refuses one at EOF and "
+                                "the merge bar runs it")
             back = read_budget(scratch)
-            want = {f.key for f in case}
+            want = {name: {f.key for f in case if section_of(f.key) == name}
+                    for name in SECTIONS}
             if back != want:
-                problems.append(f"budget round-trip: wrote {sorted(want)}, "
-                                f"read back {sorted(back or [])}")
-            new_k, gone_k = _diff(want, back or set())
-            if new_k or gone_k:
-                problems.append(f"budget round-trip: --check would report "
-                                f"new={new_k} gone={gone_k} against its own "
-                                f"freshly written budget")
+                problems.append(f"budget round-trip: wrote {want}, read back "
+                                f"{back}")
+            for name in SECTIONS:
+                new_k, gone_k = _diff(want[name], (back or {}).get(name, set()))
+                if new_k or gone_k:
+                    problems.append(f"budget round-trip [{name}]: --check would "
+                                    f"report new={new_k} gone={gone_k} against "
+                                    "its own freshly written budget")
         # a key carrying the comment character must survive too: the reader
         # strips the location note by shape, not by cutting at the first `#`
         esc = Finding("m.sv", "VRFC 10-3380", "\\hash#in~side ", "7", "m")
@@ -486,11 +799,77 @@ def _selftest_logic():
             problems.append(f"key {esc.key!r} carries trailing whitespace, "
                             "which the budget format cannot represent")
         write_budget([esc], scratch)
-        if read_budget(scratch) != {esc.key}:
+        if read_budget(scratch) != {"hdl": {esc.key}, "submodules": set()}:
             problems.append("budget round-trip: a key containing '#' (an "
                             "escaped identifier) did not survive the reader")
+        # A key filed under the wrong section must be REFUSED, not re-filed:
+        # silently re-filing it is the donor-against-hdl/ trade the sections
+        # exist to stop, and would make the headers decorative.
+        scratch.write_text("# --- section hdl: 1 finding(s) ---\n"
+                           f"{sub.key}\n")
+        try:
+            read_budget(scratch)
+            problems.append("budget sections: a submodule key filed under "
+                            "`hdl` was accepted; a hand edit can then trade "
+                            "donor debt against hdl/ debt")
+        except BudgetError:
+            pass
     finally:
         shutil.rmtree(scratch.parent, ignore_errors=True)
+
+    # ---- scope arms (#224, #236) -------------------------------------------
+    # These need no xvlog, so they run in CI too, where the live detection arm
+    # can only skip. They are what re-narrowing the scope would break.
+    if display_path(f"{sub_label}/hdl/top/t.sv") != f"{sub_label}:hdl/top/t.sv":
+        problems.append("display_path: a processor source is not keyed with "
+                        "its `<submodule>:` prefix, so scripts/pp_srcs.py "
+                        "--check would read the budget as a hand-written copy "
+                        "of the submodule source list")
+    if display_path("hdl/common/x.sv") != "hdl/common/x.sv":
+        problems.append("display_path: an hdl/ key changed spelling, which "
+                        "would orphan every banked hdl/ entry")
+    if (section_of(f"{sub_label}:hdl/top/t.sv|C|i") != "submodules"
+            or section_of("hdl/common/x.sv|C|i") != "hdl"):
+        problems.append("section_of: a finding lands in the wrong budget "
+                        "section")
+
+    absent = {label for label, _why in
+              missing_submodule_trees(sources=lambda label, tree: None)}
+    if absent != {label for label, _tree, _why in SUBMODULE_TREES}:
+        problems.append(f"tree refusal: not every absent processor tree is "
+                        f"flagged, got {sorted(absent)}")
+    if missing_submodule_trees(sources=lambda label, tree: ["x.sv"]):
+        problems.append("tree refusal: a present processor tree was flagged "
+                        "absent, so the gate would refuse on every lane")
+
+    # #224: the one tracked `.v` under hdl/ is in the analysed set. Asserted
+    # against git, not against a hardcoded name, so the arm still bites when
+    # another `.v` is added.
+    out = subprocess.run(["git", "ls-files", "hdl/**/*.v", "hdl/*.v"],
+                         cwd=ROOT, capture_output=True, text=True)
+    tracked_v = set(out.stdout.split()) if out.returncode == 0 else set()
+    pkgs, mods = hdl_sources()
+    analysed = set(pkgs) | set(mods)
+    if tracked_v - analysed:
+        problems.append(f"hdl scope: tracked Verilog file(s) "
+                        f"{sorted(tracked_v - analysed)} are not analysed, so "
+                        "the census claims more modules than it measures")
+    if any(f.endswith(".svh") for f in analysed):
+        problems.append("hdl scope: an include header reached the module list; "
+                        "it is analysed through its includer, not alone")
+
+    # #236: a checked-out processor tree really does contribute sources. When
+    # it is absent the gate refuses, so there is nothing to assert.
+    _p, plan_mods, counts = source_plan()
+    for label, tree, _why in SUBMODULE_TREES:
+        if submodule_sources(label, tree) is None:
+            continue
+        if not any(m.startswith(tree + "/") for m in _p + plan_mods):
+            problems.append(f"submodule scope: {tree} is checked out but "
+                            "contributes no analysed source")
+    if counts["hdl"] != len(analysed):
+        problems.append(f"census: the printed hdl/ count {counts['hdl']} is "
+                        f"not the number of files analysed ({len(analysed)})")
     return problems
 
 
@@ -516,34 +895,53 @@ def main(argv):
     if args.selftest:
         return cmd_selftest(xvlog)
 
+    # Order matters, and the docstring says why: with no tool nothing can be
+    # measured, so the skip is decided BEFORE the missing-tree refusal.
     if xvlog is None:
         print("xvlog gate: SKIPPED (no Vivado xvlog found; set $XVLOG or install "
               "to /home/alex/Xilinx/2026.1). A skip is not a pass.")
         return 0
 
+    missing = missing_submodule_trees()
+    if missing:
+        return _refuse_missing(missing)
+
+    _pkgs, _mods, counts = source_plan()
     findings, pkg_errors = analyse(xvlog)
     if pkg_errors:
         return _fail_setup(pkg_errors)
-    _print_census(findings)
+    _print_census(findings, counts)
 
     keys = {f.key for f in findings}
-    budget = read_budget()
+    try:
+        budget = read_budget()
+    except BudgetError as exc:
+        print(f"xvlog gate: {exc}", file=sys.stderr)
+        return 2
 
     if args.check:
         if budget is None:
             print("xvlog gate: no scripts/xvlog.budget to check against; run "
                   "scripts/xvlog_gate.py once to create it", file=sys.stderr)
             return 1
-        new, gone = _diff(keys, budget)
-        for k in new:
-            print(f"  REGRESSION: {k} is not grandfathered in scripts/"
-                  f"xvlog.budget - fix it or add it with a reason", file=sys.stderr)
-        for k in gone:
-            print(f"  BANK IT: {k} no longer occurs - run scripts/xvlog_gate.py "
-                  f"to lower the ratchet", file=sys.stderr)
-        if new or gone:
-            return 1
-        print(f"xvlog gate: PASS ({len(keys)} finding(s) == ratchet)")
+        rc = 0
+        for name in SECTIONS:
+            here = {k for k in keys if section_of(k) == name}
+            new, gone = _diff(here, budget[name])
+            for k in new:
+                print(f"  REGRESSION [{name}]: {k} is not grandfathered in "
+                      f"scripts/xvlog.budget - fix it or add it with a reason",
+                      file=sys.stderr)
+            for k in gone:
+                print(f"  BANK IT [{name}]: {k} no longer occurs - run "
+                      f"scripts/xvlog_gate.py to lower the ratchet",
+                      file=sys.stderr)
+            if new or gone:
+                rc = 1
+        if rc:
+            return rc
+        per = ", ".join(f"{len(budget[n])} {SECTION_LABEL[n]}" for n in SECTIONS)
+        print(f"xvlog gate: PASS ({len(keys)} finding(s) == ratchet; {per})")
         return 0
 
     write_budget(findings)

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -75,6 +75,36 @@ any other stage, any other mode, any extra record, an unparsable record or a
 record only UNDER the path refuses before enumeration, census, budget read or
 budget write. _index_pin below is that enumeration.
 
+AND THE BYTES ARE PROVED, NOT INFERRED FROM AN INDEX ANSWER. [R0] round 3 found
+the same class a THIRD time, one level down again: the checkout side asked git
+`diff --name-only HEAD --`, and git answers that question with the index's
+worktree hints applied. `git update-index --assume-unchanged` and
+`--skip-worktree` each make a changed or a deleted file invisible to it, to
+`git status` and to `git ls-files`'s idea of what is there; a real
+use-before-declaration planted under `assume-unchanged` was analysed, printed
+as the pinned census, reported as an ordinary ratchet regression and exited 1,
+not the setup 2. Enumerating those two hints - and then the next one - would be
+the fourth instance of one class, so the shape changes instead: the question is
+no longer asked at all.
+
+The pinned population is now DERIVED FROM THE PIN OBJECT (`git ls-tree -r <pin>`
+inside the checkout, never `git ls-files`), and every file in it must hash to
+the blob id the pin records, over the exact bytes on disk that xvlog will open,
+before anything is analysed. That is a POSITIVE per-file proof rather than the
+absence of known-bad signals: no index record, no stage, no refresh hint, no
+sparse or skip-worktree state, no fsmonitor, no `.git` file indirection and no
+clean/smudge filter participates in it, so a state nobody has enumerated yet
+cannot make the proof succeed - it can only fail to reproduce a blob id. The
+state names below exist to give a reader the right message and the right fix.
+They never decide acceptance; the hash equality does.
+
+THE PARENT'S OWN hdl/ IS NOT PROVED THAT WAY, deliberately: it IS the tree
+under test. A local edit under hdl/ is exactly what the author is gating, so
+the bytes on disk are the population by definition and there is no revision
+they should equal. The processors are the opposite case - the superproject
+DECLARES which revision they are, so a local edit there makes the census claim
+bytes nobody committed and lets a default run bank a ratchet from them.
+
 ONE FINDING PER MODULE, NOT ONE PER OCCURRENCE. xvlog stops at the first error in
 a compilation unit and prints only the 10-8530 cascade after it, so a module with
 many use-before-declaration occurrences yields ONE finding, naming the first
@@ -322,9 +352,8 @@ def hdl_sources():
     "every". `.svh` is not matched: an include header is analysed through the
     file that includes it, and compiling one alone is not a compilation unit.
     """
-    out = subprocess.run(["git", "ls-files",
-                          "hdl/**/*.sv", "hdl/*.sv", "hdl/**/*.v", "hdl/*.v"],
-                         cwd=ROOT, capture_output=True, text=True)
+    out = _git(["ls-files",
+                "hdl/**/*.sv", "hdl/*.sv", "hdl/**/*.v", "hdl/*.v"], ROOT)
     if out.returncode:
         raise SystemExit(f"git ls-files failed: {out.stderr.strip()}")
     files = sorted(set(out.stdout.split()))
@@ -333,10 +362,25 @@ def hdl_sources():
     return _split_packages(files)
 
 
+#: Environment variables that REDIRECT what a `git -C <dir>` call reads - the
+#: git directory, the index, the object store, the ref namespace. They are
+#: cleared for every call below so that `cwd` means what it says. The byte
+#: proof itself does not need this (a pin SHA comes from the superproject's own
+#: index record, the object it names is content-addressed, and the file bytes
+#: come from the filesystem), but the states decided AROUND it - which
+#: repository the path is, what its HEAD is - would otherwise be answerable
+#: from a different repository entirely.
+_GIT_ENV_OVERRIDES = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+                      "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY",
+                      "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE")
+
+
 def _git(args, cwd):
     """One git invocation, captured. `cwd` must already be known to be a repo."""
+    env = {k: v for k, v in os.environ.items()
+           if k not in _GIT_ENV_OVERRIDES}
     return subprocess.run(["git"] + args, cwd=str(cwd),
-                          capture_output=True, text=True)
+                          capture_output=True, text=True, env=env)
 
 
 class TreeState:
@@ -360,6 +404,16 @@ class TreeState:
     That is the pin-bump false green #236 exists to close, so the check is now
     the superproject's declaration compared against the checkout, and it
     refuses BEFORE anything is enumerated.
+
+    Reading the CHECKOUT loosely is that class once more, and [R0] round 3
+    reproduced it on the tracked source KL_pp_prng.sv: with
+    `git update-index --assume-unchanged` (or `--skip-worktree`) set, an edited
+    file is invisible to `git status` and to `git diff --name-only HEAD --`,
+    which is the question the old check asked. No question is asked now. The
+    population comes from the pin's own tree object and every file in it is
+    HASHED and compared to the blob id the pin records, so acceptance is a
+    positive proof over the bytes xvlog opens rather than the absence of a
+    known-bad signal.
 
     Reading that declaration LOOSELY is the same class one level down, and
     [R0] round 2 reproduced it twice: an index holding `160000` stage 2 beside
@@ -394,13 +448,28 @@ class TreeState:
                       UP from it to the SUPERPROJECT - the gate would answer
                       with hdl/ twice and call the processors covered
       wrong-revision  HEAD is not the pinned revision (git's `+` prefix)
-      modified        HEAD is the pinned revision, tracked files under it are
-                      not. Same class: the analysed population is not the
-                      pinned one. Untracked files are IGNORED - `git ls-files`
-                      never analyses them, and local gates litter a tree with
-                      generated `.hex`
-      empty           pinned and clean, but nothing tracked to analyse
-      ok              the pinned population - only then are its files used
+      unreadable      HEAD is the pinned revision, but the pin's own tree
+                      cannot be read (an object format whose blob ids this
+                      gate cannot reproduce, an unreadable or unparsable tree
+                      record): there is no population to prove
+      unpinnable      the PIN ITSELF names a `.sv`/`.v` entry that is not a
+                      regular-file blob - a committed symlink or a nested
+                      gitlink. Its bytes are not the entry's bytes, so it
+                      cannot be proved byte-identical and is not analysed
+      empty           the pin carries no `.sv`/`.v` source at all
+      incomplete      a pinned source is not present in the working tree as a
+                      regular file: deleted, never checked out (sparse or
+                      skip-worktree), replaced by a symlink or a directory, or
+                      unreadable. A symlink is refused even when its target
+                      holds the pinned bytes - the pin names a file
+      modified        every pinned source is present, but one of them does not
+                      HASH to the blob id the pin records. Same class as
+                      wrong-revision: the analysed population is not the
+                      pinned one. Files that are not in the pin are ignored,
+                      whatever their state - they are never analysed, and
+                      local gates litter a tree with generated `.hex`
+      ok              every pinned source is present and byte-identical to the
+                      pin - only then are its files used
 
     `expected` and `actual` carry the two revisions so the refusal can name
     them; `files` is filled only for `ok`.
@@ -442,10 +511,24 @@ _STATE_WHAT = {
                      "(an aborted `git submodule update` leaves one)",
     "wrong-revision": "checked out at the WRONG revision "
                       "(`git submodule status` prints `+`)",
-    "modified": "at the pinned revision with LOCAL MODIFICATIONS to tracked "
-                "files, so the sources are not the pinned sources",
-    "empty": "checked out at the pinned revision but carries no tracked "
-             ".sv/.v source",
+    "unreadable": "at the pinned revision, but the PIN's OWN TREE cannot be "
+                  "read (an object format whose blob ids this gate cannot "
+                  "reproduce, or a tree record it cannot parse), so there is "
+                  "no population to prove",
+    "unpinnable": "at the pinned revision, but the PIN ITSELF names a source "
+                  "that is not a regular file - a committed symlink or a "
+                  "nested gitlink - whose bytes cannot be proved to be the "
+                  "entry's bytes",
+    "incomplete": "at the pinned revision, but the working tree does not hold "
+                  "every pinned source AS A REGULAR FILE: deleted, never "
+                  "checked out (sparse or skip-worktree), replaced by a "
+                  "symlink or a directory, or unreadable",
+    "modified": "at the pinned revision, but a pinned source's BYTES do not "
+                "hash to the blob id the pin records, so the sources are not "
+                "the pinned sources. An index hint cannot hide this: the "
+                "bytes are hashed, never asked about",
+    "empty": "checked out at the pinned revision, whose tree carries no "
+             ".sv/.v source at all",
 }
 
 _STATE_FIX = {
@@ -460,8 +543,21 @@ _STATE_FIX = {
                      "(move any standalone checkout at the path aside first)",
     "no-repository": "git submodule update --init {label}",
     "wrong-revision": "git submodule update --init --checkout {label}",
+    "unreadable": "git submodule update --init --force {label}; if it "
+                  "persists, that checkout's object store cannot serve the "
+                  "pin and must be re-cloned",
+    "unpinnable": "nothing local to fix: the PIN names a source this gate "
+                  "cannot prove. Bump {label} to a revision whose sources are "
+                  "regular files.",
+    "incomplete": "restore every pinned source, then `git submodule update "
+                  "--init --force {label}`. A sparse or skip-worktree "
+                  "checkout of {label} is not the pinned population: clear it "
+                  "with `git -C {label} sparse-checkout disable` and "
+                  "`git -C {label} update-index --no-skip-worktree <path>`",
     "modified": "commit or drop the local changes, then "
-                "`git submodule update --init --force {label}`",
+                "`git submodule update --init --force {label}`. Clear any "
+                "index hint first - `git -C {label} ls-files -v` prints `h` "
+                "for assume-unchanged and `S` for skip-worktree",
     "empty": "git submodule update --init --force {label}",
 }
 
@@ -529,6 +625,12 @@ def _index_pin(label, root=None):
     committed as ordinary files must read as "no gitlink", never as "many
     conflict stages".
 
+    Read with `git ls-files --stage`, which PRINTS the record. `git status`
+    and `git diff` would instead compute a comparison, and a comparison is
+    what an index worktree hint can silence (see _unpinned_bytes), so an
+    `assume-unchanged` or `skip-worktree` bit on the gitlink path itself
+    cannot change what is read here either.
+
     The INDEX, not HEAD, on purpose: that is what `git submodule status`
     compares a checkout against, and it is the revision the next commit will
     carry. A deliberate pin bump that is staged therefore agrees with a
@@ -584,6 +686,121 @@ def _foreign_head(path):
             if head else "an unregistered repository with no HEAD")
 
 
+#: How a blob id is spelled, per object format, and the hash that reproduces
+#: one from bytes. `git hash-object` is deliberately NOT used to reproduce it:
+#: that command applies the checkout's clean filters and .gitattributes, which
+#: are themselves worktree state, and a proof ABOUT worktree state must not be
+#: computed through worktree state. A format not listed here is refused, never
+#: guessed at.
+_OBJECT_HASH = {"sha1": hashlib.sha1, "sha256": hashlib.sha256}
+
+#: One `git ls-tree -r -z <commit>` record: mode, type, object, path. Anchored
+#: and total for the same reason _INDEX_RECORD_RE is - a record this cannot
+#: read is a population this gate cannot prove, so it refuses.
+_TREE_RECORD_RE = re.compile(r"^([0-7]{6}) (\w+) ([0-9a-f]{40,64})\t(.*)$",
+                             re.S)
+
+#: What counts as a source, matched against the PIN's own tree. `.svh` is
+#: excluded here for the same reason hdl_sources() excludes it: an include
+#: header is analysed through the file that includes it.
+_SOURCE_SUFFIXES = (".sv", ".v")
+
+
+def _blob_id(data, algo):
+    """The object id git records for exactly these bytes.
+
+    Computed here rather than shelled out to, so that no repository
+    configuration - filters, .gitattributes, core.autocrlf - can stand between
+    the bytes on disk and the id they are compared against.
+    """
+    h = _OBJECT_HASH[algo]()
+    h.update(b"blob %d\0" % len(data))
+    h.update(data)
+    return h.hexdigest()
+
+
+def _pinned_entries(path, pin, rel):
+    """The population the PIN declares: `(entries, kind, detail)`.
+
+    `entries` is `[(blob id, path relative to the checkout)]` sorted by path,
+    or None with a refusable `kind` when the pin's own tree cannot be turned
+    into a population that can be proved.
+
+    Read from the PIN OBJECT, never from `git ls-files`: the index is worktree
+    state (a `git rm --cached`, a sparse or skip-worktree entry, a conflicted
+    stage) and the population must not be a function of it. What the next
+    commit carries is what the pin's tree holds.
+    """
+    listed = _git(["ls-tree", "-r", "-z", pin, "--", rel], path)
+    if listed.returncode:
+        first = (listed.stderr.strip().splitlines() or ["git ls-tree failed"])[0]
+        return (None, "unreadable",
+                f"the pinned commit's tree could not be read: {first}")
+    entries, unprovable = [], []
+    for record in listed.stdout.split("\0"):
+        if not record:
+            continue
+        m = _TREE_RECORD_RE.match(record)
+        if m is None:
+            return (None, "unreadable",
+                    f"a tree record this gate cannot parse: {record!r}")
+        mode, kind, obj, name = (m.group(1), m.group(2),
+                                 m.group(3), m.group(4))
+        if not name.endswith(_SOURCE_SUFFIXES):
+            continue
+        if kind != "blob" or mode not in ("100644", "100755"):
+            unprovable.append(f"{name} (mode {mode} {kind})")
+        else:
+            entries.append((obj, name))
+    if unprovable:
+        shown = ", ".join(sorted(unprovable)[:3]) + \
+            (", ..." if len(unprovable) > 3 else "")
+        return (None, "unpinnable",
+                f"{len(unprovable)} pinned source(s) are not regular-file "
+                f"blobs: {shown}")
+    return (sorted(entries, key=lambda e: e[1]), "", "")
+
+
+def _unpinned_bytes(path, entries, algo):
+    """`(missing, differing)` - the pinned sources this worktree does not hold.
+
+    Every file is OPENED and HASHED. That is the whole answer to [R0] round 3:
+    `git status` and `git diff --name-only HEAD --` are answers git computes
+    THROUGH the index, and `git update-index --assume-unchanged` /
+    `--skip-worktree` tell it not to look. Nothing here consults the index, so
+    no hint - present, future, or not yet thought of - can change the verdict.
+
+    A symlink is `missing`, not read through: the pin names a regular file,
+    and a link whose target happens to hold the pinned bytes is still not that
+    file. The same for a directory and for an unreadable path.
+
+    What this is NOT: a lock. The bytes are proved once, before enumeration; a
+    file rewritten between the proof and the xvlog run that opens it is a race
+    with a local writer, not a state the tree can be found in, and no gate that
+    hands paths to a compiler can close it.
+    """
+    missing, differing = [], []
+    for obj, name in entries:
+        fp = path / name
+        if fp.is_symlink():
+            missing.append(f"{name} (a symlink, not the pinned regular file)")
+            continue
+        try:
+            if not fp.exists():
+                missing.append(f"{name} (not present)")
+                continue
+            if not fp.is_file():
+                missing.append(f"{name} (not a regular file)")
+                continue
+            data = fp.read_bytes()
+        except OSError as exc:
+            missing.append(f"{name} (unreadable: {exc.strerror})")
+            continue
+        if _blob_id(data, algo) != obj:
+            differing.append(name)
+    return missing, differing
+
+
 def tree_state(label, tree, why, root=None):
     """Resolve one processor tree against the superproject's own gitlink.
 
@@ -631,24 +848,35 @@ def tree_state(label, tree, why, root=None):
     actual = head.stdout.strip() if head.returncode == 0 else ""
     if actual != expected:
         return state("wrong-revision", expected, actual or "(no HEAD)")
-    dirty = _git(["diff", "--name-only", "HEAD", "--"], path)
-    if dirty.returncode or dirty.stdout.strip():
-        names = dirty.stdout.split()
-        shown = ", ".join(names[:3]) + (", ..." if len(names) > 3 else "")
-        return state("modified", expected,
-                     f"{actual} + {len(names)} modified tracked file(s)"
-                     f"{': ' + shown if shown else ''}")
-    # Only a tree that IS the pinned population is enumerated. A pin whose
-    # revision carries no `tree` directory at all reads as empty, not as a
-    # crash: subprocess raises on a cwd that does not exist.
-    files = []
-    if (root / tree).is_dir():
-        listed = _git(["ls-files", "*.sv", "*.v"], root / tree)
-        if listed.returncode == 0:
-            files = sorted(set(listed.stdout.split()))
-    if not files:
+    # From here the population is the PIN's own tree and every file in it is
+    # proved byte-identical. Nothing below asks git what changed: that answer
+    # is computed through the index, and an index hint can silence it ([R0]
+    # round 3). Only a tree that IS the pinned population is enumerated.
+    fmt = _git(["rev-parse", "--show-object-format"], path).stdout.strip()
+    if fmt not in _OBJECT_HASH:
+        return state("unreadable", expected,
+                     "an object format whose blob ids this gate cannot "
+                     f"reproduce: {fmt or '(none reported)'}")
+    rel = tree[len(label) + 1:] if tree.startswith(label + "/") else tree
+    entries, kind, detail = _pinned_entries(path, expected, rel)
+    if entries is None:
+        return state(kind, expected, f"{actual} - {detail}")
+    if not entries:
         return state("empty", expected, actual)
-    return state("ok", expected, actual, [f"{tree}/{f}" for f in files])
+    missing, differing = _unpinned_bytes(path, entries, fmt)
+    if missing:
+        shown = ", ".join(missing[:3]) + (", ..." if len(missing) > 3 else "")
+        return state("incomplete", expected,
+                     f"{actual} + {len(missing)} of {len(entries)} pinned "
+                     f"source(s) not held as the pinned file: {shown}")
+    if differing:
+        shown = ", ".join(differing[:3]) + (", ..." if len(differing) > 3 else "")
+        return state("modified", expected,
+                     f"{actual} + {len(differing)} of {len(entries)} pinned "
+                     f"source(s) whose bytes do not hash to the pinned blob: "
+                     f"{shown}")
+    return state("ok", expected, actual,
+                 [f"{label}/{name}" for _obj, name in entries])
 
 
 def submodule_sources(label, tree):
@@ -1142,8 +1370,30 @@ def _selftest_tree_state():
         def state():
             return tree_state(label, tree, "the selftest fixture", root=super_)
 
+        #: Every state a real fixture below actually drove the classifier to.
+        #: Asserted against _STATE_WHAT at the end, so a state cannot be added
+        #: to the enumeration with only an injected arm behind it.
+        covered = set()
+
+        def hidden(case):
+            """git's OWN answer to the question the old check asked.
+
+            An arm that plants an index hint proves nothing unless git really
+            does report the tree as clean underneath it, so both answers the
+            old shape relied on are asserted empty here.
+            """
+            seen = _git(["diff", "--name-only", "HEAD", "--"],
+                        checkout).stdout.strip()
+            short = _git(["status", "--short"], checkout).stdout.strip()
+            if seen or short:
+                problems.append(f"tree_state [{case}]: git reported the "
+                                f"change after all (diff {seen!r}, status "
+                                f"{short!r}), so this fixture does not "
+                                "reproduce the escape it is named for")
+
         def want(case, expect_state, expect_expected=None, expect_actual=None):
             st = state()
+            covered.add(st.state)
             if st.state != expect_state:
                 problems.append(f"tree_state [{case}]: classified "
                                 f"{st.state!r}, not {expect_state!r} - the "
@@ -1181,6 +1431,78 @@ def _selftest_tree_state():
         (checkout / "hdl" / "a.sv").write_text("module a; wire x; endmodule\n")
         want("modified", "modified", rev_two, "hdl/a.sv")
         _git(["checkout", "-q", "--", "hdl/a.sv"], checkout)
+
+        # [R0] round 3: the index can be told to LIE about the worktree, and
+        # the old check asked it. `assume-unchanged` and `skip-worktree` are
+        # set BEFORE the file is touched, exactly as the review's fixtures
+        # did, and hidden() asserts that git itself then reports nothing -
+        # over a CHANGED file (the review's planted VRFC 10-3380) and over a
+        # MISSING one (the sparse/skip-worktree boundary the review named).
+        for flag, mark in (("assume-unchanged", "h"), ("skip-worktree", "S")):
+            _git(["update-index", "--" + flag, "--", "hdl/a.sv"], checkout)
+            marks = _git(["ls-files", "-v", "--", "hdl/a.sv"],
+                         checkout).stdout.split()
+            if not marks or marks[0] != mark:
+                problems.append(f"tree_state [{flag}]: the fixture did not "
+                                f"take - `git ls-files -v` printed {marks!r}, "
+                                f"not the {mark!r} mark, so the arm proves "
+                                "nothing")
+            (checkout / "hdl" / "a.sv").write_text(
+                "module a; wire hidden_w; endmodule\n")
+            hidden(flag + "-modified")
+            want(flag + "-modified", "modified", rev_two, "hdl/a.sv")
+            (checkout / "hdl" / "a.sv").unlink()
+            hidden(flag + "-missing")
+            want(flag + "-missing", "incomplete", rev_two, "hdl/a.sv")
+            _git(["update-index", "--no-" + flag, "--", "hdl/a.sv"], checkout)
+            _git(["checkout", "-q", "--", "hdl/a.sv"], checkout)
+            want(flag + "-restored", "ok", rev_two, rev_two)
+
+        # A pinned source DELETED with no hint at all: the same class, and the
+        # boundary a diff-shaped check happens to catch. Kept so the byte
+        # proof is shown to cover it too.
+        (checkout / "hdl" / "b.sv").unlink()
+        want("pinned-source-deleted", "incomplete", rev_two, "hdl/b.sv")
+        _git(["checkout", "-q", "--", "hdl/b.sv"], checkout)
+
+        # ...and the population must not be a function of the checkout's
+        # INDEX either. Dropping a record leaves the pinned bytes on disk, so
+        # this is still the pinned population - an ls-files-shaped enumeration
+        # would have analysed one file and called it the pinned processors.
+        _git(["rm", "-q", "--cached", "--", "hdl/b.sv"], checkout)
+        st = want("index-record-dropped", "ok", rev_two, rev_two)
+        if st.state == "ok" and st.files != [f"{tree}/a.sv", f"{tree}/b.sv"]:
+            problems.append(f"tree_state [index-record-dropped]: enumerated "
+                            f"{st.files} - the population followed the index "
+                            "rather than the pin")
+        _git(["reset", "-q", "HEAD", "--", "hdl/b.sv"], checkout)
+
+        # A symlink whose TARGET holds the pinned bytes is still not the
+        # pinned file: reading through it makes the population a function of
+        # whatever the link resolves to, which is the thing being proved.
+        twin = checkout / "hdl" / "twin.sv"
+        twin.write_bytes((checkout / "hdl" / "a.sv").read_bytes())
+        (checkout / "hdl" / "a.sv").unlink()
+        (checkout / "hdl" / "a.sv").symlink_to(twin)
+        want("symlink-holding-the-pinned-bytes", "incomplete", rev_two,
+             "a symlink")
+        (checkout / "hdl" / "a.sv").unlink()
+        twin.unlink()
+        _git(["checkout", "-q", "--", "hdl/a.sv"], checkout)
+
+        # A PIN that itself names a source which is not a regular-file blob.
+        # Its recorded bytes are the link target's name, so byte-identity
+        # cannot be proved for it and the gate refuses rather than analysing
+        # whatever the link resolves to on this box.
+        (donor / "hdl" / "c.sv").symlink_to("a.sv")
+        rev_link = commit("a source committed as a symlink")
+        _git(["fetch", "-q", "origin"], checkout)
+        _git(["checkout", "-q", "--detach", rev_link], checkout)
+        pin((rev_link, "0"))
+        want("pin-names-a-symlink", "unpinnable", rev_link, "hdl/c.sv")
+        _git(["checkout", "-q", "--detach", rev_two], checkout)
+        pin((rev_two, "0"))
+        want("pin-restored", "ok", rev_two, rev_two)
 
         # (1) the review's first escape: a real repository holding the pinned
         # content, at the gitlink path, that is NOT the registered checkout.
@@ -1283,6 +1605,20 @@ def _selftest_tree_state():
 
         pin()
         want("unregistered", "unregistered")
+
+        # A state in the enumeration that no REAL fixture reaches is a state
+        # whose classifier arm is a promise. `unreadable` is the single
+        # exclusion and it is named: git will not construct a repository
+        # whose object format it cannot itself read, so that state is driven
+        # only as an injected one in _selftest_logic.
+        unfixtured = set(_STATE_WHAT) - covered - {"unreadable"}
+        if unfixtured:
+            problems.append(f"tree_state: {sorted(unfixtured)} are in the "
+                            "refusal enumeration but no real git fixture "
+                            "drives the classifier to them")
+        if "ok" not in covered:
+            problems.append("tree_state: no fixture reached `ok`, so these "
+                            "arms prove only that the gate refuses")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     return problems
@@ -1456,10 +1792,30 @@ def _selftest_logic():
                                        "repository at the path"),
         "no-repository": _fixed("no-repository"),
         "wrong-revision": _fixed("wrong-revision", actual=_OFF),
-        "modified": _fixed("modified", actual=f"{_PIN} + 1 modified "
-                                              "tracked file(s): hdl/x.sv"),
+        "unreadable": _fixed("unreadable",
+                             actual="an object format whose blob ids this "
+                                    "gate cannot reproduce: (none reported)"),
+        "unpinnable": _fixed("unpinnable",
+                             actual=f"{_PIN} - 1 pinned source(s) are not "
+                                    "regular-file blobs: hdl/x.sv "
+                                    "(mode 120000 blob)"),
+        "incomplete": _fixed("incomplete",
+                             actual=f"{_PIN} + 1 of 40 pinned source(s) not "
+                                    "held as the pinned file: hdl/x.sv "
+                                    "(not present)"),
+        "modified": _fixed("modified",
+                           actual=f"{_PIN} + 1 of 40 pinned source(s) whose "
+                                  "bytes do not hash to the pinned blob: "
+                                  "hdl/x.sv"),
         "empty": _fixed("empty", actual=_PIN),
     }
+    # Exhaustive by construction: a state added to the enumeration without a
+    # refusal arm fails here rather than shipping with an unproved message.
+    if set(refusing) != set(_STATE_WHAT):
+        problems.append(f"setup refusal: "
+                        f"{sorted(set(refusing) ^ set(_STATE_WHAT))} is in one "
+                        "of _STATE_WHAT / the refusal arms and not the other, "
+                        "so a refusable state has no proved message")
     every_label = {label for label, _tree, _why in SUBMODULE_TREES}
     for name, resolver in refusing.items():
         bad = unusable_submodule_trees(states=resolver)
@@ -1499,14 +1855,82 @@ def _selftest_logic():
         problems.append("setup refusal: nothing was printed to stderr, so the "
                         "run would exit 2 with no reason given")
 
+    # ...and main() itself must reach that refusal BEFORE the census, before
+    # the budget is read and before it is written, in --check AND in default
+    # mode. [R0] round 3 measured the escape end to end: a hidden edit was
+    # analysed, printed as the pinned census, reported as an ordinary ratchet
+    # regression and exited 1 - the code that reads as "the tree got worse"
+    # and invites re-banking. $XVLOG is pointed at an executable that exists
+    # so the tool-absence SKIP (decided first, on purpose) does not stand in
+    # for the refusal; it is never run, because the refusal comes first.
+    budget_before = BUDGET.read_bytes() if BUDGET.exists() else None
+    saved_resolver = globals()["tree_state"]
+    saved_xvlog = os.environ.get("XVLOG")
+    globals()["tree_state"] = _fixed(
+        "modified", actual=f"{_PIN} + 1 of 40 pinned source(s) whose bytes do "
+                           "not hash to the pinned blob: hdl/x.sv")
+    os.environ["XVLOG"] = sys.executable
+    try:
+        for extra in ([], ["--check"]):
+            mode = extra[0] if extra else "default"
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), \
+                    contextlib.redirect_stderr(err):
+                rc = main(["xvlog_gate.py"] + extra)
+            if rc != 2:
+                problems.append(f"main [{mode}]: exited {rc} over a tree that "
+                                "is not the pinned population, not the setup "
+                                "code 2 - exit 1 is the ratchet path")
+            if "REFUSED" not in err.getvalue():
+                problems.append(f"main [{mode}]: printed no refusal on stderr")
+            if out.getvalue().strip():
+                problems.append(f"main [{mode}]: printed "
+                                f"{out.getvalue().strip()[:120]!r} on stdout - "
+                                "the census must not be reached over a "
+                                "population the pin does not stand behind")
+            after = BUDGET.read_bytes() if BUDGET.exists() else None
+            if after != budget_before:
+                problems.append(f"main [{mode}]: scripts/xvlog.budget changed "
+                                "under a setup refusal")
+    finally:
+        globals()["tree_state"] = saved_resolver
+        if saved_xvlog is None:
+            os.environ.pop("XVLOG", None)
+        else:
+            os.environ["XVLOG"] = saved_xvlog
+
+    # The byte proof's own arithmetic, checked against git rather than against
+    # itself: a blob id this reproduces differently from `git hash-object` is
+    # a proof that would refuse every clean tree, on both object formats git
+    # offers. sha256 needs a repository of that format to ask in.
+    payload = b"module a;\n  logic x;\nendmodule\n"
+    hash_tmp = pathlib.Path(tempfile.mkdtemp(prefix="xvlog-blobid-"))
+    try:
+        for algo in sorted(_OBJECT_HASH):
+            repo = hash_tmp / algo
+            repo.mkdir()
+            init = _git(["init", "-q", f"--object-format={algo}", "."], repo)
+            if init.returncode:
+                problems.append(f"blob id [{algo}]: this git cannot create a "
+                                f"{algo} repository, so the arm could not run")
+                continue
+            got = subprocess.run(["git", "hash-object", "-t", "blob",
+                                  "--stdin"], cwd=str(repo), input=payload,
+                                 capture_output=True).stdout.decode().strip()
+            if got != _blob_id(payload, algo):
+                problems.append(f"blob id [{algo}]: computed "
+                                f"{_blob_id(payload, algo)}, git says {got} - "
+                                "the byte proof would refuse a clean tree")
+    finally:
+        shutil.rmtree(hash_tmp, ignore_errors=True)
+
     # ...and the CLASSIFIER those states come from, against real git fixtures.
     problems += _selftest_tree_state()
 
     # #224: the one tracked `.v` under hdl/ is in the analysed set. Asserted
     # against git, not against a hardcoded name, so the arm still bites when
     # another `.v` is added.
-    out = subprocess.run(["git", "ls-files", "hdl/**/*.v", "hdl/*.v"],
-                         cwd=ROOT, capture_output=True, text=True)
+    out = _git(["ls-files", "hdl/**/*.v", "hdl/*.v"], ROOT)
     tracked_v = set(out.stdout.split()) if out.returncode == 0 else set()
     pkgs, mods = hdl_sources()
     analysed = set(pkgs) | set(mods)

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -125,7 +125,9 @@ tree that is not the revision this commit pins, and a malformed budget.
 """
 
 import argparse
+import contextlib
 import hashlib
+import io
 import os
 import pathlib
 import re
@@ -1254,6 +1256,20 @@ def _selftest_logic():
                                               files=["hdl/x.sv"])):
         problems.append("setup refusal: a tree at the pinned revision was "
                         "refused, so the gate would refuse on every lane")
+    # The refusal must exit 2, the SETUP code, not 1: exit 1 is the ratchet
+    # path and reads as "the tree got worse", which invites banking a smaller
+    # or different set rather than fixing the checkout.
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = _refuse_setup(unusable_submodule_trees(
+            states=_fixed("wrong-revision", actual=_OFF)))
+    if rc != 2:
+        problems.append(f"setup refusal: exited {rc}, not 2 - exit 1 is the "
+                        "ratchet path and would read as a regression")
+    if "REFUSED" not in buf.getvalue():
+        problems.append("setup refusal: nothing was printed to stderr, so the "
+                        "run would exit 2 with no reason given")
+
     # ...and the CLASSIFIER those states come from, against real git fixtures.
     problems += _selftest_tree_state()
 

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -106,6 +106,13 @@ a trust decision is therefore run with `GIT_NO_REPLACE_OBJECTS=1`, set by this
 process rather than inherited. The real-Git self-test installs that exact
 replacement ref and requires a `modified` setup refusal before census or budget.
 
+THE ONE ASSUMPTION THE PROOF RESTS ON is object-store integrity: the pinned
+blob ids are read through git from the checkout's own object store, so a forged
+loose object written under the pin's id serves altered bytes as pinned ones and
+only `git fsck` sees the hash mismatch. Whoever can write `.git/objects` can as
+easily edit this gate or its ratchet, so that boundary is stated here, like the
+not-a-lock caveat on _unpinned_bytes, rather than left to be discovered.
+
 THE PARENT'S OWN hdl/ IS NOT PROVED THAT WAY, deliberately: it IS the tree
 under test. A local edit under hdl/ is exactly what the author is gating, so
 the bytes on disk are the population by definition and there is no revision

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -48,11 +48,22 @@ look cleaner than it is. That reason stands and is not weakened here; the
 conclusion drawn from it does not, because its price was that the very class this
 gate exists to catch had live occurrences in the pinned processors with no gate
 at all (#236 measured 37 at the pin on dev, 51 at the pin PR #227 proposes). So
-the scope widens and the invariant is enforced directly instead: with a processor
-tree absent, empty, or not a checked-out submodule, the gate REFUSES - exit 2,
-naming the tree and the init command - rather than reporting a smaller clean set.
-That is scripts/lint_rtl.py's shape, which #186 forced on the lint ratchet for
-this same reason.
+the scope widens and the invariant is enforced directly instead: unless every
+processor tree IS the revision the superproject pins, the gate REFUSES - exit 2,
+naming the state, the expected and actual revisions and the remediation - rather
+than reporting a set the pin does not stand behind. That is scripts/lint_rtl.py's
+shape, which #186 forced on the lint ratchet for this same reason.
+
+THE POPULATION COMES FROM THE GITLINK, NOT FROM THE PATH. Proving each path is
+the top of SOME repository holding tracked sources is not the same claim, and
+[R0] on PR #242 reproduced both escapes it leaves open: standalone clones dropped
+at the two gitlink paths (`git submodule status` prints `-` for both) and a
+registered submodule moved off the pin (`+44489453` against a pinned `a25b5cc9`)
+were each counted as "the pinned processors" - and a default run, measured, then
+rewrote scripts/xvlog.budget from that 48-file population, turning 3 banked
+findings into 5. TreeState below enumerates every state that answers REFUSE and
+why each one would otherwise pass; nothing is enumerated until the tree is the
+pinned population.
 
 ONE FINDING PER MODULE, NOT ONE PER OCCURRENCE. xvlog stops at the first error in
 a compilation unit and prints only the 10-8530 cascade after it, so a module with
@@ -75,7 +86,7 @@ arm deliberately open; a lane doing declaration-order work has no gate for it.
 
 TOOL ABSENCE IS A SKIP, NEVER A FALSE GREEN. With no xvlog on the box (CI has
 none) the gate prints a visible SKIP marker and exits 0, the tsn-gen precedent.
-The skip is decided BEFORE the missing-tree refusal, on purpose: with no tool
+The skip is decided BEFORE the setup refusal, on purpose: with no tool
 nothing can be measured at all, so refusing there would turn a gate CONTRIBUTING
 section 3 calls inert in CI into a red one, and a skip already reads as not a
 pass.
@@ -110,7 +121,7 @@ are checked against.
 
 Exit 0 = at the ratchet (or skipped), 1 = regression / vanished finding / a
 package that will not analyse, 2 = usage or setup error, including a processor
-tree that is not checked out and a malformed budget.
+tree that is not the revision this commit pins, and a malformed budget.
 """
 
 import argparse
@@ -142,7 +153,7 @@ DEFINES = ["SYNTHESIS"]
 
 #: The pinned processor trees analysed alongside hdl/, each with the reason its
 #: sources belong in a gate about THIS repository's front-end risk, printed by
-#: the refusal when it is not checked out. Nothing here is resolved or
+#: the refusal when it is not the pinned checkout. Nothing here is resolved or
 #: elaborated - xvlog analyses one file at a time - so unlike lint_rtl.py's
 #: REQUIRED_TREES this list deliberately omits third_party/verilog-axis (leaf IP,
 #: resolution only) and external/ (SSH-only; CONTRIBUTING 2.2 keeps it out of the
@@ -310,49 +321,249 @@ def hdl_sources():
     return _split_packages(files)
 
 
+def _git(args, cwd):
+    """One git invocation, captured. `cwd` must already be known to be a repo."""
+    return subprocess.run(["git"] + args, cwd=str(cwd),
+                          capture_output=True, text=True)
+
+
+class TreeState:
+    """What the superproject PINS at one processor path, and what is there.
+
+    THE POPULATION IS ESTABLISHED FROM THE SUPERPROJECT'S GITLINK, never from
+    whatever happens to sit at the path. Proving the path is the top of *some*
+    repository holding tracked sources is not that proof, and [R0] on PR #242
+    reproduced both escapes it leaves open, from a fresh checkout:
+
+      - standalone clones dropped at the two gitlink paths, submodules never
+        initialised: `git submodule status` printed the `-` prefix for both,
+        yet the refusal returned nothing, the plan counted 46 processor files
+        and the census called them "the pinned processors";
+      - the superproject pinned at a25b5cc9 with the protocol checkout at
+        44489453: `git submodule status` printed `+44489453`, the refusal again
+        returned nothing, and a DEFAULT run (no --check) rewrote
+        scripts/xvlog.budget from that 48-file population - measured, 3 banked
+        findings became 5, with a line number silently moved.
+
+    That is the pin-bump false green #236 exists to close, so the check is now
+    the superproject's declaration compared against the checkout, and it
+    refuses BEFORE anything is enumerated. `state` is one of, in the order
+    they are decided:
+
+      unregistered    the path is not a 160000 gitlink in the superproject
+                      index, or .gitmodules does not name it
+      conflicted      the gitlink is unmerged - several index stages
+      absent          registered, but there is no directory
+      uninitialised   registered, a directory, but the superproject has no
+                      `submodule.<name>.url`: whatever is at the path is NOT
+                      the registered checkout. This is git's own definition of
+                      the `-` prefix and it is exactly what a standalone clone
+                      dropped at the path looks like
+      no-repository   the directory is not that repository's own top level. An
+                      aborted `submodule update` leaves one, and `git -C` WALKS
+                      UP from it to the SUPERPROJECT - the gate would answer
+                      with hdl/ twice and call the processors covered
+      wrong-revision  HEAD is not the pinned revision (git's `+` prefix)
+      modified        HEAD is the pinned revision, tracked files under it are
+                      not. Same class: the analysed population is not the
+                      pinned one. Untracked files are IGNORED - `git ls-files`
+                      never analyses them, and local gates litter a tree with
+                      generated `.hex`
+      empty           pinned and clean, but nothing tracked to analyse
+      ok              the pinned population - only then are its files used
+
+    `expected` and `actual` carry the two revisions so the refusal can name
+    them; `files` is filled only for `ok`.
+    """
+
+    __slots__ = ("label", "tree", "why", "state", "expected", "actual", "files")
+
+    def __init__(self, label, tree, why, state,
+                 expected="", actual="", files=None):
+        self.label = label
+        self.tree = tree
+        self.why = why
+        self.state = state
+        self.expected = expected
+        self.actual = actual
+        self.files = files
+
+    @property
+    def ok(self):
+        return self.state == "ok"
+
+
+#: What each refusable state IS, and how to get out of it. Keyed on the state
+#: so a state cannot be added without a remediation, and read by the refusal
+#: rather than restated at the print site.
+_STATE_WHAT = {
+    "unregistered": "not a registered submodule of this commit "
+                    "(no 160000 gitlink in the index, or no .gitmodules entry)",
+    "conflicted": "the gitlink is UNMERGED - the pin itself is in conflict",
+    "absent": "registered, but nothing is checked out at the path",
+    "uninitialised": "NOT the registered checkout - the superproject has no "
+                     "submodule url for it (`git submodule status` prints `-`)",
+    "no-repository": "a directory that is not that repository's own top level "
+                     "(an aborted `git submodule update` leaves one)",
+    "wrong-revision": "checked out at the WRONG revision "
+                      "(`git submodule status` prints `+`)",
+    "modified": "at the pinned revision with LOCAL MODIFICATIONS to tracked "
+                "files, so the sources are not the pinned sources",
+    "empty": "checked out at the pinned revision but carries no tracked "
+             ".sv/.v source",
+}
+
+_STATE_FIX = {
+    "unregistered": "nothing to initialise: {label} is not a gitlink in this "
+                    "commit. Check out a commit that pins it.",
+    "conflicted": "resolve the conflicted gitlink, then "
+                  "`git submodule update --init {label}`",
+    "absent": "git submodule update --init {label}",
+    "uninitialised": "git submodule update --init {label}   "
+                     "(move any standalone checkout at the path aside first)",
+    "no-repository": "git submodule update --init {label}",
+    "wrong-revision": "git submodule update --init --checkout {label}",
+    "modified": "commit or drop the local changes, then "
+                "`git submodule update --init --force {label}`",
+    "empty": "git submodule update --init --force {label}",
+}
+
+
+def _gitmodules_name(label, root=None):
+    """The submodule NAME whose registered path is `label`, or None.
+
+    Looked up rather than assumed equal to the path: git allows them to
+    differ, and `submodule.<name>.url` - the key that decides initialised -
+    is keyed on the NAME.
+    """
+    out = _git(["config", "-f", ".gitmodules", "--get-regexp",
+                r"^submodule\..*\.path$"], root or ROOT)
+    if out.returncode:
+        return None
+    for line in out.stdout.splitlines():
+        key, _sep, value = line.partition(" ")
+        if value.strip() == label and key.endswith(".path"):
+            return key[len("submodule."):-len(".path")]
+    return None
+
+
+def _gitlink_revisions(label, root=None):
+    """Every index stage's gitlink revision at `label` (usually one, or none).
+
+    The INDEX, not HEAD, on purpose: that is what `git submodule status`
+    compares a checkout against, and it is the revision the next commit will
+    carry. A deliberate pin bump that is staged therefore agrees with a
+    checkout moved to match it; a checkout moved on its own does not, and that
+    disagreement is precisely the false green #236 closes. More than one entry
+    means an unmerged gitlink.
+    """
+    out = _git(["ls-files", "--stage", "--", label], root or ROOT)
+    if out.returncode:
+        return []
+    revs = []
+    for line in out.stdout.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) >= 2 and parts[0] == "160000":
+            revs.append(parts[1])
+    return revs
+
+
+def _foreign_head(path):
+    """What is actually at an unregistered path, so the refusal can name it.
+
+    The top-level check comes FIRST because `git -C <dir>` walks UP out of a
+    plain directory and would answer with the SUPERPROJECT's HEAD - the one
+    revision that must never be reported as this tree's.
+    """
+    top = _git(["rev-parse", "--show-toplevel"], path)
+    if top.returncode or \
+            pathlib.Path(top.stdout.strip()).resolve() != path.resolve():
+        return "a directory that is not a repository of its own"
+    head = _git(["rev-parse", "HEAD"], path).stdout.strip()
+    return (f"{head} in an unregistered repository at the path"
+            if head else "an unregistered repository with no HEAD")
+
+
+def tree_state(label, tree, why, root=None):
+    """Resolve one processor tree against the superproject's own gitlink.
+
+    Every refusable state is decided BEFORE the tree's files are listed, so a
+    tree that is not the pinned population never reaches enumeration, the
+    census or the budget.
+    """
+    root = root or ROOT
+
+    def state(name, expected="", actual="", files=None):
+        return TreeState(label, tree, why, name, expected, actual, files)
+
+    revs = _gitlink_revisions(label, root)
+    if len(revs) > 1:
+        return state("conflicted", " / ".join(sorted(set(revs))))
+    name = _gitmodules_name(label, root)
+    if not revs or name is None:
+        return state("unregistered")
+    expected = revs[0]
+    path = root / label
+    if not path.is_dir():
+        return state("absent", expected)
+    if _git(["config", "--get", f"submodule.{name}.url"], root).returncode:
+        return state("uninitialised", expected, _foreign_head(path))
+    top = _git(["rev-parse", "--show-toplevel"], path)
+    if top.returncode or \
+            pathlib.Path(top.stdout.strip()).resolve() != path.resolve():
+        return state("no-repository", expected)
+    head = _git(["rev-parse", "HEAD"], path)
+    actual = head.stdout.strip() if head.returncode == 0 else ""
+    if actual != expected:
+        return state("wrong-revision", expected, actual or "(no HEAD)")
+    dirty = _git(["diff", "--name-only", "HEAD", "--"], path)
+    if dirty.returncode or dirty.stdout.strip():
+        names = dirty.stdout.split()
+        shown = ", ".join(names[:3]) + (", ..." if len(names) > 3 else "")
+        return state("modified", expected,
+                     f"{actual} + {len(names)} modified tracked file(s)"
+                     f"{': ' + shown if shown else ''}")
+    # Only a tree that IS the pinned population is enumerated. A pin whose
+    # revision carries no `tree` directory at all reads as empty, not as a
+    # crash: subprocess raises on a cwd that does not exist.
+    files = []
+    if (root / tree).is_dir():
+        listed = _git(["ls-files", "*.sv", "*.v"], root / tree)
+        if listed.returncode == 0:
+            files = sorted(set(listed.stdout.split()))
+    if not files:
+        return state("empty", expected, actual)
+    return state("ok", expected, actual, [f"{tree}/{f}" for f in files])
+
+
 def submodule_sources(label, tree):
     """Tracked design sources under one processor tree, or None if unusable.
 
-    None means REFUSE, and it covers three states that all look like a smaller
-    clean finding set: the tree is missing, the tree is present but holds no
-    tracked source, and the directory exists without being a checked-out
-    submodule.
-
-    The third is why this resolves the repository boundary before listing
-    anything. `git -C <dir>` WALKS UP when <dir> is not a repository, so an
-    empty submodule directory - what an aborted `submodule update` leaves
-    behind - would answer with the SUPERPROJECT's file list, and the gate would
-    happily analyse hdl/ twice and call the processors covered. Requiring the
-    submodule's own top-level to BE the submodule directory rules that out.
+    None means REFUSE. It is the pinned population or nothing: see TreeState
+    for every state that answers None and why each one would otherwise be
+    counted as "the pinned processors".
     """
-    root = ROOT / tree
-    if not root.is_dir():
-        return None
-    top = subprocess.run(["git", "rev-parse", "--show-toplevel"],
-                         cwd=ROOT / label, capture_output=True, text=True)
-    if top.returncode:
-        return None
-    if pathlib.Path(top.stdout.strip()).resolve() != (ROOT / label).resolve():
-        return None
-    out = subprocess.run(["git", "ls-files", "*.sv", "*.v"], cwd=root,
-                         capture_output=True, text=True)
-    if out.returncode:
-        return None
-    files = sorted(set(out.stdout.split()))
-    if not files:
-        return None
-    return [f"{tree}/{f}" for f in files]
+    st = tree_state(label, tree, "")
+    return st.files if st.ok else None
 
 
-def missing_submodule_trees(sources=None):
-    """(label, why) for every processor tree the gate cannot analyse.
+def submodule_states(states=None):
+    """A TreeState per SUBMODULE_TREES entry.
 
-    `sources` overrides the lookup so the self-test can drive both arms on any
+    `states` overrides the resolver so the self-test can drive every arm on any
     box, with no submodule present or absent - lint_rtl.py's shape.
     """
-    sources = sources or submodule_sources
-    return [(label, why) for label, tree, why in SUBMODULE_TREES
-            if not sources(label, tree)]
+    resolve = states or tree_state
+    return [resolve(label, tree, why) for label, tree, why in SUBMODULE_TREES]
+
+
+def unusable_submodule_trees(states=None):
+    """Every processor tree that is not the pinned population, worst first.
+
+    Empty means every tree in SUBMODULE_TREES is the exact revision the
+    superproject pins, clean, and carries sources.
+    """
+    return [st for st in submodule_states(states) if not st.ok]
 
 
 def source_plan():
@@ -365,9 +576,9 @@ def source_plan():
     dependency the order got wrong would surface as a package error, and the
     gate refuses to grade any module when a package will not analyse.
 
-    Callers must have cleared missing_submodule_trees() first: this function
-    silently omits a tree it cannot read, which is precisely the under-report
-    the refusal exists to prevent.
+    Callers must have cleared unusable_submodule_trees() first: this function
+    silently omits a tree that is not the pinned population, which is
+    precisely the mis-report the refusal exists to prevent.
     """
     pkgs, mods = hdl_sources()
     counts = {"hdl": len(pkgs) + len(mods), "submodules": 0}
@@ -582,11 +793,21 @@ def _scope_lines(counts):
     over a set that excluded one tracked `.v` and every processor source - so
     the counts here are computed from the list actually analysed, and what is
     NOT analysed is named rather than left to be inferred from a green line.
+
+    The word "pinned" is printed WITH the revision each tree resolved at. The
+    run has already refused unless every one of them IS the superproject's
+    gitlink, so a reader can check this line against `git submodule status`
+    instead of taking it: [R0] on PR #242 printed this same sentence over an
+    uninitialised standalone clone and over a wrong-revision checkout.
     """
     trees = ", ".join(tree for _label, tree, _why in SUBMODULE_TREES)
+    pins = "; ".join(f"{st.label}@{st.expected[:8]}"
+                     for st in submodule_states()) or "none"
     return [
         f"  analysed: {counts['hdl']} tracked .sv/.v file(s) under hdl/ and "
         f"{counts['submodules']} under the pinned processors ({trees})",
+        f"  pinned at: {pins} - the superproject gitlink, which each checkout "
+        "was required to BE before anything was enumerated",
         "  NOT analysed: third_party/ and external/ (leaf IP this repo neither "
         "owns nor edits), and",
         "                any defect only ELABORATION rejects - xvlog analyses; "
@@ -676,28 +897,176 @@ def _diff(keys, budget):
     return sorted(keys - budget), sorted(budget - keys)
 
 
-def _refuse_missing(missing):
-    """Print the missing-tree refusal and return its exit code.
+def _setup_refusal_lines(bad):
+    """The refusal text for trees that are not the pinned population.
+
+    Returned as lines rather than printed so the self-test can assert that
+    every refusal names the state, the EXPECTED and ACTUAL revisions and a
+    remediation - a refusal that says only "missing" sent a reader looking for
+    an absent directory when the real state was a wrong revision.
+    """
+    lines = ["XVLOG SETUP: REFUSED - a source tree this gate analyses is not "
+             "the revision this commit pins, so the finding set would not be "
+             "the pinned population:"]
+    for st in bad:
+        lines.append(f"  {st.label}"
+                     + (f"  ({st.why})" if st.why else ""))
+        lines.append(f"      state:    {_STATE_WHAT[st.state]}")
+        lines.append(f"      expected: {st.expected or '(no gitlink)'}"
+                     "   <- the superproject gitlink for this path")
+        lines.append(f"      actual:   {st.actual or '(nothing usable)'}")
+        lines.append("      fix:      "
+                     + _STATE_FIX[st.state].format(label=st.label))
+    lines.append("  A fresh clone or `git worktree add` inherits no "
+                 "submodules, and a standalone clone dropped at the path is "
+                 "NOT one.")
+    lines.append("  Refused rather than counted: over a tree that is not the "
+                 "pinned one the gate would print a finding set the pin does "
+                 "not stand behind - smaller (#186's trap) or simply "
+                 "different - and a default run would then rewrite the "
+                 "ratchet from it (#236).")
+    return lines
+
+
+def _refuse_setup(bad):
+    """Print the setup refusal and return its exit code.
 
     Exit 2, a setup refusal, deliberately NOT the exit-1 regression path: a
-    finding set measured over an incomplete scope proves nothing, must not read
-    as a pass, and must not invite anyone to bank a smaller ratchet from it.
+    finding set measured over the wrong population proves nothing, must not
+    read as a pass, and must not invite anyone to bank a ratchet from it.
     Same shape and same reasoning as scripts/lint_rtl.py's LINT SETUP refusal.
     """
-    print("XVLOG SETUP: REFUSED - a source tree this gate analyses is not "
-          "checked out, so the finding set would be under-reported:",
-          file=sys.stderr)
-    for label, why in missing:
-        print(f"  missing: {label:<22} ({why})", file=sys.stderr)
-    print("  A fresh clone or `git worktree add` inherits no submodules. "
-          "Initialise them:", file=sys.stderr)
-    print("    git submodule update --init "
-          + " ".join(label for label, _ in missing), file=sys.stderr)
-    print("  Refused rather than counted: with a processor tree absent the "
-          "gate would print a SMALLER clean set than the tree really carries, "
-          "which is the #186 trap the hdl/-only scope used to avoid by "
-          "narrowing.", file=sys.stderr)
+    for line in _setup_refusal_lines(bad):
+        print(line, file=sys.stderr)
     return 2
+
+
+def _selftest_tree_state():
+    """Drive tree_state() against REAL git fixtures, one per refusable state.
+
+    The injected-state arms below prove the REFUSAL reports each state; this
+    proves the CLASSIFIER reaches it, which is where [R0] on PR #242 found the
+    escape - the old check asked only whether the path was the top of some
+    repository with tracked sources, so a standalone clone at the gitlink path
+    and a checkout moved off the pin both classified as usable.
+
+    Everything is built by hand in a temp dir: a donor repository with three
+    revisions, and a superproject whose .gitmodules and INDEX gitlink are
+    written directly (`git update-index --index-info`). No network, no
+    `submodule add`, so no `protocol.file.allow` and no transport policy - the
+    arm runs on any box, CI included, where no real submodule is checked out.
+    """
+    problems = []
+    if not shutil.which("git"):
+        return ["tree_state: no git on PATH, so the setup refusal cannot be "
+                "proved against real fixtures"]
+    ident = ["-c", "user.name=xvlog gate selftest",
+             "-c", "user.email=selftest@example.invalid",
+             "-c", "commit.gpgsign=false"]
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="xvlog-treestate-"))
+    label, tree = "protocol-processor", "protocol-processor/hdl"
+    try:
+        donor = tmp / "donor"
+        donor.mkdir()
+        _git(["init", "-q", "-b", "main", "."], donor)
+
+        def commit(msg):
+            _git(["add", "-A", "."], donor)
+            _git(ident + ["commit", "-q", "-m", msg], donor)
+            return _git(["rev-parse", "HEAD"], donor).stdout.strip()
+
+        (donor / "README.md").write_text("donor\n")
+        rev_empty = commit("no sources yet")
+        (donor / "hdl").mkdir()
+        (donor / "hdl" / "a.sv").write_text("module a; endmodule\n")
+        rev_one = commit("one source")
+        (donor / "hdl" / "b.sv").write_text("module b; endmodule\n")
+        rev_two = commit("two sources")
+
+        super_ = tmp / "super"
+        super_.mkdir()
+        _git(["init", "-q", "-b", "main", "."], super_)
+        (super_ / ".gitmodules").write_text(
+            f'[submodule "{label}"]\n\tpath = {label}\n\turl = {donor}\n')
+
+        def pin(*entries):
+            """Rewrite the index gitlink; several entries = an unmerged pin."""
+            text = f"0 {'0' * 40} 0\t{label}\n"
+            text += "".join(f"160000 {rev} {stage}\t{label}\n"
+                            for rev, stage in entries)
+            subprocess.run(["git", "update-index", "--index-info"],
+                           cwd=str(super_), input=text,
+                           capture_output=True, text=True)
+
+        def state():
+            return tree_state(label, tree, "the selftest fixture", root=super_)
+
+        def want(case, expect_state, expect_expected=None, expect_actual=None):
+            st = state()
+            if st.state != expect_state:
+                problems.append(f"tree_state [{case}]: classified "
+                                f"{st.state!r}, not {expect_state!r} - the "
+                                "state this fixture is in")
+                return st
+            if expect_expected is not None and st.expected != expect_expected:
+                problems.append(f"tree_state [{case}]: expected revision "
+                                f"{st.expected!r}, not the gitlink "
+                                f"{expect_expected!r}")
+            if expect_actual is not None and expect_actual not in st.actual:
+                problems.append(f"tree_state [{case}]: actual {st.actual!r} "
+                                f"does not name {expect_actual!r}")
+            if expect_state != "ok" and st.files is not None:
+                problems.append(f"tree_state [{case}]: a refused tree was "
+                                "enumerated anyway, so the population reached "
+                                "the census before the refusal")
+            return st
+
+        checkout = super_ / label
+        _git(["clone", "-q", str(donor), str(checkout)], tmp)
+        _git(["config", f"submodule.{label}.url", str(donor)], super_)
+        pin((rev_two, "0"))
+
+        st = want("pinned", "ok", rev_two, rev_two)
+        if st.state == "ok" and st.files != [f"{tree}/a.sv", f"{tree}/b.sv"]:
+            problems.append(f"tree_state [pinned]: enumerated {st.files}, not "
+                            "the two tracked sources at the pin")
+
+        # (2) the review's second escape: registered, moved off the pin. git
+        # prints `+`; the old check returned nothing and the census counted it.
+        _git(["checkout", "-q", "--detach", rev_one], checkout)
+        want("wrong-revision", "wrong-revision", rev_two, rev_one)
+
+        _git(["checkout", "-q", "--detach", rev_two], checkout)
+        (checkout / "hdl" / "a.sv").write_text("module a; wire x; endmodule\n")
+        want("modified", "modified", rev_two, "hdl/a.sv")
+        _git(["checkout", "-q", "--", "hdl/a.sv"], checkout)
+
+        # (1) the review's first escape: a real repository holding the pinned
+        # content, at the gitlink path, that is NOT the registered checkout.
+        _git(["config", "--unset", f"submodule.{label}.url"], super_)
+        want("uninitialised", "uninitialised", rev_two, rev_two)
+        _git(["config", f"submodule.{label}.url", str(donor)], super_)
+
+        aside = tmp / "aside"
+        checkout.rename(aside)
+        checkout.mkdir()
+        want("no-repository", "no-repository", rev_two)
+        checkout.rmdir()
+        want("absent", "absent", rev_two)
+
+        aside.rename(checkout)
+        _git(["checkout", "-q", "--detach", rev_empty], checkout)
+        pin((rev_empty, "0"))
+        want("empty", "empty", rev_empty)
+
+        pin((rev_one, "1"), (rev_two, "2"), (rev_empty, "3"))
+        want("conflicted", "conflicted")
+
+        pin()
+        want("unregistered", "unregistered")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return problems
 
 
 def _selftest_logic():
@@ -833,14 +1202,60 @@ def _selftest_logic():
         problems.append("section_of: a finding lands in the wrong budget "
                         "section")
 
-    absent = {label for label, _why in
-              missing_submodule_trees(sources=lambda label, tree: None)}
-    if absent != {label for label, _tree, _why in SUBMODULE_TREES}:
-        problems.append(f"tree refusal: not every absent processor tree is "
-                        f"flagged, got {sorted(absent)}")
-    if missing_submodule_trees(sources=lambda label, tree: ["x.sv"]):
-        problems.append("tree refusal: a present processor tree was flagged "
-                        "absent, so the gate would refuse on every lane")
+    # ---- the setup refusal, one arm per state ([R0] on PR #242) ------------
+    # Injected states, so every arm runs on every box - CI included, where no
+    # submodule is checked out and the live arm can only skip. The two the
+    # review reproduced are `uninitialised` (a standalone clone dropped at the
+    # gitlink path) and `wrong-revision` (a registered submodule moved off the
+    # pin); the previous refusal returned NOTHING for both and the census
+    # called them "the pinned processors".
+    _PIN = "a25b5cc9794b8e7f70f738548f4d674e9669b469"
+    _OFF = "44489453cf362c7a41c9e020f4896f967dc2a4d1"
+
+    def _fixed(state, expected=_PIN, actual="", files=None):
+        return lambda label, tree, why: TreeState(label, tree, why, state,
+                                                  expected, actual, files)
+
+    refusing = {
+        "absent": _fixed("absent"),
+        "unregistered": _fixed("unregistered", expected=""),
+        "conflicted": _fixed("conflicted", expected=f"{_PIN} / {_OFF}"),
+        "uninitialised": _fixed("uninitialised",
+                                actual=f"{_OFF} in an unregistered "
+                                       "repository at the path"),
+        "no-repository": _fixed("no-repository"),
+        "wrong-revision": _fixed("wrong-revision", actual=_OFF),
+        "modified": _fixed("modified", actual=f"{_PIN} + 1 modified "
+                                              "tracked file(s): hdl/x.sv"),
+        "empty": _fixed("empty", actual=_PIN),
+    }
+    every_label = {label for label, _tree, _why in SUBMODULE_TREES}
+    for name, resolver in refusing.items():
+        bad = unusable_submodule_trees(states=resolver)
+        if {st.label for st in bad} != every_label:
+            problems.append(f"setup refusal [{name}]: not every processor "
+                            f"tree is refused, got {sorted(st.label for st in bad)}")
+            continue
+        text = "\n".join(_setup_refusal_lines(bad))
+        if _STATE_WHAT[name] not in text:
+            problems.append(f"setup refusal [{name}]: the refusal does not "
+                            "name what the state IS")
+        if _STATE_FIX[name].format(label=sub_label) not in text:
+            problems.append(f"setup refusal [{name}]: the refusal does not "
+                            "name a remediation")
+        want_actual = resolver("x", "y", "z").actual
+        if want_actual and want_actual not in text:
+            problems.append(f"setup refusal [{name}]: the refusal does not "
+                            "name the ACTUAL revision found")
+        if name not in ("unregistered",) and _PIN not in text:
+            problems.append(f"setup refusal [{name}]: the refusal does not "
+                            "name the EXPECTED gitlink revision")
+    if unusable_submodule_trees(states=_fixed("ok", actual=_PIN,
+                                              files=["hdl/x.sv"])):
+        problems.append("setup refusal: a tree at the pinned revision was "
+                        "refused, so the gate would refuse on every lane")
+    # ...and the CLASSIFIER those states come from, against real git fixtures.
+    problems += _selftest_tree_state()
 
     # #224: the one tracked `.v` under hdl/ is in the analysed set. Asserted
     # against git, not against a hardcoded name, so the arm still bites when
@@ -902,9 +1317,9 @@ def main(argv):
               "to /home/alex/Xilinx/2026.1). A skip is not a pass.")
         return 0
 
-    missing = missing_submodule_trees()
-    if missing:
-        return _refuse_missing(missing)
+    bad = unusable_submodule_trees()
+    if bad:
+        return _refuse_setup(bad)
 
     _pkgs, _mods, counts = source_plan()
     findings, pkg_errors = analyse(xvlog)

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -355,7 +355,9 @@ class TreeState:
       unregistered    the path is not a 160000 gitlink in the superproject
                       index, or .gitmodules does not name it
       conflicted      the gitlink is unmerged - several index stages
-      absent          registered, but there is no directory
+      absent          registered, but there is nothing at the path - no
+                      directory, or the empty one a fresh clone and
+                      `git worktree add` leave behind
       uninitialised   registered, a directory, but the superproject has no
                       `submodule.<name>.url`: whatever is at the path is NOT
                       the registered checkout. This is git's own definition of
@@ -402,7 +404,8 @@ _STATE_WHAT = {
     "unregistered": "not a registered submodule of this commit "
                     "(no 160000 gitlink in the index, or no .gitmodules entry)",
     "conflicted": "the gitlink is UNMERGED - the pin itself is in conflict",
-    "absent": "registered, but nothing is checked out at the path",
+    "absent": "registered, but nothing is checked out at the path "
+              "(no directory, or an empty one)",
     "uninitialised": "NOT the registered checkout - the superproject has no "
                      "submodule url for it (`git submodule status` prints `-`)",
     "no-repository": "a directory that is not that repository's own top level "
@@ -506,7 +509,12 @@ def tree_state(label, tree, why, root=None):
         return state("unregistered")
     expected = revs[0]
     path = root / label
-    if not path.is_dir():
+    if not path.is_dir() or not any(path.iterdir()):
+        # An EMPTY directory is `absent`, not `uninitialised`: a fresh clone
+        # and `git worktree add` both leave the gitlink path as an empty
+        # directory, and that is the common case. Calling it "not the
+        # registered checkout" would send the reader hunting for a stray
+        # repository that is not there.
         return state("absent", expected)
     if _git(["config", "--get", f"submodule.{name}.url"], root).returncode:
         return state("uninitialised", expected, _foreign_head(path))
@@ -1052,8 +1060,11 @@ def _selftest_tree_state():
         aside = tmp / "aside"
         checkout.rename(aside)
         checkout.mkdir()
+        want("absent-empty-dir", "absent", rev_two)
+        (checkout / "hdl").mkdir()
+        (checkout / "hdl" / "a.sv").write_text("module a; endmodule\n")
         want("no-repository", "no-repository", rev_two)
-        checkout.rmdir()
+        shutil.rmtree(checkout)
         want("absent", "absent", rev_two)
 
         aside.rename(checkout)

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -65,6 +65,16 @@ findings into 5. TreeState below enumerates every state that answers REFUSE and
 why each one would otherwise pass; nothing is enumerated until the tree is the
 pinned population.
 
+AND THE GITLINK IS READ WHOLE, NOT FILTERED. [R0] round 2 reproduced the same
+class one level down: an index record set of `160000` stage 2 beside `100644`
+stage 3, and a one-sided `160000` stage 2, are both UNMERGED - `git submodule
+status` prints `U000...` - yet keeping the one surviving `160000` SHA made each
+read as a resolved pin and enumerated all 40 processor sources. The accepted
+index shape is now exactly ONE record at the path, mode `160000`, stage `0`;
+any other stage, any other mode, any extra record, an unparsable record or a
+record only UNDER the path refuses before enumeration, census, budget read or
+budget write. _index_pin below is that enumeration.
+
 ONE FINDING PER MODULE, NOT ONE PER OCCURRENCE. xvlog stops at the first error in
 a compilation unit and prints only the 10-8530 cascade after it, so a module with
 many use-before-declaration occurrences yields ONE finding, naming the first
@@ -349,15 +359,31 @@ class TreeState:
 
     That is the pin-bump false green #236 exists to close, so the check is now
     the superproject's declaration compared against the checkout, and it
-    refuses BEFORE anything is enumerated. `state` is one of, in the order
-    they are decided:
+    refuses BEFORE anything is enumerated.
 
-      unregistered    the path is not a 160000 gitlink in the superproject
-                      index, or .gitmodules does not name it
-      conflicted      the gitlink is unmerged - several index stages
+    Reading that declaration LOOSELY is the same class one level down, and
+    [R0] round 2 reproduced it twice: an index holding `160000` stage 2 beside
+    `100644` stage 3, and one holding only `160000` stage 2. `git submodule
+    status` printed `U000...` for both; keeping the surviving `160000` SHA
+    made each read as a resolved pin and enumerated all 40 sources. The index
+    shape is therefore matched whole against the ONE usable shape (see
+    _index_pin), never filtered down to the records that look usable.
+
+    `state` is one of, in the order they are decided:
+
+      unregistered    the index carries no stage 0 160000 gitlink AT the
+                      path - no record at all, a tracked file or symlink at
+                      the path, or the contents committed as ordinary files
+                      under it - or .gitmodules does not name it
+      conflicted      the index is UNMERGED at the path: any record at stage
+                      1, 2 or 3, more than one record, or a record that will
+                      not parse. There is no revision the next commit carries,
+                      whatever surviving SHA a filter would have kept
       absent          registered, but there is nothing at the path - no
                       directory, or the empty one a fresh clone and
                       `git worktree add` leave behind
+      not-a-directory registered, but a file or a symlink sits at the gitlink
+                      path where the checkout must be
       uninitialised   registered, a directory, but the superproject has no
                       `submodule.<name>.url`: whatever is at the path is NOT
                       the registered checkout. This is git's own definition of
@@ -401,11 +427,15 @@ class TreeState:
 #: so a state cannot be added without a remediation, and read by the refusal
 #: rather than restated at the print site.
 _STATE_WHAT = {
-    "unregistered": "not a registered submodule of this commit "
-                    "(no 160000 gitlink in the index, or no .gitmodules entry)",
-    "conflicted": "the gitlink is UNMERGED - the pin itself is in conflict",
+    "unregistered": "not a registered submodule of this commit (no stage 0 "
+                    "160000 gitlink in the index, or no .gitmodules entry)",
+    "conflicted": "the gitlink is UNMERGED - the pin itself is in conflict, "
+                  "so the index names NO revision the next commit carries",
     "absent": "registered, but nothing is checked out at the path "
               "(no directory, or an empty one)",
+    "not-a-directory": "registered, but what sits at the path is NOT a "
+                       "directory - a file or a symlink where the checkout "
+                       "must be",
     "uninitialised": "NOT the registered checkout - the superproject has no "
                      "submodule url for it (`git submodule status` prints `-`)",
     "no-repository": "a directory that is not that repository's own top level "
@@ -424,6 +454,8 @@ _STATE_FIX = {
     "conflicted": "resolve the conflicted gitlink, then "
                   "`git submodule update --init {label}`",
     "absent": "git submodule update --init {label}",
+    "not-a-directory": "remove the file or symlink at {label}, then "
+                       "`git submodule update --init {label}`",
     "uninitialised": "git submodule update --init {label}   "
                      "(move any standalone checkout at the path aside first)",
     "no-repository": "git submodule update --init {label}",
@@ -452,25 +484,88 @@ def _gitmodules_name(label, root=None):
     return None
 
 
-def _gitlink_revisions(label, root=None):
-    """Every index stage's gitlink revision at `label` (usually one, or none).
+#: One `git ls-files --stage -z` record: mode, object, stage, path. Anchored
+#: and total on purpose - a record this does not match is REFUSED rather than
+#: guessed at, because a record the gate cannot read is a pin it cannot prove.
+_INDEX_RECORD_RE = re.compile(r"^([0-7]{6}) ([0-9a-f]{40,64}) ([0-3])\t(.*)$",
+                              re.S)
+
+
+def _index_pin(label, root=None):
+    """Classify the INDEX at `label`. Returns `(kind, revision, detail)`.
+
+    `kind` is `ok`, `conflicted` or `unregistered`; `revision` is filled only
+    for `ok`; `detail` is what the refusal prints as the ACTUAL state.
+
+    THE PINNED POPULATION IS EXACTLY ONE INDEX RECORD: mode `160000`, stage
+    `0`, at exactly this path. That is the only index shape in which git names
+    a revision the next commit will carry, so it is the only shape accepted,
+    and every other shape is refused BY CONSTRUCTION - the whole record set is
+    matched against the one usable shape, never filtered down to the records
+    that look usable. [R0] round 2 on PR #242 reproduced two escapes from
+    filtering, both on a tree where `git submodule status` printed
+    `U000...`: `160000` stage 2 beside `100644` stage 3, and a one-sided
+    `160000` stage 2 with no other side. Keeping the surviving `160000` SHA
+    made each read as a resolved pin, all 40 sources were enumerated, and a
+    default run would have rewritten the ratchet from one side of an
+    unresolved conflict.
+
+    Every index state a submodule path can be in, and where each lands:
+
+      no record at the path            unregistered  (tracked files UNDER the
+                                                      path are counted and
+                                                      named: contents
+                                                      committed as ordinary
+                                                      files are not a gitlink)
+      one record, stage 0, `160000`    ok            <- the only pin
+      one record, stage 0, other mode  unregistered  (a file or a symlink is
+                                                      tracked AT the path)
+      any record at stage 1, 2 or 3    conflicted    (unmerged: git's `U`)
+      more than one record             conflicted
+      a record this cannot parse       conflicted
+
+    Records are matched on path EQUALITY: `git ls-files -- <dir>` also lists
+    everything under a tracked directory, and a processor whose contents were
+    committed as ordinary files must read as "no gitlink", never as "many
+    conflict stages".
 
     The INDEX, not HEAD, on purpose: that is what `git submodule status`
     compares a checkout against, and it is the revision the next commit will
     carry. A deliberate pin bump that is staged therefore agrees with a
     checkout moved to match it; a checkout moved on its own does not, and that
-    disagreement is precisely the false green #236 closes. More than one entry
-    means an unmerged gitlink.
+    disagreement is precisely the false green #236 closes.
     """
-    out = _git(["ls-files", "--stage", "--", label], root or ROOT)
+    out = _git(["ls-files", "--stage", "-z", "--", label], root or ROOT)
     if out.returncode:
-        return []
-    revs = []
-    for line in out.stdout.splitlines():
-        parts = line.split(None, 2)
-        if len(parts) >= 2 and parts[0] == "160000":
-            revs.append(parts[1])
-    return revs
+        return ("unregistered", "",
+                "`git ls-files --stage` could not read the index at the path")
+    at, under = [], 0
+    for entry in out.stdout.split("\0"):
+        if not entry:
+            continue
+        m = _INDEX_RECORD_RE.match(entry)
+        if m is None:
+            return ("conflicted", "",
+                    f"an index record this gate cannot parse: {entry!r}")
+        mode, obj, stage, path = (m.group(1), m.group(2),
+                                  int(m.group(3)), m.group(4))
+        if path == label:
+            at.append((mode, obj, stage))
+        else:
+            under += 1
+    shown = ", ".join(f"stage {s} mode {m} {o}" for m, o, s in at)
+    if len(at) > 1 or any(s for _m, _o, s in at):
+        return ("conflicted", "", f"{len(at)} index record(s): {shown}")
+    if not at:
+        return ("unregistered", "",
+                "no index record at the path"
+                + (f", and {under} tracked file(s) under it" if under else ""))
+    mode, obj, _stage = at[0]
+    if mode != "160000":
+        return ("unregistered", "",
+                f"a stage 0 mode {mode} entry ({obj}) - a tracked file or "
+                "symlink AT the path, not a gitlink")
+    return ("ok", obj, f"stage 0 mode 160000 {obj}")
 
 
 def _foreign_head(path):
@@ -501,14 +596,24 @@ def tree_state(label, tree, why, root=None):
     def state(name, expected="", actual="", files=None):
         return TreeState(label, tree, why, name, expected, actual, files)
 
-    revs = _gitlink_revisions(label, root)
-    if len(revs) > 1:
-        return state("conflicted", " / ".join(sorted(set(revs))))
+    kind, expected, detail = _index_pin(label, root)
+    if kind == "conflicted":
+        return state("conflicted", "", detail)
     name = _gitmodules_name(label, root)
-    if not revs or name is None:
-        return state("unregistered")
-    expected = revs[0]
+    if kind != "ok":
+        return state("unregistered", "", detail)
+    if name is None:
+        return state("unregistered", expected,
+                     "a stage 0 gitlink, but .gitmodules names no submodule "
+                     "at this path")
     path = root / label
+    if path.is_symlink() or (path.exists() and not path.is_dir()):
+        # Decided BEFORE is_dir(): a symlink to a directory answers True to
+        # is_dir(), and git never checks a submodule out as one.
+        return state("not-a-directory", expected,
+                     "a symlink at the gitlink path, not a checkout"
+                     if path.is_symlink() else
+                     "a file at the gitlink path, not a checkout")
     if not path.is_dir() or not any(path.iterdir()):
         # An EMPTY directory is `absent`, not `uninitialised`: a fresh clone
         # and `git worktree add` both leave the gitlink path as an empty
@@ -958,7 +1063,11 @@ def _selftest_tree_state():
     proves the CLASSIFIER reaches it, which is where [R0] on PR #242 found the
     escape - the old check asked only whether the path was the top of some
     repository with tracked sources, so a standalone clone at the gitlink path
-    and a checkout moved off the pin both classified as usable.
+    and a checkout moved off the pin both classified as usable. Round 2 found
+    the same class in the INDEX parser: an unmerged path whose one surviving
+    `160000` record was read as a resolved pin. The arms below therefore drive
+    the real index through `git update-index --index-info` and check git's own
+    `U` verdict beside the classifier's.
 
     Everything is built by hand in a temp dir: a donor repository with three
     revisions, and a superproject whose .gitmodules and INDEX gitlink are
@@ -999,14 +1108,36 @@ def _selftest_tree_state():
         (super_ / ".gitmodules").write_text(
             f'[submodule "{label}"]\n\tpath = {label}\n\turl = {donor}\n')
 
-        def pin(*entries):
-            """Rewrite the index gitlink; several entries = an unmerged pin."""
-            text = f"0 {'0' * 40} 0\t{label}\n"
-            text += "".join(f"160000 {rev} {stage}\t{label}\n"
-                            for rev, stage in entries)
+        def index_info(text):
+            """Write raw index records - the only way to build a fixture that
+            is unmerged, or mixed-mode, without a real merge conflict."""
             subprocess.run(["git", "update-index", "--index-info"],
                            cwd=str(super_), input=text,
                            capture_output=True, text=True)
+
+        def pin(*entries):
+            """Rewrite the index record(s) AT the path, clearing them first.
+
+            An entry is `(rev, stage)` - a gitlink - or `(mode, obj, stage)`
+            for the non-gitlink modes an unmerged path can carry. Several
+            entries, or any nonzero stage, is what git calls unmerged.
+            """
+            text = f"0 {'0' * 40} 0\t{label}\n"
+            for entry in entries:
+                mode, obj, stage = (entry if len(entry) == 3
+                                    else ("160000",) + entry)
+                text += f"{mode} {obj} {stage}\t{label}\n"
+            index_info(text)
+
+        def git_agrees_unmerged(case):
+            """git's own verdict on the fixture, so the arm cannot pass over a
+            state git does not consider unmerged in the first place."""
+            got = _git(["submodule", "status", label], super_).stdout.strip()
+            if not got.startswith("U"):
+                problems.append(f"tree_state [{case}]: the fixture is not "
+                                f"unmerged to git either - `git submodule "
+                                f"status` printed {got!r}, so the arm proves "
+                                "nothing")
 
         def state():
             return tree_state(label, tree, "the selftest fixture", root=super_)
@@ -1074,6 +1205,81 @@ def _selftest_tree_state():
 
         pin((rev_one, "1"), (rev_two, "2"), (rev_empty, "3"))
         want("conflicted", "conflicted")
+        git_agrees_unmerged("conflicted")
+
+        # [R0] round 2 on PR #242: the shapes a filter that keeps only the
+        # 160000 records cannot see. Both were reproduced on the real
+        # protocol-processor gitlink, and both classified `ok` at 40 files.
+        # A blob object so a stage can carry a non-gitlink mode; any content
+        # will do, only the mode is under test.
+        blob = _git(["hash-object", "-w", str(donor / "README.md")],
+                    super_).stdout.strip()
+        # The checkout is put back ON the surviving stage's revision on
+        # purpose: that is the reviewer's state, and it is the only one where
+        # a filter's leftover SHA reads as a FALSE GREEN rather than merely as
+        # the wrong refusal. Without it these arms would still pass over a
+        # `wrong-revision` verdict and prove far less.
+        _git(["checkout", "-q", "--detach", rev_two], checkout)
+
+        pin((rev_two, "2"), ("100644", blob, "3"))
+        st = want("conflicted-gitlink-vs-file", "conflicted")
+        git_agrees_unmerged("conflicted-gitlink-vs-file")
+        if st.state == "conflicted" and (rev_two not in st.actual
+                                         or blob not in st.actual):
+            problems.append("tree_state [conflicted-gitlink-vs-file]: the "
+                            "refusal does not name both sides of the "
+                            "conflict, so a reader cannot tell which is which")
+        # ...and the classifier must reach the exit-2 SETUP refusal from a
+        # real index fixture, not only from an injected state. Guarded on the
+        # verdict: _refuse_setup only ever sees unusable states in production,
+        # and handing it an `ok` one would crash the arm that is already
+        # reporting the real failure.
+        if not st.ok:
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = _refuse_setup([st])
+            if rc != 2 or "REFUSED" not in buf.getvalue():
+                problems.append(f"tree_state [conflicted-gitlink-vs-file]: "
+                                f"the refusal exited {rc} with "
+                                f"{len(buf.getvalue())} byte(s) on stderr, "
+                                "not 2 with a printed reason")
+
+        pin((rev_two, "2"), ("120000", blob, "3"))
+        want("conflicted-gitlink-vs-symlink", "conflicted")
+        git_agrees_unmerged("conflicted-gitlink-vs-symlink")
+
+        pin((rev_two, "2"))
+        want("conflicted-one-sided", "conflicted")
+        git_agrees_unmerged("conflicted-one-sided")
+
+        # A stage 0 record that is not a gitlink at all: the path is TRACKED,
+        # so `git ls-files` answers, but nothing pins a revision there.
+        pin(("100644", blob, "0"))
+        want("tracked-file-at-the-path", "unregistered")
+
+        # The contents committed as ordinary files. `git ls-files -- <path>`
+        # lists everything UNDER the path too, so more than one record turns
+        # up here as well; calling that "many conflict stages" would refuse
+        # with the wrong reason and the wrong fix. TWO of them, so an arm that
+        # matched by prefix instead of by equality cannot pass this by
+        # reaching the same verdict through the mode check.
+        nested = [f"{label}/hdl/a.sv", f"{label}/hdl/b.sv"]
+        pin()
+        index_info("".join(f"100644 {blob} 0\t{n}\n" for n in nested))
+        want("contents-committed-as-files", "unregistered", "",
+             "2 tracked file(s) under it")
+        index_info("".join(f"0 {'0' * 40} 0\t{n}\n" for n in nested))
+
+        pin((rev_two, "0"))
+        aside = tmp / "file-at-the-path"
+        checkout.rename(aside)
+        checkout.write_text("not a checkout\n")
+        want("not-a-directory", "not-a-directory", rev_two, "a file")
+        checkout.unlink()
+        checkout.symlink_to(aside)
+        want("symlink-at-the-path", "not-a-directory", rev_two, "a symlink")
+        checkout.unlink()
+        aside.rename(checkout)
 
         pin()
         want("unregistered", "unregistered")
@@ -1221,7 +1427,9 @@ def _selftest_logic():
     # review reproduced are `uninitialised` (a standalone clone dropped at the
     # gitlink path) and `wrong-revision` (a registered submodule moved off the
     # pin); the previous refusal returned NOTHING for both and the census
-    # called them "the pinned processors".
+    # called them "the pinned processors". Round 2 reproduced two more, both
+    # `conflicted`: an unmerged index whose one surviving `160000` record was
+    # read as a resolved pin.
     _PIN = "a25b5cc9794b8e7f70f738548f4d674e9669b469"
     _OFF = "44489453cf362c7a41c9e020f4896f967dc2a4d1"
 
@@ -1231,8 +1439,18 @@ def _selftest_logic():
 
     refusing = {
         "absent": _fixed("absent"),
-        "unregistered": _fixed("unregistered", expected=""),
-        "conflicted": _fixed("conflicted", expected=f"{_PIN} / {_OFF}"),
+        "unregistered": _fixed("unregistered", expected="",
+                               actual="no index record at the path"),
+        # The round-2 escape shape: unmerged, with no stage 0 to name. The
+        # refusal has no single expected revision to print, so it must print
+        # the whole record set instead - that is what tells a reader which
+        # side is which.
+        "conflicted": _fixed("conflicted", expected="",
+                             actual=f"2 index record(s): stage 2 mode 160000 "
+                                    f"{_PIN}, stage 3 mode 100644 {_OFF}"),
+        "not-a-directory": _fixed("not-a-directory",
+                                  actual="a file at the gitlink path, not a "
+                                         "checkout"),
         "uninitialised": _fixed("uninitialised",
                                 actual=f"{_OFF} in an unregistered "
                                        "repository at the path"),

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -98,6 +98,14 @@ cannot make the proof succeed - it can only fail to reproduce a blob id. The
 state names below exist to give a reader the right message and the right fix.
 They never decide acceptance; the hash equality does.
 
+Git object replacements are excluded from that proof explicitly. A mutable
+`refs/replace/<pin>` makes ordinary `git ls-tree <pin>` read ANOTHER commit while
+`git rev-parse HEAD` still prints the literal pinned id, so replacement-aware
+answers can make altered bytes look pinned. Every Git call that contributes to
+a trust decision is therefore run with `GIT_NO_REPLACE_OBJECTS=1`, set by this
+process rather than inherited. The real-Git self-test installs that exact
+replacement ref and requires a `modified` setup refusal before census or budget.
+
 THE PARENT'S OWN hdl/ IS NOT PROVED THAT WAY, deliberately: it IS the tree
 under test. A local edit under hdl/ is exactly what the author is gating, so
 the bytes on disk are the population by definition and there is no revision
@@ -375,12 +383,24 @@ _GIT_ENV_OVERRIDES = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
                       "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE")
 
 
-def _git(args, cwd):
-    """One git invocation, captured. `cwd` must already be known to be a repo."""
+def _git_env():
+    """A non-redirectable Git environment for every content trust decision.
+
+    `GIT_NO_REPLACE_OBJECTS` is SET, not merely removed. Without it a local
+    `refs/replace/<pin>` silently substitutes another commit for `ls-tree
+    <pin>` while `rev-parse HEAD` continues to report the literal pin, making
+    altered worktree bytes appear byte-identical to the pinned population.
+    """
     env = {k: v for k, v in os.environ.items()
            if k not in _GIT_ENV_OVERRIDES}
+    env["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return env
+
+
+def _git(args, cwd):
+    """One git invocation, captured. `cwd` must already be known to be a repo."""
     return subprocess.run(["git"] + args, cwd=str(cwd),
-                          capture_output=True, text=True, env=env)
+                          capture_output=True, text=True, env=_git_env())
 
 
 class TreeState:
@@ -1186,8 +1206,9 @@ def cmd_selftest(xvlog):
             print(f"  SELFTEST FAILED: {p}")
         if problems:
             return 1
-        print("xvlog gate selftest: parser/dedup/ratchet arms PASS; live "
-              "detection arm SKIPPED (no xvlog on this box)")
+        print("xvlog gate selftest: parser/dedup/ratchet and Git population "
+              "integrity arms PASS; live detection arm SKIPPED (no xvlog on "
+              "this box)")
         return 0
     _pkgs, rest = hdl_sources()
     donor = "hdl/ieee8021q/ts/credit_based_shaper.sv"
@@ -1231,7 +1252,8 @@ def cmd_selftest(xvlog):
     if problems:
         return 1
     print("xvlog gate selftest: PASS (a planted use-before-declaration reddens "
-          "the gate and names the identifier; the clean donor does not)")
+          "the gate and names the identifier; the clean donor does not; a "
+          "replacement-ref population is refused)")
     return 0
 
 
@@ -1339,9 +1361,12 @@ def _selftest_tree_state():
         def index_info(text):
             """Write raw index records - the only way to build a fixture that
             is unmerged, or mixed-mode, without a real merge conflict."""
-            subprocess.run(["git", "update-index", "--index-info"],
-                           cwd=str(super_), input=text,
-                           capture_output=True, text=True)
+            out = subprocess.run(["git", "update-index", "--index-info"],
+                                 cwd=str(super_), input=text,
+                                 capture_output=True, text=True, env=_git_env())
+            if out.returncode:
+                problems.append("tree_state [fixture index]: git update-index "
+                                f"failed: {out.stderr.strip()}")
 
         def pin(*entries):
             """Rewrite the index record(s) AT the path, clearing them first.
@@ -1431,6 +1456,98 @@ def _selftest_tree_state():
         (checkout / "hdl" / "a.sv").write_text("module a; wire x; endmodule\n")
         want("modified", "modified", rev_two, "hdl/a.sv")
         _git(["checkout", "-q", "--", "hdl/a.sv"], checkout)
+
+        # [R0] round 4: refs/replace is a mutable object-name indirection, not
+        # an index hint. With ordinary Git semantics, `ls-tree <rev_two>` reads
+        # rev_replace's tree even though `rev-parse HEAD` still prints rev_two.
+        # Plant exactly the replacement bytes on disk: a replacement-aware
+        # population proof then calls this `ok`. Every trust-decision Git call
+        # must force GIT_NO_REPLACE_OBJECTS=1 so the real pin wins and this is
+        # `modified` instead. The end-to-end arm proves both public modes stop
+        # before census and leave the budget byte-for-byte untouched.
+        pinned_data = (checkout / "hdl" / "a.sv").read_bytes()
+        replacement_data = b"module a; wire replacement_ref; endmodule\n"
+        (donor / "hdl" / "a.sv").write_bytes(replacement_data)
+        rev_replace = commit("replacement-ref fixture")
+        _git(["branch", "replacement-fixture", rev_replace], donor)
+        _git(["reset", "-q", "--hard", rev_two], donor)
+        fetched = _git(["fetch", "-q", "origin", "replacement-fixture"],
+                       checkout)
+        if fetched.returncode:
+            problems.append("tree_state [replacement-ref]: could not fetch the "
+                            f"replacement object: {fetched.stderr.strip()}")
+        installed = _git(["replace", rev_two, rev_replace], checkout)
+        if installed.returncode:
+            problems.append("tree_state [replacement-ref]: could not install "
+                            f"refs/replace/{rev_two}: "
+                            f"{installed.stderr.strip()}")
+        (checkout / "hdl" / "a.sv").write_bytes(replacement_data)
+        literal_head = _git(["rev-parse", "HEAD"], checkout).stdout.strip()
+        replacement_ref = _git(
+            ["rev-parse", f"refs/replace/{rev_two}"], checkout).stdout.strip()
+        if literal_head != rev_two:
+            problems.append("tree_state [replacement-ref]: HEAD moved to "
+                            f"{literal_head!r}, so the fixture does not hold the "
+                            "pinned literal revision")
+        if replacement_ref != rev_replace:
+            problems.append("tree_state [replacement-ref]: replacement ref "
+                            f"resolved to {replacement_ref!r}, not {rev_replace}")
+        on_disk = (checkout / "hdl" / "a.sv").read_bytes()
+        if on_disk != replacement_data or on_disk == pinned_data:
+            problems.append("tree_state [replacement-ref]: altered replacement "
+                            "bytes are not on disk, so the arm proves nothing")
+        st = want("replacement-ref", "modified", rev_two, "hdl/a.sv")
+
+        if st.state == "modified":
+            budget_path = super_ / "scripts" / "xvlog.budget"
+            budget_path.parent.mkdir()
+            budget_sentinel = b"replacement-ref budget sentinel\n"
+            budget_path.write_bytes(budget_sentinel)
+            saved = {name: globals()[name]
+                     for name in ("ROOT", "HDL", "BUDGET", "SUBMODULE_TREES")}
+            saved_xvlog = os.environ.get("XVLOG")
+            globals()["ROOT"] = super_
+            globals()["HDL"] = super_ / "hdl"
+            globals()["BUDGET"] = budget_path
+            globals()["SUBMODULE_TREES"] = [
+                (label, tree, "the replacement-ref selftest fixture")]
+            os.environ["XVLOG"] = sys.executable
+            try:
+                for extra in ([], ["--check"]):
+                    mode = extra[0] if extra else "default"
+                    out, err = io.StringIO(), io.StringIO()
+                    with contextlib.redirect_stdout(out), \
+                            contextlib.redirect_stderr(err):
+                        rc = main(["xvlog_gate.py"] + extra)
+                    if rc != 2:
+                        problems.append(f"tree_state [replacement-ref {mode}]: "
+                                        f"main exited {rc}, not setup refusal 2")
+                    if "REFUSED" not in err.getvalue() or \
+                            _STATE_WHAT["modified"] not in err.getvalue():
+                        problems.append(f"tree_state [replacement-ref {mode}]: "
+                                        "main did not print the modified setup "
+                                        "refusal")
+                    if out.getvalue():
+                        problems.append(f"tree_state [replacement-ref {mode}]: "
+                                        "stdout was written, so the census was "
+                                        "reached")
+                    if budget_path.read_bytes() != budget_sentinel:
+                        problems.append(f"tree_state [replacement-ref {mode}]: "
+                                        "the budget was written under refusal")
+            finally:
+                for name, value in saved.items():
+                    globals()[name] = value
+                if saved_xvlog is None:
+                    os.environ.pop("XVLOG", None)
+                else:
+                    os.environ["XVLOG"] = saved_xvlog
+
+        removed = _git(["replace", "-d", rev_two], checkout)
+        if removed.returncode:
+            problems.append("tree_state [replacement-ref]: could not remove the "
+                            f"fixture replacement: {removed.stderr.strip()}")
+        _git(["checkout", "-q", "--", "hdl/a.sv"], checkout)
+        want("replacement-ref-restored", "ok", rev_two, rev_two)
 
         # [R0] round 3: the index can be told to LIE about the worktree, and
         # the old check asked it. `assume-unchanged` and `skip-worktree` are
@@ -1916,7 +2033,8 @@ def _selftest_logic():
                 continue
             got = subprocess.run(["git", "hash-object", "-t", "blob",
                                   "--stdin"], cwd=str(repo), input=payload,
-                                 capture_output=True).stdout.decode().strip()
+                                 capture_output=True,
+                                 env=_git_env()).stdout.decode().strip()
             if got != _blob_id(payload, algo):
                 problems.append(f"blob id [{algo}]: computed "
                                 f"{_blob_id(payload, algo)}, git says {got} - "


### PR DESCRIPTION
[A1] / [A2]

## Contents

- **[Status](#status)** -- Green/WIP/blocked, test tally, and `branch` -> `dev`.
- **[Linked Issue / roles](#linked-issue--roles)** -- Public task, executor, and independent reviewers.
- **[Description](#description)** -- What changed and why.
- **[Authoritative references](#authoritative-references)** -- Requirements/specification clauses and docs.
- **[How to get into the same state](#how-to-get-into-the-same-state)** -- Copy-pasteable checkout/dependency/environment commands.
- **[How to validate](#how-to-validate)** -- Exact reviewer commands and expected result.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** -- What this deliberately does not do, and why.
- **[Definition of Done](#definition-of-done)** -- The merge bar from [CONTRIBUTING.md](../CONTRIBUTING.md).

## Status

GREEN at head `d18db056d4f912ccd2246d335cc403e507c5c255` (tree
`5f085abd566d0040474e336f0b58946b54b7d068`), rebased onto current
`dev@a8b27a5f503b1a9c3f267e456f4683ef35df4dc7`. `dev` moved three times during this lane --
`a748e230` (PR #244), `cb444a09` (PR #227), then `a8b27a5f` (PR #240) -- so the merge base is now
`a8b27a5f`, the branch is **0 behind**, and this head's tree IS the candidate merge tree
(`git merge-tree --write-tree origin/dev HEAD` prints `5f085abd`, the head tree).
**Every figure below was re-measured at that SHA.** The round-1 figures came from `6375e4d3`, the
round-2 figures from `9ab41e17`, the round-3 figures from `d04acffc` and the round-4 answer's
figures from `0cba49d3` (none were ever posted at `352f0c75`, the [R2] MINOR); all are
superseded. The pin census carries over unchanged: the #240 delta
(`syn/ooc/`, `syn/yosys/`, `sw/builder/test_builder.py`, docs, `rtl-fast.yml`) touches neither
gitlink, so both processors stay `protocol-processor@3770ae02`, `gptp-processor@7def718e`, and it
is disjoint from this diff (`CONTRIBUTING.md`, `scripts/xvlog.budget`, `scripts/xvlog_gate.py`).

| Gate, run locally at `d18db056` | Result |
|---|---|
| `scripts/xvlog_gate.py --check` (live Vivado 2026.1) | PASS -- 5 finding(s) == ratchet (0 `hdl/`, 5 pinned processors); 69 + 48 files analysed; 2 min 20 s |
| `scripts/xvlog_gate.py --selftest` | PASS -- 23 s, live detection and replacement-ref refusal arms included |
| `scripts/run_all_suites.sh` (one full unsharded run) | PASS -- 52/52 suites, 0 failed, 0 timed out, 2 118 602 checks, 0 in-suite failures; 16 min 25 s in one call |
| `syn/yosys/run.sh` (one full serial run) | PASS -- 46/46 tops plus the tied-input and tap-purity structural gates, 48/48 `status=PASS` result files; 16 min 56 s in one call |
| `scripts/lint_rtl.py --check` | PASS -- 99 <= ratchet 99, 22 waived, 0 justified `lint_off` |
| `scripts/pp_srcs.py --check --selftest` | PASS |
| `scripts/docs_check.py` / `check_doc_paths.py` / `gen_toc.py --check` | PASS -- 0 findings over 213 md files; 1145 cited paths resolve; 152 TOC pages |
| `scripts/ci_events.py --check` / `--selftest` | PASS -- 79 contract items across 4 workflow files; 115 self-test arms |
| `scripts/check_feature_status.py` | PASS -- 0 findings |
| `git diff --check origin/dev...HEAD` | clean |
| hosted contexts | 20/20 at `352f0c75`; the run at this head re-runs on the push of this head (in flight at body-edit time; the delta since `352f0c75` is the clean rebase plus 7 docstring lines) |

Both long gates ran unsharded this round, each to completion in one call at this head, so there
is no shard table: the two rows above are the whole record. The box was shared with another
full sweep while these were measured, so wall clocks are contention-inflated; results are counts,
not timings.

`224-xvlog-gate-coverage` -> `dev`.

## Linked Issue / roles

Closes #224
Closes #236
Relates to #132, #150, #186, #193, #227

Executor: `[A1]` / `[A2]`
Internal cleared-context reviewer: `[R0]`
- round 1 NEGATIVE at `6375e4d3` (1 BLOCKER, 1 MAJOR) -- answered at `9ab41e17`
- round 2 NEGATIVE at `9ab41e17` (1 BLOCKER) -- answered at `d04acffc`
- round 3 NEGATIVE at `d04acffc` (1 BLOCKER, 1 MAJOR) -- answered at `0cba49d3`
- round 4 NEGATIVE at `0cba49d3` (1 BLOCKER: `refs/replace` object substitution) -- answered at
  `352f0c75`

Second cleared-context reviewer: `[R2]`
- round 5 NEGATIVE at `352f0c75` (1 MINOR: the PR record was banked at superseded head
  `0cba49d3`; 1 SUGGESTION, implemented). All four `[R0]` blockers independently verified fixed
  at `352f0c75`; answered at this head, `d18db056`.

## Description

### The class, recorded before implementing

`scripts/xvlog_gate.py` is a front-end oracle. Its `hdl/` ratchet is empty (#193), so its entire
remaining value is that the **next** new finding reddens it.

Both issues are one class: **the gate's printed census claims a population wider than the one it
measured.** It printed `0 findings - every hdl/ module analyses under Vivado's front-end`; it had
measured 68 of the 69 tracked HDL modules under `hdl/` (the 69th is `.v` and the glob was `*.sv`)
and none of the 46 tracked sources in the two pinned processors that `milan_datapath` elaborates
on every build. Where the claim is wider than the measurement, a new finding in the uncovered part
reddens nothing while the printed line reads as though it would, and the false negative is
invisible precisely because the gate is green. #224 item 2 is the same class along another axis:
the claim is about a front-end, the measurement is only its analysis half.

**Round 1 of [R0] found a second instance of the same class inside the first fix**, and it is
recorded here before its fix for the same reason: the widened census said "the pinned processors",
but the refusal that was supposed to guarantee that only proved each path was the top of *some* Git
repository with tracked sources. So the population was still taken from **whatever sat at the
path** instead of from **what the superproject declares**. Three states passed that check and are
not the pinned population:

1. an unregistered or uninitialised path holding any repository (`git submodule status` prints `-`);
2. a registered submodule checked out at another revision (`+`);
3. a registered submodule at the right revision with local modifications to tracked files.

**Round 2 of [R0] found the SAME class one level further down, inside that fix.** Round 1's
fix took the declaration from the superproject index, correctly, but read it **loosely**: it kept every `git ls-files --stage` record whose mode was `160000` and
discarded the stage number. An index that git itself calls UNMERGED still yielded one surviving
SHA, and that SHA was treated as a resolved pin:

```
160000 a25b5cc9794b8e7f70f738548f4d674e9669b469 2  protocol-processor
100644 c7ff9c9973f0e000ba2cacb6c2b0c8a39135f540 3  protocol-processor
git submodule status: U0000000000000000000000000000000000000000 protocol-processor
```

Reproduced at `9ab41e17` in an isolated clone: `tree_state()` returned `ok` at `a25b5cc9`,
enumerated all 40 protocol-processor files, `unusable_submodule_trees()` returned `[]`, and
`source_plan()` proceeded with 69 + 46. Same for a one-sided `160000` stage 2 with no other side.
The round-1 self-test passed because its only conflict fixture supplied three mode-`160000`
records, so `len(revs) > 1` caught that one shape and no other.

**Round 3 of [R0] found the SAME class a THIRD time, one level further down again**, and it is
what this head answers. Rounds 1 and 2 fixed *which declaration* the population is taken from (the
gitlink, read whole). Round 3 is about the *other* half: once the revision matched, the check
asked git a question -- `git diff --name-only HEAD --` -- and git deliberately answers that
question **through the index**. `git update-index --assume-unchanged` and `--skip-worktree` each
tell it not to look:

```
$ git -C protocol-processor update-index --assume-unchanged -- hdl/common/KL_pp_prng.sv
$ <plant a use-before-declaration in that file>
$ git -C protocol-processor ls-files -v -- hdl/common/KL_pp_prng.sv   ->  h hdl/common/KL_pp_prng.sv
$ git -C protocol-processor status --short                            ->  (empty)
$ git -C protocol-processor diff --name-only HEAD --                  ->  (empty)
$ git hash-object protocol-processor/hdl/common/KL_pp_prng.sv         ->  809a2be2...
$ git -C protocol-processor rev-parse HEAD:hdl/common/KL_pp_prng.sv   ->  83108846...
```

Measured at this head with the **pre-fix** gate (`fe12dd9c`) over exactly that tree: it printed the
69 + 48 census as the pinned population, called the planted
`protocol-processor:hdl/common/KL_pp_prng.sv|VRFC 10-3380|kl_r0_late_w` an ordinary ratchet
regression, and exited **1** -- the code that reads as "the tree got worse" and invites re-banking.
A default run would have rewritten `scripts/xvlog.budget` from locally altered processor RTL.

### The class, and why the SHAPE changed rather than the spelling

Three rounds, three instances, one class: **the analysed population is not provably the pinned
one.** Each previous answer closed the instance in front of it -- the filesystem check, then the
index gitlink, then the unmerged index stages -- and the next round found another door. A fourth
finding of one class is not a missing case; it is the wrong *shape* of instrument. The old shape
asked git **"has anything changed?"**, and every answer to that question is computed through state
that can be told to stay quiet. Adding `assume-unchanged` and `skip-worktree` to a list of
known-bad states would have been the fifth instance waiting to happen.

So the question is no longer asked. **Acceptance is now a positive, per-file proof:**

1. the pin comes from the superproject's own index record (`git ls-files --stage`, which *prints*
   the record rather than computing a comparison, so a hint on the gitlink path cannot alter it);
2. the population comes from **the object that pin names** -- `git ls-tree -r <pin> -- hdl` inside
   the checkout, never `git ls-files`, so the checkout's index no longer decides which files exist;
3. every file in that population is **opened and hashed**, and its `blob` id must equal the id the
   pin records, over the exact bytes `xvlog` will open.

Nothing in that chain consults the index, `git status`, `git diff`, a refresh hint, a sparse or
skip-worktree state, an `fsmonitor`, a `.git` file indirection or a clean/smudge filter. It is
content-addressed end to end: a pin SHA taken from the superproject's index, the object that SHA
names (any store able to produce it produces the same bytes), and the bytes on disk. **A state
nobody has enumerated cannot make the proof succeed** -- it can only fail to reproduce a blob id.
The state names below exist to give a reader the right message and the right remediation; they
never decide acceptance.

**Round 4 of [R0] found the one door left in that chain: the object store's own indirection.** A
mutable `refs/replace/<pin>` makes `git ls-tree <pin>` read ANOTHER commit while
`git rev-parse HEAD` and `git submodule status` still print the literal pinned id, so "the object
that pin names" was in fact whatever local replacement state said it was. [R0] reproduced it at
`0cba49d3` against the real gPTP pin: HEAD at the exact pin, no `+`/`U` marker, altered bytes on
disk, gate PASS. The fix (`352f0c75`) forces `GIT_NO_REPLACE_OBJECTS=1` on every Git call that
contributes to the trust decision, set by the gate rather than inherited, and the real-Git
self-test installs that exact replacement ref and requires a `modified` refusal before census or
budget; replacing the env assignment with a no-op reddens `--selftest`.

**[R2] verified all four closures independently and named the proof's one remaining assumption:
object-store integrity.** A forged loose object written under the pin's own id (a hash-path
mismatch only `git fsck` sees) would serve altered bytes as pinned ones. That is object-store
corruption, not a tree state; whoever can write `.git/objects` can as easily edit this gate or
its ratchet. This head's docstring states that boundary next to the not-a-lock caveat instead of
leaving it to be discovered ([R2] SUGGESTION, implemented).

### The enumeration, in decision order, which is now the implementation

Every state a submodule path can be in from the superproject's point of view, and where each
lands. Rows marked **new** are what round 3 adds.

| # | What is inspected | State found | Verdict |
|---|---|---|---|
| 1 | superproject index at the path | no record; a stage-0 record whose mode is not `160000`; records only UNDER the path | `unregistered` |
| 2 | superproject index at the path | any record at stage 1/2/3, more than one record, or a record the plumbing-format regex cannot parse | `conflicted` |
| 3 | superproject index at the path | exactly one record, stage `0`, mode `160000` | this is the pin, `P` |
| 4 | `.gitmodules` | no submodule registered at the path | `unregistered` |
| 5 | working tree at the path | a symlink, or a file | `not-a-directory` |
| 6 | working tree at the path | missing, or an empty directory | `absent` |
| 7 | superproject config | no `submodule.<name>.url` | `uninitialised` |
| 8 | the directory | not its own repository top level | `no-repository` |
| 9 | that repository | `HEAD` is not `P` | `wrong-revision` |
| 10 | that repository | an object format whose blob ids cannot be reproduced, or a tree record that will not parse | `unreadable` **(new)** |
| 11 | `P`'s own tree | a `.sv`/`.v` entry that is not a regular-file blob (a committed symlink, a nested gitlink) | `unpinnable` **(new)** |
| 12 | `P`'s own tree | no `.sv`/`.v` entry at all | `empty` |
| 13 | each pinned source, on disk | missing, a symlink, a directory, or unreadable | `incomplete` **(new)** |
| 14 | each pinned source, on disk | present, but its bytes do not hash to the pinned blob id | `modified` **(redefined)** |
| 15 | -- | every pinned source present and byte-identical to the pin | **`ok`** -- only then is anything enumerated |

Rows 13 and 14 are the two no index hint can influence, because they are the only two decided by
reading bytes. Row 11 refuses rather than following a link out of the population; row 13 refuses a
symlink **even when its target holds the pinned bytes**, because what the pin names is a file, not
a name that resolves to one.

**The parent's own `hdl/` is deliberately NOT proved this way**: it *is* the tree under test. A
local edit under `hdl/` is exactly what the author is gating, so its bytes on disk are the
population by definition and there is no revision they should equal. The processors are the
opposite case -- the superproject *declares* which revision they are, so a local edit there makes
the census claim bytes nobody committed.

**What this is NOT: a lock.** The bytes are proved once, before enumeration. A file rewritten
between the proof and the `xvlog` run that opens it is a race with a local writer, not a state the
tree can be found in, and no gate that hands paths to a compiler can close it. Said in the
docstring rather than left to be discovered.

### Decision

**#236 option 1, extended to cover #224 item 1 as well. #224 item 2 is deferred, out loud.**

- **Scope widens** to every tracked `.sv` **and** `.v` under `hdl/`, plus every tracked source
  under `protocol-processor/hdl` and `gptp-processor/hdl`.
- **The #186 invariant is kept by REFUSING, not by narrowing**, and the refusal is against the
  **gitlink, read whole, and then against the pinned BYTES**: unless each processor tree IS the
  revision this commit pins and every pinned source hashes to the blob id that revision records,
  the gate exits 2 with `XVLOG SETUP: REFUSED`, naming the state, the expected and actual
  revisions and the remediation -- before it enumerates anything, prints any census, reads or
  writes the budget. `scripts/lint_rtl.py`'s shape, which #186 forced on the lint ratchet for the
  same reason.
- **The census names the revision it measured**: `pinned at: protocol-processor@3770ae02;
  gptp-processor@7def718e`, so the claim is checkable against `git submodule status` rather than
  taken on trust.
- **Two budget sections**, `hdl` and `submodules`, each with its own totals and its own diff, so
  donor debt can never be traded against `hdl/` debt (#150) and the empty `hdl` section #193
  reached stays visibly zero. A section is **derived** from the finding's own path, and a budget
  filing a key under the other section is rejected as malformed.

**Why the other two lose.** Option 2 (a separate submodule arm run at pin-bump time) puts the gate
behind a human remembering to run it at exactly the moment the parent takes ownership of donor
sources; nothing in the repository would run it, and a gate nobody runs is not a gate. It also
needs a second budget file and a second refusal to stay honest. Option 3 (state the limit, close
nothing) satisfies the census obligation and neither of the others: it documents a live class --
37 occurrences at the pin on `dev` when #236 was written, 51 at the pin PR #227 then proposed and
has since landed -- and leaves it with no gate at all. Option 1 costs one more thing a lane must
have checked out, which CONTRIBUTING 2.2 already requires of every local-bar run, and the extra
run time the processors add (the earlier 82 s -> 139 s measurement was taken at `d04acffc` on an
idle box and is not re-quoted here; the whole `--check` run at this head took 2 min 21 s on a
loaded one).

**Deliberately NOT covered, and why the exclusions are these.** `third_party/` and `external/` are
leaf IP this repository neither owns nor edits; `scripts/lint_rtl.py` already treats
`verilog-axis` as resolution-only and never lints it, and `external/` is SSH-only and deliberately
outside CONTRIBUTING 2.2's documented init set, so requiring it would refuse on every lane.

### What changed

| Piece | Change |
|---|---|
| `hdl_sources()` | globs tracked `.v` as well as `.sv`; `.svh` still excluded (an include header is analysed through its includer) |
| `_index_pin()`, `_INDEX_RECORD_RE` | **round-2 [R0] BLOCKER**: replaces `_gitlink_revisions()`. Parses complete `git ls-files --stage -z` records (mode, object, **stage**, path), matches the whole record set against the one usable shape, and answers `ok` / `conflicted` / `unregistered` with a detail string the refusal prints |
| `TreeState`, `tree_state()` | **round-1 [R0] BLOCKER**: resolves each processor tree against the superproject's index gitlink and classifies it into one of ten states (the new one is `not-a-directory`); every refusable one is decided before `git ls-files` runs in the tree |
| `_gitmodules_name()`, `_foreign_head()` | the registration lookup and what is actually at an unregistered path -- probed only after the top-level guard, so `git -C` cannot walk up and answer with the superproject |
| `unusable_submodule_trees()`, `_setup_refusal_lines()`, `_refuse_setup()` | the exit-2 refusal, naming state / expected / actual / remediation, with an injectable state resolver so every arm self-tests on any box. A `conflicted` tree has no single expected revision to print, so it prints the whole index record set instead |
| `submodule_sources()`, `source_plan()` | derive the processor lists from the tree, tracked only, packages first -- `pp_srcs.py`'s rule, never a hand-written list; only an `ok` tree contributes |
| `display_path()`, `section_of()` | processor keys spelled `<submodule>:<path>`; section derived from the path |
| `read_budget()`, `write_budget()` | sectioned budget, per-section diff, `BudgetError` on a mis-filed key |
| `_print_census()`, `_scope_lines()` | the census prints its scope, its exclusions AND the pinned revision every run, from computed counts |
| `_pinned_entries()`, `_TREE_RECORD_RE`, `_SOURCE_SUFFIXES` | **round-3 [R0] BLOCKER**: the population is read from the object the pin names (`git ls-tree -r <pin> -- hdl`), never from `git ls-files`, so the checkout's index does not decide which files exist |
| `_unpinned_bytes()`, `_blob_id()`, `_OBJECT_HASH` | **round-3 [R0] BLOCKER**: every pinned source is opened and hashed and must equal the pinned blob id. `git hash-object` is deliberately not used (it applies the checkout's filters and `.gitattributes`, which are worktree state). Both object formats git offers are supported and checked against git |
| `tree_state()` | `git diff --name-only HEAD --` is **deleted**; three new states (`unreadable`, `unpinnable`, `incomplete`) and `modified` redefined as a byte mismatch |
| `_git()`, `_GIT_ENV_OVERRIDES` | every git call runs with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR`/`GIT_OBJECT_DIRECTORY`/`GIT_ALTERNATE_OBJECT_DIRECTORIES`/`GIT_NAMESPACE` cleared, so `cwd` means what it says; `hdl_sources()` and the `.v` scope arm go through it too |
| `_git()` replacement handling | **round-4 [R0] BLOCKER**: `GIT_NO_REPLACE_OBJECTS=1` forced on every trust-decision Git call; a real replacement-ref self-test fixture requires the `modified` refusal before census or budget |
| module docstring | **[R2] SUGGESTION**: names object-store integrity as the one assumption the byte proof rests on, beside the not-a-lock caveat |
| `main()` | skip -> refuse -> analyse, in that order, and the self-test now drives `main()` itself in both modes over a non-pinned tree (exit 2, nothing on stdout, budget byte-identical) |
| `_selftest_logic()`, `_selftest_tree_state()` | the six scope arms, ten injected-state refusal arms, an exit-code arm, and a **real git fixture** (a donor repository at four revisions plus a hand-built superproject index written with `git update-index --index-info`) that drives the classifier through **every** state in the enumeration, asserted exhaustively both ways, with no network and no `submodule add` |
| `CONTRIBUTING.md` 2.2 and 3 | the widened scope, the gitlink refusal, the exact index shape it accepts, how to check it (`-`, `+` **or `U`**), **the byte proof and the two index hints it defeats**, the sections, and the elaboration hole |

**Why a processor key is `<submodule>:<path>` and not `<submodule>/<path>`.** `scripts/pp_srcs.py
--check` -- a required `rtl-fast` context -- fails any tracked file outside its `PROSE_OK` table
that names a submodule source literally, and `scripts/xvlog.budget` is a tracked file whose whole
job is to name them. Measured against `pp_srcs.check()`: the `/` spelling fails it, the `:`
spelling does not.

### What the gate actually sees, which is not what #236 predicted

#236's table came from `synth_design`, which **warns** (`Synth 8-6901`) and keeps going. `xvlog`
stops at the first error in a compilation unit and then prints only the `10-8530` cascade, so 35
occurrences in one file collapse to **one** finding naming the first identifier. `xvlog --help`
(2026.1) offers no continue-on-error switch. So the grandfathered set is **3**, not 37 or 51: one
per affected module, a moving front rather than a complete list. Fixing the first occurrence banks
one key and raises the next, so `--check` reports one vanished **and** one new key and the
pin-bump lane re-banks deliberately.

## Authoritative references

- #132 (why the gate exists), #150 (identity not count), #186 (refuse, do not under-count), #193
  (the empty `hdl/` ratchet), #227 (where #236's numbers were measured).
- `CONTRIBUTING.md` section 2.2 (the three-submodule local-bar init), section 3 (the bar), and
  lines 226-239 (the two long aggregates and their local gates are independently required).
- `scripts/lint_rtl.py` `REQUIRED_TREES` / `LINT SETUP: REFUSED` -- the shape copied here.
- `scripts/pp_srcs.py` -- derive, never list; and the `PROSE_OK` constraint measured above.
- `git ls-files --stage` record format (mode, object, **stage**, path) and `git submodule status`
  prefixes (` `, `-`, `+`, `U`) -- the states the refusal reproduces and the ones round 2 showed
  were being read past.
- `git update-index --assume-unchanged` / `--skip-worktree` and the `h` / `S` marks
  `git ls-files -v` prints for them -- what round 3 showed `git status`, `git diff` and
  `git ls-files` are all computed through. `git ls-tree -r <commit>` and the `blob` object id
  (`sha1`/`sha256` over `blob <len>\0<bytes>`) -- what replaced them.
- `git replace` / `refs/replace/*` and `GIT_NO_REPLACE_OBJECTS` -- the object-store indirection
  round 4 showed `git ls-tree` follows, and the switch that disables it. `git fsck` -- the only
  view that sees a forged loose object under a pinned id, the stated integrity assumption.

## How to get into the same state

```sh
M=/home/alex/prjs-avb-on-fpga/milan-fpga; L=~/milan-avb-multiwork/224-xvlog-gate
git clone -q --shared --no-checkout $M $L && cd $L
git remote set-url origin git@github.com:kebag-logic/milan-fpga.git
git fetch -q origin && git checkout -q 224-xvlog-gate-coverage
git submodule update --init protocol-processor gptp-processor third_party/verilog-axis
export PATH=/home/alex/Xilinx/2026.1/Vivado/bin:$PATH   # Vivado Simulator v2026.1
export TMPDIR=$(mktemp -d)                              # temp stays under /tmp
```

## How to validate

```sh
python3 scripts/xvlog_gate.py --check      # 2 min 20 s at this head, loaded box
python3 scripts/xvlog_gate.py --selftest   # 23 s with xvlog, ~1 s without
python3 scripts/lint_rtl.py --check
python3 scripts/pp_srcs.py --check --selftest
python3 scripts/docs_check.py && python3 scripts/check_doc_paths.py && python3 scripts/gen_toc.py --check

# the two mandatory local long gates (CONTRIBUTING 226-239). BOTH take --shard,
# so a session with a command ceiling records every shard instead of skipping them.
# Yosys shard 0/4 is milan_datapath ALONE and needs its own long-running call:
for i in $(seq 0 5); do scripts/run_all_suites.sh "$(mktemp -d)" --shard $i/6 || break; done
for i in $(seq 0 3); do syn/yosys/run.sh --shard $i/4 --results yout/ || break; done
```

Expected result / pass criteria:

```
xvlog gate: 5 finding(s) across 5 module(s)
  analysed: 69 tracked .sv/.v file(s) under hdl/ and 48 under the pinned processors (...)
  pinned at: protocol-processor@3770ae02; gptp-processor@7def718e - the superproject gitlink, ...
  hdl/: 0 finding(s)
  pinned processors: 5 finding(s)
xvlog gate: PASS (5 finding(s) == ratchet; 0 hdl/, 5 pinned processors)
```

Negative controls a reviewer can run, each of which must exit **2** with no census and no write to
`scripts/xvlog.budget` (exact commands and verbatim output in the `[A1]` evidence comment):

1. a submodule-free clone of this head;
2. **standalone clones dropped at the two gitlink paths, submodules never initialised** (`git
   submodule status` prints `-`);
3. **a registered submodule moved off the pin** (`git -C protocol-processor checkout 44489453`;
   `git submodule status` prints `+`);
4. a registered submodule at the pin with a tracked file edited;
5. **an unmerged gitlink beside a file stage** -- round 2's first escape. Plant it with
   `git update-index --index-info` on a `160000` stage 2 and a `100644` stage 3; `git submodule
   status` prints `U000...`;
6. **a one-sided unmerged gitlink** -- round 2's second escape: `160000` stage 2 and nothing else;
7. an unmerged gitlink beside a **symlink** stage (`120000`);
8. the path tracked as an ordinary file at stage 0 (no gitlink at all);
9. the processor contents committed as ordinary files under the path;
10. a file, or a symlink, sitting at the gitlink path instead of a checkout;
11. **a tracked processor source edited under `git update-index --assume-unchanged`** -- round 3's
    first escape. `git status`, `git diff --name-only HEAD --` and `git ls-files` all report
    nothing; the gate refuses on the blob id;
12. **the same under `--skip-worktree`** -- round 3's second escape;
13. **a pinned source DELETED under either flag** (the sparse / skip-worktree boundary), and
    deleted with no flag at all;
14. **a pinned source replaced by a symlink whose target holds the pinned bytes**;
15. **a pinned source dropped from the checkout's index** (`git rm --cached`) with the bytes still
    on disk -- this must still PASS, because the population comes from the pin, not the index;
16. a pin that itself names a `.sv` committed as a symlink (`unpinnable`);
17. **a replacement ref installed at the pin** (`git replace`, or a raw `refs/replace/<pin>`)
    with HEAD held at the pin and the substituted bytes on disk -- round 4's escape; refused as
    `modified` in both `--check` and a default run.

Controls 11 to 14 and 17 must each exit **2**, print nothing on stdout, and leave
`scripts/xvlog.budget` byte-identical; control 15 must exit 0 with the full census.

And, for the positive direction: plant `assign a = b;` above `logic b;` in any analysed file and
the gate must name it in the right section; plant the same in
`third_party/verilog-axis/rtl/axis_fifo.v` and it must stay green.

## Known limitations / out of scope

- **#224 item 2, the elaboration arm, is DEFERRED, not solved.** `xvlog` analyses; the
  split-declaration-with-initialiser class is rejected only by `xelab` (`VRFC 10-9171`), and
  `grep -rn xelab` over this repository returns **nothing**. What ships instead is that the hole is
  stated where a lane doing declaration-order work reads it: the census prints it every run, the
  gate's docstring names the construct, and `CONTRIBUTING.md` section 3 tells that lane it has no
  gate and must check by hand. Proven, not asserted: a split initialiser planted in
  `hdl/common/csr/milan_csr.sv` leaves the gate GREEN. I recommend a follow-up Issue rather than
  holding this PR.
- **Two refusal arms have no real git fixture, and the self-test names them rather than passing
  silently.** One is an index record `git ls-files --stage -z` prints in a shape
  `_INDEX_RECORD_RE` cannot parse; the other is `unreadable`, which needs a repository whose
  object format git itself cannot read. Neither can be constructed with git, so both are claimed
  as defensive, not as tested; both fail closed, the direction that cannot produce a false green.
  The fixture-coverage guard in `_selftest_tree_state()` lists `unreadable` as its single named
  exclusion, so a state added later with no fixture fails the self-test.
- **`--selftest` still returns PASS on a hidden-modified tree, deliberately.** It makes no
  population claim and cannot: it must run in CI, where no submodule is checked out at all, so
  refusing there would turn a documented CI skip into a red. Its PASS line says only that a
  planted fault reddens the gate. The population claim belongs to `--check` and to a default run,
  and both now exit 2 before the census.
- **The byte proof is point-in-time, not a lock.** A file rewritten between the proof and the
  `xvlog` run that opens it is a race with a local writer, not a state the tree can be found in,
  and no gate that hands paths to a compiler can close it.
- **The repository's own `hdl/` population still comes from `git ls-files`, on purpose**: it is
  the tree under test, so its bytes on disk ARE the population and there is no revision they
  should equal. A tracked `hdl/` source missing from the working tree does not vanish silently
  either -- `xvlog` answers `ERROR: [XSIM 43-4316] Can not find file` and exits 1 (measured), so
  it lands as a new finding and reddens `--check`.
- **The donor findings are grandfathered, not fixed.** They are donor-side defects; the
  upstream ticket is `Mister-M-alt/protocol-processor-control-plane-avb-milan#22`.
- **The pinned processors carry 5 grandfathered findings at this head, not 3.** `dev`'s PR #227
  re-pinned `protocol-processor` `a25b5cc9 -> 3770ae02`, which adds two sources and two
  use-before-declaration occurrences (`pd_ix_w`, `cancel_hit_w`). They are donor-side defects, not
  this PR's, and the ratchet was re-banked in its own commit -- the deliberate re-bank the gate's
  docstring describes for a pin bump.
- **A staged pin bump is accepted.** "Expected" is the superproject's **index** gitlink, which is
  what `git submodule status` compares against and what the next commit will carry, so a bump that
  is staged together with the moved checkout agrees. A checkout moved on its own does not. That is
  the distinction #236 asks for; a stricter rule (compare against `HEAD`) would refuse the ordinary
  pin-bump commit as it is being made.
- **Files that are not in the pin are ignored**, whatever their state. The population is the
  pin's own tree, so an untracked stray is never analysed and never refused -- local gates litter
  a processor tree with generated `.hex`, and refusing on those would refuse on a lane that had
  just run one.
- **4 declared `tsn_fuzz` arms skipped in the local sweep** (`tsn-gen absent; set TSN_GEN_ROOT`).
  The sweep declares them and counts them as 0. The only `tsn-gen` checkout on this box is at
  `f52f1f9`, not the CI pin `fde65206`, and measuring at an unpinned revision silently changes the
  check count, so I did not substitute it -- the hosted `verilator-suites` context builds the pin
  and covers those arms. Everything else in the 52-suite sweep ran locally.
- **Not attempted: making `xvlog` report every occurrence in a module.** There is no such switch in
  2026.1; the one-per-module behaviour is documented rather than worked around.
- **The wall clocks above are contention-inflated, the results are not.** This round was measured
  in a disposable shared clone while another full sweep ran on the same box; every gate reported
  as run was run to completion at this head and its own output is quoted. Round 3's `/tmp`
  per-user-quota incident did not recur (248 GB free at measurement time; temp stayed under
  `/tmp`).
- The branch was cut from `origin/dev` by the lane recipe rather than with `gh issue develop`, so
  the `Closes #224` / `Closes #236` keywords above are what close the issues on merge.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied (#224: both items answered, item 2 deferred
      with reasons in three places; #236: decision recorded before the code, census matches the
      measurement AND names the revision it measured, every index shape that is not a resolved
      stage-0 gitlink and every checkout that is not the pinned one refuses before enumeration)
- [x] New or changed behavior has self-checking tests (the scope arms, an injected refusal arm
      for **every** state in the enumeration -- asserted exhaustively both ways -- the exit-code
      arm, a `main()`-level arm proving exit 2 with no census and a byte-identical budget in both
      modes, a `_blob_id` arm checked against `git hash-object` on both object formats, and a
      real-git-fixture classifier arm reaching every state but one named exclusion; five mutations
      caught with their exact RED lines in the evidence comment)
- [x] Required local verification bar passes, **including both long gates at this exact head**
      (see Status; both run unsharded to completion at `d18db056`)
- [x] Self-test evidence is posted in a PR comment (the `[A2]` comment at `d18db056`)
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive (rounds 1 to 4 NEGATIVE, all answered; all four
      blockers independently verified fixed by `[R2]` at `352f0c75`)
- [ ] External review is positive
- [x] Blocking and major findings are fixed and re-reviewed (all four blockers verified fixed by
      `[R2]`; `[R2]`'s MINOR and SUGGESTION answered at this head)
- [ ] No review round remains in flight
- [x] Candidate merge result is validated per [CONTRIBUTING.md](../CONTRIBUTING.md) (rebased onto
      `dev@a8b27a5f`; the merge base is that commit, the branch is 0 behind, and
      `git merge-tree --write-tree origin/dev HEAD` prints the head tree, so this head IS the
      candidate merge tree)
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done

