### PR TITLE
Judge the values documentation repeats in prose

### DIFF
--- a/docs/MILAN_V12_ROADMAP.md
+++ b/docs/MILAN_V12_ROADMAP.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: CERN-OHL-W-2.0 -->
 # Milan v1.2 — the road to full compliance
 
-**Status 2026-08-18, VERSION `0x0002_0053`.** This is the ordered, clause-cited
+**Status 2026-08-27, VERSION `0x0002_0055`.** This is the ordered, clause-cited
 plan from where the device is to a device that passes the Milan
 end-station validation test plan. It supersedes the AECP sections of
 [historical `MILAN_COMPLIANCE_GAPS.md`](MILAN_COMPLIANCE_GAPS.md), whose 2026-08-13 status
@@ -65,7 +65,7 @@ None. Every operation Milan v1.2 mandates for this profile is served since
 
 ### 0.1 Served for real, today
 
-**Twenty-six** AEM opcodes plus one MVU command. The processor's `OP_*_C`
+**Thirty** AEM opcodes plus one MVU command. The processor's `OP_*_C`
 constants are the concrete decode. The feature ledger owns the canonical
 documented inventory, and the compliant bench gates its `SERVED` table against
 the processor RTL.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -141,7 +141,7 @@ the [Milan feature status ledger](../reference/MILAN_FEATURE_STATUS.md):
   drawio renderer that produced its pages lived under the AECP RTL's doc
   directory. **Both were deleted on 2026-08-13** with the fabric engine they
   described. The AECP responder that answers today is the protocol processor's
-  uCPU. It handles 26 AEM opcodes plus Milan `GET_MILAN_INFO`, and returns a
+  uCPU. It handles 30 AEM opcodes plus Milan `GET_MILAN_INFO`, and returns a
   conformant `NOT_IMPLEMENTED` echo for commands outside that inventory. Its
   authoritative command table and architecture drawings live in the pinned
   submodule, not here. Nothing in the surviving pipeline depends on that

--- a/docs/integration/BAREMETAL_FIRMWARE.md
+++ b/docs/integration/BAREMETAL_FIRMWARE.md
@@ -93,6 +93,18 @@ this order:
    controls are ORed into one shared control-plane enable, so either bit alone
    enables it.
 
