### PR TITLE
syn/ooc: milan_datapath_ooc.tcl generates and requires both control-plane ROMs before synthesis

### DIFF
--- a/scripts/pp_srcs.py
+++ b/scripts/pp_srcs.py
@@ -94,6 +94,11 @@ PROSE_OK = {
     "sw/litex/milan_soc.py": (
         {"protocol-processor/hdl/top/protocol_processor_top.sv"},
         "a comment citing a submodule line number, not a source entry"),
+    "syn/ooc/milan_datapath_ooc.tcl": (
+        {"$PP/aecp/ucpu_pkg.sv", "$PP/acmp/pp_acmp_pkg.sv"},
+        "ROM geometry DERIVED by reading the pinned packages at run time "
+        "(#246): read targets for a validation bound, not compile entries; "
+        "the compile list stays derived through syn/ooc/dp_srcs.py"),
     "tests/steps/aecp_engine_steps.py": (
         {"protocol-processor/hdl/aecp/KL_aecp_desc_store.sv",
          "protocol-processor/hdl/aecp/KL_aecp_engine.sv",

--- a/scripts/pp_srcs.py
+++ b/scripts/pp_srcs.py
@@ -94,11 +94,6 @@ PROSE_OK = {
     "sw/litex/milan_soc.py": (
         {"protocol-processor/hdl/top/protocol_processor_top.sv"},
         "a comment citing a submodule line number, not a source entry"),
-    "syn/ooc/milan_datapath_ooc.tcl": (
-        {"$PP/aecp/ucpu_pkg.sv", "$PP/acmp/pp_acmp_pkg.sv"},
-        "ROM geometry DERIVED by reading the pinned packages at run time "
-        "(#246): read targets for a validation bound, not compile entries; "
-        "the compile list stays derived through syn/ooc/dp_srcs.py"),
     "tests/steps/aecp_engine_steps.py": (
         {"protocol-processor/hdl/aecp/KL_aecp_desc_store.sv",
          "protocol-processor/hdl/aecp/KL_aecp_engine.sv",

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -118,12 +118,38 @@ proc rom_check {path digits words} {
   return ""
 }
 
+# A declared ROM width must be a positive multiple of 4, and a depth must be
+# positive. The image contract is EXACT hex digits per word; truncating a
+# 50-bit declaration to 50/4 = 12 digits would let a stale 48-bit image
+# satisfy it with the new high bits silently zero-filled, which is #246's
+# wrong-area class again ([R-parallel] round three probed exactly that:
+# declared_width=50 accepted the 2,048x48 image). No pinned ROM is
+# non-nibble-aligned; if one ever becomes so, THIS refusal is where ceiling
+# division plus a high-bits-zero check must be added - it is not a width to
+# guess past.
+proc nibble_width {name w} {
+  if {![string is integer -strict $w] || $w <= 0 || $w % 4 != 0} {
+    error "milan_datapath OOC: $name = $w is not a positive nibble-aligned\
+ ROM width. A truncated digit count would accept a stale undersized image;\
+ add ceiling division AND a high-bits-zero check here before accepting such\
+ a width."
+  }
+  return $w
+}
+proc positive_depth {name d} {
+  if {![string is integer -strict $d] || $d <= 0} {
+    error "milan_datapath OOC: $name = $d is not a positive ROM depth (an\
+ expected word count of zero would let an empty image validate)."
+  }
+  return $d
+}
+
 set UCPU_PKG [one_source $SRC_LINES ucpu_pkg.sv]
 set ACMP_PKG [one_source $SRC_LINES pp_acmp_pkg.sv]
-set UCODE_W [pkg_num $UCPU_PKG UCODE_W_C]
+set UCODE_W [nibble_width UCODE_W_C [pkg_num $UCPU_PKG UCODE_W_C]]
 set UPC_W   [pkg_num $UCPU_PKG UPC_W_C]
-set TROM_W  [pkg_num $ACMP_PKG TROM_W_C]
-set TROM_D  [pkg_num $ACMP_PKG TROM_DEPTH_C]
+set TROM_W  [nibble_width TROM_W_C [pkg_num $ACMP_PKG TROM_W_C]]
+set TROM_D  [positive_depth TROM_DEPTH_C [pkg_num $ACMP_PKG TROM_DEPTH_C]]
 
 foreach {img gen digits words} [list \
     ltn_rom.hex $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py \

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -28,7 +28,37 @@ set REPO [file normalize [file dirname [info script]]/../..]
 set TAG  [expr {[info exists ::env(TAG)] ? $::env(TAG) : "base"}]
 puts "milan_datapath OOC: tag=$TAG"
 
-# BOTH control-plane $readmemh images, generated into the run directory FIRST,
+# The source list is printed by syn/yosys/run.sh itself (`--emit`) and relayed
+# by dp_srcs.py -- the ONE list the portability gate proves elaborates. A copy
+# here would drift, and since the processor's files are part of that list now, a
+# copy would drift a whole control plane. Nothing is read outside it, and
+# nothing re-reads run.sh: dp_srcs.py checks the record run.sh hands it, and
+# resolves $TOP in it through `sv2v --top`, so sv2v is required to run this
+# script as well as the Yosys gate (README.md's tool table). It runs FIRST
+# because it is also the authority everything below derives from: the ROM
+# geometry packages are found IN this record, never spelled here by hand
+# ([R0] round three on PR #264 -- a spelled path is a hand list in waiting,
+# and the pp_srcs.py literal gate cannot see Tcl semantics).
+set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py]] "\n"]
+
+# Exactly one file in the derived record may carry the named basename; zero
+# means the record no longer contains the geometry source (refuse, do not
+# guess a path), and two means the name stopped being an identity.
+proc one_source {src_lines tail} {
+  set hits {}
+  foreach f $src_lines {
+    if {[string match "*/$tail" $f]} { lappend hits $f }
+  }
+  if {[llength $hits] != 1} {
+    error "milan_datapath OOC: expected exactly one $tail in the derived\
+ read set, found [llength $hits]. The geometry source comes from the record\
+ dp_srcs.py hands this recipe; a record without it is a refusal, not a\
+ license to spell a path by hand."
+  }
+  return [lindex $hits 0]
+}
+
+# BOTH control-plane $readmemh images, generated into the run directory
 # before anything slow. protocol_processor_top reads its ACMP listener
 # transition ROM by the RELATIVE name "ltn_rom.hex" and KL_aecp_ucpu its
 # microcode by "ucode.hex" (UCODE_HEX_P); Vivado resolves both against ITS OWN
@@ -39,25 +69,36 @@ puts "milan_datapath OOC: tag=$TAG"
 # completed rc=0 with a full, plausible utilization report 7,923 LUT under
 # the shipping design.
 #
-# The contract, per image ([R-parallel] on PR #264 closed the survivors):
+# The contract, per image ([R-parallel] and [R0] on PR #264 closed the
+# survivors):
 #   - the target is DELETED first, generation goes to a fresh temp file, and
 #     the image is published by rename only after it validates, so a stale
 #     file in the run directory plus a no-op generator can never be measured;
 #   - `exec` takes the generator's exit status (a failed generator aborts);
 #   - the image must hold EXACTLY its ROM's geometry, derived from the
-#     pinned packages (never copied here, where it would drift): after
-#     //-comment stripping, depth words of width/4 hex digits, x/z refused.
-#     $readmemh part-fills a short image with X and Vivado prices the X-ROM;
-#     a one-word "non-empty" image is the same lie as an absent one.
-set PP $REPO/protocol-processor/hdl
+#     pinned packages named by the record above (never copied here, where it
+#     would drift): after comment stripping, depth words of width/4 hex
+#     digits, x/z refused. $readmemh part-fills a short image with X and
+#     Vivado prices the X-ROM; a one-word "non-empty" image is the same lie
+#     as an absent one.
 
+# The ONE live declaration of the named localparam, comments stripped FIRST:
+# a `// stale example: UCODE_W_C = 48` above a live `= 52` must never win,
+# and the name is boundary-anchored so MY_UCODE_W_C is not UCODE_W_C ([R0]
+# round three). Zero live declarations, more than one, and any spelling this
+# does not recognize are refusals, never a guess.
 proc pkg_num {path name} {
   set fh [open $path r]; set text [read $fh]; close $fh
-  if {![regexp "$name\\s*=\\s*(\\d+)" $text -> v]} {
-    error "milan_datapath OOC: cannot derive $name from $path (geometry\
-source moved?)"
+  regsub -all {/\*.*?\*/} $text "" text
+  regsub -all -line {//.*$} $text "" text
+  set pat [format {(?n)^\s*(?:localparam|parameter)\y[^=;]*?\y%s\y\s*=\s*(\d+)\s*;} $name]
+  set hits [regexp -all -inline -- $pat $text]
+  if {[llength $hits] != 2} {
+    error "milan_datapath OOC: expected exactly one live declaration of\
+ $name in $path, found [expr {[llength $hits] / 2}] (comments stripped; a\
+ spelling this parser does not recognize is a refusal, not a guess)"
   }
-  return $v
+  return [lindex $hits 1]
 }
 
 proc rom_check {path digits words} {
@@ -77,10 +118,12 @@ proc rom_check {path digits words} {
   return ""
 }
 
-set UCODE_W [pkg_num $PP/aecp/ucpu_pkg.sv UCODE_W_C]
-set UPC_W   [pkg_num $PP/aecp/ucpu_pkg.sv UPC_W_C]
-set TROM_W  [pkg_num $PP/acmp/pp_acmp_pkg.sv TROM_W_C]
-set TROM_D  [pkg_num $PP/acmp/pp_acmp_pkg.sv TROM_DEPTH_C]
+set UCPU_PKG [one_source $SRC_LINES ucpu_pkg.sv]
+set ACMP_PKG [one_source $SRC_LINES pp_acmp_pkg.sv]
+set UCODE_W [pkg_num $UCPU_PKG UCODE_W_C]
+set UPC_W   [pkg_num $UCPU_PKG UPC_W_C]
+set TROM_W  [pkg_num $ACMP_PKG TROM_W_C]
+set TROM_D  [pkg_num $ACMP_PKG TROM_DEPTH_C]
 
 foreach {img gen digits words} [list \
     ltn_rom.hex $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py \
@@ -115,17 +158,12 @@ set UCODE_GENERIC "PP_UCODE_HEX_P=\"[file normalize ucode.hex]\""
 # wrong number -- the one failure of this instrument that still returns a
 # figure. Promote it to an ERROR so any image this preflight does not cover
 # (a future option-ON gptp_ucode.hex, a renamed image) fails the run outright
-# instead of shaping the report.
+# instead of shaping the report. What must hold at synth_design is the
+# EFFECTIVE severity: a later downgrade of the same id is the same defect as
+# never promoting, and the self-test asserts the final state, not this line's
+# spelling ([R0] round three).
 set_msg_config -id {Synth 8-4445} -new_severity ERROR
 
-# The source list is printed by syn/yosys/run.sh itself (`--emit`) and relayed
-# by dp_srcs.py -- the ONE list the portability gate proves elaborates. A copy
-# here would drift, and since the processor's files are part of that list now, a
-# copy would drift a whole control plane. Nothing is read outside it, and
-# nothing re-reads run.sh: dp_srcs.py checks the record run.sh hands it, and
-# resolves $TOP in it through `sv2v --top`, so sv2v is required to run this
-# script as well as the Yosys gate (README.md's tool table).
-set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py]] "\n"]
 set SV {}
 set V  {}
 foreach f $SRC_LINES {

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -28,6 +28,45 @@ set REPO [file normalize [file dirname [info script]]/../..]
 set TAG  [expr {[info exists ::env(TAG)] ? $::env(TAG) : "base"}]
 puts "milan_datapath OOC: tag=$TAG"
 
+# BOTH control-plane $readmemh images, generated into the run directory FIRST,
+# before anything slow. protocol_processor_top reads its ACMP listener
+# transition ROM by the RELATIVE name "ltn_rom.hex" and KL_aecp_ucpu its
+# microcode by "ucode.hex" (UCODE_HEX_P); Vivado resolves both against ITS OWN
+# run directory. This recipe is documented to run from an EMPTY directory, so
+# it must generate what it requires: until #246 it generated only
+# ltn_rom.hex, and Vivado read the absent ucode.hex as an all-zero ROM behind
+# one CRITICAL WARNING (Synth 8-4445), constant-folded the AECP uCPU, and
+# completed rc=0 with a full, plausible utilization report 7,923 LUT under
+# the shipping design. `exec` takes each generator's exit status (a failed
+# generator aborts the script); the check after it refuses an image a
+# generator left missing or empty, exactly pp_shadow_ooc.tcl's contract.
+foreach {img gen} [list \
+    ltn_rom.hex $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py \
+    ucode.hex   $REPO/protocol-processor/hdl/aecp/ucode/gen_ucode.py] {
+  exec python3 $gen -o $img
+  if {![file exists $img] || [file size $img] == 0} {
+    error "milan_datapath OOC: $img is missing or empty in [pwd] after its\
+generator ($gen) exited 0. Refusing to synthesize: an area report built on a\
+ROM Vivado could not open is not a measurement (#246)."
+  }
+}
+
+# The absolute paths reach synth_design as generics, so the figure cannot
+# depend on where vivado was launched from and cannot quietly measure an
+# all-zero ROM. UG901: a STRING generic's value must reach -generic wrapped
+# in literal double quotes, or Vivado takes it for an integer/bit-vector and
+# drops it.
+set TROM_GENERIC  "PP_TROM_HEX_P=\"[file normalize ltn_rom.hex]\""
+set UCODE_GENERIC "PP_UCODE_HEX_P=\"[file normalize ucode.hex]\""
+
+# And the refusal the tool itself already offers: a $readmem image Vivado
+# cannot open is CRITICAL WARNING Synth 8-4445 and a completed run with a
+# wrong number -- the one failure of this instrument that still returns a
+# figure. Promote it to an ERROR so any image this preflight does not cover
+# (a future option-ON gptp_ucode.hex, a renamed image) fails the run outright
+# instead of shaping the report.
+set_msg_config -id {Synth 8-4445} -new_severity ERROR
+
 # The source list is printed by syn/yosys/run.sh itself (`--emit`) and relayed
 # by dp_srcs.py -- the ONE list the portability gate proves elaborates. A copy
 # here would drift, and since the processor's files are part of that list now, a
@@ -45,17 +84,6 @@ puts "milan_datapath OOC: [llength $SV] SystemVerilog + [llength $V] Verilog sou
 read_verilog -sv $SV
 read_verilog $V
 
-# protocol_processor_top $readmemh's its ACMP listener transition ROM by the
-# RELATIVE name "ltn_rom.hex", which Vivado resolves against ITS OWN run
-# directory. Generate it into that directory and hand synth_design the absolute
-# path, so the utilization report cannot depend on where vivado was launched
-# from — and cannot quietly measure an all-zero ROM.
-set TROM [file normalize ltn_rom.hex]
-exec python3 $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py -o $TROM
-# UG901: a STRING generic's value must reach -generic wrapped in literal
-# double quotes, or Vivado takes it for an integer/bit-vector and drops it.
-set TROM_GENERIC "PP_TROM_HEX_P=\"$TROM\""
-
 set INCS [list $REPO/hdl/common $REPO/hdl/common/csr \
                $REPO/hdl/common/eth_event_counter $REPO/hdl/ieee17221/adp \
                $REPO/hdl/ieee8021q/ts $REPO/hdl/ieee8021as/ptp_timestamp \
@@ -63,7 +91,7 @@ set INCS [list $REPO/hdl/common $REPO/hdl/common/csr \
                $REPO/configs/generated/endstation_arty_current]
 
 synth_design -mode out_of_context -top milan_datapath -part xc7a100tfgg484-2 \
-  -include_dirs $INCS -generic $TROM_GENERIC
+  -include_dirs $INCS -generic $TROM_GENERIC -generic $UCODE_GENERIC
 
 create_clock -period 10.000 -name clk [get_ports -quiet axis_clk]
 report_utilization -hierarchical -file util_hier_$TAG.rpt

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -37,18 +37,69 @@ puts "milan_datapath OOC: tag=$TAG"
 # ltn_rom.hex, and Vivado read the absent ucode.hex as an all-zero ROM behind
 # one CRITICAL WARNING (Synth 8-4445), constant-folded the AECP uCPU, and
 # completed rc=0 with a full, plausible utilization report 7,923 LUT under
-# the shipping design. `exec` takes each generator's exit status (a failed
-# generator aborts the script); the check after it refuses an image a
-# generator left missing or empty, exactly pp_shadow_ooc.tcl's contract.
-foreach {img gen} [list \
-    ltn_rom.hex $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py \
-    ucode.hex   $REPO/protocol-processor/hdl/aecp/ucode/gen_ucode.py] {
-  exec python3 $gen -o $img
-  if {![file exists $img] || [file size $img] == 0} {
-    error "milan_datapath OOC: $img is missing or empty in [pwd] after its\
-generator ($gen) exited 0. Refusing to synthesize: an area report built on a\
-ROM Vivado could not open is not a measurement (#246)."
+# the shipping design.
+#
+# The contract, per image ([R-parallel] on PR #264 closed the survivors):
+#   - the target is DELETED first, generation goes to a fresh temp file, and
+#     the image is published by rename only after it validates, so a stale
+#     file in the run directory plus a no-op generator can never be measured;
+#   - `exec` takes the generator's exit status (a failed generator aborts);
+#   - the image must hold EXACTLY its ROM's geometry, derived from the
+#     pinned packages (never copied here, where it would drift): after
+#     //-comment stripping, depth words of width/4 hex digits, x/z refused.
+#     $readmemh part-fills a short image with X and Vivado prices the X-ROM;
+#     a one-word "non-empty" image is the same lie as an absent one.
+set PP $REPO/protocol-processor/hdl
+
+proc pkg_num {path name} {
+  set fh [open $path r]; set text [read $fh]; close $fh
+  if {![regexp "$name\\s*=\\s*(\\d+)" $text -> v]} {
+    error "milan_datapath OOC: cannot derive $name from $path (geometry\
+source moved?)"
   }
+  return $v
+}
+
+proc rom_check {path digits words} {
+  set fh [open $path r]; set lines [split [read $fh] "\n"]; close $fh
+  set n 0
+  foreach line $lines {
+    regsub {//.*$} $line "" line
+    foreach tok [split $line] {
+      if {$tok eq ""} continue
+      incr n
+      if {![regexp {^[0-9a-fA-F]+$} $tok] || [string length $tok] != $digits} {
+        return "word $n ($tok) is not exactly $digits hex digits"
+      }
+    }
+  }
+  if {$n != $words} { return "$n words, expected exactly $words" }
+  return ""
+}
+
+set UCODE_W [pkg_num $PP/aecp/ucpu_pkg.sv UCODE_W_C]
+set UPC_W   [pkg_num $PP/aecp/ucpu_pkg.sv UPC_W_C]
+set TROM_W  [pkg_num $PP/acmp/pp_acmp_pkg.sv TROM_W_C]
+set TROM_D  [pkg_num $PP/acmp/pp_acmp_pkg.sv TROM_DEPTH_C]
+
+foreach {img gen digits words} [list \
+    ltn_rom.hex $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py \
+                [expr {$TROM_W / 4}] $TROM_D \
+    ucode.hex   $REPO/protocol-processor/hdl/aecp/ucode/gen_ucode.py \
+                [expr {$UCODE_W / 4}] [expr {1 << $UPC_W}]] {
+  set tmp $img.gen.[pid]
+  file delete -force $img $tmp
+  exec python3 $gen -o $tmp
+  set diag "the generator exited 0 leaving no file"
+  if {[file exists $tmp]} { set diag [rom_check $tmp $digits $words] }
+  if {$diag ne ""} {
+    file delete -force $tmp
+    error "milan_datapath OOC: $img is malformed after generation by $gen:\
+$diag (expected ${words}x[expr {$digits * 4}]-bit). Refusing to synthesize:\
+an area report built on a ROM \$readmemh part-fills with X is not a\
+measurement (#246)."
+  }
+  file rename -force $tmp $img
 }
 
 # The absolute paths reach synth_design as generics, so the figure cannot

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -8,19 +8,27 @@ empty, and it takes the source generator's exit status. Both refusals had
 manual evidence and no test ([R0] on PR #240): deleting either one left every
 hosted check green, which is the definition of a defense that rots.
 
-milan_datapath_ooc.tcl (#246) GENERATES both images into its run directory
-and then applies the same missing-or-empty refusal; a ROM generator that
-fails, or one that exits 0 leaving an empty image, must abort the script
-before anything is read. Its arms below plant exactly those failures through
-a dispatching `python3` stub that hands every other invocation (dp_srcs.py,
-the other generator) to the real interpreter.
+milan_datapath_ooc.tcl (#246) GENERATES both images into fresh temp targets,
+validates their exact geometry against the pinned packages (word count and
+width, //-comments stripped, x/z refused), and publishes each by rename only
+after it validates, so a stale file plus a no-op generator, a one-token
+image, a truncated image and a malformed word are all refusals before
+anything is read ([R-parallel] on PR #264 closed those survivors). Its arms
+below plant exactly those failures through a dispatching `python3` stub that
+hands every other invocation (dp_srcs.py, the other generator) to the real
+interpreter.
 
 WHAT IT RUNS IS THE REAL .TCL, not a copy of its logic. `tclsh` sources the
-tracked file with the Vivado-only commands stubbed, and `read_verilog` -- the
-first command after the refusals -- prints a sentinel and exits 0. So an arm
-that expects a refusal fails if the sentinel appears, and the positive arm fails
-if it does not: removing the guard from the .tcl reddens this, and so does a
-guard that fires on a well-formed directory.
+tracked file with the Vivado-only commands stubbed. `read_verilog` RETURNS
+(it does not exit), so the run reaches `synth_design`, whose stub is where
+the sentinel prints -- after it has validated every `-generic *_HEX_P=...`
+it receives: the value must be quoted, absolute, and name an existing
+non-empty file, or the stub errors. `set_msg_config` is recorded and echoed
+at synth_design as an `OOC-MSGCFG:` line, so the arms can assert the exact
+`Synth 8-4445` promotion is (or, on a mutant, is not) in force. Mutation
+copies of the datapath recipe itself (promotion deleted, the ucode generic
+deleted, the ucode generic redirected at a missing image) prove each of
+those assertions can fail.
 
 `tclsh` is the interpreter Vivado embeds, so the guard is exercised by the
 language it is written in rather than reimplemented in Python.
@@ -29,10 +37,11 @@ language it is written in rather than reimplemented in Python.
 
 Runs in .github/workflows/rtl-fast.yml beside syn/ooc/dp_srcs.py --selftest.
 Needs the protocol-processor and verilog-axis submodules, because both .tcl
-files derive their read set (and the datapath one generates its ROMs) on the
-way to their refusals.
+files derive their read set (and the datapath one generates and validates
+its ROMs) on the way to their refusals.
 """
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -43,26 +52,52 @@ REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
 TCL = os.path.join(HERE, "pp_shadow_ooc.tcl")
 DP_TCL = os.path.join(HERE, "milan_datapath_ooc.tcl")
 SENTINEL = "OOC-GUARD-PASSED"
+PROMOTION = "-id {Synth 8-4445} -new_severity ERROR"
 REAL_PYTHON = shutil.which("python3") or sys.executable
+GEN_UCODE = os.path.join(REPO, "protocol-processor", "hdl", "aecp", "ucode",
+                         "gen_ucode.py")
+GEN_LTN = os.path.join(REPO, "protocol-processor", "hdl", "acmp", "rom",
+                       "gen_ltn_rom.py")
 
-#: The Vivado commands the .tcl recipes call after their refusals.
-#: `read_verilog` is the first of them, so reaching it means every refusal let
-#: the run through.
+#: The Vivado commands the .tcl recipes call. `read_verilog` returns, so the
+#: script reaches `synth_design`; the sentinel prints THERE, after the stub
+#: has validated every `-generic *_HEX_P` it received (quoted, absolute,
+#: existing, non-empty) and echoed the recorded `set_msg_config` calls. An
+#: arm that expects a refusal fails if the sentinel appears, and the
+#: positive arms assert the generic and promotion lines it prints.
 STUBS = """
-proc read_verilog args { puts "%s"; exit 0 }
-proc synth_design args {}
+set ::ooc_msgcfg {}
+proc read_verilog args {}
+proc synth_design args {
+  for {set i 0} {$i < [llength $args]} {incr i} {
+    if {[lindex $args $i] eq "-generic"} {
+      set g [lindex $args [expr {$i + 1}]]
+      if {[regexp {^(PP_[A-Z_]+_HEX_P)="(.*)"$} $g -> name val]} {
+        if {[file pathtype $val] ne "absolute"} {
+          error "SYNTH-GENERIC-NOT-ABSOLUTE: $g"
+        }
+        if {![file exists $val] || [file size $val] == 0} {
+          error "SYNTH-GENERIC-IMAGE-MISSING: $g"
+        }
+        puts "OOC-GENERIC-OK: $name"
+      }
+    }
+  }
+  puts "OOC-MSGCFG: $::ooc_msgcfg"
+  puts "%s"
+}
 proc create_clock args {}
 proc get_ports args { return {} }
 proc report_utilization args {}
 proc report_timing_summary args {}
-proc set_msg_config args {}
+proc set_msg_config args { lappend ::ooc_msgcfg $args }
 source {%s}
 """
 
-#: python3 dispatcher for the milan_datapath arms: sabotage the one script the
-#: arm plants a failure in, hand everything else (dp_srcs.py, the other
-#: generator) to the real interpreter, so the generation path the positive arm
-#: proves is the shipping one.
+#: python3 dispatcher for the milan_datapath arms: sabotage the one script
+#: the arm plants a failure in, hand everything else (dp_srcs.py, the other
+#: generator) to the real interpreter, so the generation path the positive
+#: arm proves is the shipping one. `$out` holds the -o target.
 PY_DISPATCH = """#!/bin/sh
 out=""
 prev=""
@@ -79,7 +114,7 @@ exec %(real)s "$@"
 """
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 9
+ARMS = 18
 
 
 def _run(workdir, env=None, tcl=TCL):
@@ -110,9 +145,20 @@ def _py_sabotage(target, action):
     return stub
 
 
-def _write(workdir, name, content):
-    with open(os.path.join(workdir, name), "w") as fh:
-        fh.write(content)
+def _mutant(pattern, replacement, label):
+    """A copy of the real datapath recipe, in this directory (it derives the
+    repo root from its own location), with one substitution applied. The
+    pattern MUST hit: a mutation that no longer matches is testing nothing."""
+    with open(DP_TCL) as fh:
+        text = fh.read()
+    mutated, n = re.subn(pattern, replacement, text)
+    if n != 1:
+        raise AssertionError("mutation %r: pattern hit %d times, expected 1 "
+                             "(the recipe moved?)" % (label, n))
+    fd, path = tempfile.mkstemp(suffix=".tcl", prefix=".ooc-mut-", dir=HERE)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(mutated)
+    return path
 
 
 def selftest():
@@ -148,10 +194,14 @@ def selftest():
                                 % (name, want, rc, reached, log.strip()))
                 return
             if check:
-                miss = check(d)
+                miss = check(d, log)
                 if miss:
                     problems.append("SELF-TEST FAILED [%s]: %s\n%s"
                                     % (name, miss, log.strip()))
+
+    def _write(workdir, name, content):
+        with open(os.path.join(workdir, name), "w") as fh:
+            fh.write(content)
 
     def images(*names):
         def setup(d):
@@ -162,12 +212,12 @@ def selftest():
                     os.rename(os.path.join(d, n), os.path.join(d, n[:-1]))
         return setup
 
+    # ---- pp_shadow_ooc.tcl: requires, does not generate ------------------
+
     # Arm 1. Neither image. The first one named is the one reported.
     arm("no-images", "ltn_rom.hex is missing or empty", False)
 
-    # Arm 2. The image the finding document used to name on its own. The AECP
-    # microcode ROM is the one it did not, and its absence is a CRITICAL
-    # WARNING ending in "ignoring" plus a utilization number 17 % low.
+    # Arm 2. The image the finding document used to name on its own.
     arm("ucode-missing", "ucode.hex is missing or empty", False,
         images("ltn_rom.hex"))
 
@@ -180,9 +230,8 @@ def selftest():
     # synthesis. Without this arm a guard that always fires passes arms 1-3.
     arm("both-images-present", None, True, images("ltn_rom.hex", "ucode.hex"))
 
-    # Arm 5. The .tcl must take the generator's exit status. A consumer that
-    # discards it synthesizes whatever a broken generator printed, and an empty
-    # source list builds cleanly while proving nothing (CONTRIBUTING.md 3).
+    # Arm 5. The .tcl must take the generator's exit status (dp_srcs.py here:
+    # the read-set generator is the first exec this recipe runs).
     stub = tempfile.mkdtemp(prefix="dp-srcs-fails-")
     with open(os.path.join(stub, "python3"), "w") as fh:
         fh.write("#!/bin/sh\necho 'dp_srcs: planted generator failure' >&2\n"
@@ -193,53 +242,137 @@ def selftest():
         env={"PATH": stub + os.pathsep + os.environ.get("PATH", "")})
     shutil.rmtree(stub, ignore_errors=True)
 
-    # ---- milan_datapath_ooc.tcl (#246). It GENERATES both images, so its
-    # arms plant failures in the generators themselves, not in the directory.
+    # ---- milan_datapath_ooc.tcl: generates, validates, publishes ---------
 
     def dp_env(target, action):
         stub = _py_sabotage(target, action)
         return stub, {"PATH": stub + os.pathsep + os.environ.get("PATH", "")}
 
-    # Arm 6. A dead microcode generator aborts the script: its exit status is
-    # taken by `exec`, never discarded. Before #246 nothing ran the generator
-    # at all and Vivado priced an all-zero ROM at rc=0.
-    stub, env = dp_env("gen_ucode.py",
-                       "echo 'planted ucode generator failure' >&2\n  exit 3")
-    arm("dp-ucode-generator-fail", "planted ucode generator failure", False,
-        env=env, tcl=DP_TCL)
-    shutil.rmtree(stub, ignore_errors=True)
+    def dp_arm(name, want, target, action, expect_rc0=False, setup=None,
+               check=None):
+        stub, env = dp_env(target, action)
+        try:
+            arm(name, want, expect_rc0, setup=setup, env=env, tcl=DP_TCL,
+                check=check)
+        finally:
+            shutil.rmtree(stub, ignore_errors=True)
 
-    # Arm 7. A generator that exits 0 leaving an empty image is the same
-    # refusal: `file exists` alone would pass it, and Vivado reads an empty
-    # image exactly as it reads an absent one.
-    stub, env = dp_env("gen_ucode.py", ": > \"$out\"\n  exit 0")
-    arm("dp-ucode-empty", "ucode.hex is missing or empty", False,
-        env=env, tcl=DP_TCL)
-    shutil.rmtree(stub, ignore_errors=True)
+    # Arm 6. A dead microcode generator aborts the script: its exit status
+    # is taken by `exec`, never discarded.
+    dp_arm("dp-ucode-generator-fail", "planted ucode generator failure",
+           "gen_ucode.py",
+           "echo 'planted ucode generator failure' >&2\n  exit 3")
 
-    # Arm 8. The transition-ROM generator gets the identical treatment.
-    stub, env = dp_env("gen_ltn_rom.py",
-                       "echo 'planted ltn generator failure' >&2\n  exit 3")
-    arm("dp-ltn-generator-fail", "planted ltn generator failure", False,
-        env=env, tcl=DP_TCL)
-    shutil.rmtree(stub, ignore_errors=True)
+    # Arm 7. A generator that exits 0 leaving an empty image: zero words is
+    # not the ROM's geometry.
+    dp_arm("dp-ucode-empty", "0 words, expected exactly 2048",
+           "gen_ucode.py", ": > \"$out\"\n  exit 0")
 
-    # Arm 9. ANTI-VACUITY. From an EMPTY directory the real generators run,
-    # both images land in the run directory non-empty, and the script reaches
-    # synthesis. Without this arm a preflight that always refuses passes
-    # arms 6-8.
-    def dp_images_present(d):
+    # Arm 8. ONE syntactically valid word ([R-parallel]'s exact plant): it
+    # is non-empty, and $readmemh would load it and leave 2,047 words X.
+    dp_arm("dp-ucode-one-word", "1 words, expected exactly 2048",
+           "gen_ucode.py", "printf '000000000000\\n' > \"$out\"\n  exit 0")
+
+    # Arm 9. Truncated: right words, too few of them.
+    dp_arm("dp-ucode-truncated", "1000 words, expected exactly 2048",
+           "gen_ucode.py",
+           "%s %s -o \"$out.full\" > /dev/null && "
+           "head -1000 \"$out.full\" > \"$out\" && rm -f \"$out.full\"\n"
+           "  exit 0" % (REAL_PYTHON, GEN_UCODE))
+
+    # Arm 10. Malformed word: full depth, one word the wrong shape. `Z` is
+    # $readmemh-legal and loads as Z, which is exactly why it is refused.
+    dp_arm("dp-ucode-malformed", "not exactly 12 hex digits",
+           "gen_ucode.py",
+           "%s %s -o \"$out\" > /dev/null && "
+           "sed -i '5s/.*/00000000000Z/' \"$out\"\n  exit 0"
+           % (REAL_PYTHON, GEN_UCODE))
+
+    # Arm 11. STALE image + no-op generator ([R-parallel]'s exact plant):
+    # the pre-created file must not survive to be measured; the no-op leaves
+    # no temp file, which is the refusal, and the stale image is deleted.
+    def stale_gone(d, log):
+        if os.path.exists(os.path.join(d, "ucode.hex")):
+            return "the stale ucode.hex survived the refusal"
+        return None
+    dp_arm("dp-ucode-stale-noop", "leaving no file", "gen_ucode.py",
+           "exit 0", setup=lambda d: _write(d, "ucode.hex", "STALE\n"),
+           check=stale_gone)
+
+    # Arm 12. The transition ROM gets the identical geometry contract.
+    dp_arm("dp-ltn-one-word", "1 words, expected exactly 128",
+           "gen_ltn_rom.py", "printf '00000000\\n' > \"$out\"\n  exit 0")
+
+    # Arm 13. ...and the identical width contract.
+    dp_arm("dp-ltn-malformed", "not exactly 8 hex digits", "gen_ltn_rom.py",
+           "%s %s -o \"$out\" > /dev/null && sed -i '2s/.*/123/' \"$out\"\n"
+           "  exit 0" % (REAL_PYTHON, GEN_LTN))
+
+    # Arm 14. ...and its generator's exit status.
+    dp_arm("dp-ltn-generator-fail", "planted ltn generator failure",
+           "gen_ltn_rom.py",
+           "echo 'planted ltn generator failure' >&2\n  exit 3")
+
+    # Arm 15. ANTI-VACUITY. From an EMPTY directory the real generators run,
+    # both images land in the run directory validated and non-empty, the run
+    # reaches synth_design with BOTH absolute ROM generics validated by the
+    # stub, and the exact Synth 8-4445 promotion is in force.
+    def dp_positive(d, log):
         for img in ("ltn_rom.hex", "ucode.hex"):
             p = os.path.join(d, img)
             if not os.path.isfile(p) or os.path.getsize(p) == 0:
                 return "%s was not generated into the run directory" % img
+        for name in ("PP_TROM_HEX_P", "PP_UCODE_HEX_P"):
+            if ("OOC-GENERIC-OK: %s" % name) not in log:
+                return "synth_design did not receive a valid %s generic" % name
+        if PROMOTION not in log:
+            return "the Synth 8-4445 promotion is not in force at synth_design"
         return None
     arm("dp-empty-dir-generates-and-passes", None, True, tcl=DP_TCL,
-        check=dp_images_present)
+        check=dp_positive)
+
+    # Arm 16. MUTATION: the promotion deleted from a copy of the recipe. The
+    # detector must distinguish, or arm 15's promotion assertion is vacuous.
+    mut = _mutant(r"set_msg_config -id \{Synth 8-4445\} -new_severity ERROR\n",
+                  "", "promotion-deleted")
+    try:
+        def promo_gone(d, log):
+            if PROMOTION in log:
+                return "the mutant still shows the promotion: the detector " \
+                       "cannot distinguish"
+            return None
+        arm("dp-mut-promotion-deleted", None, True, tcl=mut, check=promo_gone)
+    finally:
+        os.unlink(mut)
+
+    # Arm 17. MUTATION: the ucode generic deleted from synth_design's call.
+    mut = _mutant(r" -generic \$UCODE_GENERIC", "", "ucode-generic-deleted")
+    try:
+        def generic_gone(d, log):
+            if "OOC-GENERIC-OK: PP_UCODE_HEX_P" in log:
+                return "the mutant still shows the ucode generic: the " \
+                       "detector cannot distinguish"
+            return None
+        arm("dp-mut-ucode-generic-deleted", None, True, tcl=mut,
+            check=generic_gone)
+    finally:
+        os.unlink(mut)
+
+    # Arm 18. MUTATION: the ucode generic redirected at a missing image
+    # ([R-parallel]'s exact plant). The synth_design stub itself refuses.
+    mut = _mutant(r'set UCODE_GENERIC "PP_UCODE_HEX_P=\\"\[file normalize '
+                  r'ucode\.hex\]\\""',
+                  'set UCODE_GENERIC "PP_UCODE_HEX_P=\\"[file normalize '
+                  'missing-ucode.hex]\\""', "ucode-generic-redirected")
+    try:
+        arm("dp-mut-ucode-generic-redirected", "SYNTH-GENERIC-IMAGE-MISSING",
+            False, tcl=mut)
+    finally:
+        os.unlink(mut)
 
     if ran != ARMS:
-        problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this file "
-                        "declares %d." % (ran, ARMS))
+        problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this "
+                        "file declares %d." % (ran, ARMS))
     return problems, ran
 
 

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -8,37 +8,48 @@ empty, and it takes the source generator's exit status. Both refusals had
 manual evidence and no test ([R0] on PR #240): deleting either one left every
 hosted check green, which is the definition of a defense that rots.
 
-milan_datapath_ooc.tcl (#246) GENERATES both images into fresh temp targets,
-validates their exact geometry against the pinned packages (word count and
-width, //-comments stripped, x/z refused), and publishes each by rename only
-after it validates, so a stale file plus a no-op generator, a one-token
-image, a truncated image and a malformed word are all refusals before
-anything is read ([R-parallel] on PR #264 closed those survivors). Its arms
-below plant exactly those failures through a dispatching `python3` stub that
-hands every other invocation (dp_srcs.py, the other generator) to the real
-interpreter.
+milan_datapath_ooc.tcl (#246) derives its read set from dp_srcs.py, finds its
+geometry packages IN that record, reads each geometry number from the ONE
+live declaration (comments stripped, name boundary-anchored), GENERATES both
+images into fresh temp targets, validates their exact geometry, and publishes
+by rename only after validation. Stale+no-op, one-token, truncated and
+malformed images, commented-out or duplicated declarations, and a record
+without the packages are all refusals before anything is read ([R-parallel]
+and [R0] on PR #264 closed those survivors, round by round).
 
 WHAT IT RUNS IS THE REAL .TCL, not a copy of its logic. `tclsh` sources the
 tracked file with the Vivado-only commands stubbed. `read_verilog` RETURNS
-(it does not exit), so the run reaches `synth_design`, whose stub is where
-the sentinel prints -- after it has validated every `-generic *_HEX_P=...`
-it receives: the value must be quoted, absolute, and name an existing
-non-empty file, or the stub errors. `set_msg_config` is recorded and echoed
-at synth_design as an `OOC-MSGCFG:` line, so the arms can assert the exact
-`Synth 8-4445` promotion is (or, on a mutant, is not) in force. Mutation
-copies of the datapath recipe itself (promotion deleted, the ucode generic
-deleted, the ucode generic redirected at a missing image) prove each of
-those assertions can fail.
+(it does not exit) and RECORDS every file it is handed; the sentinel prints
+at `synth_design`, whose stub is the observation point for the synthesis
+safeguards:
+
+  - every `-generic *_HEX_P=...` it receives must be quoted, absolute, an
+    existing non-empty file, carry the CANONICAL basename for its parameter
+    (PP_UCODE_HEX_P -> ucode.hex, PP_TROM_HEX_P -> ltn_rom.hex), and hold
+    that ROM's geometry, or the stub errors -- an existing-but-wrong file
+    opens cleanly, so Synth 8-4445 never protects that case;
+  - `set_msg_config` is MODELLED, not transcribed: the stub keeps the final
+    severity per message id, and the positive arm requires the EFFECTIVE
+    severity of Synth 8-4445 at synth_design to be ERROR -- a downgrade
+    applied after the promotion is the same defect as never promoting;
+  - the recorded read set is written out and the positive arm requires it to
+    EQUAL what dp_srcs.py derives, so a hand-written list cannot stand in
+    for the record while the suite stays green.
+
+Mutation copies of the recipe prove every one of those detectors can fail.
 
 `tclsh` is the interpreter Vivado embeds, so the guard is exercised by the
-language it is written in rather than reimplemented in Python.
+language it is written in rather than reimplemented in Python. What tclsh
+cannot prove is Vivado's own semantics; the real-Vivado negative control for
+the promotion (a missing image at synthesis with the preflight removed must
+abort, not warn) is recorded on the PR that lands a change.
 
     python3 syn/ooc/ooc_tcl_selftest.py
 
 Runs in .github/workflows/rtl-fast.yml beside syn/ooc/dp_srcs.py --selftest.
-Needs the protocol-processor and verilog-axis submodules, because both .tcl
-files derive their read set (and the datapath one generates and validates
-its ROMs) on the way to their refusals.
+Needs the protocol-processor and verilog-axis submodules and sv2v, because
+the datapath recipe derives its read set before anything else, so every arm
+pays one dp_srcs.py run (~5 minutes total).
 """
 import os
 import re
@@ -52,45 +63,84 @@ REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
 TCL = os.path.join(HERE, "pp_shadow_ooc.tcl")
 DP_TCL = os.path.join(HERE, "milan_datapath_ooc.tcl")
 SENTINEL = "OOC-GUARD-PASSED"
-PROMOTION = "-id {Synth 8-4445} -new_severity ERROR"
+EFFECTIVE_OK = "OOC-EFFECTIVE-SEV: {Synth 8-4445} = ERROR"
+READ_LIST = "ooc-read-list.txt"
 REAL_PYTHON = shutil.which("python3") or sys.executable
 GEN_UCODE = os.path.join(REPO, "protocol-processor", "hdl", "aecp", "ucode",
                          "gen_ucode.py")
 GEN_LTN = os.path.join(REPO, "protocol-processor", "hdl", "acmp", "rom",
                        "gen_ltn_rom.py")
 
-#: The Vivado commands the .tcl recipes call. `read_verilog` returns, so the
-#: script reaches `synth_design`; the sentinel prints THERE, after the stub
-#: has validated every `-generic *_HEX_P` it received (quoted, absolute,
-#: existing, non-empty) and echoed the recorded `set_msg_config` calls. An
-#: arm that expects a refusal fails if the sentinel appears, and the
-#: positive arms assert the generic and promotion lines it prints.
+#: The Vivado commands the .tcl recipes call, stubbed as the docstring
+#: describes. The canonical-image map in synth_design is TEST knowledge: the
+#: recipe under test must arrive at the same binding on its own.
 STUBS = """
-set ::ooc_msgcfg {}
-proc read_verilog args {}
-proc synth_design args {
+set ::ooc_read {}
+set ::ooc_sev [dict create]
+proc read_verilog args {
+  foreach a $args {
+    if {$a eq "-sv"} continue
+    foreach f $a { lappend ::ooc_read $f }
+  }
+}
+proc set_msg_config args {
+  set id ""; set sev ""
   for {set i 0} {$i < [llength $args]} {incr i} {
-    if {[lindex $args $i] eq "-generic"} {
-      set g [lindex $args [expr {$i + 1}]]
-      if {[regexp {^(PP_[A-Z_]+_HEX_P)="(.*)"$} $g -> name val]} {
-        if {[file pathtype $val] ne "absolute"} {
-          error "SYNTH-GENERIC-NOT-ABSOLUTE: $g"
-        }
-        if {![file exists $val] || [file size $val] == 0} {
-          error "SYNTH-GENERIC-IMAGE-MISSING: $g"
-        }
-        puts "OOC-GENERIC-OK: $name"
-      }
+    switch -- [lindex $args $i] {
+      -id           { set id  [lindex $args [incr i]] }
+      -new_severity { set sev [lindex $args [incr i]] }
     }
   }
-  puts "OOC-MSGCFG: $::ooc_msgcfg"
+  if {$id ne "" && $sev ne ""} { dict set ::ooc_sev $id $sev }
+}
+proc synth_design args {
+  set expect [dict create PP_TROM_HEX_P {ltn_rom.hex 8 128} \\
+                          PP_UCODE_HEX_P {ucode.hex 12 2048}]
+  for {set i 0} {$i < [llength $args]} {incr i} {
+    if {[lindex $args $i] ne "-generic"} continue
+    set g [lindex $args [expr {$i + 1}]]
+    if {![regexp {^(PP_[A-Z_]+_HEX_P)="(.*)"$} $g -> name val]} continue
+    if {[file pathtype $val] ne "absolute"} {
+      error "SYNTH-GENERIC-NOT-ABSOLUTE: $g"
+    }
+    if {![file exists $val] || [file size $val] == 0} {
+      error "SYNTH-GENERIC-IMAGE-MISSING: $g"
+    }
+    if {[dict exists $expect $name]} {
+      lassign [dict get $expect $name] tail digits words
+      if {[file tail $val] ne $tail} {
+        error "SYNTH-GENERIC-WRONG-IMAGE: $name -> [file tail $val] (canonical $tail)"
+      }
+      set fh [open $val r]; set text [read $fh]; close $fh
+      set n 0
+      foreach line [split $text "\\n"] {
+        regsub {//.*$} $line "" line
+        foreach tok [split $line] {
+          if {$tok eq ""} continue
+          incr n
+          if {![regexp {^[0-9a-fA-F]+$} $tok] || [string length $tok] != $digits} {
+            error "SYNTH-GENERIC-BAD-GEOMETRY: $name word $n at [file tail $val]"
+          }
+        }
+      }
+      if {$n != $words} {
+        error "SYNTH-GENERIC-BAD-GEOMETRY: $name $n words at [file tail $val], want $words"
+      }
+    }
+    puts "OOC-GENERIC-OK: $name"
+  }
+  foreach id [dict keys $::ooc_sev] {
+    puts "OOC-EFFECTIVE-SEV: [list $id] = [dict get $::ooc_sev $id]"
+  }
+  set fh [open %s w]
+  foreach f $::ooc_read { puts $fh $f }
+  close $fh
   puts "%s"
 }
 proc create_clock args {}
 proc get_ports args { return {} }
 proc report_utilization args {}
 proc report_timing_summary args {}
-proc set_msg_config args { lappend ::ooc_msgcfg $args }
 source {%s}
 """
 
@@ -114,7 +164,20 @@ exec %(real)s "$@"
 """
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 18
+ARMS = 27
+
+_DERIVED = None
+
+
+def derived_sources():
+    """dp_srcs.py's own answer, cached: the record the recipe must consume."""
+    global _DERIVED
+    if _DERIVED is None:
+        out = subprocess.run(
+            [REAL_PYTHON, os.path.join(HERE, "dp_srcs.py")],
+            capture_output=True, text=True, check=True)
+        _DERIVED = sorted(l for l in out.stdout.splitlines() if l.strip())
+    return _DERIVED
 
 
 def _run(workdir, env=None, tcl=TCL):
@@ -126,7 +189,7 @@ def _run(workdir, env=None, tcl=TCL):
     fd, driver = tempfile.mkstemp(suffix=".tcl", prefix="ooc-driver-")
     try:
         with os.fdopen(fd, "w") as fh:
-            fh.write(STUBS % (SENTINEL, tcl))
+            fh.write(STUBS % (READ_LIST, SENTINEL, tcl))
         out = subprocess.run(["tclsh", driver], cwd=workdir, env=e,
                              capture_output=True, text=True)
     finally:
@@ -242,7 +305,7 @@ def selftest():
         env={"PATH": stub + os.pathsep + os.environ.get("PATH", "")})
     shutil.rmtree(stub, ignore_errors=True)
 
-    # ---- milan_datapath_ooc.tcl: generates, validates, publishes ---------
+    # ---- milan_datapath_ooc.tcl: derives, generates, validates -----------
 
     def dp_env(target, action):
         stub = _py_sabotage(target, action)
@@ -313,10 +376,12 @@ def selftest():
            "gen_ltn_rom.py",
            "echo 'planted ltn generator failure' >&2\n  exit 3")
 
-    # Arm 15. ANTI-VACUITY. From an EMPTY directory the real generators run,
-    # both images land in the run directory validated and non-empty, the run
-    # reaches synth_design with BOTH absolute ROM generics validated by the
-    # stub, and the exact Synth 8-4445 promotion is in force.
+    # Arm 15. ANTI-VACUITY, and the observation point for every synthesis
+    # safeguard: from an EMPTY directory the real generators run, both
+    # validated images land in the run directory, synth_design receives BOTH
+    # canonical absolute ROM generics (the stub has rechecked basename and
+    # geometry), the EFFECTIVE severity of Synth 8-4445 there is ERROR, and
+    # the read set the stubs recorded EQUALS what dp_srcs.py derives.
     def dp_positive(d, log):
         for img in ("ltn_rom.hex", "ucode.hex"):
             p = os.path.join(d, img)
@@ -325,41 +390,63 @@ def selftest():
         for name in ("PP_TROM_HEX_P", "PP_UCODE_HEX_P"):
             if ("OOC-GENERIC-OK: %s" % name) not in log:
                 return "synth_design did not receive a valid %s generic" % name
-        if PROMOTION not in log:
-            return "the Synth 8-4445 promotion is not in force at synth_design"
+        if EFFECTIVE_OK not in log:
+            return ("the EFFECTIVE severity of Synth 8-4445 at synth_design "
+                    "is not ERROR")
+        rl = os.path.join(d, READ_LIST)
+        if not os.path.isfile(rl):
+            return "the stubs recorded no read set"
+        got = sorted(l.strip() for l in open(rl) if l.strip())
+        if got != derived_sources():
+            return ("the read set (%d files) is not the dp_srcs.py record "
+                    "(%d files): the derived-source connection is broken"
+                    % (len(got), len(derived_sources())))
         return None
     arm("dp-empty-dir-generates-and-passes", None, True, tcl=DP_TCL,
         check=dp_positive)
 
-    # Arm 16. MUTATION: the promotion deleted from a copy of the recipe. The
-    # detector must distinguish, or arm 15's promotion assertion is vacuous.
+    # Arm 16. MUTATION: the promotion deleted. The detector must distinguish,
+    # or arm 15's effective-severity assertion is vacuous.
     mut = _mutant(r"set_msg_config -id \{Synth 8-4445\} -new_severity ERROR\n",
                   "", "promotion-deleted")
     try:
-        def promo_gone(d, log):
-            if PROMOTION in log:
-                return "the mutant still shows the promotion: the detector " \
-                       "cannot distinguish"
-            return None
-        arm("dp-mut-promotion-deleted", None, True, tcl=mut, check=promo_gone)
+        arm("dp-mut-promotion-deleted", None, True, tcl=mut,
+            check=lambda d, log: None if EFFECTIVE_OK not in log
+            else "the mutant still shows an ERROR effective severity")
     finally:
         os.unlink(mut)
 
-    # Arm 17. MUTATION: the ucode generic deleted from synth_design's call.
+    # Arm 17. MUTATION: the promotion followed by a DOWNGRADE of the same id
+    # ([R0]'s exact plant). Historical text still contains the ERROR
+    # spelling; only the effective-severity model can tell them apart.
+    mut = _mutant(r"(set_msg_config -id \{Synth 8-4445\} -new_severity ERROR\n)",
+                  "\\1set_msg_config -id {Synth 8-4445} -new_severity "
+                  "{CRITICAL WARNING}\n", "promotion-downgraded-after")
+    try:
+        def downgraded(d, log):
+            if EFFECTIVE_OK in log:
+                return "the downgrade-after-promotion mutant still reads as " \
+                       "an ERROR effective severity"
+            if "OOC-EFFECTIVE-SEV: {Synth 8-4445} = CRITICAL WARNING" not in log:
+                return "the effective-severity model did not record the " \
+                       "downgrade"
+            return None
+        arm("dp-mut-promotion-downgraded-after", None, True, tcl=mut,
+            check=downgraded)
+    finally:
+        os.unlink(mut)
+
+    # Arm 18. MUTATION: the ucode generic deleted from synth_design's call.
     mut = _mutant(r" -generic \$UCODE_GENERIC", "", "ucode-generic-deleted")
     try:
-        def generic_gone(d, log):
-            if "OOC-GENERIC-OK: PP_UCODE_HEX_P" in log:
-                return "the mutant still shows the ucode generic: the " \
-                       "detector cannot distinguish"
-            return None
         arm("dp-mut-ucode-generic-deleted", None, True, tcl=mut,
-            check=generic_gone)
+            check=lambda d, log: None
+            if "OOC-GENERIC-OK: PP_UCODE_HEX_P" not in log
+            else "the mutant still shows the ucode generic")
     finally:
         os.unlink(mut)
 
-    # Arm 18. MUTATION: the ucode generic redirected at a missing image
-    # ([R-parallel]'s exact plant). The synth_design stub itself refuses.
+    # Arm 19. MUTATION: the ucode generic redirected at a MISSING image.
     mut = _mutant(r'set UCODE_GENERIC "PP_UCODE_HEX_P=\\"\[file normalize '
                   r'ucode\.hex\]\\""',
                   'set UCODE_GENERIC "PP_UCODE_HEX_P=\\"[file normalize '
@@ -367,6 +454,137 @@ def selftest():
     try:
         arm("dp-mut-ucode-generic-redirected", "SYNTH-GENERIC-IMAGE-MISSING",
             False, tcl=mut)
+    finally:
+        os.unlink(mut)
+
+    # Arm 20. MUTATION: the ucode generic CROSS-WIRED at the OTHER image
+    # ([R0]'s exact plant). The file exists and opens, so Synth 8-4445 never
+    # fires; only the canonical-basename binding refuses it.
+    mut = _mutant(r'set UCODE_GENERIC "PP_UCODE_HEX_P=\\"\[file normalize '
+                  r'ucode\.hex\]\\""',
+                  'set UCODE_GENERIC "PP_UCODE_HEX_P=\\"[file normalize '
+                  'ltn_rom.hex]\\""', "ucode-cross-wired")
+    try:
+        arm("dp-mut-ucode-cross-wired", "SYNTH-GENERIC-WRONG-IMAGE", False,
+            tcl=mut)
+    finally:
+        os.unlink(mut)
+
+    # Arm 21. MUTATION: the transition-ROM generic cross-wired the other way.
+    mut = _mutant(r'set TROM_GENERIC  "PP_TROM_HEX_P=\\"\[file normalize '
+                  r'ltn_rom\.hex\]\\""',
+                  'set TROM_GENERIC  "PP_TROM_HEX_P=\\"[file normalize '
+                  'ucode.hex]\\""', "trom-cross-wired")
+    try:
+        arm("dp-mut-trom-cross-wired", "SYNTH-GENERIC-WRONG-IMAGE", False,
+            tcl=mut)
+    finally:
+        os.unlink(mut)
+
+    # ---- the geometry parser ([R0] round three, finding 2) ---------------
+
+    def pkg_mutant(pkg_text, label):
+        """The recipe with UCPU_PKG pointed at a synthetic package file."""
+        fd, pkg = tempfile.mkstemp(suffix=".sv", prefix=".ooc-pkg-")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(pkg_text)
+        mut = _mutant(r"set UCPU_PKG \[one_source \$SRC_LINES ucpu_pkg\.sv\]",
+                      "set UCPU_PKG {%s}" % pkg, label)
+        return pkg, mut
+
+    # Arm 22. [R0]'s exact plant: a stale value in a line comment above a
+    # live declaration of 52. The LIVE value must win; with 52 the real
+    # 48-bit generator output no longer fits, and THAT refusal is the proof
+    # the comment did not win (had it won, the run would have passed).
+    pkg, mut = pkg_mutant(
+        "// stale example: UCODE_W_C = 48\n"
+        "localparam int unsigned UCODE_W_C = 52;\n"
+        "localparam int unsigned UPC_W_C = 11;\n", "pkg-comment-shadow")
+    try:
+        arm("dp-pkg-comment-shadow-live-wins", "not exactly 13 hex digits",
+            False, tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # Arm 23. Block comments are stripped and prefixed identifiers do not
+    # match: a /* UCODE_W_C = 40; */ and an XUCODE_W_C = 99 beside the live
+    # 48/11 must leave the run WELL-FORMED (the real image fits 48).
+    pkg, mut = pkg_mutant(
+        "/* stale block:\n   localparam int unsigned UCODE_W_C = 40;\n*/\n"
+        "localparam int unsigned XUCODE_W_C = 99;\n"
+        "localparam int unsigned UCODE_W_C  = 48;\n"
+        "localparam int unsigned UPC_W_C    = 11;\n", "pkg-block-and-prefix")
+    try:
+        arm("dp-pkg-block-comment-and-prefix", None, True, tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # Arm 24. TWO live declarations: a refusal, never a pick.
+    pkg, mut = pkg_mutant(
+        "localparam int unsigned UCODE_W_C = 48;\n"
+        "localparam int unsigned UCODE_W_C = 52;\n"
+        "localparam int unsigned UPC_W_C = 11;\n", "pkg-duplicate")
+    try:
+        arm("dp-pkg-duplicate", "expected exactly one live declaration",
+            False, tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # Arm 25. ZERO live declarations (only a commented one): same refusal.
+    pkg, mut = pkg_mutant(
+        "// localparam int unsigned UCODE_W_C = 48;\n"
+        "localparam int unsigned UPC_W_C = 11;\n", "pkg-missing")
+    try:
+        arm("dp-pkg-missing", "expected exactly one live declaration", False,
+            tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # ---- the derived-source connection ([R0] round three, finding 5) -----
+
+    # Arm 26. MUTATION: dp_srcs.py's record replaced by [R0]'s exact plant, a
+    # hand list of the two packages. Geometry still resolves and the run
+    # still reaches synthesis, which is exactly why the read-set-equality
+    # detector exists: it must distinguish, or arm 15 is vacuous. The plant's
+    # paths are COMPOSED here, not spelled: the contiguous submodule-source
+    # path exists only in the untracked mutant, which is the planted defect
+    # under test -- a tracked spelling would rightly trip
+    # scripts/pp_srcs.py --check, and that trip is itself part of what this
+    # plant is shown to hit on the real tree (PR #264 evidence).
+    pp_root = "$REPO/protocol-processor" + "/hdl"
+    mut = _mutant(
+        r"set SRC_LINES \[split \[string trim \[exec python3 "
+        r"\$REPO/syn/ooc/dp_srcs\.py\]\] \"\\n\"\]",
+        "set SRC_LINES [list %s/aecp/ucpu_pkg.sv %s/acmp/pp_acmp_pkg.sv]"
+        % (pp_root, pp_root),
+        "srcs-hand-list")
+    try:
+        def hand_list_detected(d, log):
+            rl = os.path.join(d, READ_LIST)
+            if not os.path.isfile(rl):
+                return "the stubs recorded no read set"
+            got = sorted(l.strip() for l in open(rl) if l.strip())
+            if got == derived_sources():
+                return "the hand-list mutant read set equals the record: " \
+                       "the detector cannot distinguish"
+            return None
+        arm("dp-mut-srcs-hand-list", None, True, tcl=mut,
+            check=hand_list_detected)
+    finally:
+        os.unlink(mut)
+
+    # Arm 27. MUTATION: the dp_srcs.py invocation DELETED. Nothing downstream
+    # may quietly supply a list: the recipe must die on its first consumer.
+    mut = _mutant(
+        r"set SRC_LINES \[split \[string trim \[exec python3 "
+        r"\$REPO/syn/ooc/dp_srcs\.py\]\] \"\\n\"\]\n",
+        "", "srcs-deleted")
+    try:
+        arm("dp-mut-srcs-deleted", "SRC_LINES", False, tcl=mut)
     finally:
         os.unlink(mut)
 

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -164,7 +164,7 @@ exec %(real)s "$@"
 """
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 27
+ARMS = 33
 
 _DERIVED = None
 
@@ -483,13 +483,19 @@ def selftest():
 
     # ---- the geometry parser ([R0] round three, finding 2) ---------------
 
-    def pkg_mutant(pkg_text, label):
-        """The recipe with UCPU_PKG pointed at a synthetic package file."""
+    def pkg_mutant(pkg_text, label, which="ucpu"):
+        """The recipe with one geometry package pointed at a synthetic file."""
         fd, pkg = tempfile.mkstemp(suffix=".sv", prefix=".ooc-pkg-")
         with os.fdopen(fd, "w") as fh:
             fh.write(pkg_text)
-        mut = _mutant(r"set UCPU_PKG \[one_source \$SRC_LINES ucpu_pkg\.sv\]",
-                      "set UCPU_PKG {%s}" % pkg, label)
+        if which == "ucpu":
+            mut = _mutant(
+                r"set UCPU_PKG \[one_source \$SRC_LINES ucpu_pkg\.sv\]",
+                "set UCPU_PKG {%s}" % pkg, label)
+        else:
+            mut = _mutant(
+                r"set ACMP_PKG \[one_source \$SRC_LINES pp_acmp_pkg\.sv\]",
+                "set ACMP_PKG {%s}" % pkg, label)
         return pkg, mut
 
     # Arm 22. [R0]'s exact plant: a stale value in a line comment above a
@@ -543,6 +549,35 @@ def selftest():
     finally:
         os.unlink(mut)
         os.unlink(pkg)
+
+    # Arms 25a-25f. NON-NIBBLE widths refuse outright ([R-parallel] round
+    # three): 50/4 truncates to 12 digits and the exact probe showed the
+    # stale 2,048x48 image satisfying a declared width of 50. Widths 49-51
+    # (microcode) and 33-35 (transition ROM) must each refuse BEFORE any
+    # image can validate; the supported widths keep their behavior (48/32
+    # pristine in arm 15, and 52 correctly demanding 13 digits in arm 22).
+    for w in (49, 50, 51):
+        pkg, mut = pkg_mutant(
+            "localparam int unsigned UCODE_W_C = %d;\n"
+            "localparam int unsigned UPC_W_C = 11;\n" % w,
+            "pkg-width-%d" % w)
+        try:
+            arm("dp-pkg-width-%d-not-nibble" % w,
+                "not a positive nibble-aligned", False, tcl=mut)
+        finally:
+            os.unlink(mut)
+            os.unlink(pkg)
+    for w in (33, 34, 35):
+        pkg, mut = pkg_mutant(
+            "localparam int unsigned TROM_W_C = %d;\n"
+            "localparam int unsigned TROM_DEPTH_C = 128;\n" % w,
+            "pkg-trom-width-%d" % w, which="acmp")
+        try:
+            arm("dp-pkg-trom-width-%d-not-nibble" % w,
+                "not a positive nibble-aligned", False, tcl=mut)
+        finally:
+            os.unlink(mut)
+            os.unlink(pkg)
 
     # ---- the derived-source connection ([R0] round three, finding 5) -----
 

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Kebag Logic
 # SPDX-License-Identifier: CERN-OHL-W-2.0
-"""Drive syn/ooc/pp_shadow_ooc.tcl's two pre-synthesis refusals, automatically.
+"""Drive the two OOC .tcl recipes' pre-synthesis refusals, automatically.
 
-That script refuses to synthesize when a `$readmemh` image is missing or empty,
-and it takes the source generator's exit status. Both refusals had manual
-evidence and no test ([R0] on PR #240): deleting either one left every hosted
-check green, which is the definition of a defense that rots.
+pp_shadow_ooc.tcl refuses to synthesize when a `$readmemh` image is missing or
+empty, and it takes the source generator's exit status. Both refusals had
+manual evidence and no test ([R0] on PR #240): deleting either one left every
+hosted check green, which is the definition of a defense that rots.
+
+milan_datapath_ooc.tcl (#246) GENERATES both images into its run directory
+and then applies the same missing-or-empty refusal; a ROM generator that
+fails, or one that exits 0 leaving an empty image, must abort the script
+before anything is read. Its arms below plant exactly those failures through
+a dispatching `python3` stub that hands every other invocation (dp_srcs.py,
+the other generator) to the real interpreter.
 
 WHAT IT RUNS IS THE REAL .TCL, not a copy of its logic. `tclsh` sources the
 tracked file with the Vivado-only commands stubbed, and `read_verilog` -- the
-first command after both refusals -- prints a sentinel and exits 0. So an arm
+first command after the refusals -- prints a sentinel and exits 0. So an arm
 that expects a refusal fails if the sentinel appears, and the positive arm fails
 if it does not: removing the guard from the .tcl reddens this, and so does a
 guard that fires on a well-formed directory.
@@ -21,8 +28,9 @@ language it is written in rather than reimplemented in Python.
     python3 syn/ooc/ooc_tcl_selftest.py
 
 Runs in .github/workflows/rtl-fast.yml beside syn/ooc/dp_srcs.py --selftest.
-Needs the protocol-processor and verilog-axis submodules, because the .tcl
-derives its read set before it reaches either refusal.
+Needs the protocol-processor and verilog-axis submodules, because both .tcl
+files derive their read set (and the datapath one generates its ROMs) on the
+way to their refusals.
 """
 import os
 import shutil
@@ -33,10 +41,13 @@ import tempfile
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
 TCL = os.path.join(HERE, "pp_shadow_ooc.tcl")
+DP_TCL = os.path.join(HERE, "milan_datapath_ooc.tcl")
 SENTINEL = "OOC-GUARD-PASSED"
+REAL_PYTHON = shutil.which("python3") or sys.executable
 
-#: The Vivado commands pp_shadow_ooc.tcl calls after its refusals. `read_verilog`
-#: is the first of them, so reaching it means every refusal let the run through.
+#: The Vivado commands the .tcl recipes call after their refusals.
+#: `read_verilog` is the first of them, so reaching it means every refusal let
+#: the run through.
 STUBS = """
 proc read_verilog args { puts "%s"; exit 0 }
 proc synth_design args {}
@@ -44,14 +55,34 @@ proc create_clock args {}
 proc get_ports args { return {} }
 proc report_utilization args {}
 proc report_timing_summary args {}
+proc set_msg_config args {}
 source {%s}
-""" % (SENTINEL, TCL)
+"""
+
+#: python3 dispatcher for the milan_datapath arms: sabotage the one script the
+#: arm plants a failure in, hand everything else (dp_srcs.py, the other
+#: generator) to the real interpreter, so the generation path the positive arm
+#: proves is the shipping one.
+PY_DISPATCH = """#!/bin/sh
+out=""
+prev=""
+hit=0
+for a in "$@"; do
+  case "$a" in */%(target)s) hit=1 ;; esac
+  [ "$prev" = "-o" ] && out="$a"
+  prev="$a"
+done
+if [ "$hit" = 1 ]; then
+  %(action)s
+fi
+exec %(real)s "$@"
+"""
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 5
+ARMS = 9
 
 
-def _run(workdir, env=None):
+def _run(workdir, env=None, tcl=TCL):
     e = dict(os.environ)
     e.update(env or {})
     # A driver FILE, not tclsh's stdin: reading a script from stdin makes an
@@ -60,12 +91,23 @@ def _run(workdir, env=None):
     fd, driver = tempfile.mkstemp(suffix=".tcl", prefix="ooc-driver-")
     try:
         with os.fdopen(fd, "w") as fh:
-            fh.write(STUBS)
+            fh.write(STUBS % (SENTINEL, tcl))
         out = subprocess.run(["tclsh", driver], cwd=workdir, env=e,
                              capture_output=True, text=True)
     finally:
         os.unlink(driver)
     return out.returncode, out.stdout + out.stderr
+
+
+def _py_sabotage(target, action):
+    """A scratch bin dir whose python3 dispatches; caller prepends to PATH."""
+    stub = tempfile.mkdtemp(prefix="dp-rom-plant-")
+    p = os.path.join(stub, "python3")
+    with open(p, "w") as fh:
+        fh.write(PY_DISPATCH % {"target": target, "action": action,
+                                "real": REAL_PYTHON})
+    os.chmod(p, 0o755)
+    return stub
 
 
 def _write(workdir, name, content):
@@ -83,24 +125,33 @@ def selftest():
                 "unexercised refusal is the defect this file tests for."
                 % os.path.relpath(TCL, REPO)], 0
 
-    def arm(name, want, expect_rc0, setup=None, env=None):
+    def arm(name, want, expect_rc0, setup=None, env=None, tcl=TCL,
+            check=None):
         nonlocal ran
         ran += 1
         with tempfile.TemporaryDirectory() as d:
             if setup:
                 setup(d)
-            rc, log = _run(d, env)
-        reached = SENTINEL in log
-        if expect_rc0:
-            if rc != 0 or not reached:
-                problems.append("SELF-TEST FAILED [%s]: a well-formed run must "
-                                "reach synthesis, got rc=%d, sentinel=%s\n%s"
-                                % (name, rc, reached, log.strip()))
-            return
-        if rc == 0 or reached or want not in log:
-            problems.append("SELF-TEST FAILED [%s]: expected a refusal naming "
-                            "%r before synthesis, got rc=%d, sentinel=%s\n%s"
-                            % (name, want, rc, reached, log.strip()))
+            rc, log = _run(d, env, tcl)
+            reached = SENTINEL in log
+            if expect_rc0:
+                if rc != 0 or not reached:
+                    problems.append("SELF-TEST FAILED [%s]: a well-formed run "
+                                    "must reach synthesis, got rc=%d, "
+                                    "sentinel=%s\n%s"
+                                    % (name, rc, reached, log.strip()))
+                    return
+            elif rc == 0 or reached or want not in log:
+                problems.append("SELF-TEST FAILED [%s]: expected a refusal "
+                                "naming %r before synthesis, got rc=%d, "
+                                "sentinel=%s\n%s"
+                                % (name, want, rc, reached, log.strip()))
+                return
+            if check:
+                miss = check(d)
+                if miss:
+                    problems.append("SELF-TEST FAILED [%s]: %s\n%s"
+                                    % (name, miss, log.strip()))
 
     def images(*names):
         def setup(d):
@@ -142,6 +193,50 @@ def selftest():
         env={"PATH": stub + os.pathsep + os.environ.get("PATH", "")})
     shutil.rmtree(stub, ignore_errors=True)
 
+    # ---- milan_datapath_ooc.tcl (#246). It GENERATES both images, so its
+    # arms plant failures in the generators themselves, not in the directory.
+
+    def dp_env(target, action):
+        stub = _py_sabotage(target, action)
+        return stub, {"PATH": stub + os.pathsep + os.environ.get("PATH", "")}
+
+    # Arm 6. A dead microcode generator aborts the script: its exit status is
+    # taken by `exec`, never discarded. Before #246 nothing ran the generator
+    # at all and Vivado priced an all-zero ROM at rc=0.
+    stub, env = dp_env("gen_ucode.py",
+                       "echo 'planted ucode generator failure' >&2\n  exit 3")
+    arm("dp-ucode-generator-fail", "planted ucode generator failure", False,
+        env=env, tcl=DP_TCL)
+    shutil.rmtree(stub, ignore_errors=True)
+
+    # Arm 7. A generator that exits 0 leaving an empty image is the same
+    # refusal: `file exists` alone would pass it, and Vivado reads an empty
+    # image exactly as it reads an absent one.
+    stub, env = dp_env("gen_ucode.py", ": > \"$out\"\n  exit 0")
+    arm("dp-ucode-empty", "ucode.hex is missing or empty", False,
+        env=env, tcl=DP_TCL)
+    shutil.rmtree(stub, ignore_errors=True)
+
+    # Arm 8. The transition-ROM generator gets the identical treatment.
+    stub, env = dp_env("gen_ltn_rom.py",
+                       "echo 'planted ltn generator failure' >&2\n  exit 3")
+    arm("dp-ltn-generator-fail", "planted ltn generator failure", False,
+        env=env, tcl=DP_TCL)
+    shutil.rmtree(stub, ignore_errors=True)
+
+    # Arm 9. ANTI-VACUITY. From an EMPTY directory the real generators run,
+    # both images land in the run directory non-empty, and the script reaches
+    # synthesis. Without this arm a preflight that always refuses passes
+    # arms 6-8.
+    def dp_images_present(d):
+        for img in ("ltn_rom.hex", "ucode.hex"):
+            p = os.path.join(d, img)
+            if not os.path.isfile(p) or os.path.getsize(p) == 0:
+                return "%s was not generated into the run directory" % img
+        return None
+    arm("dp-empty-dir-generates-and-passes", None, True, tcl=DP_TCL,
+        check=dp_images_present)
+
     if ran != ARMS:
         problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this file "
                         "declares %d." % (ran, ARMS))
@@ -154,7 +249,7 @@ def main() -> int:
         print("  -", b, file=sys.stderr)
     if bad:
         return 2
-    print("pp_shadow OOC refusal self-test: %d arm(s) passed" % ran)
+    print("OOC .tcl refusal self-test: %d arm(s) passed" % ran)
     return 0
 
 


### PR DESCRIPTION
[A3]

## Contents

- **[Status](#status)**
- **[Linked Issue / roles](#linked-issue--roles)**
- **[Description](#description)**
- **[The re-measured area: old vs new](#the-re-measured-area-old-vs-new)**
- **[The public area figures on #231 / #232](#the-public-area-figures-on-231--232)**
- **[How to get into the same state](#how-to-get-into-the-same-state)**
- **[How to validate](#how-to-validate)**
- **[Known limitations / out of scope](#known-limitations--out-of-scope)**
- **[Definition of Done](#definition-of-done)**

## Status

GREEN at head `2cace1e8`, answering [R-parallel]'s round-three pair on `e5885c4a` (non-nibble width truncation; the table's date), on top of [R0]'s six on `4eb75c25` and [R-parallel]'s three on `c41a52d6`. Base `dev` `4b381c09`, unchanged since the last round. All figures below were measured at this head or at the named historical commits; full transcripts in the [A3] comments.

`246-synoocmilan_datapath_ooctcl-never-generates-ucodehex-...` -> `dev`.

## Linked Issue / roles

Closes #246
Relates to #235 / PR #240 (whose refusal pattern and self-test this extends) and #245 / PR #262 (the Yosys member; separate branch, disjoint diffs: as of this round this PR's net diff vs `dev` is exactly `syn/ooc/milan_datapath_ooc.tcl` + `syn/ooc/ooc_tcl_selftest.py`, and the earlier shared `scripts/pp_srcs.py` edit is reverted, so the previous shared-file note is retired).

Executor: `[A3]`
External reviewers: `[R-parallel]` (round one), `[R0]` (round two) - both NEGATIVE rounds answered at this head.

## Description

`syn/ooc/milan_datapath_ooc.tcl` never generated `ucode.hex`: Vivado read the absent image as an all-zero ROM behind one `CRITICAL WARNING [Synth 8-4445]`, constant-folded the AECP uCPU, and completed rc=0 with a plausible, wrong utilization report. Two review rounds then closed the survivors of the first two fixes. The recipe now:

- **derives first**: `dp_srcs.py`'s record is the first thing the recipe runs, and everything else consumes it - including the ROM geometry packages, which are FOUND IN the record (`one_source`: exactly one file with the canonical basename, else refuse), never spelled as paths. No submodule-source literal remains in the recipe, so the reviewer's hand-list plant now trips `scripts/pp_srcs.py --check` itself (that file is back at its `dev` state; the previous `PROSE_OK` exemption is gone);
- **reads geometry from the one LIVE declaration**: `pkg_num` strips `//` and `/* */` comments first, requires exactly one boundary-anchored `localparam`/`parameter NAME = <int>;` at line start, and refuses zero, multiple, or unsupported spellings - a stale value in a comment can never win again. A declared width that is not a positive multiple of 4 REFUSES outright (truncating 50/4 to 12 digits would let a stale 48-bit image satisfy a 50-bit declaration - [R-parallel] round three's probe), naming ceiling-division-plus-high-bits-zero as the upgrade path if a non-aligned ROM ever exists; a zero depth refuses too;
- **generates and validates per image**: target deleted, fresh temp target, `exec` takes the generator's status, exact geometry (depth x width from the packages, `[0-9a-fA-F]` only), atomic rename publish;
- **hands `synth_design` both absolute canonical paths** as `PP_TROM_HEX_P` / `PP_UCODE_HEX_P`, and promotes `Synth 8-4445` to ERROR, with the stated contract that the EFFECTIVE severity at `synth_design` is what must hold.

`syn/ooc/ooc_tcl_selftest.py` (33 arms) now OBSERVES every synthesis safeguard: `read_verilog` returns and records; the sentinel prints at `synth_design`, whose stub validates each `*_HEX_P` generic as quoted + absolute + existing + non-empty + CANONICAL basename for its parameter + correct geometry at the synth boundary; `set_msg_config` is modelled (final severity per id) and the positive arm requires the EFFECTIVE `Synth 8-4445` severity to be ERROR; the recorded read set must EQUAL `dp_srcs.py`'s own answer. Mutation copies of the recipe prove each detector can fail: promotion deleted, promotion downgraded AFTER promotion (the [R0] plant), ucode generic deleted / redirected at a missing image / CROSS-WIRED at the other ROM (the [R0] plant), transition generic cross-wired, the record replaced by the [R0] hand-list plant, the `dp_srcs.py` invocation deleted, and ten package-parser plants (line-comment shadow with a different live value, block-comment + prefixed-identifier decoys, duplicate declaration, missing declaration, and the six non-nibble widths 49/50/51 and 33/34/35, each of which must refuse before any image can validate while the supported 48/52 and 32 keep their behavior). A real-Vivado negative control closes the tool-semantics gap: the `dev` recipe with ONLY the promotion added, run from an empty directory, turns its old rc=0-with-CRITICAL-WARNING into `ERROR: [Synth 8-4445]`, rc=1, zero report files.

## The re-measured area: old vs new

Vivado 2026.1, `xc7a100tfgg484-2`, `synth_design -mode out_of_context`, 100 MHz, every run from its own EMPTY directory.

| run | tree | `milan_datapath` LUT | FF | device LUT | exit |
|---|---|---|---|---|---|
| recipe as checked in on `dev` (no `ucode.hex`) | `e69bf4b5` | **31,764** | 36,755 | 50.10 % | 0, one `Synth 8-4445` CRITICAL WARNING |
| fixed recipe, THIS head | `e5885c4a` | **39,776** | 43,781 | 62.74 % | 0, no `Synth 8-4445`, no CRITICAL WARNING |
| **the lie's size at this head** | | **+8,012** | +7,026 | +12.64 points | |

(The rounds' intermediate heads measured identically: 39,776 / 43,781 / 62.74 % at both `e69bf4b5`+round-1 and `4b381c09`+round-2, and `git diff --name-only e69bf4b5 4b381c09` is tsn_fuzz + docs only, so the ROM-less "old" figure remains the valid comparator at this head.)

## The public area figures on #231 / #232

Those tickets' [A1] comments quote a whole-datapath pair `34,215 -> 38,611 LUT` from the pre-fix recipe. Reconciliation, done by measurement at the exact commits and posted on both tickets:

- **Base: reproduces bit-for-bit.** `dev` `04b55dad` (pin `a25b5cc9`) with a proven-complete `ucode.hex`: **34,215 LUT / 38,141 FF / 53.97 %**, zero `Synth 8-4445`, rc=0.
- **Head: does NOT reproduce.** Exact PR #227 head `b3507ddd` (pin `44489453`), empty directory, freshly generated geometry-validated image, zero `Synth 8-4445`: **38,879 LUT (61.32 %) / 42,555 FF** - not the quoted 38,611 / 42,120. A control run of the same head with the BASE pin's complete-but-different image (576 lines differ) returns the IDENTICAL 38,879 / 42,555, so microcode content does not move utilization and no complete-image run of `b3507ddd` yields 38,611; a ROM-less run yields the 30,9xx class. The quoted figure was therefore measured on some other tree state (plausibly another force-push revision of the branch - the comment names no SHA - or another environment).
- **Figures of record now on the tickets:** base 34,215 (exact), head-of-record for `b3507ddd` **38,879 (61.32 %)**, pin delta **+4,664 LUT / +7.35 points** (vs the quoted +4,396 / +6.93); the tickets' structure attribution is unchanged in kind, adjusted at most 268 LUT in degree. Comments: [#231 base](https://github.com/kebag-logic/milan-fpga/issues/231#issuecomment-5410760834), [#231 head correction](https://github.com/kebag-logic/milan-fpga/issues/231#issuecomment-5411378865), [#232](https://github.com/kebag-logic/milan-fpga/issues/232#issuecomment-5411380930).

`docs/design/AREA_BUDGET.md`'s 35,113 stays excluded from this audit for the corrected reason ([R0] finding 6): that table is **post-synthesis hierarchical utilization** (not placement) and was MEASURED 2026-07-27, before the 2026-08-13 processor substitution, so it describes a design that no longer exists. This PR's first evidence comment misstated first the instrument and then the date; it now carries the fully corrected note.

## How to get into the same state

```sh
git fetch origin && git checkout 246-synoocmilan_datapath_ooctcl-never-generates-ucodehex-it-reports-30925-lut-for-a-design-that-is-38848-and-exits-0
git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
```

## How to validate

```sh
python3 syn/ooc/ooc_tcl_selftest.py    # 33 arms, ~4 min (every dp arm pays one dp_srcs.py run)
# prove the arms bite (the suite refuses to even certify the previous recipe):
git checkout 4eb75c25 -- syn/ooc/milan_datapath_ooc.tcl && python3 syn/ooc/ooc_tcl_selftest.py; git checkout HEAD -- syn/ooc/milan_datapath_ooc.tcl
# the real instrument, from an EMPTY directory (tens of minutes):
mkdir /tmp/dp-ooc && cd /tmp/dp-ooc && vivado -mode batch -source <repo>/syn/ooc/milan_datapath_ooc.tcl -nojournal
```

Plus the standard bar at this head (results and exit codes in the [A3] evidence comment): `scripts/lint_rtl.py --check`, `scripts/pp_srcs.py --check --selftest`, `scripts/docs_check.py`, `scripts/check_doc_paths.py`, `scripts/gen_toc.py --check`, `scripts/ci_events.py --check`, `syn/ooc/dp_srcs.py --selftest`, `git diff --check`.

## Known limitations / out of scope

- **No suite input is touched.** `git diff --name-only origin/dev` is exactly `syn/ooc/milan_datapath_ooc.tcl` and `syn/ooc/ooc_tcl_selftest.py`. Nothing under `hdl/`, `tb/`, `tests/`, `scripts/` or any submodule; no pin moves. The full Verilator sweep is not owed and was not run.
- **The self-test costs ~4 minutes** because every datapath arm pays a real `dp_srcs.py` derivation - the price of the record running first so nothing downstream can be tested without it. The hosted job it runs in has a 30-minute budget and multi-minute elaborations already.
- **The geometry bound is count/width/charset, not semantics**; wrong-CONTENT protection is the fresh-temp regeneration from the pinned generator. Measured corollary: microcode content does not change the utilization report (the `b3507ddd` control), so content-level provenance matters for behavior, not for area.
- **The canonical-image binding in the self-test stub is test knowledge** (the map `PP_UCODE_HEX_P -> ucode.hex`, `PP_TROM_HEX_P -> ltn_rom.hex` with per-image geometry); the recipe must arrive at the same binding on its own, and the cross-wire mutants prove the stub notices when it does not.
- **The figures are post-synthesis out-of-context**: not post-place-and-route, no closure verdict.
- **CI runs the self-test, not Vivado.** All real runs (measurement, reconciliation, negative control, planted refusals) were made locally, sequentially, each in its own directory.
- `pp_shadow_ooc.tcl` still requires-but-does-not-generate; converging it on this recipe's contract is a candidate follow-up, not #246's scope.
- The pre-existing `check_doc_paths.py` stale-ALLOW note about `scripts/ci_scope.py` is unchanged by this PR.

## Definition of Done

- [x] Linked Issue acceptance criteria are satisfied
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation is updated where needed
- [ ] Post-merge containment will be checked before the Issue moves to Done
