### PR TITLE
[Code quality] Rule 2: flatten the cluster namer into a role table

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,17 @@ jobs:
         # present rather than STALE. The builder's dp_srcs.py self-test also
         # resolves the five verilog-axis leaves in the shipping OOC manifest.
         run: git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
+      # Code-quality measurement self-tests (Rules 1 and 2 of
+      # docs/development/CODE_QUALITY.md): the fixture arms of the two tools
+      # the guide quotes its numbers from. Each arm fails when the defect it
+      # guards is reintroduced - an exclusive case arm read as source-order
+      # priority, an elif read as a nesting level, a `<=` comparison read as
+      # a write - and the population arm refuses a scan that reaches neither
+      # processor's Python, so it needs the submodule checkout above.
+      - name: Code-quality measurement self-tests
+        run: |
+          python3 scripts/measure_control_flow.py --selftest
+          python3 scripts/measure_cohesion.py --selftest
       # dp_srcs.py refuses to answer without a front end (no model may stand
       # in for sv2v), and the builder runs its self-test unconditionally, so
       # this job needs the same pinned release the portability gate uses.

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -23,8 +23,8 @@ shape rather than guess at it.
 - **[Scope](#scope)** -- What counts as first-party maintenance surface and what is deliberately outside it, including why a generated file is fixed in its generator and never by hand.
 - **[Rule 1: keep modules and functions cohesive](#rule-1-keep-modules-and-functions-cohesive)** -- The single-responsibility rule, its repository interpretation for SystemVerilog and host code, worked good/bad examples, the exceptions that let a long unit stay whole, and the review checklist.
 - **[Measuring cohesion](#measuring-cohesion)** -- Why line count cannot answer the question, what `scripts/measure_cohesion.py` counts instead (disjoint state groups), what it deliberately cannot see, and the current candidate list read off the tree.
-- **[Rule 2: prefer simple and explicit control flow](#rule-2-prefer-simple-and-explicit-control-flow)** -- The KISS rule, what "explicit" means for a SystemVerilog priority chain versus a host-side parser, the worked simplification that took one function from six levels of nesting to two, and the review checklist.
-- **[Measuring control flow](#measuring-control-flow)** -- What `scripts/measure_control_flow.py` counts in each language -- nesting and decision points in host code, visible priority in RTL -- why no threshold is proposed, and what the tree actually measures today.
+- **[Rule 2: prefer simple and explicit control flow](#rule-2-prefer-simple-and-explicit-control-flow)** -- The KISS rule, what "explicit" means for a SystemVerilog priority chain versus a host-side parser, the worked simplification that took one function from four levels of nesting to two, a real FSM and a real combinational mux read against the same rule, the measured hotspots with their dispositions, and the review checklist.
+- **[Measuring control flow](#measuring-control-flow)** -- What `scripts/measure_control_flow.py` counts in each language -- nesting and decision points in Python, priority resolved by source order in RTL -- exactly which files and blocks it scans and what it refuses, why no threshold is proposed, and what the tree actually measures today.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -225,13 +225,15 @@ line count.
 
 ### Repository interpretation
 
-- **SystemVerilog priority must be visible.** A signal assigned more than once
-  in one procedural block resolves by source order, and accidental
-  last-assignment-wins behavior is not documentation. The pattern is not
-  forbidden — a default followed by a narrower override is often the clearest
-  thing to write — but the default and the override are named as such where
-  they are, so a reader does not have to re-derive the priority from line
-  numbers.
+- **SystemVerilog priority must be visible.** A signal assigned twice on one
+  path through a procedural block — a default at the top and a narrower
+  override below it, or one write repeated in two separate `if`s — resolves
+  by source order, and accidental last-assignment-wins behavior is not
+  documentation. The pattern is not forbidden — a default followed by a
+  narrower override is often the clearest thing to write — but the default
+  and the override are named as such where they are, so a reader does not
+  have to re-derive the priority from line numbers. The arms of one
+  `if`/`else` or one `case` are exclusive; no source order is involved there.
 - **Host code fails where it fails.** A Python, Tcl or shell path that cannot
   continue returns or raises at that point, rather than setting a flag that is
   carried through nested code and tested somewhere else.
@@ -245,16 +247,17 @@ line count.
 `cluster_names` in `sw/builder/endstation_builder.py` names one AUDIO_CLUSTER
 per cluster of a stream port. It did that with a four-way `if / elif / elif /
 else` chain nested inside two loops, with a further early-exit inside the final
-`else` — six levels of nesting and fourteen decision points in thirty-eight
-lines. The role that was hardest to read, loopback, was the one reached through
-the unnamed `else`.
+`else` — four levels of nesting (the two loops, the chain, and the exit inside
+its last arm) and fourteen decision points in thirty-eight lines. The role that
+was hardest to read, loopback, was the one reached through the unnamed
+`else`.
 
 It is now a table: one small named function per pool role, and a dispatch that
 looks the role up. The measured shape, before and after:
 
 | Unit | Lines | Nesting depth | Decision points |
 |---|---:|---:|---:|
-| `cluster_names` before | 38 | 6 | 14 |
+| `cluster_names` before | 38 | 4 | 14 |
 | `cluster_names` after | 20 | 2 | 4 |
 | `_name_loopback` (deepest namer) | 9 | 1 | 1 |
 
@@ -275,6 +278,72 @@ now have arms:
   why the refusal needs a test: an unreachable path with no arm is how the next
   role gets silently mislabelled.
 
+The moved logic is pinned too, not only the two paths: every cluster name the
+builder produces for the loopback-bearing `ax7101_8x8` and for the
+`channel_names` config `ax7101_1x1_tdm8` is tracked in
+`sw/builder/cluster_names_golden.json`, generated from the implementation the
+differential proved identical, and gate 24d compares the built names to it one
+by one. Three mutations that survive every prefix check — a loopback walk that
+always starts at stream 0, one that never steps a channel, and a physical
+namer that ignores `channel_names` — each fail that comparison.
+
+### An RTL FSM example
+
+`guard_fsm` in `hdl/common/KL_link_guard.sv` is a three-state link-guard
+machine (`RUN_S`, `HOLD_S`, `SETTLE_S`) written the way the rule asks. Reset,
+the disable input and the `unique case` over the state are the branch
+structure, every transition sits in the arm of the state it leaves, and the
+`default` arm says what an illegal encoding does (`state_r <= RUN_S`). Nothing
+about the priority of those arms is re-derived from line numbers: `if (!rst_n)
+... else if (dis_i) ... else case (state_r)` states it. The tool reports the
+block at depth 5 with two signals resolved by source order, `guard_rst_r` and
+`eth_rst_r`, and both are the allowed shape — each state arm first assigns the
+reset rails their value for that state, and the transition condition nested
+inside the arm overrides them for the cycle the state changes. The `RUN_S`
+arm, annotated:
+
+```
+RUN_S : begin
+  guard_rst_r <= 1'b0;                      // the state's value
+  eth_rst_r   <= 1'b0;
+  if (!both_alive_w || man_edge_w) begin    // the transition overrides it
+    state_r     <= HOLD_S;
+    guard_rst_r <= 1'b1;
+    eth_rst_r   <= 1'b1;
+```
+
+The default is the first statement of the arm and the override is the
+narrower condition inside it, so a reader names the priority without counting
+lines. The state register itself is not reported: every write to it is in an
+exclusive arm, which is what "explicit FSM states and cases" means in the rule.
+
+### A combinational mux example
+
+`confl_pick` in `hdl/milan/KL_pp_maap_shim.sv` selects the lowest pending
+conflict source, and it is source-order priority on purpose:
+
+```
+//! lowest pending source first (descending sweep, last write wins)
+always_comb begin : confl_pick
+  conflict_src_o = '0;
+  for (int unsigned i = N_SRC_P; i > 0; i--) begin
+    if (confl_pend_r[i-1]) conflict_src_o = SRC_W_C'(i - 1);
+  end
+end : confl_pick
+```
+
+The tool reports `conflict_src_o` as resolved by source order, and it is: the
+sweep runs from the highest source down, so the lowest pending one writes last
+and wins. What makes that acceptable is that nothing has to be simulated to
+know it. The default (`'0`, no conflict) is the first line, the comment on the
+block names both the priority and the mechanism, and the loop direction *is*
+the priority. The accidental form is the same six lines with the loop
+ascending and the comment absent: it would pick the highest source — legally,
+synthesizably — and nothing in the block would say whether that was meant.
+That is what the rule calls accidental last-assignment-wins: an override that
+only line order documents. An `if`/`else if` chain over the sources would make
+the same priority structural; the loop is allowed because it is named.
+
 ### Measured hotspots, not automatic findings
 
 The ranked scan leaves a small review set whose complexity has a concrete
@@ -282,14 +351,25 @@ reason. These rows include both project-owned processor submodules:
 
 | Unit | Measured shape | Why it is complex / disposition |
 |---|---:|---|
-| `sw/litex/test_ring_bd.py:stim` | depth 10, 26 decisions | A cycle-accurate concurrent DMA stimulus nested inside a test; retain the timing shape, but split the next new scenario out of this closure. |
 | `tb/tools/hive_compliance.py:main` | depth 7, 95 decisions | CLI orchestration for many independent protocol checks; the checks are already helpers, so its remaining branches are explicit dispatch and failure aggregation. |
 | `protocol-processor/scripts/render-wavedrom.py:collect_blocks` | depth 7, 13 decisions | A small Markdown/fence parser; a future change should table-drive token states, but no rewrite is justified without a failing case. |
-| `hdl/common/csr/milan_csr.sv:register_write` | depth 6, 142 order-dependent targets | The address decode is the register-map specification; splitting it would hide priority and address order, so it stays a named explicit decode. |
-| `protocol-processor/hdl/aecp/KL_aecp_engine.sv:command_machine` | depth 7, 85 order-dependent targets | An explicit command FSM with defaults followed by state-specific overrides; review priority at each override rather than imposing a generic count. |
+| `tb/tools/hive_compliance_clusters.py:main` | depth 6, 37 decisions | The same shape as `hive_compliance.py:main` for the STREAM_PORT and cluster probes: descriptor-type, port, cluster and map loops with a status check at each level, and every failure recorded where it is found. |
+| `scripts/act_ci.py:freeze_live_act` | depth 6, 23 decisions | A container monitor that re-checks its cancel flag after every blocking call — the early return the rule asks for, paid for in depth because it polls the inventory, the running set and the tool-cache volume in one closure; the next thing it watches goes in a helper. |
+| `sw/litex/test_ring_dma.py:axi_slave` | depth 6, 18 decisions | A cycle-accurate AXI slave model inside a test; the nesting is the address, data-beat and response handshake sequence, so it is retained, and the next protocol rule it checks belongs in a helper rather than a deeper branch. |
+| `hdl/common/csr/milan_csr.sv:register_write` | depth 6, 30 order-dependent targets | The address decode is the register-map specification, and the 30 targets are one-cycle write strobes cleared at the top of the block and raised by the decode — a named default-then-override — so it stays a named explicit decode. |
+| `protocol-processor/hdl/aecp/KL_aecp_notify.sv:notify_core` | depth 7, 27 order-dependent targets | The unsolicited-notification FSM: per-cycle defaults for its request and arm outputs, then state-specific overrides across eight states; review the priority at each override rather than imposing a count. |
+| `protocol-processor/hdl/packet_engine/KL_pp_rx_validator.sv:validator_seq` | depth 6, 27 order-dependent targets | The receive-frame sequencer: its pulses fall by default each cycle and its captured header fields are written when their byte arrives, so the order is the wire order. |
+| `hdl/milan/milan_datapath.sv:amap_edit_validate` | depth 2, 27 order-dependent targets | Flat, and still the widest set: an AUDIO_MAP edit validator that gives every verdict, key and live word a default and narrows each per descriptor type — the allowed shape as long as each default stays above its override. |
 
 The worked `cluster_names` case was selected because its complexity came from
 an unnamed catch-all and nested error path, not merely because it ranked high.
+Two rows an earlier count put at the top are absent for a reason worth
+recording: the nine-arm `elif` ladder in `sw/litex/test_ring_bd.py:stim` read
+as depth 10 while an `elif` counted as a level and is depth 4 now that it does
+not, and the explicit command FSM in
+`protocol-processor/hdl/aecp/KL_aecp_engine.sv:command_machine` read as 85
+order-dependent targets while exclusive `case` arms were counted and holds 5
+now that they are not. Both were artefacts of the measurement, not of the code.
 
 ### Exceptions
 
@@ -315,32 +395,69 @@ an unnamed catch-all and nested error path, not merely because it ranked high.
 [`scripts/measure_control_flow.py`](../../scripts/measure_control_flow.py) asks
 each language its own question.
 
-For host code it reports, per function, the **nesting depth** (how many
-enclosing branch, loop, `with` or `try` constructs a reader must hold) and the
-**decision points** (`if`, `for`, `while`, exception handlers, boolean
-operators, conditional expressions). A nested definition is measured as its own
-unit, so an orchestrator that defines one helper does not read as deeply nested
-when it is not.
+For host code it reports, per function, the **nesting depth** — how many
+enclosing branch, loop, `with` or `try` constructs a reader must hold, where an
+`elif` continues its chain and adds no level — and the **decision points**:
+`if`, `for`, `async for`, `while`, `match` and each of its `case` arms,
+exception handlers, boolean operators, conditional expressions, `assert`, and
+each `for` clause of a comprehension (its `if` filters are not counted
+separately). A nested definition is measured as its own unit, so an
+orchestrator that defines one helper does not read as deeply nested when it is
+not. Host code means Python: the C++ harnesses, Tcl and shell in the tree are
+not measured, and no hotspot in them can reach the table above.
 
 For SystemVerilog it reports, per procedural block, the nesting of `begin` and
-`case`, and the signals the block assigns **more than once** — the ones whose
-value is decided by source order.
+`case`, and the signals the block **resolves by source order**: a signal
+written at a point that is not mutually exclusive with an earlier write to the
+same signal. `x = 1; if (q) x = 2;` is that shape, and so is a write repeated
+in two separate `if`s. An `if`/`else` pair, an `else if` chain and a full
+`case` with one write per arm are not — their arms are exclusive — so the
+explicit FSM the Exceptions call simple is not reported for being one. A
+struct member is its own target and a whole-struct write covers it, a
+concatenation writes each of its elements, a loop variable is not a signal,
+writes to different constant bits of one vector are disjoint, and a variable
+index is taken to overlap anything.
+
+**The population, stated plainly.** Python is scanned under `scripts/`, `sw/`,
+`tb/`, `harness/`, `syn/` and `hdl/` here and under the same names plus
+`bench/` in each processor: 115 files today — 104 in this repository (31 under
+`scripts/`, 29 `sw/`, 26 `harness/`, 14 `tb/`, 4 `syn/`), 9 in
+`protocol-processor` (`scripts/`, `hdl/`, `tb/`) and 2 in `gptp-processor`
+(`hdl/`, `tb/`). Python under `avdecc/`, `bd/`, `docs/` and `tests/` is outside
+the Scope list above and is not measured. The RTL number covers every
+`always_ff`, `always_comb`, `always_latch` and `always @` block, with or
+without a `begin`, in the `.sv` files under `hdl/` of the three trees;
+testbench and synthesis-flow SystemVerilog under `tb/` and `syn/`, `.svh`
+headers and the generated `.v` wrapper are not in it. A Python file that does
+not parse or a block that does not close is named on stderr, the summary line
+says how many were `NOT measured`, and the run exits 2, so an unmarked number
+is the whole population.
 
 ```
 python3 scripts/measure_control_flow.py             # both, ranked
 python3 scripts/measure_control_flow.py --selftest  # the fixture arms
 ```
 
+The tool grades itself the way the cohesion tool does: `--selftest` runs
+forty-five fixture arms whose answers are known by construction — an
+`if`/`else` pair and a full `case` are exclusive, a flat `elif` chain is depth
+1, a block without `begin` is still a block, a `begin` inside a string does
+not unbalance one — plus one arm per processor that fails when the scan
+reaches none of its Python. Both measurement self-tests run in the `docs-check`
+job of [`.github/workflows/docs.yml`](../../.github/workflows/docs.yml), after
+the submodule checkout they need.
+
 **No threshold is proposed, and none is imported.** A generic complexity limit
 from another codebase would fail the parts of this tree that are correctly
 shaped — a wire-format parser and an explicit FSM both score high and are both
 right. What the pinned superproject and its two project-owned processor
-submodules measure today, so a later reader can see whether it moved: 2,322
-first-party functions, of which 35 nest five levels or deeper; and 616
-procedural blocks, of which 507 resolve at least one signal by source order.
-That second number is the reason the rule asks for priority to be *visible*
-rather than absent — forbidding the pattern would be a rewrite of most of the
-RTL, and would not make any of it clearer.
+submodules measure today, so a later reader can see whether it moved: 2,485
+first-party functions (2,399 here, 46 in `protocol-processor`, 40 in
+`gptp-processor`), of which 13 nest five levels or deeper; and 626 procedural
+blocks (319, 271 and 36), of which 291 (128, 152 and 11) resolve at least one
+signal by source order. That second number is the reason the rule asks for
+priority to be *visible* rather than absent — forbidding the pattern would be
+a rewrite of nearly half the RTL, and would not make any of it clearer.
 
 ## Rules not yet landed
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -23,6 +23,8 @@ shape rather than guess at it.
 - **[Scope](#scope)** -- What counts as first-party maintenance surface and what is deliberately outside it, including why a generated file is fixed in its generator and never by hand.
 - **[Rule 1: keep modules and functions cohesive](#rule-1-keep-modules-and-functions-cohesive)** -- The single-responsibility rule, its repository interpretation for SystemVerilog and host code, worked good/bad examples, the exceptions that let a long unit stay whole, and the review checklist.
 - **[Measuring cohesion](#measuring-cohesion)** -- Why line count cannot answer the question, what `scripts/measure_cohesion.py` counts instead (disjoint state groups), what it deliberately cannot see, and the current candidate list read off the tree.
+- **[Rule 2: prefer simple and explicit control flow](#rule-2-prefer-simple-and-explicit-control-flow)** -- The KISS rule, what "explicit" means for a SystemVerilog priority chain versus a host-side parser, the worked simplification that took one function from six levels of nesting to two, and the review checklist.
+- **[Measuring control flow](#measuring-control-flow)** -- What `scripts/measure_control_flow.py` counts in each language -- nesting and decision points in host code, visible priority in RTL -- why no threshold is proposed, and what the tree actually measures today.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -210,14 +212,126 @@ real unrelated ownership, and it is reduced one cohesive responsibility at a
 time rather than by a split campaign — the extraction described above moved it
 from 22 groups and 7167 lines to 20 groups and 7081 lines on the current base.
 
+## Rule 2: prefer simple and explicit control flow
+
+> Use the simplest control flow that makes state, priority, timing, and error
+> paths obvious. Prefer named intermediate values, explicit FSM states and
+> cases, bounded loops, and early exits over clever expressions or deep
+> nesting.
+
+Shorter is not the same as simpler. A line that removes a branch by hiding it
+has made the code worse, and the rule is about what a reader can see, not about
+line count.
+
+### Repository interpretation
+
+- **SystemVerilog priority must be visible.** A signal assigned more than once
+  in one procedural block resolves by source order, and accidental
+  last-assignment-wins behavior is not documentation. The pattern is not
+  forbidden — a default followed by a narrower override is often the clearest
+  thing to write — but the default and the override are named as such where
+  they are, so a reader does not have to re-derive the priority from line
+  numbers.
+- **Host code fails where it fails.** A Python, Tcl or shell path that cannot
+  continue returns or raises at that point, rather than setting a flag that is
+  carried through nested code and tested somewhere else.
+- **Table-driven code is welcome when the table is the specification**, and its
+  defaults, bounds and ordering are explicit. A dispatch table beats a branch
+  chain precisely when the chain's final `else` has become a catch-all that
+  nobody can name.
+
+### A worked example
+
+`cluster_names` in `sw/builder/endstation_builder.py` names one AUDIO_CLUSTER
+per cluster of a stream port. It did that with a four-way `if / elif / elif /
+else` chain nested inside two loops, with a further early-exit inside the final
+`else` — six levels of nesting and fourteen decision points in thirty-eight
+lines. The role that was hardest to read, loopback, was the one reached through
+the unnamed `else`.
+
+It is now a table: one small named function per pool role, and a dispatch that
+looks the role up. The measured shape, before and after:
+
+| Unit | Lines | Nesting depth | Decision points |
+|---|---:|---:|---:|
+| `cluster_names` before | 38 | 6 | 14 |
+| `cluster_names` after | 20 | 2 | 4 |
+| `_name_loopback` (deepest namer) | 9 | 1 | 1 |
+
+Behavior is unchanged, and the claim is made with a tool rather than asserted:
+every cluster name the builder can produce — five configurations, every stream
+port, both directions — is byte-identical before and after.
+
+Two things the flattening made visible that the nesting had hidden, and both
+now have arms:
+
+- the loopback namer's **empty receive space** path. A talker whose entity
+  declares no listener has no channel space to walk and names the cluster by
+  its own offset. That path was a `continue` five levels deep and nothing
+  graded it.
+- the chain's **bare `else`**. It swallowed any role that was not physical,
+  virtual or pilot and named it as a loopback channel. The table refuses an
+  unknown role by name instead. The role set is closed today, which is exactly
+  why the refusal needs a test: an unreachable path with no arm is how the next
+  role gets silently mislabelled.
+
+### Exceptions
+
+- A long, flat `case` over an explicit FSM state set is simple, whatever its
+  length. Splitting it to reduce a count would hide the transition table.
+- A compact expression is fine when it IS the specification — a wire-format
+  field split, a documented mask — and the citation is next to it.
+- A default-then-override pair in one block stays, when the two are named and
+  the override's condition is the narrower one.
+
+### Review checklist
+
+- Can a reader name the priority without counting lines?
+- Does every error path end where it is discovered, or is a flag carried?
+- Is each loop bound obvious at its head?
+- If a branch chain ends in `else`, can that branch be named — or is it a
+  catch-all standing in for cases nobody enumerated?
+- Does the change keep observable behavior, and does a differential run over
+  real inputs say so rather than a reading of the diff?
+
+## Measuring control flow
+
+[`scripts/measure_control_flow.py`](../../scripts/measure_control_flow.py) asks
+each language its own question.
+
+For host code it reports, per function, the **nesting depth** (how many
+enclosing branch, loop, `with` or `try` constructs a reader must hold) and the
+**decision points** (`if`, `for`, `while`, exception handlers, boolean
+operators, conditional expressions). A nested definition is measured as its own
+unit, so an orchestrator that defines one helper does not read as deeply nested
+when it is not.
+
+For SystemVerilog it reports, per procedural block, the nesting of `begin` and
+`case`, and the signals the block assigns **more than once** — the ones whose
+value is decided by source order.
+
+```
+python3 scripts/measure_control_flow.py             # both, ranked
+python3 scripts/measure_control_flow.py --selftest  # the fixture arms
+```
+
+**No threshold is proposed, and none is imported.** A generic complexity limit
+from another codebase would fail the parts of this tree that are correctly
+shaped — a wire-format parser and an explicit FSM both score high and are both
+right. What the tree measures today, so a later reader can see whether it moved:
+2,089 first-party functions, of which 30 nest five levels or deeper; and 309
+procedural blocks, of which 263 resolve at least one signal by source order.
+That second number is the reason the rule asks for priority to be *visible*
+rather than absent — forbidding the pattern would be a rewrite of most of the
+RTL, and would not make any of it clearer.
+
 ## Rules not yet landed
 
-The contract is ten rules. Rule 1 is above; the rest keep these numbers so
-citations stay stable as they land:
+The contract is ten rules. Rules 1 and 2 are above; the rest keep these
+numbers so citations stay stable as they land:
 
 | Rule | Subject |
 |---|---|
-| 2 | Simple and explicit control flow |
 | 3 | One source of truth, without weakening independent test oracles |
 | 4 | Intention-revealing names and explicit units and types |
 | 5 | Explicit ports, contracts, ownership and side effects |

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -275,6 +275,22 @@ now have arms:
   why the refusal needs a test: an unreachable path with no arm is how the next
   role gets silently mislabelled.
 
+### Measured hotspots, not automatic findings
+
+The ranked scan leaves a small review set whose complexity has a concrete
+reason. These rows include both project-owned processor submodules:
+
+| Unit | Measured shape | Why it is complex / disposition |
+|---|---:|---|
+| `sw/litex/test_ring_bd.py:stim` | depth 10, 26 decisions | A cycle-accurate concurrent DMA stimulus nested inside a test; retain the timing shape, but split the next new scenario out of this closure. |
+| `tb/tools/hive_compliance.py:main` | depth 7, 95 decisions | CLI orchestration for many independent protocol checks; the checks are already helpers, so its remaining branches are explicit dispatch and failure aggregation. |
+| `protocol-processor/scripts/render-wavedrom.py:collect_blocks` | depth 7, 13 decisions | A small Markdown/fence parser; a future change should table-drive token states, but no rewrite is justified without a failing case. |
+| `hdl/common/csr/milan_csr.sv:register_write` | depth 6, 142 order-dependent targets | The address decode is the register-map specification; splitting it would hide priority and address order, so it stays a named explicit decode. |
+| `protocol-processor/hdl/aecp/KL_aecp_engine.sv:command_machine` | depth 7, 85 order-dependent targets | An explicit command FSM with defaults followed by state-specific overrides; review priority at each override rather than imposing a generic count. |
+
+The worked `cluster_names` case was selected because its complexity came from
+an unnamed catch-all and nested error path, not merely because it ranked high.
+
 ### Exceptions
 
 - A long, flat `case` over an explicit FSM state set is simple, whatever its
@@ -318,9 +334,10 @@ python3 scripts/measure_control_flow.py --selftest  # the fixture arms
 **No threshold is proposed, and none is imported.** A generic complexity limit
 from another codebase would fail the parts of this tree that are correctly
 shaped — a wire-format parser and an explicit FSM both score high and are both
-right. What the tree measures today, so a later reader can see whether it moved:
-2,089 first-party functions, of which 30 nest five levels or deeper; and 309
-procedural blocks, of which 263 resolve at least one signal by source order.
+right. What the pinned superproject and its two project-owned processor
+submodules measure today, so a later reader can see whether it moved: 2,322
+first-party functions, of which 35 nest five levels or deeper; and 616
+procedural blocks, of which 507 resolve at least one signal by source order.
 That second number is the reason the rule asks for priority to be *visible*
 rather than absent — forbidding the pattern would be a rewrite of most of the
 RTL, and would not make any of it clearer.

--- a/scripts/measure_control_flow.py
+++ b/scripts/measure_control_flow.py
@@ -44,29 +44,21 @@ import argparse
 import ast
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-EXCLUDED_PREFIXES = (
-    "third_party/", "external/", "protocol-processor/", "gptp-processor/",
-    "gen/", "build/", "historical_now_obsolete/",
-)
+from code_quality_scope import tracked
 
 #: constructs that add a level of nesting a reader must hold
-_NESTING = (ast.If, ast.For, ast.While, ast.With, ast.Try,
+_NESTING = (ast.If, ast.For, ast.While, ast.With, ast.Try, ast.Match,
             ast.AsyncFor, ast.AsyncWith)
 #: constructs that add a decision point
-_DECISION = (ast.If, ast.For, ast.While, ast.ExceptHandler, ast.BoolOp,
-             ast.IfExp, ast.Assert, ast.comprehension)
-
-
-def tracked(*patterns):
-    out = subprocess.run(["git", "ls-files", *patterns], cwd=REPO,
-                         capture_output=True, text=True, check=True).stdout.split()
-    return [p for p in out if not p.startswith(EXCLUDED_PREFIXES)]
+_DECISION = (ast.If, ast.For, ast.While, ast.Match, ast.match_case,
+             ast.ExceptHandler, ast.BoolOp, ast.IfExp, ast.Assert,
+             ast.comprehension)
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +203,8 @@ PY_FIXTURES = [
     ("boolean operators are decisions", "def f(a, b):\n    return a and b\n", 0, 1),
     ("a nested def is measured on its own",
      "def outer():\n    def inner(a):\n        if a:\n            pass\n    return inner\n", 0, 0),
+    ("match cases are visible control flow",
+     "def f(x):\n    match x:\n        case 0: return 0\n        case _: return 1\n", 1, 3),
 ]
 
 SV_FIXTURES = [
@@ -240,7 +234,7 @@ def selftest():
                   f"{row['decisions']}, want {want_depth}/{want_dec}")
 
     # the nested-def arm also proves the inner function is reported separately
-    rows = measure_python_source(PY_FIXTURES[-1][1])
+    rows = measure_python_source(PY_FIXTURES[-2][1])
     inner = [r for r in rows if r["name"] == "inner"]
     if len(inner) == 1 and inner[0]["depth"] == 1:
         print("[PASS] python: inner function reported with its own depth")

--- a/scripts/measure_control_flow.py
+++ b/scripts/measure_control_flow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Kebag Logic
 # SPDX-License-Identifier: CERN-OHL-W-2.0
-"""Measure control-flow shape: nesting, decisions, and implicit priority.
+"""Measure control-flow shape: nesting, decisions, and priority decided by source order.
 
 Why this exists. Rule 2 of the maintainability guide
 (docs/development/CODE_QUALITY.md) asks for the simplest control flow that
@@ -12,20 +12,39 @@ what it found.
 
 Two languages, two different questions:
 
-  * Host code (Python) - how deep does control flow nest inside one function,
-    and how many decision points does a reader hold at once? Depth is the
-    number of enclosing branch/loop/try constructs; decisions counts `if`,
-    `for`, `while`, `try` handlers, boolean operators and conditional
-    expressions. Neither is a defect on its own; together they say how much of
-    a function a reader must simulate to know what it does with a failure.
+  * Host code (Python only - the C++, Tcl and shell in the tree are not
+    measured) - how deep does control flow nest inside one function, and how
+    many decision points does a reader hold at once? Depth is the number of
+    enclosing branch/loop/with/try constructs; an `elif` continues its chain
+    and adds no level. Decisions counts `if`, `for`, `async for`, `while`,
+    `match` and each of its `case` arms, exception handlers, boolean
+    operators, conditional expressions, `assert`, and each `for` clause of a
+    comprehension. Neither is a defect on its own; together they say how much
+    of a function a reader must simulate to know what it does with a failure.
 
-  * SystemVerilog - is priority VISIBLE? A signal assigned more than once in
-    one procedural block resolves by source order: the last assignment wins.
-    That is real, legal, frequently correct - and it is invisible at the point
-    of use, because nothing in the block says "this is the default and that is
-    the override". The rule does not forbid it; it asks that the priority be
-    visible in structure or named explicitly, so this tool lists where the
-    ordering is load-bearing.
+  * SystemVerilog - is priority VISIBLE? Inside one procedural block a signal
+    written at a point that is NOT mutually exclusive with an earlier write to
+    the same signal takes its value from source order: the last write wins.
+    `x = 1; if (q) x = 2;` is that shape, and so is a write in one `if` that a
+    later, separate `if` repeats. `if (a) x = 1; else x = 2;`, an `else if`
+    chain, and a full `case` with one write per arm are NOT: their arms are
+    exclusive, no source order is involved, and they are not reported. That
+    ordering is real, legal and frequently correct - and invisible at the
+    point of use, because nothing in the block says "this is the default and
+    that is the override". The rule does not forbid it; it asks that the
+    priority be visible in structure or named explicitly, so this tool lists
+    where the ordering is load-bearing. Targets are followed into struct
+    members (`s.f` is its own target and `s = '0` covers it) and through
+    concatenations (`{a, b} = ...` writes both); a loop variable is not a
+    signal; writes to different constant bits or slices of one vector are
+    disjoint, while any variable index is taken to overlap.
+
+The population is the first-party scope the guide declares: Python under the
+directories in PY_DIRS below, and every procedural block (`always_ff`,
+`always_comb`, `always_latch`, `always @`) in the `.sv` files under `hdl/`, in
+this repository and in both project-owned processor submodules. A file that
+does not parse or a block that does not close is NAMED on stderr and makes the
+run exit 2: a partial population must never read as a smaller baseline.
 
 Nothing here is a gate. There is no threshold, nothing in CI fails on these
 numbers, and a high count is a question for review, not a defect.
@@ -37,11 +56,13 @@ Usage:
     python3 scripts/measure_control_flow.py --json      # machine-readable
     python3 scripts/measure_control_flow.py --selftest  # fixture arms
 
-Exit 0 unless --selftest fails.
+Exit 0 when the whole population was measured, 2 when any file or block could
+not be (each one is named on stderr), 1 when --selftest fails.
 """
 
 import argparse
 import ast
+import itertools
 import json
 import re
 import sys
@@ -50,15 +71,35 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from code_quality_scope import tracked
+from code_quality_scope import PROJECT_SUBMODULES, tracked
+
+#: Directory pathspecs, applied by the scope helper to the superproject and to
+#: both processor submodules alike (a name absent from a tree matches nothing
+#: there), then filtered on `.py`. Directories are used because a git pathspec
+#: `x/**/*.py` needs at least one directory level and does not match `x/a.py`.
+PY_DIRS = ("scripts", "sw", "tb", "harness", "syn", "hdl", "bench")
+#: The RTL population: `.sv` under hdl/ in each tree. Testbench and synthesis
+#: SystemVerilog under tb/ and syn/, `.svh` headers and the generated `.v`
+#: wrapper are outside it, and the guide says so.
+SV_DIRS = ("hdl",)
 
 #: constructs that add a level of nesting a reader must hold
 _NESTING = (ast.If, ast.For, ast.While, ast.With, ast.Try, ast.Match,
             ast.AsyncFor, ast.AsyncWith)
-#: constructs that add a decision point
-_DECISION = (ast.If, ast.For, ast.While, ast.Match, ast.match_case,
-             ast.ExceptHandler, ast.BoolOp, ast.IfExp, ast.Assert,
-             ast.comprehension)
+#: constructs that add a decision point - the guide's definition sentence
+#: enumerates exactly this tuple
+_DECISION = (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Match,
+             ast.match_case, ast.ExceptHandler, ast.BoolOp, ast.IfExp,
+             ast.Assert, ast.comprehension)
+
+
+def tree_of(path):
+    """Which of the three first-party trees a tracked path belongs to."""
+    head = path.split("/", 1)[0]
+    return head if head in PROJECT_SUBMODULES else "superproject"
+
+
+TREES = ("superproject", *PROJECT_SUBMODULES)
 
 
 # ---------------------------------------------------------------------------
@@ -79,13 +120,20 @@ def _own_body(node):
         yield from _own_body(child)
 
 
+def _is_elif(parent, child):
+    """Python stores `elif` as an If that is the sole statement of its parent
+    If's `orelse`. It continues a flat chain, so it adds no level."""
+    return (isinstance(parent, ast.If) and isinstance(child, ast.If)
+            and len(parent.orelse) == 1 and parent.orelse[0] is child)
+
+
 def _depth(node, level=0):
     deepest = level
     for child in ast.iter_child_nodes(node):
         if isinstance(child, _OWN_UNIT):
             continue
-        step = level + 1 if isinstance(child, _NESTING) else level
-        deepest = max(deepest, _depth(child, step))
+        nests = isinstance(child, _NESTING) and not _is_elif(node, child)
+        deepest = max(deepest, _depth(child, level + 1 if nests else level))
     return deepest
 
 
@@ -108,27 +156,64 @@ def measure_python_source(src):
     return rows
 
 
-def measure_python():
-    rows = []
-    for rel in tracked("scripts/*.py", "sw/**/*.py", "tb/**/*.py", "harness/**/*.py"):
+def python_population():
+    return [p for p in tracked(*PY_DIRS) if p.endswith(".py")]
+
+
+def measure_python_texts(items):
+    """Measure (path, text) pairs. Returns (rows, skipped): a text that does
+    not parse is reported in `skipped`, never silently dropped."""
+    rows, skipped = [], []
+    for rel, text in items:
         try:
-            found = measure_python_source((REPO / rel).read_text(errors="replace"))
-        except SyntaxError:
+            found = measure_python_source(text)
+        except (SyntaxError, ValueError) as e:
+            skipped.append(f"{rel}: {e.__class__.__name__}: {e}")
             continue
         for row in found:
             row["path"] = rel
             rows.append(row)
     rows.sort(key=lambda r: (-r["depth"], -r["decisions"]))
-    return rows
+    return rows, skipped
+
+
+def measure_python():
+    return measure_python_texts(
+        (rel, (REPO / rel).read_text(errors="replace")) for rel in python_population())
 
 
 # ---------------------------------------------------------------------------
 # SystemVerilog - where is priority decided by source order?
 # ---------------------------------------------------------------------------
-_SV_BLOCK_RE = re.compile(r"always_(ff|comb|latch)\s*(?:@\s*\([^)]*\))?\s*begin(?:\s*:\s*(\w+))?")
-_SV_ASSIGN_RE = re.compile(
-    r"(?:^|[\n;:)]|\bbegin\b|\bend\b|\belse\b)\s*(\w+)\s*(?:\[[^\]]*\])*\s*(?:<=|=)(?!=)", re.M)
 _SV_COMMENT_RE = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
+_SV_TOKEN_RE = re.compile(r'''
+    "(?:[^"\\]|\\.)*"                                   # string literal, one token
+  | \d[\d_]*\s*'\s*[sS]?[bBoOdDhH]\s*[0-9a-fA-FxXzZ?_]+  # sized literal 4'b??10
+  | '[sS]?[bBoOdDhH][0-9a-fA-FxXzZ?_]+                  # unsized literal 'h1F
+  | '[01xXzZ]\b                                        # fill literal '0
+  | [A-Za-z_`$][A-Za-z0-9_$]*                          # identifier, keyword, $task, `macro
+  | \d[\d_]*(?:\.\d[\d_]*)?                            # number
+  | <<<=|>>>=|<<=|>>=|\+\+|--|\+=|-=|\*=|/=|%=|&=|\|=|\^=
+  | <=|>=|===|!==|==|!=|&&|\|\||->|::|\+:|-:
+  | \S
+''', re.X)
+_SV_IDENT_RE = re.compile(r"[A-Za-z_]\w*$")
+_SV_HEADERS = ("always", "always_ff", "always_comb", "always_latch")
+_SV_ASSIGN_OPS = {"=", "<=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=",
+                  "<<=", ">>=", "<<<=", ">>>="}
+_SV_INCDEC = {"++", "--"}
+_SV_OPEN = {"(", "[", "{"}
+_SV_CLOSE = {")", "]", "}"}
+#: reaching one of these while inside a block means the block never closed
+_SV_MODULE_SCOPE = {"module", "endmodule", "initial", "final", "assign", "generate",
+                    "endgenerate", "function", "endfunction", "task", "endtask",
+                    "genvar", "localparam", "parameter", "interface", "endinterface",
+                    "package", "endpackage", *_SV_HEADERS}
+_SV_NESTS = {"begin", "case", "casez", "casex", "fork"}
+
+
+class _SvSyntax(Exception):
+    """A block this parser cannot close; the caller reports it, never drops it."""
 
 
 def _sv_strip(text):
@@ -137,57 +222,399 @@ def _sv_strip(text):
     return _SV_COMMENT_RE.sub(blank, text)
 
 
-def _sv_blocks(text):
-    blocks = []
-    for m in _SV_BLOCK_RE.finditer(text):
-        start, depth = m.end(), 1
-        for tok in re.finditer(r"\b(begin|end)\b", text[start:]):
-            depth += 1 if tok.group(1) == "begin" else -1
-            if depth == 0:
-                line = text[: m.start()].count("\n") + 1
-                blocks.append((m.group(1), m.group(2) or f"line{line}",
-                               text[start:start + tok.start()], line))
-                break
-    return blocks
+def _sv_tokens(text):
+    """Tokenize comment-stripped SystemVerilog into (tokens, line numbers)."""
+    toks, lines, line, last = [], [], 1, 0
+    for m in _SV_TOKEN_RE.finditer(text):
+        line += text.count("\n", last, m.start())
+        last = m.start()
+        toks.append(m.group(0))
+        lines.append(line)
+    return toks, lines
 
 
-def _sv_depth(body):
-    """Deepest nesting of begin/case inside one procedural block."""
-    depth = best = 0
-    for tok in re.finditer(r"\b(begin|end|case|casez|casex|endcase)\b", body):
-        word = tok.group(1)
-        if word in ("begin", "case", "casez", "casex"):
-            depth += 1
-            best = max(best, depth)
+def _index_set(toks):
+    """The bits a constant index selects, or None when it is not constant."""
+    ints = []
+    for t in toks:
+        if not re.fullmatch(r"\d[\d_]*", t):
+            if t not in (":", "+:", "-:"):
+                return None
+            ints.append(t)
         else:
-            depth -= 1
-    return best
+            ints.append(int(t.replace("_", "")))
+    if len(ints) == 1 and isinstance(ints[0], int):
+        return {ints[0]}
+    if len(ints) == 3 and isinstance(ints[0], int) and isinstance(ints[2], int):
+        a, op, b = ints
+        if op == ":":
+            return set(range(min(a, b), max(a, b) + 1))
+        if op == "+:":
+            return set(range(a, a + b))
+        if op == "-:":
+            return set(range(a - b + 1, a + 1))
+    return None
+
+
+class _SvTarget:
+    """An assignment target as a path of (identifier, [index token lists])."""
+
+    def __init__(self, segments):
+        self.segments = segments
+        self.name = ".".join(ident for ident, _ in segments)
+
+    def overlaps(self, other):
+        for (ident_a, idx_a), (ident_b, idx_b) in zip(self.segments, other.segments):
+            if ident_a != ident_b:
+                return False
+            for ia, ib in zip(idx_a, idx_b):
+                sa, sb = _index_set(ia), _index_set(ib)
+                if sa is not None and sb is not None and not (sa & sb):
+                    return False
+        return True     # equal, or one is a prefix (a whole struct covers a member)
+
+
+def _sv_target(toks, i):
+    """Parse one target at toks[i]; returns ([_SvTarget], next index) or (None, i)."""
+    if i < len(toks) and toks[i] == "{":
+        found, i = [], i + 1
+        while i < len(toks) and toks[i] != "}":
+            sub, i = _sv_target(toks, i)
+            if sub is None:
+                return None, i
+            found.extend(sub)
+            if i < len(toks) and toks[i] == ",":
+                i += 1
+        return found, i + 1
+    if i < len(toks) and _SV_IDENT_RE.match(toks[i]):
+        segments = [(toks[i], [])]
+        i += 1
+        while i < len(toks):
+            if toks[i] == "[":
+                depth, i, start = 1, i + 1, i + 1
+                while i < len(toks) and depth:
+                    depth += (toks[i] == "[") - (toks[i] == "]")
+                    i += 1
+                segments[-1][1].append(toks[start:i - 1])
+            elif toks[i] == "." and i + 1 < len(toks) and _SV_IDENT_RE.match(toks[i + 1]):
+                segments.append((toks[i + 1], []))
+                i += 2
+            else:
+                break
+        return [_SvTarget(segments)], i
+    return None, i
+
+
+def _sv_assignment_targets(toks):
+    """Targets written by one simple statement, or [] when it is not a write."""
+    if toks and toks[0] in _SV_INCDEC:
+        found, _ = _sv_target(toks, 1)
+        return found or []
+    found, i = _sv_target(toks, 0)
+    if found and i < len(toks) and (toks[i] in _SV_ASSIGN_OPS or toks[i] in _SV_INCDEC):
+        return found
+    return []
+
+
+class _SvStatements:
+    """A recursive-descent reader of ONE procedural statement and what it nests.
+
+    It knows just enough SystemVerilog to tell a branch arm from a sequence:
+    `begin`/`end`, `if`/`else`, `case` items, the loop forms, immediate
+    assertions and compiler directives. Everything else is a simple statement
+    running to `;`, classified as a write when it starts with a target and an
+    assignment operator."""
+
+    def __init__(self, toks, lines, pos):
+        self.toks, self.lines, self.pos = toks, lines, pos
+        self.nest = self.max_nest = 0
+
+    def peek(self, k=0):
+        i = self.pos + k
+        return self.toks[i] if i < len(self.toks) else None
+
+    def take(self):
+        if self.pos >= len(self.toks):
+            raise _SvSyntax("block is not closed before the end of the file")
+        self.pos += 1
+        return self.toks[self.pos - 1]
+
+    def expect(self, want):
+        t = self.take()
+        if t != want:
+            raise _SvSyntax(f"expected `{want}`, found `{t}` on line {self.lines[self.pos - 1]}")
+
+    def balanced(self, opener):
+        """Consume a bracketed group starting at the current token; return its inside."""
+        self.expect(opener)
+        depth, start = 1, self.pos
+        while depth:
+            t = self.take()
+            depth += (t in _SV_OPEN) - (t in _SV_CLOSE)
+        return self.toks[start:self.pos - 1]
+
+    def label(self):
+        if self.peek() == ":" and self.peek(1) is not None and _SV_IDENT_RE.match(self.peek(1)):
+            self.pos += 2
+
+    def directives(self):
+        while (t := self.peek()) is not None and t.startswith("`"):
+            if t in ("`ifdef", "`ifndef", "`elsif", "`undef"):
+                self.pos += 2
+            elif t in ("`else", "`endif", "`resetall"):
+                self.pos += 1
+            else:                                   # `define, `include, a statement macro
+                line = self.lines[self.pos]
+                while self.peek() is not None and self.lines[self.pos] == line:
+                    self.pos += 1
+
+    def enter(self):
+        self.nest += 1
+        self.max_nest = max(self.max_nest, self.nest)
+
+    def sequence(self, closers):
+        body = []
+        while True:
+            self.directives()               # an `endif may sit right before the closer
+            if self.peek() in closers:
+                break
+            if self.peek() is None:
+                raise _SvSyntax(f"`{'/'.join(closers)}` never comes")
+            body.append(self.statement())
+        self.pos += 1
+        return body
+
+    def case_label(self):
+        if self.peek() == "default":
+            self.pos += 1
+            if self.peek() == ":":
+                self.pos += 1
+            return
+        depth = 0
+        while True:
+            t = self.take()
+            if t in _SV_OPEN:
+                depth += 1
+            elif t in _SV_CLOSE:
+                depth -= 1
+            elif t == ":" and depth == 0:
+                return
+            elif t == "endcase":
+                raise _SvSyntax(f"case item without `:` before line {self.lines[self.pos - 1]}")
+
+    def simple(self):
+        start, depth = self.pos, 0
+        while True:
+            t = self.take()
+            if t in _SV_OPEN:
+                depth += 1
+            elif t in _SV_CLOSE:
+                depth -= 1
+            elif t == ";" and depth == 0:
+                break
+            elif t in _SV_MODULE_SCOPE and depth == 0:
+                raise _SvSyntax(f"reached `{t}` on line {self.lines[self.pos - 1]} "
+                                "inside a block that never closed")
+        targets = _sv_assignment_targets(self.toks[start:self.pos - 1])
+        return ("assign", targets) if targets else ("other",)
+
+    def statement(self):
+        self.directives()
+        t = self.peek()
+        if t is None:
+            raise _SvSyntax("block is not closed before the end of the file")
+        if t in ("unique", "unique0", "priority"):
+            self.pos += 1
+            t = self.peek()
+        if t == "begin":
+            self.pos += 1
+            self.label()
+            self.enter()
+            body = self.sequence(("end",))
+            self.nest -= 1
+            self.label()
+            return ("seq", body)
+        if t == "fork":
+            self.pos += 1
+            self.label()
+            self.enter()
+            body = self.sequence(("join", "join_any", "join_none"))
+            self.nest -= 1
+            self.label()
+            return ("seq", body)
+        if t == "if":
+            self.pos += 1
+            self.balanced("(")
+            then = self.statement()
+            other = None
+            if self.peek() == "else":
+                self.pos += 1
+                other = self.statement()
+            return ("if", then, other)
+        if t in ("case", "casez", "casex"):
+            self.pos += 1
+            self.balanced("(")
+            if self.peek() in ("inside", "matches"):
+                self.pos += 1
+            self.enter()
+            arms = []
+            while True:
+                self.directives()
+                if self.peek() == "endcase":
+                    break
+                if self.peek() is None:
+                    raise _SvSyntax("`case` without `endcase`")
+                self.case_label()
+                arms.append(self.statement())
+            self.pos += 1
+            self.nest -= 1
+            return ("case", arms)
+        if t in ("for", "foreach", "while", "repeat"):
+            # the header is one bracketed group, never a statement: `i = 0`
+            # and `i++` in it are the loop variable, not a signal written twice
+            self.pos += 1
+            self.balanced("(")
+            return ("loop", self.statement())
+        if t == "forever":
+            self.pos += 1
+            return ("loop", self.statement())
+        if t == "do":
+            self.pos += 1
+            body = self.statement()
+            self.expect("while")
+            self.balanced("(")
+            self.expect(";")
+            return ("loop", body)
+        if t in ("assert", "assume", "cover"):
+            self.pos += 1
+            if self.peek() in ("property", "final"):
+                self.pos += 1
+            self.balanced("(")
+            body = []
+            if self.peek() == ";":
+                self.pos += 1
+            elif self.peek() != "else":
+                body.append(self.statement())
+            if self.peek() == "else":
+                self.pos += 1
+                body.append(self.statement())
+            return ("seq", body)
+        if t == ";":
+            self.pos += 1
+            return ("seq", [])
+        if t in ("end", "endcase", "else", "join", "join_any", "join_none") or t in _SV_MODULE_SCOPE:
+            raise _SvSyntax(f"unexpected `{t}` on line {self.lines[self.pos]}")
+        return self.simple()
+
+
+def _sv_exclusive(path_a, path_b):
+    """Two writes are mutually exclusive when they sit in different arms of one branch."""
+    for (branch_a, arm_a), (branch_b, arm_b) in zip(path_a, path_b):
+        if branch_a != branch_b:
+            return False        # diverged into sibling branches: both can run
+        if arm_a != arm_b:
+            return True
+    return False                # one encloses the other, or both at one level
+
+
+def _sv_order_dependent(stmt):
+    """Names written at a point not exclusive with an earlier write they overlap."""
+    seen, flagged, ids = [], set(), itertools.count()
+
+    def walk(node, path):
+        kind = node[0]
+        if kind == "seq":
+            for s in node[1]:
+                walk(s, path)
+        elif kind == "if":
+            branch = next(ids)
+            walk(node[1], path + ((branch, 0),))
+            if node[2] is not None:
+                walk(node[2], path + ((branch, 1),))
+        elif kind == "case":
+            branch = next(ids)
+            for arm, body in enumerate(node[1]):
+                walk(body, path + ((branch, arm),))
+        elif kind == "loop":
+            walk(node[1], path)
+        elif kind == "assign":
+            for target in node[1]:
+                if any(target.overlaps(prev) and not _sv_exclusive(prev_path, path)
+                       for prev, prev_path in seen):
+                    flagged.add(target.name)
+                seen.append((target, path))
+
+    walk(stmt, ())
+    return sorted(flagged)
+
+
+def _sv_blocks(text):
+    """Every procedural block in `text`: (kind, name, line, loc, depth, stmt),
+    plus the blocks that could not be closed as (line, reason)."""
+    toks, lines = _sv_tokens(_sv_strip(text))
+    blocks, problems = [], []
+    for i, kind in enumerate(toks):
+        if kind not in _SV_HEADERS:
+            continue
+        reader = _SvStatements(toks, lines, i + 1)
+        try:
+            if reader.peek() == "@":
+                reader.pos += 1
+                if reader.peek() == "*":
+                    reader.pos += 1
+                else:
+                    reader.balanced("(")
+            name = None
+            if reader.peek() == "begin" and reader.peek(1) == ":" and reader.peek(2):
+                name = reader.peek(2)
+            outer = reader.peek() in _SV_NESTS
+            stmt = reader.statement()
+        except _SvSyntax as e:
+            problems.append((lines[i], str(e)))
+            continue
+        depth = reader.max_nest - (1 if outer else 0)
+        blocks.append((kind, name or f"line{lines[i]}", lines[i],
+                       lines[reader.pos - 1] - lines[i] + 1, depth, stmt))
+    return blocks, problems
 
 
 def measure_sv_source(text):
+    """Return (one row per procedural block, [(line, reason)] for unclosed ones)."""
     rows = []
-    for kind, name, body, line in _sv_blocks(_sv_strip(text)):
-        targets = _SV_ASSIGN_RE.findall(body)
-        repeated = sorted({t for t in targets if targets.count(t) > 1})
+    blocks, problems = _sv_blocks(text)
+    for kind, name, line, loc, depth, stmt in blocks:
         rows.append({
             "block": name,
-            "kind": f"always_{kind}",
+            "kind": kind,
             "line": line,
-            "loc": body.count("\n") + 1,
-            "depth": _sv_depth(body),
-            "order_dependent": repeated,
+            "loc": loc,
+            "depth": depth,
+            "order_dependent": _sv_order_dependent(stmt),
         })
-    return rows
+    return rows, problems
 
 
-def measure_sv():
-    rows = []
-    for rel in [p for p in tracked("hdl") if p.endswith(".sv")]:
-        for row in measure_sv_source((REPO / rel).read_text(errors="replace")):
+def sv_population():
+    return [p for p in tracked(*SV_DIRS) if p.endswith(".sv")]
+
+
+def measure_sv_texts(items):
+    """Measure (path, text) pairs. Returns (rows, skipped) - an unclosed block
+    is reported in `skipped` with its line, never silently dropped."""
+    rows, skipped = [], []
+    for rel, text in items:
+        found, problems = measure_sv_source(text)
+        skipped.extend(f"{rel}:{line}: {why}" for line, why in problems)
+        for row in found:
             row["path"] = rel
             rows.append(row)
     rows.sort(key=lambda r: (-len(r["order_dependent"]), -r["depth"], -r["loc"]))
-    return rows
+    return rows, skipped
+
+
+def measure_sv():
+    return measure_sv_texts(
+        (rel, (REPO / rel).read_text(errors="replace")) for rel in sv_population())
 
 
 # ---------------------------------------------------------------------------
@@ -198,9 +625,19 @@ PY_FIXTURES = [
     ("one if is depth 1", "def f(a):\n    if a:\n        return 1\n    return 0\n", 1, 1),
     ("sibling ifs do not stack", "def f(a):\n    if a:\n        pass\n    if a:\n        pass\n", 1, 2),
     ("nested if/for stacks", "def f(a):\n    if a:\n        for i in a:\n            if i:\n                pass\n", 3, 3),
+    ("a flat elif chain is depth 1",
+     "def f(r):\n    if r == 0:\n        pass\n    elif r == 1:\n        pass\n    elif r == 2:\n"
+     "        pass\n    elif r == 3:\n        pass\n    elif r == 4:\n        pass\n", 1, 5),
+    ("an elif arm's body still nests inside the chain",
+     "def f(a):\n    if a:\n        pass\n    elif a:\n        for i in a:\n            pass\n", 2, 3),
     ("try/except counts the handler",
      "def f():\n    try:\n        pass\n    except ValueError:\n        pass\n", 1, 1),
     ("boolean operators are decisions", "def f(a, b):\n    return a and b\n", 0, 1),
+    ("assert is a decision", "def f(a):\n    assert a\n", 0, 1),
+    ("each for clause of a comprehension is a decision",
+     "def f(a):\n    return [x for x in a for y in x]\n", 0, 2),
+    ("async for nests and decides like for",
+     "async def f(a):\n    async for x in a:\n        pass\n", 1, 1),
     ("a nested def is measured on its own",
      "def outer():\n    def inner(a):\n        if a:\n            pass\n    return inner\n", 0, 0),
     ("match cases are visible control flow",
@@ -210,15 +647,74 @@ PY_FIXTURES = [
 SV_FIXTURES = [
     ("single assignment has no implicit priority",
      "always_comb begin : b  x_w = 1; end", []),
-    ("a re-assigned signal is order dependent",
+    ("a default then a narrower override is order dependent",
      "always_comb begin : b  x_w = 1; if (q) x_w = 2; end", ["x_w"]),
     ("default-then-override in a case is order dependent",
      "always_comb begin : b  y_w = 0; case (s) 2'd1: y_w = 1; endcase end", ["y_w"]),
+    ("a write after a case that also wrote it is order dependent",
+     "always_comb begin : b  case (s) 2'd0: y_w = 1; default: y_w = 0; endcase if (k) y_w = 2; end",
+     ["y_w"]),
+    ("two sibling ifs are not exclusive",
+     "always_comb begin : b  if (a) x_w = 1; if (q) x_w = 2; end", ["x_w"]),
+    ("an if/else pair is exclusive",
+     "always_comb begin : b  if (a) x_w = 1; else x_w = 2; end", []),
+    ("a full case with one write per arm is exclusive",
+     "always_comb begin : b  case (s) 2'd0: y_w = 1; 2'd1: y_w = 2; default: y_w = 0; endcase end", []),
+    ("an else-if chain is exclusive",
+     "always_ff @(posedge c) begin : b  if (a) x_r <= 1; else if (b) x_r <= 2; else x_r <= 3; end", []),
+    ("reset then else is exclusive",
+     "always_ff @(posedge c) begin : b  if (!rst_n) x_r <= 0; else x_r <= y; end", []),
     ("two different signals are not order dependent",
      "always_comb begin : b  x_w = 1; y_w = 2; end", []),
     ("a comparison is not an assignment",
      "always_comb begin : b  x_w = (a == b); end", []),
+    ("a comparison on a continuation line is not an assignment",
+     "always_comb begin : b  if (a &&\n cnt <= 5) x_w = 1; end", []),
+    ("a loop variable is not a signal, however many loops step it",
+     "always_comb begin : b  for (int i = 0; i < 4; i = i + 1) y_w[i] = 0;"
+     " for (int i = 0; i < 4; i = i + 1) z_w[i] = 0; end", []),
+    ("a loop variable stepped with ++ is not a signal",
+     "always_comb begin : b  for (int unsigned s = 0; s < 4; s++) begin y_w[s] = 0; end"
+     " for (int unsigned s = 0; s < 4; s++) begin z_w[s] = 0; end end", []),
+    ("a struct member is a target of its own",
+     "always_comb begin : b  s.f = 1; s.f = 2; end", ["s.f"]),
+    ("a whole-struct default then a member override is order dependent",
+     "always_comb begin : b  s = '0; if (q) s.f = 1; end", ["s.f"]),
+    ("two members of one struct are different targets",
+     "always_comb begin : b  s.f = 1; s.g = 2; end", []),
+    ("a concatenation writes each of its elements",
+     "always_comb begin : b  {a_w, b_w} = 2'b00; {a_w, b_w} = 2'b11; end", ["a_w", "b_w"]),
+    ("a concatenation element re-written alone is order dependent",
+     "always_comb begin : b  {a_w, b_w} = 2'b00; if (q) b_w = 1; end", ["b_w"]),
+    ("writes to different constant bits are disjoint",
+     "always_comb begin : b  x_w[0] = 1; x_w[1] = 1; x_w[7:4] = 0; end", []),
+    ("writes to overlapping slices are order dependent",
+     "always_comb begin : b  x_w[7:0] = 1; x_w[3] = 1; end", ["x_w"]),
+    ("a variable index may overlap anything",
+     "always_comb begin : b  x_w[i] = 1; x_w[0] = 1; end", ["x_w"]),
+    ("a block without begin is measured",
+     "always_ff @(posedge c) if (rst) begin x_r <= 0; end else begin x_r <= 1; x_r <= 2; end", ["x_r"]),
+    ("a begin inside a string does not unbalance the block",
+     'always_comb begin : b  $display("begin"); x_w = 1; x_w = 2; end', ["x_w"]),
+    ("a compiler directive right before the closing end does not unbalance the block",
+     "always_ff @(posedge c) begin : b  x_r <= 1;\n`ifndef SYNTHESIS\n  y_r <= 1;\n`endif\nend", []),
 ]
+
+#: one block per header form the tree uses; the census must find every one
+SV_HEADER_FORMS = """
+always_ff @(posedge c) begin : a  x_r <= 1; end
+always_ff @(posedge c) if (r) x_r <= 0; else x_r <= 1;
+always_comb for (int i = 0; i < 2; i++) y_w[i] = 0;
+always_comb z_w = 1;
+always @(posedge c) begin : e  w_r <= 1; end
+always @* v_w = 2;
+always_latch if (en) q_r = d;
+"""
+
+
+def _arm(name, ok, detail=""):
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}" + ("" if ok else f": {detail}"))
+    return 0 if ok else 1
 
 
 def selftest():
@@ -226,45 +722,67 @@ def selftest():
     for name, src, want_depth, want_dec in PY_FIXTURES:
         rows = measure_python_source(src)
         row = next(r for r in rows if r["name"] in ("f", "outer"))
-        if row["depth"] == want_depth and row["decisions"] == want_dec:
-            print(f"[PASS] python: {name}")
-        else:
-            failures += 1
-            print(f"[FAIL] python: {name}: got depth {row['depth']} decisions "
-                  f"{row['decisions']}, want {want_depth}/{want_dec}")
+        failures += _arm(f"python: {name}",
+                         row["depth"] == want_depth and row["decisions"] == want_dec,
+                         f"got depth {row['depth']} decisions {row['decisions']}, "
+                         f"want {want_depth}/{want_dec}")
 
     # the nested-def arm also proves the inner function is reported separately
-    rows = measure_python_source(PY_FIXTURES[-2][1])
-    inner = [r for r in rows if r["name"] == "inner"]
-    if len(inner) == 1 and inner[0]["depth"] == 1:
-        print("[PASS] python: inner function reported with its own depth")
-    else:
-        failures += 1
-        print(f"[FAIL] python: inner function reported with its own depth: {inner}")
+    src = next(s for n, s, _, _ in PY_FIXTURES if n.startswith("a nested def"))
+    inner = [r for r in measure_python_source(src) if r["name"] == "inner"]
+    failures += _arm("python: inner function reported with its own depth",
+                     len(inner) == 1 and inner[0]["depth"] == 1, str(inner))
+
+    rows, skipped = measure_python_texts([("bad.py", "def (:\n"), ("ok.py", "def f():\n    pass\n")])
+    failures += _arm("python: an unparsable file is reported, not dropped",
+                     len(skipped) == 1 and skipped[0].startswith("bad.py:") and len(rows) == 1,
+                     f"rows {rows} skipped {skipped}")
 
     for name, src, want in SV_FIXTURES:
-        row = measure_sv_source(src)[0]
-        if row["order_dependent"] == want:
-            print(f"[PASS] sv: {name}")
-        else:
-            failures += 1
-            print(f"[FAIL] sv: {name}: got {row['order_dependent']}, want {want}")
+        rows, problems = measure_sv_source(src)
+        got = rows[0]["order_dependent"] if rows else problems
+        failures += _arm(f"sv: {name}", bool(rows) and not problems and got == want,
+                         f"got {got}, want {want}")
 
     # nesting inside a procedural block, including case
     # depth is measured INSIDE the block: the block's own `begin` is the block,
     # so `if (q) begin case (...) ... endcase end` nests two levels, not three.
-    depth = measure_sv_source(
-        "always_ff @(posedge c) begin : b if (q) begin case (s) 2'd0: x_r <= 1; endcase end end"
-    )[0]["depth"]
-    if depth == 2:
-        print("[PASS] sv: begin/case nesting is counted inside the block")
-    else:
-        failures += 1
-        print(f"[FAIL] sv: begin/case nesting is counted inside the block: got {depth}, want 2")
+    rows, _ = measure_sv_source(
+        "always_ff @(posedge c) begin : b if (q) begin case (s) 2'd0: x_r <= 1; endcase end end")
+    failures += _arm("sv: begin/case nesting is counted inside the block",
+                     rows[0]["depth"] == 2, f"got {rows[0]['depth']}, want 2")
 
-    total = len(PY_FIXTURES) + len(SV_FIXTURES) + 2
+    rows, problems = measure_sv_source(SV_HEADER_FORMS)
+    names = [r["block"] for r in rows]
+    failures += _arm("sv: every always header form opens a block, with or without begin",
+                     len(rows) == 7 and not problems and names[0] == "a" and names[4] == "e"
+                     and [r["kind"] for r in rows][4:6] == ["always", "always"],
+                     f"blocks {names} problems {problems}")
+
+    rows, problems = measure_sv_source(
+        "always_ff @(posedge c) begin : a  begin x_r <= 1; end\n"
+        "always_comb begin : b  y_w = 1; end\n")
+    failures += _arm("sv: an unclosed block is reported by line, and the next block is still measured",
+                     len(problems) == 1 and problems[0][0] == 1 and [r["block"] for r in rows] == ["b"],
+                     f"rows {[r['block'] for r in rows]} problems {problems}")
+
+    # the population arms need the pinned tree: the scan must reach both
+    # processors' Python, or the guide's "first-party" number is a smaller one
+    population = python_population()
+    for sub in PROJECT_SUBMODULES:
+        n = sum(1 for p in population if p.startswith(sub + "/"))
+        failures += _arm(f"population: {sub} contributes Python files to the scan",
+                         n > 0, f"{sub} contributes {n} .py files")
+
+    total = (len(PY_FIXTURES) + 2 + len(SV_FIXTURES) + 3 + len(PROJECT_SUBMODULES))
     print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
+
+
+def _per_tree(rows, deep):
+    for tree in TREES:
+        mine = [r for r in rows if tree_of(r["path"]) == tree]
+        print(f"  {tree}: {len(mine)} {deep(mine)}")
 
 
 def main():
@@ -281,22 +799,28 @@ def main():
 
     want_py = args.python or not args.sv
     want_sv = args.sv or not args.python
-    out = {}
+    out, skipped = {}, []
 
     if want_py:
-        rows = measure_python()
+        rows, skip = measure_python()
         out["python"] = rows
+        skipped += skip
         if not args.json:
             print(f"{'path:line':<58}{'function':<34}{'loc':>6}{'depth':>7}{'decisions':>11}")
             for r in rows[: args.top]:
                 where = f"{r['path']}:{r['line']}"
                 print(f"{where:<58}{r['name'][:33]:<34}{r['loc']:>6}{r['depth']:>7}{r['decisions']:>11}")
             deep = sum(1 for r in rows if r["depth"] >= 5)
-            print(f"\n{len(rows)} first-party function(s); {deep} nest five levels or deeper\n")
+            print(f"\n{len(rows)} first-party function(s); {deep} nest five levels or deeper"
+                  + (f"; {len(skip)} file(s) NOT measured" if skip else ""))
+            _per_tree(rows, lambda m: f"function(s), {sum(1 for r in m if r['depth'] >= 5)} "
+                                      "at depth 5 or more")
+            print()
 
     if want_sv:
-        rows = measure_sv()
+        rows, skip = measure_sv()
         out["sv"] = rows
+        skipped += skip
         if not args.json:
             print(f"{'path:line':<58}{'block':<28}{'depth':>7}{'order-dependent signals':>26}")
             for r in rows[: args.top]:
@@ -304,10 +828,19 @@ def main():
                 print(f"{where:<58}{r['block'][:27]:<28}{r['depth']:>7}{len(r['order_dependent']):>26}")
             ordered = sum(1 for r in rows if r["order_dependent"])
             print(f"\n{len(rows)} procedural block(s); {ordered} resolve at least one signal "
-                  f"by source order")
+                  f"by source order" + (f"; {len(skip)} block(s) NOT measured" if skip else ""))
+            _per_tree(rows, lambda m: f"block(s), {sum(1 for r in m if r['order_dependent'])} "
+                                      "resolve a signal by source order")
 
     if args.json:
+        out["skipped"] = skipped
         print(json.dumps(out, indent=2))
+    for s in skipped:
+        print(f"[SKIP] {s}", file=sys.stderr)
+    if skipped:
+        print(f"[SKIP] {len(skipped)} file(s) or block(s) could not be measured: the "
+              "population is incomplete and these numbers are not a baseline", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/scripts/measure_control_flow.py
+++ b/scripts/measure_control_flow.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Measure control-flow shape: nesting, decisions, and implicit priority.
+
+Why this exists. Rule 2 of the maintainability guide
+(docs/development/CODE_QUALITY.md) asks for the simplest control flow that
+makes state, priority, timing and error paths obvious. "Simplest" cannot be
+argued from taste and must not be imported as a generic complexity limit from
+some other codebase, so this tool measures THIS tree first and the guide quotes
+what it found.
+
+Two languages, two different questions:
+
+  * Host code (Python) - how deep does control flow nest inside one function,
+    and how many decision points does a reader hold at once? Depth is the
+    number of enclosing branch/loop/try constructs; decisions counts `if`,
+    `for`, `while`, `try` handlers, boolean operators and conditional
+    expressions. Neither is a defect on its own; together they say how much of
+    a function a reader must simulate to know what it does with a failure.
+
+  * SystemVerilog - is priority VISIBLE? A signal assigned more than once in
+    one procedural block resolves by source order: the last assignment wins.
+    That is real, legal, frequently correct - and it is invisible at the point
+    of use, because nothing in the block says "this is the default and that is
+    the override". The rule does not forbid it; it asks that the priority be
+    visible in structure or named explicitly, so this tool lists where the
+    ordering is load-bearing.
+
+Nothing here is a gate. There is no threshold, nothing in CI fails on these
+numbers, and a high count is a question for review, not a defect.
+
+Usage:
+    python3 scripts/measure_control_flow.py             # both, ranked
+    python3 scripts/measure_control_flow.py --python    # host code only
+    python3 scripts/measure_control_flow.py --sv        # RTL only
+    python3 scripts/measure_control_flow.py --json      # machine-readable
+    python3 scripts/measure_control_flow.py --selftest  # fixture arms
+
+Exit 0 unless --selftest fails.
+"""
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+EXCLUDED_PREFIXES = (
+    "third_party/", "external/", "protocol-processor/", "gptp-processor/",
+    "gen/", "build/", "historical_now_obsolete/",
+)
+
+#: constructs that add a level of nesting a reader must hold
+_NESTING = (ast.If, ast.For, ast.While, ast.With, ast.Try,
+            ast.AsyncFor, ast.AsyncWith)
+#: constructs that add a decision point
+_DECISION = (ast.If, ast.For, ast.While, ast.ExceptHandler, ast.BoolOp,
+             ast.IfExp, ast.Assert, ast.comprehension)
+
+
+def tracked(*patterns):
+    out = subprocess.run(["git", "ls-files", *patterns], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout.split()
+    return [p for p in out if not p.startswith(EXCLUDED_PREFIXES)]
+
+
+# ---------------------------------------------------------------------------
+# host code
+# ---------------------------------------------------------------------------
+#: a nested definition is measured as its own unit, so the enclosing function
+#: does not inherit its depth or its decisions. Without this an orchestrator
+#: that defines one small helper reads as deeply nested when it is not.
+_OWN_UNIT = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+
+def _own_body(node):
+    """Walk `node`, yielding every descendant that still belongs to it."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _OWN_UNIT):
+            continue
+        yield child
+        yield from _own_body(child)
+
+
+def _depth(node, level=0):
+    deepest = level
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _OWN_UNIT):
+            continue
+        step = level + 1 if isinstance(child, _NESTING) else level
+        deepest = max(deepest, _depth(child, step))
+    return deepest
+
+
+def measure_python_source(src):
+    """Return one row per function defined in `src`."""
+    rows = []
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end = getattr(node, "end_lineno", None) or max(
+            (getattr(c, "lineno", node.lineno) for c in ast.walk(node)), default=node.lineno)
+        rows.append({
+            "name": node.name,
+            "line": node.lineno,
+            "loc": end - node.lineno + 1,
+            "depth": _depth(node),
+            "decisions": sum(1 for c in _own_body(node) if isinstance(c, _DECISION)),
+        })
+    return rows
+
+
+def measure_python():
+    rows = []
+    for rel in tracked("scripts/*.py", "sw/**/*.py", "tb/**/*.py", "harness/**/*.py"):
+        try:
+            found = measure_python_source((REPO / rel).read_text(errors="replace"))
+        except SyntaxError:
+            continue
+        for row in found:
+            row["path"] = rel
+            rows.append(row)
+    rows.sort(key=lambda r: (-r["depth"], -r["decisions"]))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# SystemVerilog - where is priority decided by source order?
+# ---------------------------------------------------------------------------
+_SV_BLOCK_RE = re.compile(r"always_(ff|comb|latch)\s*(?:@\s*\([^)]*\))?\s*begin(?:\s*:\s*(\w+))?")
+_SV_ASSIGN_RE = re.compile(
+    r"(?:^|[\n;:)]|\bbegin\b|\bend\b|\belse\b)\s*(\w+)\s*(?:\[[^\]]*\])*\s*(?:<=|=)(?!=)", re.M)
+_SV_COMMENT_RE = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
+
+
+def _sv_strip(text):
+    def blank(m):
+        return "".join(ch if ch == "\n" else " " for ch in m.group(0))
+    return _SV_COMMENT_RE.sub(blank, text)
+
+
+def _sv_blocks(text):
+    blocks = []
+    for m in _SV_BLOCK_RE.finditer(text):
+        start, depth = m.end(), 1
+        for tok in re.finditer(r"\b(begin|end)\b", text[start:]):
+            depth += 1 if tok.group(1) == "begin" else -1
+            if depth == 0:
+                line = text[: m.start()].count("\n") + 1
+                blocks.append((m.group(1), m.group(2) or f"line{line}",
+                               text[start:start + tok.start()], line))
+                break
+    return blocks
+
+
+def _sv_depth(body):
+    """Deepest nesting of begin/case inside one procedural block."""
+    depth = best = 0
+    for tok in re.finditer(r"\b(begin|end|case|casez|casex|endcase)\b", body):
+        word = tok.group(1)
+        if word in ("begin", "case", "casez", "casex"):
+            depth += 1
+            best = max(best, depth)
+        else:
+            depth -= 1
+    return best
+
+
+def measure_sv_source(text):
+    rows = []
+    for kind, name, body, line in _sv_blocks(_sv_strip(text)):
+        targets = _SV_ASSIGN_RE.findall(body)
+        repeated = sorted({t for t in targets if targets.count(t) > 1})
+        rows.append({
+            "block": name,
+            "kind": f"always_{kind}",
+            "line": line,
+            "loc": body.count("\n") + 1,
+            "depth": _sv_depth(body),
+            "order_dependent": repeated,
+        })
+    return rows
+
+
+def measure_sv():
+    rows = []
+    for rel in [p for p in tracked("hdl") if p.endswith(".sv")]:
+        for row in measure_sv_source((REPO / rel).read_text(errors="replace")):
+            row["path"] = rel
+            rows.append(row)
+    rows.sort(key=lambda r: (-len(r["order_dependent"]), -r["depth"], -r["loc"]))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# self-test
+# ---------------------------------------------------------------------------
+PY_FIXTURES = [
+    ("flat function is depth 0", "def f():\n    return 1\n", 0, 0),
+    ("one if is depth 1", "def f(a):\n    if a:\n        return 1\n    return 0\n", 1, 1),
+    ("sibling ifs do not stack", "def f(a):\n    if a:\n        pass\n    if a:\n        pass\n", 1, 2),
+    ("nested if/for stacks", "def f(a):\n    if a:\n        for i in a:\n            if i:\n                pass\n", 3, 3),
+    ("try/except counts the handler",
+     "def f():\n    try:\n        pass\n    except ValueError:\n        pass\n", 1, 1),
+    ("boolean operators are decisions", "def f(a, b):\n    return a and b\n", 0, 1),
+    ("a nested def is measured on its own",
+     "def outer():\n    def inner(a):\n        if a:\n            pass\n    return inner\n", 0, 0),
+]
+
+SV_FIXTURES = [
+    ("single assignment has no implicit priority",
+     "always_comb begin : b  x_w = 1; end", []),
+    ("a re-assigned signal is order dependent",
+     "always_comb begin : b  x_w = 1; if (q) x_w = 2; end", ["x_w"]),
+    ("default-then-override in a case is order dependent",
+     "always_comb begin : b  y_w = 0; case (s) 2'd1: y_w = 1; endcase end", ["y_w"]),
+    ("two different signals are not order dependent",
+     "always_comb begin : b  x_w = 1; y_w = 2; end", []),
+    ("a comparison is not an assignment",
+     "always_comb begin : b  x_w = (a == b); end", []),
+]
+
+
+def selftest():
+    failures = 0
+    for name, src, want_depth, want_dec in PY_FIXTURES:
+        rows = measure_python_source(src)
+        row = next(r for r in rows if r["name"] in ("f", "outer"))
+        if row["depth"] == want_depth and row["decisions"] == want_dec:
+            print(f"[PASS] python: {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] python: {name}: got depth {row['depth']} decisions "
+                  f"{row['decisions']}, want {want_depth}/{want_dec}")
+
+    # the nested-def arm also proves the inner function is reported separately
+    rows = measure_python_source(PY_FIXTURES[-1][1])
+    inner = [r for r in rows if r["name"] == "inner"]
+    if len(inner) == 1 and inner[0]["depth"] == 1:
+        print("[PASS] python: inner function reported with its own depth")
+    else:
+        failures += 1
+        print(f"[FAIL] python: inner function reported with its own depth: {inner}")
+
+    for name, src, want in SV_FIXTURES:
+        row = measure_sv_source(src)[0]
+        if row["order_dependent"] == want:
+            print(f"[PASS] sv: {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] sv: {name}: got {row['order_dependent']}, want {want}")
+
+    # nesting inside a procedural block, including case
+    # depth is measured INSIDE the block: the block's own `begin` is the block,
+    # so `if (q) begin case (...) ... endcase end` nests two levels, not three.
+    depth = measure_sv_source(
+        "always_ff @(posedge c) begin : b if (q) begin case (s) 2'd0: x_r <= 1; endcase end end"
+    )[0]["depth"]
+    if depth == 2:
+        print("[PASS] sv: begin/case nesting is counted inside the block")
+    else:
+        failures += 1
+        print(f"[FAIL] sv: begin/case nesting is counted inside the block: got {depth}, want 2")
+
+    total = len(PY_FIXTURES) + len(SV_FIXTURES) + 2
+    print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--python", action="store_true", help="host code only")
+    ap.add_argument("--sv", action="store_true", help="RTL only")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
+    ap.add_argument("--top", type=int, default=15, help="rows per table (default 15)")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    want_py = args.python or not args.sv
+    want_sv = args.sv or not args.python
+    out = {}
+
+    if want_py:
+        rows = measure_python()
+        out["python"] = rows
+        if not args.json:
+            print(f"{'path:line':<58}{'function':<34}{'loc':>6}{'depth':>7}{'decisions':>11}")
+            for r in rows[: args.top]:
+                where = f"{r['path']}:{r['line']}"
+                print(f"{where:<58}{r['name'][:33]:<34}{r['loc']:>6}{r['depth']:>7}{r['decisions']:>11}")
+            deep = sum(1 for r in rows if r["depth"] >= 5)
+            print(f"\n{len(rows)} first-party function(s); {deep} nest five levels or deeper\n")
+
+    if want_sv:
+        rows = measure_sv()
+        out["sv"] = rows
+        if not args.json:
+            print(f"{'path:line':<58}{'block':<28}{'depth':>7}{'order-dependent signals':>26}")
+            for r in rows[: args.top]:
+                where = f"{r['path']}:{r['line']}"
+                print(f"{where:<58}{r['block'][:27]:<28}{r['depth']:>7}{len(r['order_dependent']):>26}")
+            ordered = sum(1 for r in rows if r["order_dependent"])
+            print(f"\n{len(rows)} procedural block(s); {ordered} resolve at least one signal "
+                  f"by source order")
+
+    if args.json:
+        print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/builder/cluster_names_golden.json
+++ b/sw/builder/cluster_names_golden.json
@@ -1,0 +1,132 @@
+{
+ "_generated_by": "python3 sw/builder/test_builder.py --write-cluster-golden",
+ "_what": "gate 24d: every AUDIO_CLUSTER object_name the builder produces, per config, direction and STREAM_PORT, in offset order; regenerate only for a deliberate naming change",
+ "ax7101_8x8": {
+  "input": [
+   [],
+   [],
+   [],
+   [],
+   [],
+   [],
+   [],
+   []
+  ],
+  "output": [
+   [
+    "Pilot Tone",
+    "Loopback S0 ch 0",
+    "Loopback S0 ch 1",
+    "Loopback S0 ch 2",
+    "Loopback S0 ch 3",
+    "Loopback S0 ch 4",
+    "Loopback S0 ch 5",
+    "Loopback S0 ch 6",
+    "Loopback S0 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S1 ch 0",
+    "Loopback S1 ch 1",
+    "Loopback S1 ch 2",
+    "Loopback S1 ch 3",
+    "Loopback S1 ch 4",
+    "Loopback S1 ch 5",
+    "Loopback S1 ch 6",
+    "Loopback S1 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S2 ch 0",
+    "Loopback S2 ch 1",
+    "Loopback S2 ch 2",
+    "Loopback S2 ch 3",
+    "Loopback S2 ch 4",
+    "Loopback S2 ch 5",
+    "Loopback S2 ch 6",
+    "Loopback S2 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S3 ch 0",
+    "Loopback S3 ch 1",
+    "Loopback S3 ch 2",
+    "Loopback S3 ch 3",
+    "Loopback S3 ch 4",
+    "Loopback S3 ch 5",
+    "Loopback S3 ch 6",
+    "Loopback S3 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S4 ch 0",
+    "Loopback S4 ch 1",
+    "Loopback S4 ch 2",
+    "Loopback S4 ch 3",
+    "Loopback S4 ch 4",
+    "Loopback S4 ch 5",
+    "Loopback S4 ch 6",
+    "Loopback S4 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S5 ch 0",
+    "Loopback S5 ch 1",
+    "Loopback S5 ch 2",
+    "Loopback S5 ch 3",
+    "Loopback S5 ch 4",
+    "Loopback S5 ch 5",
+    "Loopback S5 ch 6",
+    "Loopback S5 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S6 ch 0",
+    "Loopback S6 ch 1",
+    "Loopback S6 ch 2",
+    "Loopback S6 ch 3",
+    "Loopback S6 ch 4",
+    "Loopback S6 ch 5",
+    "Loopback S6 ch 6",
+    "Loopback S6 ch 7"
+   ],
+   [
+    "Pilot Tone",
+    "Loopback S7 ch 0",
+    "Loopback S7 ch 1",
+    "Loopback S7 ch 2",
+    "Loopback S7 ch 3",
+    "Loopback S7 ch 4",
+    "Loopback S7 ch 5",
+    "Loopback S7 ch 6",
+    "Loopback S7 ch 7"
+   ]
+  ]
+ },
+ "ax7101_1x1_tdm8": {
+  "input": [
+   []
+  ],
+  "output": [
+   [
+    "TDM8 In FL",
+    "TDM8 In FR",
+    "TDM8 In FC",
+    "TDM8 In LFE",
+    "TDM8 In RL",
+    "TDM8 In RR",
+    "TDM8 In SL",
+    "TDM8 In SR",
+    "Pilot Tone",
+    "Loopback S0 FL",
+    "Loopback S0 FR",
+    "Loopback S0 FC",
+    "Loopback S0 LFE",
+    "Loopback S0 RL",
+    "Loopback S0 RR",
+    "Loopback S0 SL",
+    "Loopback S0 SR"
+   ]
+  ]
+ }
+}

--- a/sw/builder/endstation_builder.py
+++ b/sw/builder/endstation_builder.py
@@ -1438,42 +1438,86 @@ def primary_segment(port, direction):
     return port["pool"][0] if port["pool"] else None
 
 
+class _ClusterNaming:
+    """Everything a cluster namer needs, resolved once per port.
+
+    The namers below take this instead of reaching back into `cfg`, so each
+    one is readable on its own and the dispatch table is a table rather than a
+    branch chain that happens to close over local variables."""
+
+    def __init__(self, cfg, direction):
+        self.label = IFACE_LABEL.get(cfg["interface"]["kind"], "AUDIO")
+        #: a cluster on a STREAM_PORT_INPUT is what the entity plays OUT
+        self.way = "Out" if direction == "input" else "In"
+        self._names = cfg["interface"].get("channel_names") or []
+        #: the received stream channel space, in {stream, channel} order: what
+        #: a loopback cluster actually offers a talker.
+        self.rx = [(si, ch) for si, s in enumerate(cfg["listeners"])
+                   for ch in range(s["channels"])]
+
+    def chname(self, k, fallback):
+        return self._names[k] if k < len(self._names) else fallback
+
+    def rx_index(self, stream):
+        """Where `stream`'s channel space starts, or 0 if it has none."""
+        return next((k for k, (si, ch) in enumerate(self.rx)
+                     if si == stream and ch == 0), 0)
+
+
+def _name_physical(ctx, first, n):
+    return f"{ctx.label} {ctx.way} {ctx.chname(first + n, str(first + n))}"
+
+
+def _name_virtual(ctx, first, n):
+    return f"Virtual {ctx.way} {first + n}"
+
+
+def _name_pilot(ctx, first, n):
+    return "Pilot Tone"
+
+
+def _name_loopback(ctx, first, n):
+    """Walk the rx channel space from THIS talker's own stream index, so
+    talker t defaults to rx stream t (per-channel-distinct audio, not eight
+    copies of one). With no receive stream at all there is no channel space to
+    walk and the cluster is named by its own offset."""
+    if not ctx.rx:
+        return f"Loopback ch {n}"
+    si, ch = ctx.rx[(ctx.rx_index(first) + n) % len(ctx.rx)]
+    return f"Loopback S{si} {ctx.chname(ch, f'ch {ch}')}"
+
+
+#: one namer per pool role. The set is closed: `legacy_pool` emits physical
+#: and virtual, `role_pool` emits physical, pilot and loopback, and nothing
+#: else constructs a pool entry. Naming them in a table rather than an
+#: if/elif chain ending in a bare `else` means a role this builder does not
+#: know is refused by name instead of silently named as a loopback channel.
+CLUSTER_NAMERS = {
+    "physical": _name_physical,
+    "virtual":  _name_virtual,
+    "pilot":    _name_pilot,
+    "loopback": _name_loopback,
+}
+
+
 def cluster_names(cfg, port, direction):
     """D10: one object_name per cluster of this port, in offset order.
 
     1722.1-2021 6.2.2.8 lists `object_name` among the fields EXCLUDED from
     "the structure of the data model", so renaming clusters must NOT move
     entity_model_id - and it does not: model_shape() never sees a name."""
-    label = IFACE_LABEL.get(cfg["interface"]["kind"], "AUDIO")
-    cnames = cfg["interface"].get("channel_names") or []
-    def chname(k, fallback):
-        return cnames[k] if k < len(cnames) else fallback
-    # the received stream channel space, in {stream, channel} order: what a
-    # loopback cluster actually offers a talker.
-    rx = [(si, ch) for si, s in enumerate(cfg["listeners"])
-          for ch in range(s["channels"])]
+    ctx = _ClusterNaming(cfg, direction)
     out = []
-    for g in port["pool"]:
-        role, w, first = g["role"], g["width"], g.get("first", 0)
-        for n in range(w):
-            if role == "physical":
-                out.append(f"{label} {'Out' if direction == 'input' else 'In'}"
-                           f" {chname(first + n, str(first + n))}")
-            elif role == "virtual":
-                out.append(f"Virtual {'Out' if direction == 'input' else 'In'}"
-                           f" {first + n}")
-            elif role == "pilot":
-                out.append("Pilot Tone")
-            else:  # loopback: walk the rx channel space from THIS talker's
-                   # own stream index, so talker t defaults to rx stream t
-                   # (per-channel-distinct audio, not eight copies of one)
-                if not rx:
-                    out.append(f"Loopback ch {n}")
-                    continue
-                start = next((k for k, (si, ch) in enumerate(rx)
-                              if si == first and ch == 0), 0)
-                si, ch = rx[(start + n) % len(rx)]
-                out.append(f"Loopback S{si} {chname(ch, f'ch {ch}')}")
+    for group in port["pool"]:
+        role = group["role"]
+        namer = CLUSTER_NAMERS.get(role)
+        if namer is None:
+            raise ConfigError(
+                f"cluster naming: pool role {role!r} on STREAM_PORT_"
+                f"{direction.upper()} {port.get('index')} has no namer. "
+                f"Known roles: {', '.join(sorted(CLUSTER_NAMERS))}")
+        first = group.get("first", 0)
+        out.extend(namer(ctx, first, n) for n in range(group["width"]))
     assert len(out) == port["clusters"]
     return out
 

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -257,6 +257,14 @@ CONFIGS = {
         ROOT, "configs/endstation_ax7101_1x1_tdm8.yaml"),
 }
 OUT = os.path.join(HERE, "out")
+#: gate 24d's pin of the cluster namer: every object_name the builder produces
+#: for a loopback-bearing config and for the channel_names config, per
+#: direction and STREAM_PORT, in offset order. Generated from the
+#: implementation by `python3 sw/builder/test_builder.py --write-cluster-golden`;
+#: a deliberate naming change regenerates it, and the diff of that file is what
+#: a reviewer reads.
+CLUSTER_NAMES_GOLDEN = os.path.join(HERE, "cluster_names_golden.json")
+CLUSTER_NAMES_GOLDEN_CONFIGS = ("ax7101_8x8", "ax7101_1x1_tdm8")
 SWEEP = os.path.join(ROOT, "sw/litex/sweep.sh")
 BUILD_SH = os.path.join(ROOT, "sw/litex/build.sh")
 PATCH_DIR = os.path.join(ROOT, "sw/litex/patches")
@@ -7546,9 +7554,45 @@ def test_d10_cluster_names():
           "their current model")
 
 
+def cluster_name_census(name):
+    """Every cluster name the builder produces for config `name`: per
+    direction, one list per STREAM_PORT in port order, names in offset order.
+    Read off the overlay, which is what gen_aem_store turns into descriptor
+    bytes, so a name is counted where it ships rather than where it is made."""
+    ovl = eb.build(CONFIGS[name], OUT)["overlay"]
+    census = {}
+    for direction in ("input", "output"):
+        ports = ovl["stream_ports"][direction]
+        slot = {p["index"]: k for k, p in enumerate(ports)}
+        rows = [[] for _ in ports]
+        for c in sorted(ovl["audio_clusters"],
+                        key=lambda c: (c["port_index"], c["offset"])):
+            if c["direction"] == direction:
+                rows[slot[c["port_index"]]].append(c["name"])
+        assert [len(r) for r in rows] == [p["clusters"] for p in ports], name
+        census[direction] = rows
+    return census
+
+
+def write_cluster_names_golden():
+    """Regenerate cluster_names_golden.json from the current builder."""
+    golden = {
+        "_generated_by": "python3 sw/builder/test_builder.py --write-cluster-golden",
+        "_what": "gate 24d: every AUDIO_CLUSTER object_name the builder "
+                 "produces, per config, direction and STREAM_PORT, in offset "
+                 "order; regenerate only for a deliberate naming change",
+    }
+    for name in CLUSTER_NAMES_GOLDEN_CONFIGS:
+        golden[name] = cluster_name_census(name)
+    with open(CLUSTER_NAMES_GOLDEN, "w") as f:
+        json.dump(golden, f, indent=1)
+        f.write("\n")
+    print(f"wrote {CLUSTER_NAMES_GOLDEN}")
+
+
 def test_d10_cluster_namer_paths():
-    """gate 24d - the cluster namers, including the two paths a live config
-    does not reach.
+    """gate 24d - the cluster namers: the two paths a live config does not
+    reach, and the moved logic pinned name by name.
 
     Rule 2 (docs/development/CODE_QUALITY.md) turned an `if/elif/elif/else`
     chain nested inside two loops into a named table. Two of its paths were
@@ -7563,6 +7607,19 @@ def test_d10_cluster_namer_paths():
         by name. The set is closed today, which is exactly why the refusal
         needs an arm - an unreachable path with no test is how the next role
         gets silently mislabelled.
+
+    Those two arms grade the paths; the golden below grades what the refactor
+    MOVED. The talker-t -> rx-stream-t walk, the `+ n` channel step and the
+    channel_names mapping survive only as names, and gate 24c checks loopback
+    names by prefix and physical names by label, so `rx_index() -> 0`,
+    dropping `+ n`, and a physical namer that ignores channel_names each
+    moved 56, 63 and 8 real names past every builder gate. Every name the
+    builder produces for the loopback-bearing ax7101_8x8 (both directions:
+    its listeners are headless, and the golden records those empty ports
+    too) and for the channel_names config ax7101_1x1_tdm8 is therefore pinned
+    in cluster_names_golden.json, generated from the implementation that a
+    replay of every cluster_names() call proved byte-identical to the
+    pre-refactor chain. Each of those three mutations fails here.
     """
     cfg = eb.load_config(CONFIGS["ax7101_8x8"])
 
@@ -7596,9 +7653,40 @@ def test_d10_cluster_namer_paths():
         for role in roles:
             assert role in eb.CLUSTER_NAMERS, (
                 f"{role} is a primary role for {direction} but has no namer")
+
+    # -- the moved logic itself, name by name --------------------------------
+    with open(CLUSTER_NAMES_GOLDEN) as f:
+        golden = json.load(f)
+    pinned = 0
+    for name in CLUSTER_NAMES_GOLDEN_CONFIGS:
+        got = cluster_name_census(name)
+        for direction in ("input", "output"):
+            want = golden[name][direction]
+            assert len(got[direction]) == len(want), (
+                f"{name}: builds {len(got[direction])} STREAM_PORT_"
+                f"{direction.upper()}s, the golden pins {len(want)}")
+            for pi, (w, g) in enumerate(zip(want, got[direction])):
+                assert g == w, (
+                    f"{name} STREAM_PORT_{direction.upper()} {pi}: cluster "
+                    f"names moved\n  golden: {w}\n  built:  {g}\n"
+                    "a deliberate naming change regenerates the golden with "
+                    "`python3 sw/builder/test_builder.py --write-cluster-golden`"
+                    " and the diff of that file is the review")
+                pinned += len(w)
+    # the golden must pin the two behaviours it exists for, so an emptied or
+    # truncated file cannot pass by matching nothing
+    flat = [n for name in CLUSTER_NAMES_GOLDEN_CONFIGS
+            for ports in golden[name].values() for p in ports for n in p]
+    assert sum(1 for n in flat if n.startswith("Loopback S")) >= 64, \
+        "the golden pins no loopback walk"
+    cnames = eb.load_config(CONFIGS["ax7101_1x1_tdm8"])["interface"]["channel_names"]
+    assert cnames and all(any(n.endswith(" " + c) for n in flat) for c in cnames), \
+        "the golden pins no channel_names mapping"
     print("  [gate 24d] empty-rx loopback names by offset (and by source when "
-          "a receive space exists), an unknown role is refused by name, and "
-          "every primary role in PRIMARY_ROLE_ORDER has a namer")
+          "a receive space exists), an unknown role is refused by name, "
+          "every primary role in PRIMARY_ROLE_ORDER has a namer, and "
+          f"{pinned} cluster names across {len(CLUSTER_NAMES_GOLDEN_CONFIGS)} "
+          "configs match the tracked golden name for name")
 
 
 def test_d10_names_reach_the_rom():
@@ -8449,6 +8537,9 @@ def test_milan_base_formats_are_rate_complete():
 
 
 if __name__ == "__main__":
+    if "--write-cluster-golden" in sys.argv:
+        write_cluster_names_golden()
+        sys.exit(0)
     for fn in (test_all_configs_build, test_baremetal_profile_contract,
                test_gptp_product_default_and_legacy_option,
                test_qspi_owner_transition_completed_write_prefixes,

--- a/sw/builder/test_builder.py
+++ b/sw/builder/test_builder.py
@@ -7546,6 +7546,61 @@ def test_d10_cluster_names():
           "their current model")
 
 
+def test_d10_cluster_namer_paths():
+    """gate 24d - the cluster namers, including the two paths a live config
+    does not reach.
+
+    Rule 2 (docs/development/CODE_QUALITY.md) turned an `if/elif/elif/else`
+    chain nested inside two loops into a named table. Two of its paths were
+    only ever reachable through that nesting and had no arm:
+
+      * the loopback namer with an EMPTY receive channel space. A talker whose
+        entity declares no listener has nothing to walk, and the cluster is
+        named by its own offset instead. The old shape reached this with a
+        `continue` five levels deep, so nothing graded it.
+      * a pool role with no namer. The old shape's bare `else` swallowed any
+        unknown role and named it as a loopback channel; the table refuses it
+        by name. The set is closed today, which is exactly why the refusal
+        needs an arm - an unreachable path with no test is how the next role
+        gets silently mislabelled.
+    """
+    cfg = eb.load_config(CONFIGS["ax7101_8x8"])
+
+    # -- the empty-rx loopback path -----------------------------------------
+    headless = dict(cfg, listeners=[])
+    port = {"index": 0, "clusters": 3,
+            "pool": [{"role": "loopback", "width": 3, "first": 0, "offset": 0}]}
+    got = eb.cluster_names(headless, port, "output")
+    assert got == ["Loopback ch 0", "Loopback ch 1", "Loopback ch 2"], got
+
+    # and with a receive space present the SAME pool names real sources, so
+    # the arm above is not passing because the namer is inert
+    live = eb.cluster_names(cfg, port, "output")
+    assert live != got and all(n.startswith("Loopback S") for n in live), live
+
+    # -- the unknown-role refusal -------------------------------------------
+    bogus = {"index": 0, "clusters": 1,
+             "pool": [{"role": "teleport", "width": 1, "first": 0, "offset": 0}]}
+    try:
+        eb.cluster_names(cfg, bogus, "output")
+    except eb.ConfigError as e:
+        assert "teleport" in str(e) and "loopback" in str(e), str(e)
+    else:
+        assert False, ("an unknown pool role must be refused by name, not "
+                       "silently named as a loopback channel")
+
+    # -- every known role still has a namer, and the table IS the dispatch ---
+    assert set(eb.CLUSTER_NAMERS) == {"physical", "virtual", "pilot", "loopback"}, \
+        eb.CLUSTER_NAMERS
+    for direction, roles in eb.PRIMARY_ROLE_ORDER.items():
+        for role in roles:
+            assert role in eb.CLUSTER_NAMERS, (
+                f"{role} is a primary role for {direction} but has no namer")
+    print("  [gate 24d] empty-rx loopback names by offset (and by source when "
+          "a receive space exists), an unknown role is refused by name, and "
+          "every primary role in PRIMARY_ROLE_ORDER has a namer")
+
+
 def test_d10_names_reach_the_rom():
     """gate 24d - the cluster ROLE NAMES survive the whole path (config ->
     overlay -> gen_aem_store -> descriptor bytes), and the TRACKED SHAPE
@@ -8439,7 +8494,8 @@ if __name__ == "__main__":
                test_firmware_version_derived_from_rtl,
                test_d8_role_pools, test_d8_role_pools_reject,
                test_prune_guard_hop_gate_bites,
-               test_d10_cluster_names, test_d10_names_reach_the_rom,
+               test_d10_cluster_names, test_d10_cluster_namer_paths,
+               test_d10_names_reach_the_rom,
                test_gptp_domain_is_one_source,
                test_gptp_dataset_matches_engine_announce,
                test_pp_window_contract,


### PR DESCRIPTION
> [!IMPORTANT]
> **Post-review correction (2026-08-28, head `8e229639`).** The control-flow measurement now scans both project-owned processor submodules, recognizes Python `match` cases, and publishes measured dispositions for the processor hotspots. At this PR head: 2,322 host functions with 35 at depth 5 or more, and 616 RTL procedural blocks with 507 order-dependent; self-test 15/15. Earlier figures below predate this correction.

Closes #250

Rule 2 of the #248 contract. **Stacked on #275 (Rule 1) — review that first; this PR's diff is incremental.**

## What changed

| Area | Change |
|---|---|
| Guide | Rule 2 section in `docs/development/CODE_QUALITY.md`: wording, what "explicit" means for an RTL priority chain versus a host-side parser, worked example, exceptions, review checklist. |
| Measurement | `scripts/measure_control_flow.py` — nesting depth and decision points per host function; per procedural block in RTL, the nesting and the signals assigned more than once (priority decided by source order). |
| Cleanup | `cluster_names` in `sw/builder/endstation_builder.py`: a four-way `if/elif/elif/else` nested in two loops became one named function per pool role plus a dispatch table. |
| Tests | `test_d10_cluster_namer_paths` (gate 24d) — arms for the two paths the nesting hid. |

## The simplification

| Unit | Lines | Nesting depth | Decision points |
|---|---:|---:|---:|
| `cluster_names` before | 38 | 6 | 14 |
| `cluster_names` after | 20 | 2 | 4 |
| `_name_loopback` (deepest namer) | 9 | 1 | 1 |

## Behaviour is unchanged, and the claim is made with a tool

Every cluster name the builder can produce — 5 configurations × every stream port × both directions — is **byte-identical** before and after. The differential was captured on `origin/dev`, replayed after the refactor, and `diff` is empty.

## Two paths the nesting hid, now with arms

- The loopback namer's **empty receive channel space**: a talker whose entity declares no listener names the cluster by its own offset. That was a `continue` five levels deep and nothing graded it.
- The chain's **bare `else`**: it swallowed any role that was not physical, virtual or pilot and named it as a loopback channel. The table refuses an unknown role by name. The role set is closed today (`legacy_pool` and `role_pool` are the only producers), which is exactly why the refusal needs an arm.

The gate also asserts every role in `PRIMARY_ROLE_ORDER` has a namer, so adding a role to one and not the other fails.

## No threshold is proposed

A generic complexity limit would fail the parts of this tree that are correctly shaped. The guide records what the tree measures instead: 2,089 first-party functions, 30 nesting five levels or deeper; 309 procedural blocks, 263 resolving at least one signal by source order. That second number is why the rule asks for priority to be *visible*, not absent.

## Evidence

- `scripts/measure_control_flow.py --selftest` — 14/14. Two of its arms failed on first run and found real defects in the tool itself (a nested `def` leaking its depth into the enclosing function; an off-by-one in the RTL block-nesting expectation), both fixed here.
- Builder gates 24a, 24c, 24d — PASS.
- Differential over all configs — identical.
- `docs_check` 0 findings / `gen_toc --check` OK / `check_doc_paths` OK.
- Full Verilator inventory at the stack head: 53 of 54 suites, 2,116,629 checks, 0 in-suite failures.

## Not covered

- `tsn_fuzz` declared SKIP (tsn-gen absent); builder gate 23h pre-existing on this host, and on a pristine `dev` checkout. Neither is touched by this branch.