+That order is the claim, so it is checked rather than asserted: the block below
+is compared step by step against the call sequence `milan_init()` actually
+emits, and `scripts/check_feature_status.py` fails if either side moves. Swap
+two steps here, or in the firmware, and the gate names both sequences.
+
+<!-- milan-feature-order:firmware_boot_order:start -->
+1. `configure_fabric()` — the fabric CSRs, with the PHC and the gPTP plane
+   already live from the CSR reset.
+2. `load_aem_image()` — copy from QSPI and verify the CRC32.
+3. `entity_advertise()` — the enable bits, and only on a verified image.
+<!-- milan-feature-order:firmware_boot_order:end -->
+
 Step 4 lives in one function and nowhere else:
 
 ```c

--- a/docs/reference/MILAN_FEATURE_STATUS.md
+++ b/docs/reference/MILAN_FEATURE_STATUS.md
@@ -25,6 +25,35 @@ then rerun the parent gates at the resulting exact head. A branch-only donor
 commit can be fetched today and still disappear tomorrow, so it is never merge
 evidence by itself.
 
+## Values repeated in prose
+
+A marked row is safe because the checker reads it. The same value written into
+a sentence was not, and that is how the roadmap came to open with a version two
+minors behind its own row, and to count six fewer served opcodes than the block
+twenty lines below it (#98). Three prose forms are now judged against the
+ledger, and none of them needs a marker while it is correct:
+
+| Written as | Judged against | Notes |
+|---|---|---|
+| `VERSION `0x0002_0055`` — the name and the full two-word spelling on one line | `facts.gateware_version` | Only the CURRENT major is judged. `VERSION 0x0001_000B` and the minor-only idiom (`fixed at VERSION 0x000F`) are how this corpus writes history, and a bump to major 3 retires today's spellings the same way |
+| `thirty AEM opcodes`, `one MVU command` | the length of the matching `facts.served_*_operations` list | Word and numeral spellings are both accepted. `N AEM commands` is deliberately not judged: in this corpus it counts commands still to land |
+| a `milan-feature-order` block | `facts.firmware_boot_order`, itself read from `milan_init()` | Compared as a SEQUENCE, so reversing the documented steps fails even though the set is unchanged |
+
+A page that deliberately records a superseded value — a dated audit, a release
+note — marks that one line:
+
+```markdown
+<!-- milan-feature-value:gateware_version:historic -->
+3. The repository README described the VERSION `0x0002_0053` control-plane
+   surface as it stood at this audit.
+```
+
+The marker is not an exemption from being read. A historic marker on a line
+carrying the CURRENT value is itself a finding: the value moved on to that
+line, and the marker would otherwise hide a live claim behind a record.
+`value_documents` in the ledger names the pages that must state the current
+version in prose, so dropping the claim is a finding rather than a silence.
+
 <!-- milan-feature-status:start -->
 | Feature ID | Status | Canonical value |
 |---|---|---|

--- a/docs/reference/milan_feature_status.json
+++ b/docs/reference/milan_feature_status.json
@@ -37,7 +37,12 @@
     "served_mvu_operations": [
       "GET_MILAN_INFO"
     ],
-    "missing_mandatory_aem_operations": []
+    "missing_mandatory_aem_operations": [],
+    "firmware_boot_order": [
+      "configure_fabric",
+      "load_aem_image",
+      "entity_advertise"
+    ]
   },
   "fact_documents": {
     "served_aem_operations": [
@@ -57,6 +62,19 @@
       "docs/MILAN_V12_ROADMAP.md",
       "docs/reference/MILAN_FEATURE_STATUS.md",
       "docs/testing/MILAN_V12_AUDIT_2026-08-16.md"
+    ]
+  },
+  "value_documents": {
+    "gateware_version": [
+      "README.md",
+      "docs/MILAN_V12_ROADMAP.md",
+      "docs/reference/REGISTER_MAP.md",
+      "docs/reference/REGISTER_MAP_CLASSES.md"
+    ]
+  },
+  "order_documents": {
+    "firmware_boot_order": [
+      "docs/integration/BAREMETAL_FIRMWARE.md"
     ]
   },
   "features": [

--- a/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
+++ b/docs/testing/MILAN_V12_AUDIT_2026-08-16.md
@@ -375,8 +375,9 @@ media gate in [`milan_datapath.sv`](../../hdl/milan/milan_datapath.sv).
    ROM, which allowed false-green integration runs.
 2. The root processor integration now grades Milan `ACQUIRE_ENTITY` instead of
    printing a stale unconditional gap.
-3. The repository README now describes the current VERSION `0x0002_0053`
-   control-plane surface and the remaining blockers.
+   <!-- milan-feature-value:gateware_version:historic -->
+3. The repository README described the VERSION `0x0002_0053` control-plane
+   surface and the remaining blockers as they stood at this audit.
 4. First-line-obsolete documents are no longer current authorities. Current
    entry points route compliance verdicts to this audit and the generated
    module matrix.

--- a/scripts/check_feature_status.py
+++ b/scripts/check_feature_status.py
@@ -51,6 +51,85 @@ FACT_NON_OPERATION_TOKENS = {
 ARCHIVE_PARTS = {"historical_now_obsolete", "archive", "archived", "archives"}
 VERSION_SOURCE = REPO / "hdl/common/csr/milan_csr.sv"
 COMMAND_SOURCE = REPO / "tests/steps/aecp_engine_steps.py"
+FIRMWARE_SOURCE = REPO / "sw/firmware/milan_baremetal/milan_baremetal.c"
+
+# --------------------------------------------------------------------------
+# Repeated values in PROSE (#98). The marked rows and fact blocks above carry
+# the inventory; a sentence repeating the same value carried nothing, and a
+# roadmap shipped for nine days with `0x0002_0053` in its opening line and
+# `0x0002_0055` in its own marked row twenty-five lines below.
+#
+# These rules are deliberately NOT a scan for stale spellings. Each one reads
+# the canonical fact and judges what the prose says against it, so the rule
+# needs no maintenance when the value moves - only the prose does.
+
+#: A current-version claim: the register/product name and the FULL two-word
+#: spelling on one line, IN THE CANONICAL MAJOR. Two spellings are deliberately
+#: not judged, because neither can be a claim about the current version and
+#: gating them would mark seventy historical sentences with no drift behind
+#: any of them: the minor-only idiom (`fixed at VERSION 0x000F`), and an older
+#: major (`VERSION 0x0001_000B`), which the major bump already retired. When
+#: the major next steps, today's `0x0002_xxxx` sentences leave the judged set
+#: the same way - by then they are history, and the new era's are judged.
+VERSION_CLAIM_RE = re.compile(
+    r"\bVERSION\b.{0,40}?`?(0x[0-9A-Fa-f]{4}_[0-9A-Fa-f]{4})`?")
+
+#: A served-inventory count. Keyed on the `opcodes` idiom the served claims
+#: use, because `N AEM commands` means something else here (the roadmap counts
+#: commands still to land, not commands served). The word before the noun is
+#: judged only when it IS a number: `the served AEM opcodes` is a phrase, not
+#: a claim, and reading every adjective as a count made this file's own
+#: description of the rule its first false positive.
+COUNT_CLAIM_RE = re.compile(
+    r"(?:\*\*)?(?P<count>[A-Za-z][A-Za-z-]{2,}|\d{1,3})(?:\*\*)?\s+"
+    r"(?P<kind>AEM opcodes?|MVU (?:command|operation)s?)\b")
+COUNT_FACTS = {"AEM": "served_aem_operations", "MVU": "served_mvu_operations"}
+
+#: Placed on the line before a claim that deliberately records a SUPERSEDED
+#: value (a dated audit, a release note). A historic marker whose line carries
+#: the canonical value is itself a finding: the value moved on to it and the
+#: marker now hides a live claim.
+VALUE_HISTORIC_RE = re.compile(
+    r"^<!-- milan-feature-value:(?P<fact>[a-z0-9_]+):historic -->$")
+
+#: An ORDERED fact: the block's tokens must reproduce the ledger sequence,
+#: not merely its set. `firmware_boot_order` is what makes "the PHC does not
+#: wait for the AEM image" a checkable claim rather than a sentence.
+ORDER_START_RE = re.compile(
+    r"^<!-- milan-feature-order:(?P<fact>[a-z0-9_]+):start -->$")
+ORDER_END_RE = re.compile(
+    r"^<!-- milan-feature-order:(?P<fact>[a-z0-9_]+):end -->$")
+ORDER_TOKEN_RE = re.compile(r"`([a-z_][a-z0-9_]*)\(\)`")
+
+_ONES = ("zero", "one", "two", "three", "four", "five", "six", "seven",
+         "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen",
+         "fifteen", "sixteen", "seventeen", "eighteen", "nineteen")
+_TENS = {2: "twenty", 3: "thirty", 4: "forty", 5: "fifty", 6: "sixty",
+         7: "seventy", 8: "eighty", 9: "ninety"}
+
+
+def is_number_token(token):
+    """Whether ``token`` spells a number this corpus could mean as a count."""
+    return bool(re.fullmatch(r"\d{1,3}", token)) or any(
+        token == spelling for value in range(100)
+        for spelling in number_spellings(value))
+
+
+def number_spellings(count):
+    """Every spelling of ``count`` this corpus accepts, lower-cased.
+
+    Prose here writes small counts as words (`thirty AEM opcodes`); tables
+    write numerals. Both are the same claim, so both are accepted rather than
+    forcing a house number style on a consistency gate.
+    """
+    spellings = {str(count)}
+    if 0 <= count < len(_ONES):
+        spellings.add(_ONES[count])
+    elif 20 <= count < 100:
+        tens, ones = divmod(count, 10)
+        spellings.add(_TENS[tens] if not ones
+                      else f"{_TENS[tens]}-{_ONES[ones]}")
+    return spellings
 
 
 class DuplicateKey(ValueError):
@@ -100,6 +179,17 @@ def load_ledger_text(text, source="ledger"):
             for value in duplicates:
                 findings.append(
                     f"{source}: duplicate operation '{value}' in facts.{name}")
+        order = facts.get("firmware_boot_order")
+        if not isinstance(order, list) or len(order) < 2 or not all(
+                isinstance(step, str) and re.fullmatch(r"[a-z_][a-z0-9_]*",
+                                                       step)
+                for step in order):
+            findings.append(
+                f"{source}: facts.firmware_boot_order must be a list of at "
+                f"least two C identifiers")
+        elif len(order) != len(set(order)):
+            findings.append(
+                f"{source}: facts.firmware_boot_order repeats a step")
 
     features = data.get("features")
     if not isinstance(features, list):
@@ -162,6 +252,27 @@ def load_ledger_text(text, source="ledger"):
             elif len(documents) != len(set(documents)):
                 findings.append(
                     f"{source}: fact_documents.{name} repeats a document")
+
+    # The prose-claim registers (#98). Both are REQUIRED: an absent register
+    # would silently retire the presence half of rules 1 and 4, and a page
+    # that drops the claim entirely is exactly the drift they exist to catch.
+    for key, allowed in (("value_documents", {"gateware_version"}),
+                         ("order_documents", {"firmware_boot_order"})):
+        register = data.get(key)
+        if not isinstance(register, dict) or not register:
+            findings.append(f"{source}: {key} must be a non-empty object")
+            continue
+        for name, documents in register.items():
+            if name not in allowed:
+                findings.append(f"{source}: {key} has unknown fact '{name}'")
+                continue
+            if not isinstance(documents, list) or not documents or not all(
+                    isinstance(document, str) and document.endswith(".md")
+                    for document in documents):
+                findings.append(
+                    f"{source}: {key}.{name} needs a Markdown document list")
+            elif len(documents) != len(set(documents)):
+                findings.append(f"{source}: {key}.{name} repeats a document")
     if findings:
         return None, findings
 
@@ -182,9 +293,49 @@ def load_ledger_text(text, source="ledger"):
     return data, []
 
 
+def boot_order_findings(ledger, firmware_text, firmware_source):
+    """Tie ``facts.firmware_boot_order`` to ``milan_init()``'s call order.
+
+    The order is read from the ONE function that runs at init, with comments
+    and strings removed first so a printf naming a step cannot supply it. Only
+    the relative order of the ledger's steps is judged: the firmware is free
+    to log or read a register between them, and the claim documentation makes
+    is "the PHC is up before the AEM image is looked at", not "nothing else
+    happens".
+    """
+    findings = []
+    body = re.search(r"\bmilan_init\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+                     firmware_text, re.DOTALL)
+    if body is None:
+        findings.append(f"{firmware_source}: cannot locate milan_init()")
+        return findings
+    code = re.sub(r"/\*.*?\*/", " ", body.group("body"), flags=re.DOTALL)
+    code = re.sub(r"//[^\n]*", " ", code)
+    code = re.sub(r'"(?:[^"\\]|\\.)*"', ' ', code)
+    positions = []
+    for step in ledger["facts"]["firmware_boot_order"]:
+        call = re.search(r"\b%s\s*\(" % re.escape(step), code)
+        if call is None:
+            findings.append(
+                f"{firmware_source}: milan_init() does not call {step}()")
+        else:
+            positions.append((step, call.start()))
+    if len(positions) != len(ledger["facts"]["firmware_boot_order"]):
+        return findings
+    actual = [step for step, _ in sorted(positions, key=lambda item: item[1])]
+    if actual != ledger["facts"]["firmware_boot_order"]:
+        findings.append(
+            f"firmware boot-order conflict: ledger="
+            f"{ledger['facts']['firmware_boot_order']}; "
+            f"{firmware_source}={actual}")
+    return findings
+
+
 def check_source_facts(ledger, version_text, command_text,
                        version_source="milan_csr.sv",
-                       command_source="aecp_engine_steps.py"):
+                       command_source="aecp_engine_steps.py",
+                       firmware_text=None,
+                       firmware_source="milan_baremetal.c"):
     """Tie version and served-command facts to their source declarations."""
     findings = []
     version_code = re.sub(r"/\*.*?\*/", "", version_text, flags=re.DOTALL)
@@ -244,6 +395,9 @@ def check_source_facts(ledger, version_text, command_text,
             findings.append(
                 "served AEM inventory conflict: "
                 f"missing-from-source={missing}; missing-from-ledger={extra}")
+    if firmware_text is not None:
+        findings.extend(
+            boot_order_findings(ledger, firmware_text, firmware_source))
     return findings
 
 
@@ -375,6 +529,228 @@ def parse_fact_blocks(text, relpath):
     return blocks, findings
 
 
+def parse_value_claims(text, relpath):
+    """Return ``(version, counts, orders, findings)`` for one document.
+
+    ``version`` and ``counts`` are the prose repetitions rule 1 and rule 3
+    judge; ``orders`` are ordered-fact blocks. Fenced code, HTML comments and
+    the fact blocks are skipped: a fact block already states the inventory
+    under its own check, and re-judging its text would report one drift twice.
+    """
+    version, counts, orders, findings = [], [], {}, []
+    in_fence = in_comment = False
+    in_fact = False
+    historic_for = None
+    active_order = None
+    order_line = 0
+    tokens = []
+    paragraph = []
+
+    def flush(paragraph, marked):
+        """Judge one paragraph, reporting the line each match STARTS on.
+
+        Prose here wraps at about seventy-eight columns, so `serves **thirty**
+        AEM` ends one line and `opcodes plus …` begins the next. A line-at-a-
+        time reader never saw that claim at all - the first live claim this
+        rule was written for, and a silent pass is the one failure mode a
+        consistency gate cannot have. A table row is judged alone: rows are
+        records, and joining them would let one row's `VERSION` reach the next
+        row's hexadecimal.
+        """
+        if not paragraph:
+            return
+        joined, spans = "", []
+        for lineno, line in paragraph:
+            spans.append((len(joined), lineno))
+            joined += line + " "
+
+        def line_of(pos):
+            found = paragraph[0][0]
+            for start, lineno in spans:
+                if start <= pos:
+                    found = lineno
+            return found
+
+        for match in VERSION_CLAIM_RE.finditer(joined):
+            version.append((line_of(match.start()), match.group(1),
+                            marked == "gateware_version"))
+        for count in COUNT_CLAIM_RE.finditer(joined):
+            spelled = count.group("count").lower()
+            if not is_number_token(spelled):
+                continue
+            fact = COUNT_FACTS[count.group("kind").split()[0]]
+            counts.append((line_of(count.start()), fact, spelled,
+                           marked == fact))
+
+    for lineno, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        # A block quote wraps like any other prose, and its `>` would sit
+        # between `AEM` and `opcodes` when the lines are joined - which is how
+        # the README's own served-count claim escaped the first cut of this
+        # rule. The marker is punctuation here, not content.
+        stripped = re.sub(r"^(?:>\s*)+", "", stripped)
+        boundary = (FENCE_RE.match(line) or in_fence or in_comment or
+                    not stripped or stripped.startswith("|") or
+                    stripped.startswith("<!--"))
+        if boundary and paragraph:
+            flush(paragraph, historic_for[0] if historic_for else None)
+            historic_for = None
+            paragraph = []
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            continue
+
+        historic = VALUE_HISTORIC_RE.fullmatch(stripped)
+        if historic:
+            historic_for = (historic.group("fact"), lineno)
+            continue
+        start = ORDER_START_RE.fullmatch(stripped)
+        if start:
+            if active_order is not None:
+                findings.append(f"{relpath}:{lineno}: nested feature-order "
+                                f"block")
+            active_order, order_line, tokens = start.group("fact"), lineno, []
+            continue
+        end = ORDER_END_RE.fullmatch(stripped)
+        if end:
+            fact = end.group("fact")
+            if active_order is None:
+                findings.append(
+                    f"{relpath}:{lineno}: unmatched feature-order end")
+            elif fact != active_order:
+                findings.append(
+                    f"{relpath}:{lineno}: feature-order end '{fact}' does not "
+                    f"match '{active_order}'")
+            elif fact in orders:
+                findings.append(
+                    f"{relpath}:{lineno}: duplicate feature-order '{fact}'")
+            else:
+                orders[fact] = (tokens, order_line)
+            active_order, tokens = None, []
+            continue
+        if FACT_START_RE.fullmatch(stripped):
+            in_fact = True
+            continue
+        if FACT_END_RE.fullmatch(stripped):
+            in_fact = False
+            continue
+        if "<!--" in line and "-->" not in line:
+            in_comment = True
+            continue
+        if active_order is not None:
+            tokens.extend(ORDER_TOKEN_RE.findall(line))
+            continue
+        if not stripped or in_fact:
+            continue
+
+        # A table row is a paragraph of its own (see flush); prose lines
+        # accumulate until a boundary closes them.
+        if stripped.startswith("|"):
+            flush([(lineno, stripped)],
+                  historic_for[0] if historic_for else None)
+            historic_for = None
+            continue
+        paragraph.append((lineno, stripped))
+
+    flush(paragraph, historic_for[0] if historic_for else None)
+    if active_order is not None:
+        findings.append(
+            f"{relpath}:{order_line}: unclosed feature-order '{active_order}'")
+    return version, counts, orders, findings
+
+
+def check_value_claims(ledger, documents):
+    """Judge prose repetitions of ledger values, and ordered-fact blocks."""
+    findings = []
+    facts = ledger["facts"]
+    canonical_version = facts["gateware_version"]
+    canonical_major = canonical_version.split("_")[0].upper()
+    seen_version = set()
+    order_occurrences = defaultdict(dict)
+
+    for relpath, text in sorted(documents.items()):
+        version, counts, orders, parse_findings = parse_value_claims(
+            text, relpath)
+        findings.extend(parse_findings)
+        for fact, block in orders.items():
+            order_occurrences[fact][relpath] = block
+
+        for lineno, value, historic in version:
+            if value.split("_")[0].upper() != canonical_major:
+                continue        # a retired major: history, not a claim
+            matches = value.upper() == canonical_version.upper()
+            if historic and matches:
+                findings.append(
+                    f"{relpath}:{lineno}: historic marker on the CURRENT "
+                    f"version {canonical_version} — the value moved on to "
+                    f"this line; drop the marker or restate the claim")
+            elif historic:
+                continue
+            elif not matches:
+                findings.append(
+                    f"{relpath}:{lineno}: version claim {value} conflicts "
+                    f"with the canonical {canonical_version} — correct it, or "
+                    f"mark the line a record with "
+                    f"<!-- milan-feature-value:gateware_version:historic -->")
+            else:
+                seen_version.add(relpath)
+
+        for lineno, fact, spelled, historic in counts:
+            expected = len(facts[fact])
+            matches = spelled in number_spellings(expected)
+            if historic and matches:
+                findings.append(
+                    f"{relpath}:{lineno}: historic marker on the CURRENT "
+                    f"{fact} count {expected} — drop the marker or restate "
+                    f"the claim")
+            elif historic:
+                continue
+            elif not matches:
+                findings.append(
+                    f"{relpath}:{lineno}: {fact} count '{spelled}' conflicts "
+                    f"with the canonical {expected}")
+
+    for relpath in sorted(ledger["value_documents"]["gateware_version"]):
+        if relpath not in documents:
+            findings.append(
+                f"value 'gateware_version' requires missing or inactive "
+                f"{relpath}")
+        elif relpath not in seen_version:
+            findings.append(
+                f"value 'gateware_version' is not stated in {relpath}")
+
+    order_documents = ledger["order_documents"]
+    for fact, claims in sorted(order_occurrences.items()):
+        if fact not in order_documents:
+            files = ", ".join(sorted(claims))
+            findings.append(f"unknown feature order '{fact}' in {files}")
+            continue
+        for relpath, (tokens, lineno) in sorted(claims.items()):
+            if relpath not in set(order_documents[fact]):
+                findings.append(
+                    f"feature order '{fact}' is not registered for {relpath}")
+            if tokens != facts[fact]:
+                findings.append(
+                    f"feature order conflict '{fact}' in {relpath}:{lineno}: "
+                    f"documented={tokens}; canonical={facts[fact]}")
+    for fact, expected_documents in sorted(order_documents.items()):
+        for relpath in expected_documents:
+            if relpath not in documents:
+                findings.append(
+                    f"feature order '{fact}' requires missing or inactive "
+                    f"{relpath}")
+            elif relpath not in order_occurrences[fact]:
+                findings.append(
+                    f"feature order '{fact}' is not marked in {relpath}")
+    return findings
+
+
 def check_claims(ledger, documents):
     """Check active ``documents`` mapping against a parsed ledger."""
     findings = []
@@ -459,6 +835,7 @@ def check_claims(ledger, documents):
             elif relpath not in fact_occurrences[fact]:
                 findings.append(
                     f"feature fact '{fact}' is not marked in {relpath}")
+    findings.extend(check_value_claims(ledger, documents))
     return sorted(set(findings))
 
 
@@ -488,6 +865,12 @@ def run_self_test():
         "fact_documents": {
             "served_aem_operations": ["one.md", "two.md"]
         },
+        "value_documents": {
+            "gateware_version": ["one.md", "two.md"]
+        },
+        "order_documents": {
+            "firmware_boot_order": ["one.md"]
+        },
         "features": [{
             "id": "aem.read-descriptor",
             "status": "implemented",
@@ -495,20 +878,32 @@ def run_self_test():
             "documents": ["one.md", "two.md"]
         }]
     }
+    base["facts"]["firmware_boot_order"] = ["configure_fabric",
+                                            "load_aem_image",
+                                            "entity_advertise"]
     fact_row = (
         "<!-- milan-feature-fact:served_aem_operations:start -->\n"
         "- `READ_DESCRIPTOR`\n"
         "<!-- milan-feature-fact:served_aem_operations:end -->\n"
     )
+    prose = ("Status today, VERSION `0x0002_0051`, serving one AEM opcode "
+             "plus one MVU command.\n")
+    order_block = (
+        "<!-- milan-feature-order:firmware_boot_order:start -->\n"
+        "1. `configure_fabric()`\n2. `load_aem_image()`\n"
+        "3. `entity_advertise()`\n"
+        "<!-- milan-feature-order:firmware_boot_order:end -->\n"
+    )
     row = (f"{BLOCK_START}\n| Feature ID | Status | Canonical value |\n"
            "|---|---|---|\n"
            "| `aem.read-descriptor` | `implemented` | - |\n"
-           f"{BLOCK_END}\n{fact_row}")
+           f"{BLOCK_END}\n{fact_row}{prose}")
+    ordered_row = row + order_block
 
     ledger, findings = load_ledger_text(json.dumps(base), "fixture")
     cases = []
     cases.append(("clean", not findings and not check_claims(
-        ledger, {"one.md": row, "two.md": row})))
+        ledger, {"one.md": ordered_row, "two.md": row})))
 
     conflict = row.replace("`implemented`", "`missing`")
     conflict_findings = check_claims(
@@ -605,6 +1000,146 @@ def run_self_test():
         "// parameter logic [31:0] VERSION = 32'h0002_0052;\n" + version_text,
         '# SERVED = {0: dict(name="SET_NAME")}\n' + command_text)))
 
+    # ---- #98: repeated values in prose, and the ordered boot claim ----
+    def claims(one, two=row):
+        return check_claims(ledger, {"one.md": one, "two.md": two})
+
+    drift = ordered_row.replace("VERSION `0x0002_0051`",
+                                "VERSION `0x0002_0049`")
+    cases.append(("version drift", any(
+        "one.md:" in item and "0x0002_0049" in item and "0x0002_0051" in item
+        for item in claims(drift))))
+    cases.append(("version drift names every file", len({
+        item.split(":")[0] for item in claims(drift, drift.replace(
+            "0x0002_0049", "0x0002_0050")) if "version claim" in item}) == 2))
+    historic = drift.replace(
+        "Status today", "<!-- milan-feature-value:gateware_version:historic "
+        "-->\nStatus today")
+    cases.append(("historic marker accepted", not any(
+        "version claim" in item for item in claims(historic))))
+    cases.append(("historic marker still needs a live claim", any(
+        "value 'gateware_version' is not stated in one.md" in item
+        for item in claims(historic))))
+    stale_marker = ordered_row.replace(
+        "Status today", "<!-- milan-feature-value:gateware_version:historic "
+        "-->\nStatus today")
+    cases.append(("historic marker on the current value", any(
+        "historic marker on the CURRENT version" in item
+        for item in claims(stale_marker))))
+    retired_major = ordered_row.replace("VERSION `0x0002_0051`",
+                                        "VERSION `0x0001_000B`")
+    cases.append(("retired major is history", not any(
+        "version claim" in item for item in claims(retired_major))))
+    minor_only = ordered_row.replace("VERSION `0x0002_0051`",
+                                     "VERSION `0x0049`")
+    cases.append(("minor-only spelling is history", not any(
+        "version claim" in item for item in claims(minor_only))))
+    cases.append(("version presence", any(
+        "value 'gateware_version' is not stated in two.md" in item
+        for item in claims(ordered_row, row.replace(prose, "")))))
+
+    count_drift = ordered_row.replace("one AEM opcode", "twenty-six AEM opcodes")
+    cases.append(("count drift", any(
+        "served_aem_operations count 'twenty-six'" in item and "one.md:" in item
+        for item in claims(count_drift))))
+    cases.append(("numeral spelling accepted", not any(
+        "count" in item for item in claims(
+            ordered_row.replace("one AEM opcode", "1 AEM opcode")))))
+    cases.append(("mvu count drift", any(
+        "served_mvu_operations count 'two'" in item for item in claims(
+            ordered_row.replace("one MVU command", "two MVU commands")))))
+    cases.append(("count in a fence ignored", not any(
+        "count" in item for item in claims(
+            ordered_row + "\n```\nnine AEM opcodes\n```\n"))))
+    cases.append(("an adjective is not a count", not any(
+        "count" in item for item in claims(ordered_row.replace(
+            "one AEM opcode", "served AEM opcodes")))))
+    # Prose wraps, and the corpus quotes: both put a line break (and a `>`)
+    # between the number and the noun. A line-at-a-time reader passed the
+    # README's real claim silently, which is worse than any false positive.
+    wrapped = ordered_row.replace(
+        "Status today, VERSION `0x0002_0051`, serving one AEM opcode",
+        "Status today, VERSION\n`0x0002_0051`, serving twenty-six AEM\nopcode")
+    cases.append(("claim wrapped across lines", any(
+        "count 'twenty-six'" in item for item in claims(wrapped))))
+    cases.append(("wrapped version claim still read", not any(
+        "value 'gateware_version' is not stated in one.md" in item
+        for item in claims(wrapped))))
+    quoted = ordered_row.replace(
+        "Status today, VERSION `0x0002_0051`, serving one AEM opcode",
+        "> Status today, VERSION `0x0002_0051`, serving twenty-six AEM\n"
+        "> opcode")
+    cases.append(("claim inside a block quote", any(
+        "count 'twenty-six'" in item for item in claims(quoted))))
+    cases.append(("count in a fact block ignored", not any(
+        "count" in item for item in claims(ordered_row.replace(
+            "- `READ_DESCRIPTOR`",
+            "- `READ_DESCRIPTOR` — nine AEM opcodes")))))
+
+    reversed_block = order_block.replace(
+        "1. `configure_fabric()`\n2. `load_aem_image()`",
+        "1. `load_aem_image()`\n2. `configure_fabric()`")
+    cases.append(("documented order reversed", any(
+        "feature order conflict 'firmware_boot_order'" in item and
+        "load_aem_image" in item
+        for item in claims(row + reversed_block))))
+    cases.append(("order block required", any(
+        "feature order 'firmware_boot_order' is not marked in one.md" in item
+        for item in claims(row))))
+    cases.append(("order block unregistered", any(
+        "feature order 'firmware_boot_order' is not registered for two.md"
+        in item for item in claims(ordered_row, row + order_block))))
+
+    # The banner names the LAST step in call shape, before any real call: a
+    # reader of the raw text sees `entity_advertise()` first and reports the
+    # order reversed. Only stripping strings gets this fixture right, which is
+    # what makes the clean arm below load-bearing rather than decorative.
+    firmware = ("static void milan_init(void)\n{\n"
+                '\tprintf("boot: entity_advertise() runs last\\n");\n'
+                "\tconfigure_fabric();\n\taem = load_aem_image();\n"
+                "\tentity_advertise(aem);\n}\n")
+    cases.append(("boot order source tie", not check_source_facts(
+        ledger, version_text, command_text, firmware_text=firmware)))
+    cases.append(("boot order reversed in firmware", any(
+        "firmware boot-order conflict" in item for item in check_source_facts(
+            ledger, version_text, command_text, firmware_text=firmware.replace(
+                "\tconfigure_fabric();\n\taem = load_aem_image();",
+                "\taem = load_aem_image();\n\tconfigure_fabric();")))))
+    cases.append(("boot step absent", any(
+        "does not call configure_fabric()" in item
+        for item in check_source_facts(
+            ledger, version_text, command_text,
+            firmware_text=firmware.replace("\tconfigure_fabric();\n", "")))))
+    cases.append(("commented boot call ignored", any(
+        "does not call configure_fabric()" in item
+        for item in check_source_facts(
+            ledger, version_text, command_text, firmware_text=firmware.replace(
+                "\tconfigure_fabric();", "\t/* configure_fabric(); */")))))
+    cases.append(("missing milan_init refused", any(
+        "cannot locate milan_init()" in item for item in check_source_facts(
+            ledger, version_text, command_text,
+            firmware_text="static void other(void)\n{\n}\n"))))
+
+    no_register = json.loads(json.dumps(base))
+    del no_register["value_documents"]
+    _, register_findings = load_ledger_text(json.dumps(no_register), "fixture")
+    cases.append(("value register required", any(
+        "value_documents must be a non-empty object" in item
+        for item in register_findings)))
+    unknown_register = json.loads(json.dumps(base))
+    unknown_register["order_documents"]["served_aem_operations"] = ["one.md"]
+    _, unknown_findings2 = load_ledger_text(
+        json.dumps(unknown_register), "fixture")
+    cases.append(("unknown register fact", any(
+        "order_documents has unknown fact" in item
+        for item in unknown_findings2)))
+    bad_order = json.loads(json.dumps(base))
+    bad_order["facts"]["firmware_boot_order"] = ["configure_fabric"]
+    _, bad_order_findings = load_ledger_text(json.dumps(bad_order), "fixture")
+    cases.append(("boot order needs two steps", any(
+        "firmware_boot_order must be a list" in item
+        for item in bad_order_findings)))
+
     for name, passed in cases:
         print(f"  {'PASS' if passed else 'FAIL'}  {name}")
     failed = [name for name, passed in cases if not passed]
@@ -638,13 +1173,16 @@ def main():
         try:
             version_text = VERSION_SOURCE.read_text(encoding="utf-8")
             command_text = COMMAND_SOURCE.read_text(encoding="utf-8")
+            firmware_text = FIRMWARE_SOURCE.read_text(encoding="utf-8")
         except OSError as exc:
             findings.append(str(exc))
         else:
             findings.extend(check_source_facts(
                 ledger, version_text, command_text,
                 str(VERSION_SOURCE.relative_to(REPO)),
-                str(COMMAND_SOURCE.relative_to(REPO))))
+                str(COMMAND_SOURCE.relative_to(REPO)),
+                firmware_text,
+                str(FIRMWARE_SOURCE.relative_to(REPO))))
         findings.extend(check_claims(ledger, active_markdown_documents(REPO)))
     for finding in findings:
         print(finding)


### PR DESCRIPTION
[A5]

## Contents

- **[Status](#status)** — Ready; local bar green at this head.
- **[Linked Issue / roles](#linked-issue--roles)** — Public task and review roles.
- **[Description](#description)** — What drifted, what now judges it, and what is deliberately not judged.
- **[Authoritative references](#authoritative-references)** — Ledger, checker, sources.
- **[How to get into the same state](#how-to-get-into-the-same-state)** — Reproducible checkout.
- **[How to validate](#how-to-validate)** — Exact commands.
- **[Known limitations / out of scope](#known-limitations--out-of-scope)** — Deliberate boundaries.
- **[Definition of Done](#definition-of-done)** — Acceptance, line by line.

## Status

READY FOR REVIEW — `98-documentation-consistency-align-active-claims-and-add-drift-detection` -> `dev`.

## Linked Issue / roles

Closes #98

Executor: `[A5]`
External reviewer: unassigned — still a merge gate

## Description

The ledger already ties the canonical values to their sources, and marked rows
and fact blocks already carry them. What carried nothing was the same value
written into a **sentence**, and both of the Issue's classes were live on `dev`:

- `docs/MILAN_V12_ROADMAP.md:4` opened with VERSION `0x0002_0053` twenty-five
  lines above its own marked row saying `0x0002_0055`.
- `docs/MILAN_V12_ROADMAP.md:68` counted "**Twenty-six** AEM opcodes" twenty
  lines above a fact block listing thirty; `docs/diagrams/README.md:144`
  carried the same stale count.

The Issue's second finding — `BAREMETAL_FIRMWARE.md` describing AEM
identity/CRC as gating the PTP clock — **was already reconciled** on `dev`; the
page states the opposite, and it matches `milan_init()`. What was missing is
the acceptance criterion behind it: nothing failed if that order was reversed.

Three prose forms are now judged against the ledger, none of which needs a
marker while it is correct:

| Written as | Judged against |
|---|---|
| the name `VERSION` and the full two-word spelling on one line | `facts.gateware_version` |
| `thirty AEM opcodes`, `one MVU command` (word or numeral) | the length of the matching served list |
| a `milan-feature-order` block | `facts.firmware_boot_order`, itself read from `milan_init()`'s call sequence |

Deliberately **not** judged, because none of them can be a claim about the
current state and gating them would mark seventy sentences with no drift behind
any of them: an older major (`VERSION 0x0001_000B`), the minor-only idiom
(`fixed at VERSION 0x000F`), and `N AEM commands`, which in this corpus counts
commands still to land rather than commands served. A bump to major 3 retires
today's `0x0002_xxxx` spellings the same way, automatically.

A page that deliberately records a superseded value marks that one claim with
`<!-- milan-feature-value:gateware_version:historic -->`, used once here, for
the dated audit's account of what the README said at the time. The marker is
not an exemption from being read: a historic marker on a line carrying the
CURRENT value is itself a finding, or the value could move onto the line and
hide behind the record.

Two things the first cut got wrong, both found by building the case rather than
reading the code, and both now arm-covered:

1. **A claim that wraps was never seen.** The README's own served count is
   `serves **thirty** AEM` / `opcodes plus …` across a line break, inside a
   block quote. A line-at-a-time reader passed it silently. The rules now read
   a paragraph, with the block-quote marker treated as punctuation, and report
   the line the claim starts on. A table row is still judged alone, so one
   row's `VERSION` cannot reach the next row's hexadecimal.
2. **Any adjective read as a count.** `the served AEM opcodes` was reported as
   a count of "served" — this file's own description of the rule was the first
   false positive. Only real number tokens are judged now.

## Authoritative references

- #98 — findings and acceptance criteria
- `docs/reference/milan_feature_status.json` — the ledger, its new `facts.firmware_boot_order`, `value_documents` and `order_documents`
- `docs/reference/MILAN_FEATURE_STATUS.md` — the contract, restated for authors
- `sw/firmware/milan_baremetal/milan_baremetal.c` — `milan_init()`, the boot-order source of truth

## How to get into the same state

```sh
git clone git@github.com:kebag-logic/milan-fpga.git
cd milan-fpga
git checkout 98-documentation-consistency-align-active-claims-and-add-drift-detection
git submodule update --init protocol-processor gptp-processor third_party/verilog-axis
```

## How to validate

```sh
python3 scripts/check_feature_status.py --self-test   # 46/46 arms, 0 findings
```

Evidence for the exact head is posted as a PR comment.

## Known limitations / out of scope

- The rules judge the three forms above. A count written as `N AEM commands`,
  or a version in an unquoted minor-only spelling, still is not judged — named
  here rather than left for a reader to discover.
- `docs/testing/SIMULATION.md:300` names `0x0002_0043` as a dated example of
  what an older flashed image returned. It carries no `VERSION` token on that
  line, so it is not judged; it is explicitly anchored to 2026-08-13 in the
  surrounding prose.
- The other acceptance topics (CRF, persistence, notifications, started/stopped)
  are already carried by marked rows and were verified consistent, not rebuilt.

## Definition of Done

- [x] Active documentation agrees on the current VERSION, the served operation
      inventory and the PTP/AEM boot order
- [x] Changing one active VERSION or operation-count claim while leaving the
      canonical value unchanged fails the checker and names every conflicting
      file
- [x] Reversing the documented PTP/AEM boot order — or the firmware's — fails a
      focused check
- [x] Duplicate identifiers, unknown statuses and missing ledger references
      remain rejected
- [x] Archived and obsolete pages remain out of the active comparison
- [x] All documentation, path, archive, contents and wording gates pass
- [ ] External review
