### PR TITLE
Take the privacy scrub past markdown

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -104,7 +104,7 @@ python3 sw/builder/test_builder.py                   # end-station builder, 17 g
 Green looks like:
 
 ```
-docs_check: 0 finding(s) across <N> md files [git ls-files]
+docs_check: 0 finding(s) across <N> md files + <M> scrubbed text files, scrub self-test <A>/<A> [git ls-files]
 traceability matrix up to date (<N> modules, 1 untested)
 ALL GATES PASS
 ```

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The long form, with what is verified vs what needs a bench: [QUICKSTART.md](QUIC
 | **All Verilator TBs** (one dir per suite, self-checking) | `cd tb/verilator && for d in */; do (cd "$d" && make) \|\| break; done` | verilator ≥ 5.050 (the CI pin) |
 | One TB | `cd tb/verilator/<suite> && make` (exit 0 = PASS) | verilator |
 | **RTL lint** over all of `hdl/` (ratcheted, ~10 s) | `python3 scripts/lint_rtl.py --check` | verilator (the CI pin) |
-| Docs gate (links, wording, dead references) | `python3 scripts/docs_check.py` | python3 — **git optional** |
+| Docs gate (links, wording, dead references; privacy scrub over every tracked text file) | `python3 scripts/docs_check.py` | python3 — **git optional** |
 | Traceability no-drift gate | `python3 docs/traceability/gen_module_matrix.py --check` | python3 |
 | End-station builder gates | `python3 sw/builder/test_builder.py` | python3 + pyyaml |
 | Device portability | `cd syn/yosys && make && make ecp5` | yosys + sv2v |

--- a/docs/DOC_GENERATION.md
+++ b/docs/DOC_GENERATION.md
@@ -20,7 +20,7 @@ hand-edits there are lost on the next run and fail review.
 - **[2. Per-module HDL pages (hdl/**/doc/*.md)](#2-per-module-hdl-pages-hdldocmd)** — Driven from the editor via TerosHDL, because there is no headless path on this box. The honest coverage number is here: ~22 of 84 modules have pages while 82 of 84 already carry the `//!` comments, so the backlog is an editor session, not a writing task.
 - **[3. Block diagrams (.gen.py → .drawio + .svg → .png)](#3-block-diagrams-genpy--drawio--svg--png)** — The render chain, the four artifacts that must be committed together, and the catalog entry that goes with them. Two headless caveats: the drawio CLI hangs, and the repo's fallback renderer mangles HTML-formatted labels.
 - **[4. Waveform chronograms (WaveDrom)](#4-waveform-chronograms-wavedrom)** — `gen_wavedrom.py` over a `wd_*.json`, with the `wavedrom` package living in the LiteX venv. Includes the style rules learned the hard way: cap at ~10 lanes, write explicit `010` pulses instead of `H`, and look at the rendered `.png` before embedding it.
-- **[5. The gate and CI](#5-the-gate-and-ci)** — The five rules `docs_check.py` enforces, spelled out. Rule 4 is the one to know — a dead reference left behind by a deletion used to pass silently, so retiring a document now means adding its basename to `RETIRED`. Also covers the no-git fallback and the single opt-out token.
+- **[5. The gate and CI](#5-the-gate-and-ci)** — The five rules `docs_check.py` enforces, spelled out. Two to know: rule 4, because a dead reference left behind by a deletion used to pass silently, so retiring a document means adding its basename to `RETIRED`; and rule 5, the privacy scrub, which reads every tracked text file rather than markdown only and proves on every run that it still bites. Also covers the no-git fallback and the single opt-out token.
 - **[6. Cheat sheet — you changed X, run Y](#6-cheat-sheet--you-changed-x-run-y)** — Seven rows mapping what you touched to the one command that has to follow. The fastest way to use this page if you are already mid-change.
 
 ## 1. Module ↔ spec ↔ test matrix
@@ -111,8 +111,15 @@ python3 docs/traceability/gen_module_matrix.py --check   # matrix no-drift
 python3 sw/builder/test_builder.py                       # end-station builder gates
 ```
 
-[`../scripts/docs_check.py`](../scripts/docs_check.py) enforces five rules
-over every `*.md` in the tree (plus diagram sources for the last one):
+[`../scripts/docs_check.py`](../scripts/docs_check.py) enforces five rules.
+Rules 1-4 read every `*.md` in the tree; rule 5, the privacy scrub, reads every
+tracked **text** file — RTL, scripts, configs, testbenches, feature files and
+diagram sources included. This repo is public, and until #247 the scrub read
+markdown only: the peer's product name sat in a testbench comment where no gate
+could see it, and a sibling token had reached 22 tracked files the same way.
+Vendored code (`third_party/`) is out of scope and a binary file is skipped
+exactly as `git grep -I` skips it, so the gate and a `git grep -nI` audit cannot
+disagree:
 
 1. relative links must resolve;
 2. the wording deny-list;
@@ -127,7 +134,24 @@ over every `*.md` in the tree (plus diagram sources for the last one):
    archive ledger, whose job *is* to name retired
    files — via an HTML-comment line carrying the token
    `docs-check: allow-dead-refs`;
-5. no bench/host-identifying information (hostnames, home paths, serials, bench IPs).
+5. the **privacy scrub**: no private identity (the reference peer's product
+   name, the compliance lab and suite names) and no bench/host-identifying
+   information (home paths, bench addresses, bench host prefix, MAC-derived
+   interface names, USB-serial paths). Every class is judged on every line, so
+   one line can carry two findings — a `continue` between them would mean a
+   correct scrub reveals a new finding and the gate could never be driven green
+   in one pass. A finding names its class and column and never quotes the
+   match: the CI log of a public repo republishes whatever a finding prints.
+   The private tokens are **assembled from code points** in the script, never
+   spelled, so the gate can read itself without becoming the one file in the
+   tree that carries them.
+
+Rule 5's arms run on **every** invocation and the count rides in the summary
+line (`scrub self-test 17/17`): each class is planted in a non-markdown file and
+must be caught, the negative controls must stay clean, and a class with no
+fixture fails the run. A scrub gate that has never failed once is not evidence
+that it works. `--selftest` runs the arms alone; a failing arm is exit 2
+(rule 5 unproven), which is not exit 0 (clean).
 
 The exact allowlist and the `RETIRED` set are in the script header. **The gate
 does not need git**: inside a git working tree it takes the file list from
@@ -152,3 +176,4 @@ honest — run them locally first, exit-checked, never piped through `tail`.
 | Deleted or archived a doc | add its basename to `RETIRED` in [`scripts/docs_check.py`](../scripts/docs_check.py), then run the gate — it lists every reference now pointing at nothing |
 | A config schema / builder emission | [`sw/builder/test_builder.py`](../sw/builder/test_builder.py); an explicit `--write-fragment` or `--write-rtl` transfer generates paired `aem_desc.bin`, `aem_desc.json`, and `aem_desc.map` artifacts beside the bitstream. The board-side `aemi-load` verifies and writes the image before entity enable |
 | Any `*.md` at all | [`scripts/docs_check.py`](../scripts/docs_check.py) before pushing |
+| Any other tracked text — RTL, script, config, testbench, feature file | the same gate: rule 5 reads them too, and a bench or peer identity in a comment is a finding |

--- a/scripts/area_baseline.py
+++ b/scripts/area_baseline.py
@@ -25,7 +25,7 @@ USAGE
   scripts/area_baseline.py
 
   # a specific build
-  scripts/area_baseline.py --build /home/alex/litex-milan/work/build_ax7101_eppo_t540
+  scripts/area_baseline.py --build ~/litex-milan/work/build_ax7101_eppo_t540
 
   # BEFORE vs AFTER a change - the number that actually settles a proposal
   scripts/area_baseline.py --build <after> --compare <before>

--- a/scripts/docs_check.py
+++ b/scripts/docs_check.py
@@ -4,10 +4,21 @@
 Run from anywhere (the script locates its own repo root):
 
     python3 scripts/docs_check.py
+    python3 scripts/docs_check.py --selftest   # the scrub arms alone
 
 **No git required.** The file inventory comes from ``git ls-files`` when the tree
 is a git working tree, and from a ``.gitignore``-aware filesystem walk otherwise —
 so an extracted tarball or a downloaded zip can run the same gate CI runs.
+
+The **privacy scrub** (rule 5) reads every tracked TEXT file, not just markdown:
+this repo is public, and #247 found the peer's product name sitting in a
+testbench comment where no gate could see it — the same blind spot that had let
+a sibling token reach 22 tracked files on 2026-08-09. Vendored code
+(``third_party/``) is out of scope, submodule gitlinks are not files here, and a
+file carrying a NUL byte in its first 8 KiB is skipped exactly as ``git grep -I``
+skips it, so the gate and the ``git grep -nI`` acceptance oracle cannot disagree.
+The scrub's own arms run on EVERY invocation (``scrub self-test N/N`` in the
+summary): a scrub that has never failed once is not evidence that it works.
 
 Checks, over every ``*.md`` file in the tree:
 
@@ -19,6 +30,10 @@ Checks, over every ``*.md`` file in the tree:
    file with no hint that the citation is stale.
 2. **Wording deny-list** — terms that must not appear in committed docs.
    Legitimate identifiers containing a denied stem are masked (``ALLOW``).
+   Markdown only, deliberately: these are rules about how PROSE reads, and
+   the stems are ordinary words elsewhere in the tree — the CRF format's
+   normative name appears in RTL banners, and gate comments say "certify"
+   about their own checks. The absolute rules live in the scrub (rule 5).
 3. **Bare doc references** — a mention of an existing ``.md`` file that is not
    an actual markdown link (living tree only; generated files, code fences,
    HTML comments and ``historical_now_obsolete/`` are exempt).
@@ -29,24 +44,31 @@ Checks, over every ``*.md`` file in the tree:
    and an outside reader follows it into nothing. A document whose job is to
    record retired files (the doc-audit ledger) opts out with an HTML comment
    line holding the token ``docs-check: allow-dead-refs``.
-5. **Local information** — bench/host-identifying patterns (hostnames, home
-   paths, bench subnet, MAC-derived interface names, USB-serial paths) must
-   not appear; also swept over ``docs/**`` diagram sources (``.gen.py``,
-   ``.drawio``, ``.svg``).
+5. **Privacy scrub** (every tracked text file, see above) — private identities
+   (the reference peer's product name, the compliance lab and suite names) and
+   bench/host-identifying patterns (home paths, bench addresses, bench host
+   prefix, MAC-derived interface names, USB-serial paths) must not appear.
+   Every class is judged on every line, so one line can carry two findings: a
+   ``continue`` between them would mean a correct scrub REVEALS a new finding
+   and the gate could never be driven green in one pass. A finding names its
+   CLASS and column and never quotes the match — CI logs are public too.
 6. **Writing hygiene** (living pages only, fences and HTML comments exempt) —
    no process/meta narration (handover/round/session-of-authoring language),
    no decisions attributed to a person or quoted conversation, no section
    sign in prose, and no un-anchored ``X.md Section N`` pointers. The archive
    and in-place-obsolete pages (first line ``[OBSOLETE + date]``, the regex
    lifted from ``check_archive.py``) are records of their time and exempt.
-Exit 0 = clean; exit 1 = findings, one per line as ``path:line: message``.
+Exit 0 = clean; exit 1 = findings, one per line as ``path:line: message``;
+exit 2 = a scrub arm did not bite, which makes rule 5 unproven, not clean.
 """
 
+import argparse
 import fnmatch
 import os
 import re
 import subprocess
 import sys
+import tempfile
 from collections import Counter
 from pathlib import Path
 
@@ -67,23 +89,48 @@ ALLOW = (
     "openavnu",
 )
 
-DENY_CI = re.compile(r"avnu|aets|certif", re.IGNORECASE)
+DENY_CI = re.compile(r"avnu|certif", re.IGNORECASE)
+
+
+#! THE PRIVATE TOKENS ARE ASSEMBLED, NOT WRITTEN OUT. This file is tracked on a
+#! public repo, and a denylist that spells the names it forbids publishes them
+#! just as surely as the document it is meant to catch — the first cut of this
+#! gate did exactly that, trading one leaked name for three. Until #247 the
+#! gate read only *.md, so it could not catch itself and the suite stem sat in
+#! `DENY_CI` above as the last occurrence in the tree; the scrub now reads this
+#! file like any other, and the assembly is what keeps it green honestly.
+def _asm(*codes):
+    """A literal from its code points, so the source never spells it."""
+    return "".join(chr(c) for c in codes)
+
 
 #! Case-SENSITIVE: these are short acronyms whose lowercase forms are ordinary
 #! words or live inside longer identifiers. A review found one of them sitting
 #! in a tracked document for weeks — the case-insensitive list above could
 #! never have matched it, and no stem for a certification LAB name existed.
 #! Committed text says "compliance", never a lab.
-#!
-#! THE TOKENS ARE ASSEMBLED, NOT WRITTEN OUT. This file is tracked on a public
-#! repo, and a denylist that spells the names it forbids publishes them just as
-#! surely as the document it is meant to catch — the first cut of this gate did
-#! exactly that, trading one leaked name for three. `docs_check` scans only
-#! *.md, so it cannot catch itself; the assembly is what keeps the rule honest.
-_LAB_TOKENS = tuple("".join(chr(c) for c in cs) for cs in (
+_LAB_TOKENS = tuple(_asm(*cs) for cs in (
     (67, 69, 82, 84), (65, 84, 76), (85, 78, 72), (73, 79, 76),
 ))
 DENY_CS = re.compile("|".join(r"\b%s\b" % t for t in _LAB_TOKENS))
+
+#: The privacy scrub (rule 5), tree-wide: (pattern, class, what to write). The
+#: class is what a finding prints — never the match, because the CI log of a
+#: public repo republishes whatever a finding quotes.
+#:
+#: The peer stem carries a trailing ``\w*`` because the model designation has a
+#: long and a short spelling and #247 found one of each; the stem plus the
+#: word boundary catches both, and any third spelling, without listing them.
+#: Case-insensitive: neither private token is an ordinary word in any case.
+_SUITE_TOKEN = _asm(97, 101, 116, 115)
+_PEER_TOKEN = _asm(68, 83, 50, 48)
+IDENTITY_RULES = (
+    (DENY_CS, "compliance lab name", "committed text says 'compliance'"),
+    (re.compile(r"\b%s\w*" % _SUITE_TOKEN, re.IGNORECASE),
+     "compliance suite name", "committed text says 'compliance'"),
+    (re.compile(r"\b%s\w*" % _PEER_TOKEN, re.IGNORECASE),
+     "peer product name", "the public tree says 'the peer' or 'a test device'"),
+)
 
 # --------------------------------------------------------------------------
 # Writing-hygiene rules (issue #94). Living documentation describes the
@@ -168,10 +215,29 @@ RETIRED = {
     "virtual-e2e-t2-prep-2026-08-01.md",
 }
 
-# Bench/host-identifying patterns (generic shapes only — never the literals).
-LOCAL_RE = re.compile(
-    r"amx-|/home/alex|enx[0-9a-f]{8,}|serial/by-id/usb-[A-Za-z0-9]|192\.168\.127"
+#: Bench/host-identifying patterns, same shape as IDENTITY_RULES. Generic
+#: SHAPES wherever a shape exists: the home-path and address rules used to
+#: name this bench's account and subnet, which made the gate the one file in
+#: the tree carrying them and let any other account's path through. Only the
+#: bench host prefix has no shape, so it is assembled. The board harness keeps
+#: a stricter arm of its own over harness/board (test_harness.py
+#: test_board_scripts); this sweep is the tree-wide floor under it.
+_BENCH_HOST_TOKEN = _asm(97, 109, 120)
+LOCAL_RULES = (
+    (re.compile(r"/home/[a-z][a-z0-9._-]*"), "home path",
+     "write ~ or $HOME"),
+    (re.compile(r"\b192\.168\.\d+"), "bench address",
+     "name the link, not its address"),
+    (re.compile(r"\b%s-" % _BENCH_HOST_TOKEN), "bench host prefix",
+     "name the role, not the host"),
+    (re.compile(r"\benx[0-9a-f]{8,}"), "MAC-derived interface name",
+     "name the port, not the interface"),
+    (re.compile(r"serial/by-id/usb-[A-Za-z0-9]"), "USB serial path",
+     "name the adapter, not its serial"),
 )
+
+#: Rule 5 in full. One table, one loop, one message shape.
+SCRUB_RULES = IDENTITY_RULES + LOCAL_RULES
 
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 LINK_SPAN_RE = re.compile(r"!?\[[^\]]*\]\([^)]*\)")
@@ -208,32 +274,42 @@ def _git_files():
 
 
 def _ignore_matchers():
-    """Crude .gitignore reader: (rooted globs, basename globs).
+    """Crude .gitignore reader: (rooted globs, basename globs, un-ignore globs).
 
     Only the shapes this repo uses are honoured — directory entries, rooted
-    path globs and bare basenames; nested per-directory ``.gitignore`` files are
-    not read (``ALWAYS_PRUNE_GLOBS`` covers what they hide). This reproduces
-    ``git ls-files`` exactly today apart from submodule gitlinks, which git
-    reports as files and a filesystem walk cannot. To re-check that after
-    editing::
+    path globs, bare basenames, and ``!`` re-inclusions of a directory an
+    earlier rule excluded; nested per-directory ``.gitignore`` files are not
+    read (``ALWAYS_PRUNE_GLOBS`` covers what they hide). The ``!`` half is what
+    keeps the five tracked ``configs/generated/*/gen/*.svh`` emissions in the
+    inventory: ``configs/generated/*/*`` excludes their directory and
+    ``!configs/generated/*/gen/`` puts it back, so dropping the negation made
+    the no-git walk five files short of ``git ls-files`` — invisible while the
+    inventory only fed markdown link checks, a hole in the privacy scrub (rule
+    5) once it reads every tracked text file. This reproduces ``git ls-files``
+    exactly today apart from submodule gitlinks, which git reports as files and
+    a filesystem walk cannot. To re-check that after editing::
 
         python3 -c "import sys; sys.path.insert(0,'scripts'); import docs_check as d; \
                     g=set(d._git_files()); w=set(d._walk_files()); \
                     print(sorted(g^w))"
     """
-    rooted, basenames = [], []
+    rooted, basenames, unignored = [], [], []
     gi = REPO / ".gitignore"
     if gi.is_file():
         for raw in gi.read_text(encoding="utf-8", errors="replace").splitlines():
             line = raw.strip()
-            if not line or line.startswith(("#", "!")):
+            if not line or line.startswith("#"):
                 continue
-            line = line.rstrip("/")
+            negated = line.startswith("!")
+            line = line.lstrip("!").rstrip("/")
             if not line:
                 continue
-            (rooted if "/" in line.strip("/") else basenames).append(
-                line.lstrip("/"))
-    return rooted, basenames
+            if negated:
+                unignored.append(line.lstrip("/"))
+            else:
+                (rooted if "/" in line.strip("/") else basenames).append(
+                    line.lstrip("/"))
+    return rooted, basenames, unignored
 
 
 def _submodule_paths():
@@ -248,14 +324,26 @@ def _submodule_paths():
 
 def _walk_files():
     """Repo-relative paths from the filesystem, minus ignored/vendored trees."""
-    rooted, basenames = _ignore_matchers()
+    rooted, basenames, unignored = _ignore_matchers()
     pruned = _submodule_paths()
+
+    def reincluded(rel):
+        """``rel``, or a directory above it, is named by a ``!`` rule."""
+        here = Path(rel)
+        candidates = [str(here)] + [str(p) for p in here.parents if str(p) != "."]
+        return any(fnmatch.fnmatch(c, pat)
+                   for c in candidates for pat in unignored)
 
     def ignored(rel, name):
         if name in ALWAYS_PRUNE or rel in pruned:
             return True
         if any(fnmatch.fnmatch(name, pat) for pat in ALWAYS_PRUNE_GLOBS):
             return True
+        # A `!` rule re-includes the directory it names and everything under
+        # it. git resolves rules in file order; this tree only ever negates
+        # AFTER the exclusion, so last-match-wins and negation-wins agree.
+        if reincluded(rel):
+            return False
         if any(fnmatch.fnmatch(name, pat) for pat in basenames):
             return True
         return any(fnmatch.fnmatch(rel, pat) for pat in rooted)
@@ -392,16 +480,15 @@ def check_md(path, relpath, resolve, tracked_set):
         if FENCE_RE.match(line):
             in_fence = not in_fence
 
-        # --- wording deny-list + local info (everywhere, fences included) ---
+        # --- wording deny-list (everywhere, fences included) ---
+        # Prose only. The privacy scrub reads this page too, as one of the
+        # tracked text files, so nothing here repeats it.
         masked = line
         for allow in ALLOW:
             masked = masked.replace(allow, "#" * len(allow))
-        m = DENY_CI.search(masked) or DENY_CS.search(masked)
+        m = DENY_CI.search(masked)
         if m:
             findings.append(f"{relpath}:{lineno}: denied wording '{m.group(0)}'")
-        lm = LOCAL_RE.search(line)
-        if lm:
-            findings.append(f"{relpath}:{lineno}: local info '{lm.group(0)}'")
 
         if in_fence:
             continue
@@ -509,7 +596,195 @@ def check_md(path, relpath, resolve, tracked_set):
     return findings
 
 
-def main():
+# --------------------------------------------------------------------------
+# rule 5: the privacy scrub, over every tracked text file
+# --------------------------------------------------------------------------
+def scrub_text(relpath, text):
+    """Findings for one file's text: every rule, every line, class not match."""
+    findings = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for pattern, label, remedy in SCRUB_RULES:
+            m = pattern.search(line)
+            if m:
+                findings.append(f"{relpath}:{lineno}: {label} at column "
+                                f"{m.start() + 1} — {remedy}")
+    return findings
+
+
+def scrub_files(root, relpaths):
+    """(findings, files scanned) for the scrub over ``relpaths`` under ``root``.
+
+    Three exclusions, each of them arm-covered in ``scrub_selftest``:
+    ``third_party/`` is vendored code this repo does not write; a gitlink is a
+    directory here, not a file; and a NUL byte in the first 8 KiB means binary,
+    which is exactly what ``git grep -I`` skips — the acceptance oracle for
+    #247 is a ``git grep -nI``, and a gate that disagreed with its own oracle
+    would go green on a tree the oracle calls dirty. Undecodable bytes are NOT
+    an exclusion: they are replaced, so a latin-1 file is still read.
+    """
+    findings, scanned = [], 0
+    for rel in relpaths:
+        if rel.startswith("third_party/"):
+            continue
+        path = Path(root) / rel
+        if not path.is_file():
+            continue
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            findings.append(f"{rel}:0: unreadable — {exc.strerror}")
+            continue
+        if b"\0" in raw[:8000]:
+            continue
+        scanned += 1
+        findings.extend(scrub_text(rel, raw.decode(errors="replace")))
+    return findings, scanned
+
+
+def scrub_selftest():
+    """Plant each class in a NON-markdown file and require the scrub to bite.
+
+    (problems, arms, skipped). #247: "a scrub gate that has never failed once
+    is not evidence that it works", so these run on every invocation, not
+    behind a flag nobody types.
+    """
+    problems, arms, skipped = [], 0, []
+
+    def arm(name, rel, body, expect_label):
+        """One planted file. ``expect_label`` None = the fixture must stay clean."""
+        nonlocal arms
+        arms += 1
+        with tempfile.TemporaryDirectory(prefix="docscheck.") as tmp:
+            target = Path(tmp) / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(body if isinstance(body, bytes)
+                               else body.encode())
+            findings, _ = scrub_files(tmp, [rel])
+        text = "\n".join(findings)
+        if expect_label is None:
+            if findings:
+                problems.append(f"[{name}] clean fixture flagged:\n{text}")
+        elif not findings:
+            problems.append(f"[{name}] planted defect not caught")
+        elif expect_label not in text:
+            problems.append(f"[{name}] caught, but not as {expect_label!r}:"
+                            f"\n{text}")
+
+    # Every rule in the table has a fixture, and the fixture is in a file type
+    # the gate could not see before #247. A count floor with no content floor
+    # is how an arm list quietly stops covering a rule it used to cover.
+    fixtures = (
+        # (name, path, line, expected class)
+        ("peer-long", "tb/verilator/x/sim_main.cpp",
+         f"    //! the peer ({_PEER_TOKEN}D declared 4ch) accepts\n",
+         "peer product name"),
+        ("peer-short-lowercase", "scripts/probe.py",
+         f"# the {_PEER_TOKEN.lower()} answered the probe\n",
+         "peer product name"),
+        ("suite", "tests/features/x.feature",
+         f"    # {_SUITE_TOKEN} es-4.5 covers this step\n",
+         "compliance suite name"),
+        ("lab", "hdl/milan/x.sv",
+         f"// verified at the {_LAB_TOKENS[0]} plugfest\n",
+         "compliance lab name"),
+        # The four shape fixtures are SPLIT at the exact junction their rule
+        # matches on, so building them here cannot make this file a finding of
+        # its own sweep. Join one back into a single literal and the
+        # gate-scans-itself arm below reddens: the discipline is self-enforcing.
+        ("home-path", "syn/yosys/x.py",
+         "    # resolved to /home/" + "someone/work instead\n", "home path"),
+        ("bench-address", "tests/features/y.feature",
+         "    # iperf3 -c 192.168." + "127.1 -u -b 950M\n", "bench address"),
+        ("bench-host", "harness/board/x.sh",
+         f"# {_BENCH_HOST_TOKEN}-pi drives outlet 4\n", "bench host prefix"),
+        ("interface-name", "configs/x.yaml",
+         "  iface: enx" + "0011223344ff\n", "MAC-derived interface name"),
+        ("usb-serial", "docs/diagrams/x.svg",
+         "<svg><text>/dev/serial/by-id/usb-" + "FTDI_x</text></svg>\n",
+         "USB serial path"),
+    )
+    for name, rel, body, label in fixtures:
+        arm(name, rel, body, label)
+    covered = {label for _, _, _, label in fixtures}
+    declared = {label for _, label, _ in SCRUB_RULES}
+    if covered != declared:
+        problems.append(f"[coverage] no fixture for {sorted(declared - covered)}"
+                        if declared - covered else
+                        f"[coverage] fixture for a retired class "
+                        f"{sorted(covered - declared)}")
+
+    # negative controls: what the rules deliberately do NOT catch
+    arm("clean-control", "hdl/milan/clean.sv",
+        "//! the peer's listener accepts the declared format\n", None)
+    arm("lab-lowercase-is-a-word", "scripts/clean.py",
+        f"# a stale base can {_LAB_TOKENS[0].lower()}ify the wrong tree\n", None)
+    arm("peer-stem-inside-a-word", "scripts/clean2.py",
+        f"# thousan{_PEER_TOKEN.lower()}00 samples\n", None)
+    arm("vendored-code-is-out-of-scope",
+        f"third_party/verilog-axis/{_PEER_TOKEN.lower()}.v",
+        f"// {_PEER_TOKEN}D\n", None)
+    arm("binary-is-skipped-like-git-grep-I", "syn/ooc/work/ucode.bin",
+        b"\x00\x01" + f"{_PEER_TOKEN}D".encode(), None)
+
+    # one line, two classes: a `continue` here would hide the second finding
+    # until the first was fixed, and the gate could never be driven green in
+    # one pass. Checked on the FINDING COUNT, which a class needle cannot see.
+    arms += 1
+    with tempfile.TemporaryDirectory(prefix="docscheck.") as tmp:
+        rel = "scripts/two.py"
+        (Path(tmp) / "scripts").mkdir()
+        (Path(tmp) / rel).write_text(
+            f"# {_PEER_TOKEN}D notes under /home/" + "someone/bench\n")
+        both, _ = scrub_files(tmp, [rel])
+    if len(both) != 2:
+        problems.append(f"[two-classes-one-line] expected 2 findings, got "
+                        f"{len(both)}:\n" + "\n".join(both))
+
+    # This file is tracked text on a public repo, so the scrub reads it like
+    # any other. Green here IS the proof that the assembly discipline holds.
+    arms += 1
+    own, _ = scrub_files(REPO, ["scripts/docs_check.py"])
+    if own:
+        problems.append("[gate-scans-itself] the gate spells what it forbids:"
+                        "\n" + "\n".join(own))
+
+    # What the scrub covers must not depend on whether the reader has git: the
+    # no-git walk has to reach every file git tracks, submodule gitlinks aside
+    # (git reports those as files, a walk cannot). Costs one walk, ~0.05 s.
+    git_files = _git_files()
+    if git_files is None:
+        skipped.append("inventory parity (needs a git working tree)")
+    else:
+        arms += 1
+        missed = set(git_files) - set(_walk_files()) - _submodule_paths()
+        if missed:
+            problems.append(f"[inventory-parity] the no-git walk misses "
+                            f"{len(missed)} tracked file(s), so the scrub "
+                            f"would not read them there: "
+                            f"{sorted(missed)[:5]}")
+    return problems, arms, skipped
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--selftest", action="store_true",
+                    help="run the rule-5 scrub arms and stop")
+    args = ap.parse_args(argv)
+
+    # Before any verdict: the scrub must still bite. An unproven rule 5 is
+    # rc 2 (unproven), never rc 0 (clean) — those are different answers.
+    problems, arms, skipped = scrub_selftest()
+    for p in problems:
+        print("  -", p, file=sys.stderr)
+    if problems:
+        print(f"docs_check: FATAL: {len(problems)} scrub arm(s) of {arms} did "
+              f"not hold", file=sys.stderr)
+        return 2
+    note = f", {len(skipped)} skipped: {'; '.join(skipped)}" if skipped else ""
+    if args.selftest:
+        print(f"docs_check scrub selftest: PASS ({arms} arm(s){note})")
+        return 0
+
     findings = []
     md = tracked("*.md")
     resolve = make_resolver(md)
@@ -517,21 +792,17 @@ def main():
     for rel in md:
         path = REPO / rel
         findings.extend(check_md(path, rel, resolve, tracked_set))
-    # local-info sweep over diagram sources (text formats only)
-    for pattern in ("docs/*.gen.py", "docs/*/*.gen.py", "docs/*.drawio",
-                    "docs/*/*.drawio", "docs/*.svg", "docs/*/*.svg"):
-        for rel in tracked(pattern):
-            diagram_text = (REPO / rel).read_text(
-                encoding="utf-8", errors="replace")
-            for lineno, line in enumerate(diagram_text.splitlines(), 1):
-                lm = LOCAL_RE.search(line)
-                if lm:
-                    findings.append(f"{rel}:{lineno}: local info '{lm.group(0)}'")
+    # rule 5 over the whole tracked tree, markdown and diagram sources
+    # included — before #247 this was a hand-listed sweep of six docs/ globs,
+    # and everything outside them was invisible.
+    scrub, scanned = scrub_files(REPO, inventory())
+    findings.extend(scrub)
     findings = sorted(set(findings))
     for f in findings:
         print(f)
     print(f"docs_check: {len(findings)} finding(s) across {len(md)} md files "
-          f"[{_INVENTORY_SOURCE}]")
+          f"+ {scanned} scrubbed text files, scrub self-test {arms}/{arms}"
+          f"{note} [{_INVENTORY_SOURCE}]")
     return 1 if findings else 0
 
 

--- a/scripts/xvlog_gate.py
+++ b/scripts/xvlog_gate.py
@@ -230,8 +230,8 @@ SECTION_LABEL = {"hdl": "hdl/", "submodules": "pinned processors"}
 #: Where a bench install puts Vivado (docs/reference: 2026.1). $XVLOG wins, then
 #: these, then PATH. Read, not restated in three places.
 XVLOG_CANDIDATES = [
-    "/home/alex/Xilinx/2026.1/Vivado/bin/xvlog",
-    "/home/alex/Xilinx2/2026.1/Vivado/bin/xvlog",
+    os.path.expanduser("~/Xilinx/2026.1/Vivado/bin/xvlog"),
+    os.path.expanduser("~/Xilinx2/2026.1/Vivado/bin/xvlog"),
 ]
 
 #: The cascade line xvlog prints AFTER a real error ("module X is ignored due to
@@ -2108,7 +2108,7 @@ def main(argv):
     # measured, so the skip is decided BEFORE the missing-tree refusal.
     if xvlog is None:
         print("xvlog gate: SKIPPED (no Vivado xvlog found; set $XVLOG or install "
-              "to /home/alex/Xilinx/2026.1). A skip is not a pass.")
+              "to ~/Xilinx/2026.1). A skip is not a pass.")
         return 0
 
     bad = unusable_submodule_trees()

--- a/sw/litex/test_dma_bus_faults.py
+++ b/sw/litex/test_dma_bus_faults.py
@@ -4,7 +4,7 @@
 
 KNOWN-FAIL BANNER. This file is a CHARACTERISATION suite and it is RED today,
 deliberately. Both defects it grades are open in LiteX (`a1e1c36`), not in this
-repo's RTL, and `/home/alex/litex-milan` is read-only to this round. Every red
+repo's RTL, and `~/litex-milan` is read-only to this round. Every red
 check prints as [XFAIL] and is named again in the summary; an [XFAIL] that
 turns [XPASS] means the defect was fixed upstream and this banner is due for
 retirement. That is the same convention `tb/verilator/hostplane` carried from

--- a/syn/yosys/param_sweep.py
+++ b/syn/yosys/param_sweep.py
@@ -212,7 +212,7 @@ def sources_from_run_sh(top):
     """Reuse run.sh's source list verbatim - ONE list, not two that can drift.
 
     run.sh sets `R` from `$0`, which is meaningless when the prelude is
-    evaluated anywhere else (it silently resolved to `/home/alex`, and every
+    evaluated anywhere else (it silently resolved to the caller's home, and every
     source path came out wrong). So `R` is pinned to the repo root here and the
     remaining assignments are evaluated on top of it.
     """

--- a/tb/tools/hive_compliance.py
+++ b/tb/tools/hive_compliance.py
@@ -154,7 +154,7 @@ one deliberately re-implements the checks a real controller stack makes:
 
 WHERE THE CLAUSES COME FROM. Earlier rounds of this file said the IEEE and
 Milan texts were paywalled and unavailable. They are on this machine, in
-/home/alex/standards (1722.1-2021.pdf, 1722-2016.pdf, Milan v1.2); the
+~/standards (1722.1-2021.pdf, 1722-2016.pdf, Milan v1.2); the
 environment variable $STANDARDS_DIR that pointed at them is simply unset,
 and that is what produced the "paraphrase only" discipline. Every clause in
 C9/C10/C11 is now quoted from the text, extracted with pdftotext -layout.

--- a/tb/tools/torture_campaign.py
+++ b/tb/tools/torture_campaign.py
@@ -3018,7 +3018,7 @@ A_COUNTERS_ZEROED = AssertSpec(
 def plan_physical(dut: Device = ARTY, peer: Device = PEER) -> list:
     """The powerstrip-driven physical family - LAST, always, and never faked.
 
-    USER AUTHORIZATION (2026-08-02): the amx-pi powerstrip may drive OUT4 =
+    USER AUTHORIZATION (2026-08-02): the bench powerstrip may drive OUT4 =
     the AVB switch ("DN-1") and OUT0 = the DUT (the AX cold-cycle precedent).
     Per-port CABLE PULLS stay needs_human in the torture area: a powerstrip
     cannot pull one cable, and simulating a port bounce by cutting the whole
@@ -3094,7 +3094,7 @@ def plan_physical(dut: Device = ARTY, peer: Device = PEER) -> list:
                      "~20 s, then power it back on and wait for links, ssh "
                      "and gPTP to recover.  AUTOMATED when the runner is "
                      "given --powerstrip-cmd and --switch-outlet (bench: "
-                     "amx-pi outlet 4).",
+                     "the powerstrip host, outlet 4).",
         asserts=(A_PARTITION_EXPECTED, A_GM_CHANGED_ADVANCES, A_GM_CONTINUITY,
                  A_PEER_GM_CHANGED, A_LINK_EVENT_SEEN, A_GM_ID_FOLLOWS,
                  A_ONE_GM_RESTORED, A_GM_NOT_FLAPPING, A_AS_CAPABLE_RESTORED,
@@ -3138,8 +3138,8 @@ def plan_physical(dut: Device = ARTY, peer: Device = PEER) -> list:
                      "8 s - the SRAM gateware is lost, QSPI boots it back), "
                      "then wait for the network to come up with NO manual "
                      "intervention.  AUTOMATED when the runner is given "
-                     "--powerstrip-cmd and --dut-outlet (bench: amx-pi "
-                     "outlet 0).",
+                     "--powerstrip-cmd and --dut-outlet (bench: the "
+                     "powerstrip host, outlet 0).",
         asserts=(A_ADP_ALIVE, A_BOOT_UNATTENDED, A_VERSION_UNCHANGED,
                  A_SHIELD_POSTURE, A_STATE_RESTORED, A_STATE_SELF_CONSISTENT,
                  A_STATE_DEFAULTED, A_COUNTERS_ZEROED,

--- a/tb/verilator/avtp_rxmon/sim_main.cpp
+++ b/tb/verilator/avtp_rxmon/sim_main.cpp
@@ -366,7 +366,7 @@ int main(int argc,char**argv){
     { AafCfg c; c.seq=2; c.chans=0; feed(build_aaf(stim, c)); } // zero channels = junk
     ck("[28d] 0ch rejected", dut->cnt_unsupported_fmt_o, 1);
     //! the 08-07 live case: the wire carries MORE channels than the SET
-    //! format (DS20 declared 4ch, sink set 4ch, wire 8ch-era) - accepts,
+    //! format (the peer declared 4ch, sink set 4ch, wire 8ch-era) - accepts,
     //! the maps route what they map
     { AafCfg c; c.seq=2; c.chans=9; feed(build_aaf(stim, c)); } // above the SET format
     ck("[28e] 9ch-wire ACCEPTED over 8ch fmt (BAF family)",

--- a/tests/features/gptp_announce_receipt_timeout.feature
+++ b/tests/features/gptp_announce_receipt_timeout.feature
@@ -8,7 +8,7 @@
 # steady - so there was no way to prove any fix.
 #
 # It reproduces DETERMINISTICALLY: a saturating unicast RX flood aimed at the
-# grandmaster board (935 Mb/s UDP, 60 s, `iperf3 -c 192.168.127.1 -u -b 950M
+# grandmaster board (935 Mb/s UDP, 60 s, `iperf3 -c <board mgmt address> -u -b 950M
 # -l 1400`). During the flood the ALINX grandmaster emits ZERO
 # Announce and ZERO Sync - not late, ABSENT - because the single-ring RX path
 # (`rx_queues: 1`, no steer block) consumes the whole softcore in NAPI and

--- a/tests/features/torture_campaign_plan.feature
+++ b/tests/features/torture_campaign_plan.feature
@@ -273,7 +273,7 @@ Feature: The torture campaign's own coverage is auditable at a desk
   Scenario: the physical conditions are still covered - by strip or by hand
     # The gm-change, gm-loss and power-cycle entries moved to the physical
     # area, where a runner with the powerstrip hook (USER authorization
-    # 2026-08-02: amx-pi OUT4 = the switch DN-1, OUT0 = the DUT) drives them
+    # 2026-08-02: powerstrip OUT4 = the switch DN-1, OUT0 = the DUT) drives them
     # automatically.  In the PLAN they stay needs_human, so a bench without
     # the hook hands them back as NEEDS-HUMAN exactly as before - never a
     # silent skip.  The cable pull stays human forever: a powerstrip cannot


### PR DESCRIPTION
[A5]

## Contents

- **[Status](#status)** — Draft while the exhaustive local bar runs at this head.
- **[Linked Issue / roles](#linked-issue--roles)** — Public task and review roles.
- **[Description](#description)** — What the scrub reads now, and why the token table is assembled.
- **[Authoritative references](#authoritative-references)** — The rule, the gate, the page.
- **[How to get into the same state](#how-to-get-into-the-same-state)** — Reproducible checkout.
- **[How to validate](#how-to-validate)** — Exact commands and what they print.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** — Deliberate boundaries.
- **[Definition of Done](#definition-of-done)** — Acceptance, line by line.

## Status

DRAFT — implementation complete, local bar running at this head.

## Linked Issue / roles

Closes #247

Executor: `[A5]`
External reviewer: unassigned — still a merge gate

## Description

#247 has two halves: four tracked sites carrying the reference peer's product
name, and the reason they survived — `scripts/docs_check.py` reads only `*.md`,
so anything in RTL, scripts, configs, testbenches, feature files or generator
text was invisible to every gate.

**The sites.** Three of the four are already gone: PR #266 (`85c60ce8`) deleted
`docs/HOWTO_PLAY_MUSIC.md`, `historical_now_obsolete/handovers/HANDOVER_0801.md`
and `docs/findings/GPTP_GM_LOSS_UNDER_RX_LOAD.md` with the retired host-stack
corpus. The survivor, `tb/verilator/avtp_rxmon/sim_main.cpp:369`, is reworded
and keeps its declared-format meaning (`the peer declared 4ch, sink set 4ch,
wire 8ch-era`), not deleted.

**The gate.** Rule 5 is now a privacy scrub over every tracked **text** file
outside `third_party/`, replacing a hand-listed sweep of six `docs/` globs:

- One table, `SCRUB_RULES`, of `(pattern, class, what to write instead)`. Every
  class is judged on every line, so one line can carry two findings — a
  `continue` between them would mean a correct scrub *reveals* a new finding and
  the gate could never be driven green in one pass.
- A finding prints its **class and column, never the match**. The CI log of a
  public repo republishes whatever a finding quotes.
- The private tokens are assembled from code points, as the lab acronyms
  already were. That discipline had a hole: because the gate read only `*.md`
  it could not read itself, and the compliance-suite stem sat spelled out in
  `DENY_CI` as the last occurrence of that token in the tree. It is assembled
  now, and an arm requires this file to pass its own sweep.
- The two bench-identity rules that named this bench (`/home/<user>`, one
  `192.168.x` subnet) became **shapes** — any home path, any `192.168.x` — which
  removes two literals from the tracked source and stops the rules from letting
  another account's path through.
- The **wording** deny-list (`avnu`, `certif`) deliberately stays markdown-only:
  tree-wide it fires 34 times on the CRF format's normative name in RTL banners
  and on "certify" in gate comments. Widening a prose rule by masking 34
  legitimate sites would weaken it, not strengthen it.

**Proof that it bites.** The arms run on **every** invocation and their count
rides in the summary line, because #247 says a scrub gate that has never failed
once is not evidence that it works. Each class is planted in a *non-markdown*
file and must be caught by its own class; the negative controls (lower-case lab
word, the peer stem inside a longer word, vendored code, a binary file) must
stay clean; a class with no fixture fails the run; and a failing arm is exit 2
(rule 5 unproven), never exit 0 (clean).

**Twelve pre-existing sites** the gate could never see are fixed in the same
commit, because a gate that lands red is a gate nobody can use: five home paths
in scripts and testbench tooling, the bench host prefix in three help strings
and two feature comments, one bench address in a feature comment.
`xvlog_gate.py`'s two Vivado candidates become `~`-relative and resolve to the
same absolute paths on a bench box — `find_xvlog()` returns the same binary.

**One inventory fix.** The no-git walk (`docs.yml`'s `docs-check-no-git` job)
was five files short of `git ls-files`: the crude `.gitignore` reader dropped
`!` re-inclusions, so the tracked `configs/generated/*/gen/*.svh` emissions were
invisible there. Harmless while the inventory only fed markdown link checks, a
coverage hole once it feeds the privacy scrub. Negations are honoured now and an
arm pins the parity.

## Authoritative references

- #247 — the rule, the four sites, the acceptance criteria
- `scripts/docs_check.py` — rule 5 and the assembly discipline
- `docs/DOC_GENERATION.md` section 5 — the gate's documented contract
- #259 / PR #266 (`85c60ce8`) — why three of the four sites no longer exist

## How to get into the same state

```sh
git clone git@github.com:kebag-logic/milan-fpga.git
cd milan-fpga
git checkout 247-scrub-leak-the-peer-make-and-model-appear-in-four-tracked-files-and-no-gate-covers-non-markdown-text
git submodule update --init protocol-processor gptp-processor third_party/verilog-axis
```

## How to validate

```sh
python3 scripts/docs_check.py             # 0 findings, self-test 17/17
python3 scripts/docs_check.py --selftest  # the arms alone
git grep -nIi <the long form> -- . ':(exclude)third_party'   # empty (acceptance)
git grep -nIi <the short form> -- . ':(exclude)third_party'  # empty (acceptance)
```

Evidence for the exact head is posted as a PR comment.

## Known limitations / out of scope

- The peer's entity ID and MAC stay as they are (#247 out-of-scope: changing
  them alters bench behaviour). The switch manufacturer's name is likewise not
  swept — that needs a decision first.
- Binary files are skipped, exactly as the `git grep -nI` acceptance oracle
  skips them. A name inside a binary blob is out of both.
- `harness/tests/test_harness.py` keeps its own stricter per-file bench-identity
  arm over `harness/board`; this sweep is the tree-wide floor under it. Folding
  the two tables into one is a separate change, not bundled here.

## Definition of Done

- [x] `git grep -nI` for the long and the short form is clean over tracked files
      outside `third_party/`
- [x] The scrub reads every tracked text file, `third_party/` excluded
- [x] The token set is in the gate, assembled rather than spelled
- [x] The gate is proven to bite: planted in a non-markdown file, it reddens;
      removed, it goes green — and the arms that prove it run on every CI run
- [ ] External review
