### PR TITLE
[Code quality] Rule 3: make the RTL the authority for its own source lists

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,6 +89,8 @@ jobs:
       # its own expansion rather than parsing it. Placed here because it needs
       # the same submodules the builder steps above check out. A consumer whose
       # tooling is absent is reported SKIPPED by name, never dropped silently.
+      # It also reads the protocol processor's own Yosys tops array against the
+      # modules that processor declares (scripts/processor_yosys_tops.budget).
       - name: RTL source-list drift gate
         run: |
           python3 scripts/check_rtl_source_lists.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,14 +81,18 @@ jobs:
           python3 scripts/check_nvm_record_space.py
           python3 scripts/check_nvm_record_space.py --self-test
       - name: SoC source-list gate (Vivado would fail 40 min in without this)
-        run: python3 scripts/check_soc_sources.py
+        run: |
+          python3 scripts/check_soc_sources.py
+          python3 scripts/check_soc_sources.py --selftest
 
       # The other four lists of the same RTL. check_soc_sources.py guards the
       # Vivado one; this gate derives the whole milan_datapath file closure
       # from the RTL and checks every consumer against it, asking each one for
       # its own expansion rather than parsing it. Placed here because it needs
-      # the same submodules the builder steps above check out. A consumer whose
-      # tooling is absent is reported SKIPPED by name, never dropped silently.
+      # the same submodules the builder steps above check out. A consumer that
+      # cannot answer FAILS the gate (exit 2): this job runs the strict default
+      # and never passes --allow-skip, the tool-less-host opt-out that prints a
+      # loud SKIPPED marker instead of a verdict that covers it.
       # It also reads the protocol processor's own Yosys tops array against the
       # modules that processor declares (scripts/processor_yosys_tops.budget).
       - name: RTL source-list drift gate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,6 +83,17 @@ jobs:
       - name: SoC source-list gate (Vivado would fail 40 min in without this)
         run: python3 scripts/check_soc_sources.py
 
+      # The other four lists of the same RTL. check_soc_sources.py guards the
+      # Vivado one; this gate derives the whole milan_datapath file closure
+      # from the RTL and checks every consumer against it, asking each one for
+      # its own expansion rather than parsing it. Placed here because it needs
+      # the same submodules the builder steps above check out. A consumer whose
+      # tooling is absent is reported SKIPPED by name, never dropped silently.
+      - name: RTL source-list drift gate
+        run: |
+          python3 scripts/check_rtl_source_lists.py
+          python3 scripts/check_rtl_source_lists.py --selftest
+
       # CI event and SHA contract gate (#174, #181): the four workflow files
       # and docs/testing/CI_WORKFLOWS.md must agree on the triggers, the cron
       # time, the public check names, cancel-in-progress and the one-SHA rule

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -534,6 +534,34 @@ A consumer whose tooling is absent is reported `SKIPPED` by name and the verdict
 says it is not covered. A gate that silently drops a consumer it could not reach
 is how a list goes unchecked for months.
 
+### The processor-native list, and where the scope statement ends
+
+The five lists above all compile the same top, and `scripts/pp_srcs.py` feeds
+the processor half of each. One list in scope is neither: the protocol
+processor's own portability gate, `protocol-processor/syn/yosys/run.sh`, keeps
+a hand-written `tops` array that rule 2 of the processor's own HDL README says must name
+every module, so each is elaborated as a Yosys top on its own. Nothing derived
+it and nothing checked it, and at pin `3770ae02` it had drifted: 38 modules are
+declared under `protocol-processor/hdl` and the array names 32. The six absent
+ones — `KL_acmp_nvm_shadow`, `KL_mrp_strip`, `KL_pp_dispatch_fifo`,
+`KL_srp_admission`, `KL_srp_top`, `protocol_processor_top` — all elaborate when
+asked; the gate simply never asked, and both repositories reported the
+processor as covered.
+
+The same gate now reads that list too, with the declared modules as the
+authority. Every declared module is a top, or it is named in
+[`scripts/processor_yosys_tops.budget`](../../scripts/processor_yosys_tops.budget)
+with the reason it is not. The six are recorded there as **drift at the pin**,
+not as helper exceptions, because that is what they are; the fix is upstream,
+and the pin bump that brings it in deletes the lines, since a recorded name
+that has become a top is refused as stale and an omission that is not recorded
+is refused outright. The record can therefore only shrink.
+
+The gPTP processor keeps no native tops list. Its portability coverage is the
+closure walk itself — every one of its six sources is reached from
+`milan_datapath` — and `--list` prints that count so a gPTP module that fell
+out of the walk would be visible rather than merely unelaborated.
+
 ### The named-constant half
 
 `milan_datapath` passed `16'h88F7` to the timestamp unit's `ETH_TYPE`

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -499,13 +499,39 @@ module under Rule 1 broke three Verilator suites at once, each with the same
 [`scripts/check_rtl_source_lists.py`](../../scripts/check_rtl_source_lists.py)
 makes the RTL the authority and every list a derived consumer. It walks the
 compilation-unit closure of `milan_datapath` through the sources — module
-instantiations, package references and interface/modport types, transitively —
-and checks each consumer carries every file in it. A declaration makes a child
-part of that walk; a hard-coded naming-prefix allowlist does not. That
-distinction is load-bearing for `protocol_processor_top` and
-`credit_based_shaper`, whose ordinary names were silently absent from the first
-version of the closure. Package-only and interface-only files are equally
-load-bearing even though they instantiate no module.
+instantiations, package references, interface types through any modport and
+`` `include``d bodies, transitively — and checks each consumer carries every
+file in it. A declaration makes a child part of that walk; a hard-coded
+naming-prefix allowlist does not. That distinction is load-bearing for
+`protocol_processor_top` and `credit_based_shaper`, whose ordinary names were
+silently absent from the first version of the closure. Package-only and
+interface-only files are equally load-bearing even though they instantiate no
+module.
+
+The walk has to see every instantiation shape a front end accepts, because a
+shape it does not see is a file no consumer is told about. The first version
+needed two leading spaces and walked past the one column-0 instantiation the
+tree already had — `traffic_class_map` in
+`hdl/ieee8021q/ts/traffic_classifier.sv` — so both Yosys rows could drop that
+file with the gate green while Yosys failed on it. The first hop now lives
+once, in `scripts/check_soc_sources.py`: any indentation, an arrayed instance,
+`X #(` with or without the space, comments blanked first, and every included
+header spliced in the way the preprocessor does. The oracle for the walk is an
+independent front end over exactly the closure, with an include directory that
+holds only headers so no module can be found by filename; the one `.sv` copied
+beside them is the package five closure files `` `include``, which declares no
+module:
+
+```
+inc=$(mktemp -d); mkdir -p "$inc/gen"
+for f in $(git ls-files -- 'hdl/*.svh') hdl/common/ethernet_packet_pkg.sv; do
+  case "$f" in */gen/*) cp "$f" "$inc/gen/";; *) cp "$f" "$inc/";; esac; done
+verilator --lint-only -Wno-fatal -Wno-lint -Wno-style --top-module milan_datapath \
+  "+incdir+$inc" $(python3 scripts/check_rtl_source_lists.py --files) 2>&1 | grep -c MODMISSING
+```
+
+It prints `0` at this head, over 109 files. Over the 108 the first version
+derived it printed `1`, naming `traffic_class_map`.
 
 Two properties are what make it a source-of-truth gate rather than a fifth copy:
 
@@ -521,18 +547,38 @@ Two properties are what make it a source-of-truth gate rather than a fifth copy:
   (`make -s print-srcs`, `syn/yosys/run.sh --emit`, `syn/yosys/ooc.sh
   --emit-dp`) and the gate reads that. Two of those emit paths did not exist and
   were added, which is most of what this change is. The Vivado Python list has
-  no print mode: its quoted superproject entries are combined with the same
-  `scripts/pp_srcs.py` expansion that `milan_soc.py` calls for the
-  protocol-processor half.
+  no print mode, so it is read the way Python reads it: the
+  `_MILAN_DATAPATH_SOURCES` literal and the registrations beside it through the
+  `ast` module, in which a comment does not exist — a regex over the file's
+  text had counted a commented-out row as carried — with its starred
+  `_pp_sources()` entry expanded through the same `scripts/pp_srcs.py` that
+  `milan_soc.py` calls for the protocol-processor half.
 
 The unit is the **file**, not the module, because that is what a source list
 carries and one file may declare several modules — `KL_aaf_latency_chain` lives
 inside `KL_aaf_latency_taps.sv`. Comparing module names to file entries would
 demand entries that must not exist.
 
-A consumer whose tooling is absent is reported `SKIPPED` by name and the verdict
-says it is not covered. A gate that silently drops a consumer it could not reach
-is how a list goes unchecked for months.
+A consumer that cannot answer — an emit path that exits non-zero, a Makefile
+that is absent, a host without `make` — fails the gate with exit 2 by default,
+and CI runs that default. A gate that reads a consumer it could not reach as
+covered is how a list goes unchecked for months. `--allow-skip` is the explicit
+opt-out for a host without the tooling: it prints a `!! SKIPPED` marker per
+consumer and the verdict counts them as not covered, and a run in which every
+consumer was skipped is still exit 2. A diagnosed defect — `print-srcs` having
+become a Makefile's default goal, so a bare `make` prints a list instead of
+running the suite — is a finding, and no flag skips it. `--list` also prints,
+per consumer, the files it carries that the closure does not need; the two
+single-top Yosys rows each carry six today, harmless but stale.
+
+The self-test proves the bite on copies, never on the tree. It copies each
+consumer, removes one closure file from the copy and runs the copy's own emit
+path — `make -f` from the suite directory; the copied script beside the
+original under a temporary name, because it resolves the repository from its
+own location — then requires that path and nothing else to report the removal,
+and the tree to be byte-identical afterwards. Set arithmetic on an
+already-fetched list, which is what the first version did, would have passed
+with every fetcher stubbed to return the closure.
 
 ### The processor-native list, and where the scope statement ends
 
@@ -562,6 +608,20 @@ closure walk itself — every one of its six sources is reached from
 `milan_datapath` — and `--list` prints that count so a gPTP module that fell
 out of the walk would be visible rather than merely unelaborated.
 
+The gPTP engine's source list is itself an inventory item, and it is written by
+hand ten times. Five copies are in this repository — the gPTP rows of
+`sw/litex/milan_soc.py`, `GPTP_ENGINE_SRCS` in `syn/yosys/run.sh` and
+`syn/yosys/ooc.sh`, `GPTP_SRCS` in `tb/verilator/milan_dp/Makefile` and
+`tb/verilator/hostplane/Makefile` — and five are in the gPTP processor's own
+repository: its top-level Makefile's lint target, its out-of-context Tcl, the
+Arty bench Makefile and build Tcl, and its Verilator engine suite. They
+classify as follows.
+
+| Copies | Classification | Why |
+|---|---|---|
+| The five in this repository | Drift-checked derived copies | The walk reaches all six engine files from `milan_datapath`, so a gPTP file any of the five omits is a `MISSING SOURCE`. No generator like `scripts/pp_srcs.py` exists for them yet, and the comment in `milan_soc.py` that once called the `milan_dp` Makefile "authoritative" now names the gate: a copy that calls another copy authoritative is the circular authority that let four protocol-processor copies drift together. |
+| The five in the processor repository | Outside this gate | They live in the submodule at its pin, which this repository can neither generate nor edit; the gate guards the six files the superproject needs, not the processor's build inputs. They carry a defect of their own — a module added under the processor's `hdl` that the engine does not instantiate is never linted or elaborated there — which belongs to that repository's own gate, not to a superproject check parsing a pinned tree it does not own. |
+
 ### The named-constant half
 
 `milan_datapath` passed `16'h88F7` to the timestamp unit's `ETH_TYPE`
@@ -569,21 +629,44 @@ parameter while already importing `ethernet_packet_pkg`, which defines that
 exact value as `ETH_TYPE_PTP`. That is a second definition of a fact the package
 owns, and it is now the package's name.
 
-The inventory behind that choice: 57 hexadecimal literals appear in four or more
-first-party files. They classify into three kinds, and only the first is debt.
+The inventory behind that choice, measured rather than estimated: 24 distinct
+SystemVerilog hexadecimal literals (the `N'hX` spelling, exact text) appear in
+four or more first-party RTL files. The command is the definition of the
+number:
+
+```
+git ls-files --recurse-submodules -- 'hdl/*.sv' 'protocol-processor/hdl/*.sv' 'gptp-processor/hdl/*.sv' \
+  | xargs grep -oHE "[0-9]*'h[0-9A-Fa-f_]+" | sort -u | cut -d: -f2- | sort | uniq -c | awk '$1 >= 4' | wc -l
+```
+
+They classify into three kinds, and only the first is debt.
 
 | Kind | Example | Disposition |
 |---|---|---|
-| Drift — a named definition exists and the literal ignores it | `16'h88F7` beside `ETH_TYPE_PTP` | Fix. Done here for the one site whose module already imports the package. |
+| Drift — a named definition exists and the literal ignores it | `16'h88F7` beside `ETH_TYPE_PTP` | Fix. Done here for the instantiation in `milan_datapath`; the six remaining sites are listed below. |
 | Structural rails and saturation values | `0xFFFF`, `0xFFFFFFFF`, `0x0000` | Not duplication. The same rail in unrelated modules is a coincidence of width, not a shared fact. |
 | Deliberate independent oracles | `0x22F0`, `0x88F7`, `0x8100` in tests and wire-truth tools | Keep. See below. |
 
-Three further sites (`hdl/milan/KL_pp_shadow.sv`,
-`hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv`,
-`hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv`) spell the same EtherTypes raw
-but do **not** import the package. Adding an import to three modules changes
-their compile dependencies, so it is a separate change with its own
-verification rather than a rider on this one.
+Every raw EtherType site outside the package, from
+`grep -rnE "'h(88F7|22F0|8100|22EA)" hdl --include=*.sv` with
+`hdl/common/ethernet_packet_pkg.sv` itself removed:
+
+| Site | Literal | Package name | Imports the package? |
+|---|---|---|---|
+| `hdl/milan/KL_pp_shadow.sv`, `ET_1722_C` | `16'h22F0` | `ETH_TYPE_AVTP` | no |
+| `hdl/milan/KL_pp_shadow.sv`, `ET_MSRP_C` | `16'h22EA` | `ETH_TYPE_MSRP` | no |
+| `hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv`, `ET_GPTP_C` | `16'h88F7` | `ETH_TYPE_PTP` | no |
+| `hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv`, `ET_GPTP_C` | `16'h88F7` | `ETH_TYPE_PTP` | no |
+| `hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv`, `ETH_TYPE` default | `'h88F7` | `ETH_TYPE_PTP` | no |
+| `hdl/ieee8021as/ptp_timestamp/ptp_ts_core.sv`, `ETH_TYPE` default | `'h88F7` | `ETH_TYPE_PTP` | yes |
+
+The two parameter defaults are overridden on the shipping path —
+`milan_datapath` passes `ETH_TYPE_PTP` to `ptp_ts_top`, which passes it on —
+so they are defaults, not the value the wire sees; `ptp_ts_core` is the one
+remaining site whose module already imports the package. Four of the modules
+would need a new import, which changes their compile dependencies, so all six
+stay a separate change with its own verification rather than a rider on this
+one.
 
 ### Proving the oracle exception
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -25,6 +25,7 @@ shape rather than guess at it.
 - **[Measuring cohesion](#measuring-cohesion)** -- Why line count cannot answer the question, what `scripts/measure_cohesion.py` counts instead (disjoint state groups), what it deliberately cannot see, and the current candidate list read off the tree.
 - **[Rule 2: prefer simple and explicit control flow](#rule-2-prefer-simple-and-explicit-control-flow)** -- The KISS rule, what "explicit" means for a SystemVerilog priority chain versus a host-side parser, the worked simplification that took one function from four levels of nesting to two, a real FSM and a real combinational mux read against the same rule, the measured hotspots with their dispositions, and the review checklist.
 - **[Measuring control flow](#measuring-control-flow)** -- What `scripts/measure_control_flow.py` counts in each language -- nesting and decision points in Python, priority resolved by source order in RTL -- exactly which files and blocks it scans and what it refuses, why no threshold is proposed, and what the tree actually measures today.
+- **[Rule 3: keep one source of truth without weakening test oracles](#rule-3-keep-one-source-of-truth-without-weakening-test-oracles)** -- The single-definition rule and the exception that keeps a test honest, the five RTL source lists that had one authority and four unguarded copies, the drift gate that now derives all of them from the RTL, and the mutation that proves an independent oracle is really independent.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -459,14 +460,134 @@ signal by source order. That second number is the reason the rule asks for
 priority to be *visible* rather than absent — forbidding the pattern would be
 a rewrite of nearly half the RTL, and would not make any of it clearer.
 
+## Rule 3: keep one source of truth without weakening test oracles
+
+> A production fact has one authoritative definition, and derived copies are
+> generated or checked for drift. Unexplained magic values are forbidden. Tests
+> stay intentionally independent when they are an oracle: expected values come
+> from the specification, not from the definition being tested.
+
+The two halves pull in opposite directions on purpose. Sharing a constant with
+a test makes the test inherit the implementation's defect; duplicating a
+production fact makes the copies drift. The rule is that **production** has one
+definition, and a **test** may repeat a value when its independence is what
+gives the test its power — with the external rule cited where the repeat is.
+
+### Repository interpretation
+
+- Name constants with their units, and cite the standard or register map where
+  the value is not self-evident.
+- Generate repeated layout, descriptor and build artifacts from one tracked
+  source, and give each derived consumer a drift check.
+- A test may repeat a value or a mapping when independence is load-bearing. The
+  comment cites the external rule and says why importing the implementation's
+  symbol would weaken the test.
+
+### A worked example: five lists, one authority
+
+The set of RTL files needed to compile `milan_datapath` was written out five
+times: the Vivado list in `sw/litex/milan_soc.py`, the `milan_datapath` row in
+`syn/yosys/run.sh`, `DP_SRCS` in `syn/yosys/ooc.sh`, and the source lists in
+`tb/verilator/milan_dp/Makefile` and `tb/verilator/hostplane/Makefile`. Exactly
+one of them was guarded — `scripts/check_soc_sources.py` has watched the Vivado
+list since a missing entry killed three synthesis runs forty minutes in.
+
+The other four were unguarded, and the cost was paid immediately: extracting one
+module under Rule 1 broke three Verilator suites at once, each with the same
+"Cannot find file containing module", one per list nobody had told.
+
+[`scripts/check_rtl_source_lists.py`](../../scripts/check_rtl_source_lists.py)
+makes the RTL the authority and every list a derived consumer. It walks the
+module closure of `milan_datapath` through the sources — what the datapath
+instantiates, what those instantiate, transitively — and checks each consumer
+carries every file in it.
+
+Two properties are what make it a source-of-truth gate rather than a fifth copy:
+
+- **It never checks one list against another.** All five could agree and all
+  five be wrong. The authority is the RTL, and the first-hop instantiation
+  parser is *imported* from `scripts/check_soc_sources.py` rather than
+  re-written — a gate about single sources of truth that forked its own parser
+  would refute itself.
+- **It asks each consumer instead of parsing it.** A recogniser accepts what it
+  has modelled, and `make` and `bash` accept something else; the four escapes
+  recorded in [`syn/ooc/dp_srcs.py`](../../syn/ooc/dp_srcs.py) all worked that
+  way. So each consumer prints the expansion it will really use
+  (`make -s print-srcs`, `syn/yosys/run.sh --emit`, `syn/yosys/ooc.sh
+  --emit-dp`) and the gate reads that. Two of those emit paths did not exist and
+  were added, which is most of what this change is.
+
+The unit is the **file**, not the module, because that is what a source list
+carries and one file may declare several modules — `KL_aaf_latency_chain` lives
+inside `KL_aaf_latency_taps.sv`. Comparing module names to file entries would
+demand entries that must not exist.
+
+A consumer whose tooling is absent is reported `SKIPPED` by name and the verdict
+says it is not covered. A gate that silently drops a consumer it could not reach
+is how a list goes unchecked for months.
+
+### The named-constant half
+
+`milan_datapath` passed `16'h88F7` to the timestamp unit's `ETH_TYPE`
+parameter while already importing `ethernet_packet_pkg`, which defines that
+exact value as `ETH_TYPE_PTP`. That is a second definition of a fact the package
+owns, and it is now the package's name.
+
+The inventory behind that choice: 57 hexadecimal literals appear in four or more
+first-party files. They classify into three kinds, and only the first is debt.
+
+| Kind | Example | Disposition |
+|---|---|---|
+| Drift — a named definition exists and the literal ignores it | `16'h88F7` beside `ETH_TYPE_PTP` | Fix. Done here for the one site whose module already imports the package. |
+| Structural rails and saturation values | `0xFFFF`, `0xFFFFFFFF`, `0x0000` | Not duplication. The same rail in unrelated modules is a coincidence of width, not a shared fact. |
+| Deliberate independent oracles | `0x22F0`, `0x88F7`, `0x8100` in tests and wire-truth tools | Keep. See below. |
+
+Three further sites (`hdl/milan/KL_pp_shadow.sv`,
+`hdl/ieee8021as/gptp_plane/KL_gptp_shadow.sv`,
+`hdl/ieee8021as/gptp_plane/KL_gptp_txstamp.sv`) spell the same EtherTypes raw
+but do **not** import the package. Adding an import to three modules changes
+their compile dependencies, so it is a separate change with its own
+verification rather than a rider on this one.
+
+### Proving the oracle exception
+
+A test that reads its expectations back through the implementation's own
+expression agrees with any permutation of it. The claim that an oracle is
+independent is therefore made with a mutation, not asserted.
+
+`tb/verilator/aaf_latency_tap_bank` takes every LTAP word offset and field split
+from the register map at base `0x870`, not from the packing expression in
+`hdl/ieee1722/aaf/KL_aaf_latency_tap_bank.sv`. Swapping the `max` and `last`
+halves of one word in the RTL makes the harness fail — on the one check where a
+sample's maximum and its last value genuinely differ, which is exactly the check
+that can see the swap. A harness that had imported the DUT's word order would
+have stayed green through the same mutation.
+
+### Exceptions
+
+- Values that are coincidentally equal but mean different things are not
+  abstracted together. Two constants that happen to be 8 are two constants.
+- A test keeps its own copy of a specification value when importing the
+  implementation's symbol would make the test grade itself.
+- Wire-format byte comparisons stay literal where a name would hide the bytes;
+  the citation goes beside them instead.
+
+### Review checklist
+
+- Does this fact have exactly one definition, and can a reader find it?
+- If it is copied, is the copy generated or drift-checked — and by what?
+- Does the drift check derive from the authority, or from another copy?
+- If a test repeats a value, is the reason independence, and is the external
+  rule cited?
+- Would a wrong implementation constant still make the test fail?
+
 ## Rules not yet landed
 
-The contract is ten rules. Rules 1 and 2 are above; the rest keep these
+The contract is ten rules. Rules 1, 2 and 3 are above; the rest keep these
 numbers so citations stay stable as they land:
 
 | Rule | Subject |
 |---|---|
-| 3 | One source of truth, without weakening independent test oracles |
 | 4 | Intention-revealing names and explicit units and types |
 | 5 | Explicit ports, contracts, ownership and side effects |
 | 6 | Fail fast and encode invariants |

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -595,7 +595,11 @@ asked; the gate simply never asked, and both repositories reported the
 processor as covered.
 
 The same gate now reads that list too, with the declared modules as the
-authority. Every declared module is a top, or it is named in
+authority. It reads the array the way bash does — a `#` at the start of a word
+is a comment to the end of its line, quoted names are unquoted — because this
+is the one consumer that cannot be asked (its expansion path is Yosys), and
+splitting the raw text had credited a commented-out top as elaborated. Every
+declared module is a top, or it is named in
 [`scripts/processor_yosys_tops.budget`](../../scripts/processor_yosys_tops.budget)
 with the reason it is not. The six are recorded there as **drift at the pin**,
 not as helper exceptions, because that is what they are; the fix is upstream,

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -498,9 +498,14 @@ module under Rule 1 broke three Verilator suites at once, each with the same
 
 [`scripts/check_rtl_source_lists.py`](../../scripts/check_rtl_source_lists.py)
 makes the RTL the authority and every list a derived consumer. It walks the
-module closure of `milan_datapath` through the sources — what the datapath
-instantiates, what those instantiate, transitively — and checks each consumer
-carries every file in it.
+compilation-unit closure of `milan_datapath` through the sources — module
+instantiations, package references and interface/modport types, transitively —
+and checks each consumer carries every file in it. A declaration makes a child
+part of that walk; a hard-coded naming-prefix allowlist does not. That
+distinction is load-bearing for `protocol_processor_top` and
+`credit_based_shaper`, whose ordinary names were silently absent from the first
+version of the closure. Package-only and interface-only files are equally
+load-bearing even though they instantiate no module.
 
 Two properties are what make it a source-of-truth gate rather than a fifth copy:
 
@@ -515,7 +520,10 @@ Two properties are what make it a source-of-truth gate rather than a fifth copy:
   way. So each consumer prints the expansion it will really use
   (`make -s print-srcs`, `syn/yosys/run.sh --emit`, `syn/yosys/ooc.sh
   --emit-dp`) and the gate reads that. Two of those emit paths did not exist and
-  were added, which is most of what this change is.
+  were added, which is most of what this change is. The Vivado Python list has
+  no print mode: its quoted superproject entries are combined with the same
+  `scripts/pp_srcs.py` expansion that `milan_soc.py` calls for the
+  protocol-processor half.
 
 The unit is the **file**, not the module, because that is what a source list
 carries and one file may declare several modules — `KL_aaf_latency_chain` lives

--- a/docs/testing/methodology.md
+++ b/docs/testing/methodology.md
@@ -71,7 +71,11 @@ whether it is correct. Existing L1 gates:
 we advertise against what the fabric emits),
 [`check_entity_shape.py`](../../scripts/check_entity_shape.py) (one declared shape
 across config, generated headers, registers and descriptors) and
-[`check_soc_sources.py`](../../scripts/check_soc_sources.py).
+[`check_soc_sources.py`](../../scripts/check_soc_sources.py) (the Vivado source
+list carries every module `milan_datapath` instantiates), and
+[`check_rtl_source_lists.py`](../../scripts/check_rtl_source_lists.py) (the
+other four lists of the same RTL carry the whole file closure, each asked for
+its own expansion rather than parsed).
 
 **L4 and L5 are the only levels with an independent oracle**, and they are the
 only reason escapes 1 and 7 were ever found. Treat access to them as scarce and

--- a/docs/testing/methodology.md
+++ b/docs/testing/methodology.md
@@ -75,7 +75,9 @@ across config, generated headers, registers and descriptors) and
 list carries every module `milan_datapath` instantiates), and
 [`check_rtl_source_lists.py`](../../scripts/check_rtl_source_lists.py) (the
 other four lists of the same RTL carry the whole file closure, each asked for
-its own expansion rather than parsed).
+its own expansion rather than parsed; and the protocol processor's own Yosys
+`tops` array names every module it declares, with the six that drifted at the
+current pin recorded by name).
 
 **L4 and L5 are the only levels with an independent oracle**, and they are the
 only reason escapes 1 and 7 were ever found. Treat access to them as scarce and

--- a/docs/traceability/MODULE_MATRIX.md
+++ b/docs/traceability/MODULE_MATRIX.md
@@ -151,7 +151,7 @@ _CSR, CDC, RMON, utilities_
 | ✅ `milan_csr` | `common/csr/milan_csr.sv` | `csr` · `hostplane` · `milan_dp` | — |
 | ✅ `KL_mac_rmon_events` | `common/eth_event_counter/KL_mac_rmon_events.sv` | `mac_rmon` | — |
 | ✅ `ethernet_events` | `common/eth_event_counter/ethernet_events.sv` | `hostplane` · `milan_dp` | — |
-| ✅ `event_counter` | `common/eth_event_counter/event_counter.sv` | `hostplane` · ➰milan_dp | — |
+| ✅ `event_counter` | `common/eth_event_counter/event_counter.sv` | `hostplane` · `milan_dp` | — |
 
 ## Milan integration
 

--- a/hdl/common/eth_event_counter/README-tests.md
+++ b/hdl/common/eth_event_counter/README-tests.md
@@ -12,5 +12,5 @@ hand-edit. Part of the Common / integration family; rolled up in
 |---|---|---|---|
 | ✅ `KL_mac_rmon_events` | `KL_mac_rmon_events.sv` | `mac_rmon` | — |
 | ✅ `ethernet_events` | `ethernet_events.sv` | `hostplane` · `milan_dp` | — |
-| ✅ `event_counter` | `event_counter.sv` | `hostplane` · ➰milan_dp | — |
+| ✅ `event_counter` | `event_counter.sv` | `hostplane` · `milan_dp` | — |
 

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -2783,7 +2783,11 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   ptp_ts_top #(
     .TDATA_WIDTH(TDATA_WIDTH),
     .BIG_ENDIAN(0),
-    .ETH_TYPE(16'h88F7)
+    //! 802.1AS rides the PTP EtherType. The value is ETH_TYPE_PTP in
+    //! hdl/common/ethernet_packet_pkg.sv, which this module already imports;
+    //! spelling the literal here made a second definition of a fact the
+    //! package owns.
+    .ETH_TYPE(ETH_TYPE_PTP)
   ) ptp_timestamp (
     .gtx_clk(gtx_clk),
     .gtx_resetn(gtx_resetn),

--- a/scripts/check_rtl_source_lists.py
+++ b/scripts/check_rtl_source_lists.py
@@ -16,25 +16,54 @@ that nobody had told.
 
 THE AUTHORITY IS THE RTL, NOT ANOTHER LIST. This gate walks the module closure
 of `milan_datapath` through the sources themselves: what the datapath
-instantiates, what those modules instantiate, transitively. Checking one list
-against another would let all five agree and all five be wrong, which is the
-same defect wearing a different hat. `scripts/check_soc_sources.py` already
-derives the first hop this way, and this gate imports its derivation rather
-than writing a second copy of it - a gate about single sources of truth that
-forked its own instantiation parser would be self-refuting.
+instantiates, what those modules instantiate, transitively, plus every package
+and interface they reference and every unit file they `include`. Checking one
+list against another would let all five agree and all five be wrong, which is
+the same defect wearing a different hat. `scripts/check_soc_sources.py` owns
+the first hop - the instantiation shapes, the comment blanking, the include
+splicing - and this gate imports it rather than writing a second copy: a gate
+about single sources of truth that forked its own instantiation parser would
+be self-refuting. The hop has to see every shape a front end accepts, because
+a shape it does not see is a file no consumer is told about: the first
+version needed two leading spaces and walked past the one column-0
+instantiation the tree already had (`traffic_class_map` in
+`traffic_classifier.sv`), reported 108 files and "5 of 5 complete", and let
+that file be dropped from both Yosys rows with the gate green while Yosys
+failed on it. The independent oracle for the walk is a real front end over
+exactly the closure: `verilator --lint-only` with an include directory that
+holds only headers (so no module can be found by filename) must report zero
+MODMISSING.
 
 AND THE CONSUMERS ARE ASKED, NOT PARSED. A recogniser accepts what it has
 modelled, and `make` and `bash` accept something else - the lesson
 `syn/ooc/dp_srcs.py` records after four escapes. So each consumer prints its
-own expansion (`make -s print-srcs`, `syn/yosys/run.sh --emit`) and this gate
-reads that. The Vivado list is the exception: it is a Python literal with no
-expansion step, and `check_soc_sources.py` owns reading it.
+own expansion (`make -s print-srcs`, `syn/yosys/run.sh --emit`,
+`syn/yosys/ooc.sh --emit-dp`) and this gate reads that. The Vivado list has no
+expansion step; it is read the way Python reads it - the list literal and the
+registrations beside it through `ast`, in which a comment does not exist - and
+its starred `_pp_sources()` entry is expanded through the same `pp_srcs.py`
+that `milan_soc.py` itself calls. A regex over the file's text counted a
+commented-out row as carried.
 
-The Vivado consumer combines its quoted superproject entries with the
-`pp_srcs.py` expansion that `milan_soc.py` itself uses for the project-owned
-protocol-processor submodule. A consumer whose tooling is absent is reported
-SKIPPED, by name, and the verdict says so. A gate that silently drops a
-consumer it could not reach is how a list goes unchecked for months.
+A CONSUMER THAT CANNOT ANSWER FAILS THE GATE. An emit path that exits
+non-zero, a Makefile that is absent, a `make` the host lacks: each is a
+consumer this run did not check, and by default that is exit 2, never a green
+with a note in the log. `--allow-skip` is the explicit opt-out for a host
+without the tooling; it prints a loud SKIPPED marker per consumer and the
+verdict says how many were not covered. CI runs the strict default. A
+diagnosed defect - `print-srcs` having become a makefile's default goal, so a
+bare `make` prints a list instead of running the suite - is a finding (exit 1)
+and is never skippable.
+
+THE SELF-TEST MUTATES A COPY OF EACH CONSUMER AND ASKS THE COPY. Set
+arithmetic on an already-fetched list cannot fail on a passing gate, and would
+pass with every fetcher stubbed to return the closure. So `--selftest` copies
+each consumer file, removes one closure file from the copy, and runs the copy's
+own emit path: `make -f <copy>` from the suite directory, the copied script
+beside the original under a temporary name (it resolves the repository from
+its own location), the copied Python list through the same reader. The removal
+must be reported by that path and by nothing else, the tree must be
+byte-identical afterwards, and a stubbed fetcher fails the arm.
 
 THE PROCESSOR'S OWN LIST IS A SIXTH CONSUMER, OF A DIFFERENT AUTHORITY. The
 protocol processor's portability gate (`protocol-processor/syn/yosys/run.sh`)
@@ -52,58 +81,82 @@ portability coverage is the closure walk itself, and the inventory prints how
 many of its files that walk reaches.
 
 Usage:
-    python3 scripts/check_rtl_source_lists.py            # gate
-    python3 scripts/check_rtl_source_lists.py --list     # closure + per list
-    python3 scripts/check_rtl_source_lists.py --selftest # mutation arms
+    python3 scripts/check_rtl_source_lists.py               # gate, strict
+    python3 scripts/check_rtl_source_lists.py --list        # closure, per list, extras
+    python3 scripts/check_rtl_source_lists.py --files       # closure paths, packages first
+    python3 scripts/check_rtl_source_lists.py --allow-skip  # tool-less host opt-out
+    python3 scripts/check_rtl_source_lists.py --selftest    # mutation arms
 
-Exit 0 = every reachable consumer carries the whole closure, and the processor
-         tops array names every declared module that the budget does not.
-Exit 1 = a consumer is missing a module, or the processor tops array has an
-         unrecorded omission or a stale record.
-Exit 2 = the closure itself could not be built.
+Exit 0 = every consumer answered and carries the whole closure, and the
+         processor tops array names every declared module that the budget
+         does not.
+Exit 1 = a consumer is missing a file, a makefile's default goal prints the
+         list, or the processor tops array has an unrecorded omission or a
+         stale record.
+Exit 2 = the closure could not be built, or a consumer could not be asked
+         (without --allow-skip), or every consumer was skipped.
 """
 
+import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
+from typing import NamedTuple
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-#: the first-hop derivation is OWNED by check_soc_sources.py. Importing it is
-#: the point of this gate: two instantiation parsers would be two truths.
-from check_soc_sources import INST_RE, PREFIXES
+#: the first hop is OWNED by check_soc_sources.py: the instantiation regex,
+#: the comment blanking, the include splicing, the search roots and the Vivado
+#: list reader. Importing them is the point of this gate: two instantiation
+#: parsers would be two truths.
+from check_soc_sources import (INST_RE, PREFIXES, SEARCH_ROOTS, SOC, spliced,
+                               strip_comments, vivado_sources)
 from pp_srcs import pp_sources
-
-#: Trees a source list may legitimately draw from. The vendored AXI-stream
-#: RTL is here because every consumer must carry it too - it is Verilog, not
-#: SystemVerilog, which is why both suffixes are searched. A missing root is a
-#: SKIP with its name, never a silently smaller closure.
-SEARCH_ROOTS = ("hdl", "protocol-processor/hdl", "gptp-processor/hdl",
-                "third_party/verilog-axis/rtl")
 
 
 def absent_roots():
     return [r for r in SEARCH_ROOTS if not (REPO / r).is_dir()]
 
 
+def _rel(path):
+    try:
+        return Path(path).resolve().relative_to(REPO).as_posix()
+    except ValueError:
+        return str(path)
+
+
+DECL_RE = re.compile(r"^\s*(module|package|interface)\s+([A-Za-z_]\w*)\b", re.M)
+
+
 @lru_cache(maxsize=1)
 def declaration_index():
-    """Every module/package/interface declaration, indexed by unit name."""
+    """Every module/package/interface declaration, indexed by unit name.
+    Comments are blanked first, so a declaration quoted in one is not one."""
     found = {}
     for root in SEARCH_ROOTS:
         base = REPO / root
         if not base.is_dir():
             continue
         for path in sorted(list(base.rglob("*.sv")) + list(base.rglob("*.v"))):
-            text = path.read_text(errors="replace")
-            for kind, name in re.findall(
-                    r"^\s*(module|package|interface)\s+([A-Za-z_]\w*)\b",
-                    text, re.M):
+            text = strip_comments(path.read_text(errors="replace"))
+            for kind, name in DECL_RE.findall(text):
                 found.setdefault(name, (kind, path))
     return found
+
+
+@lru_cache(maxsize=1)
+def units_by_file():
+    """{resolved path: [unit names it declares]} - the index turned round."""
+    out = {}
+    for name, (_kind, path) in declaration_index().items():
+        out.setdefault(path.resolve(), []).append(name)
+    return out
 
 
 def module_file(name):
@@ -118,31 +171,43 @@ def module_file(name):
 
 
 PACKAGE_REF_RE = re.compile(r"\b([A-Za-z_]\w*)::")
-INTERFACE_REF_RE = re.compile(r"\b([A-Za-z_]\w*)\.(?:master|slave|monitor)\b")
 
 
+class Closure(NamedTuple):
+    units: dict          # unit name -> repo-relative file declaring it
+    unresolved: set      # project-looking module names no source declares
+    bad_includes: list   # (unit, include name) pairs no file answers to
+
+
+@lru_cache(maxsize=None)
 def closure(top="milan_datapath"):
     """Every project compilation unit reachable from `top`.
 
-    Module instantiations, package-qualified references and interface/modport
-    types all add their declaring file. Returns (units, unresolved): the unit
-    names, and project-looking module names whose source could not be found.
+    A module instantiation (any shape the first hop accepts, inside included
+    bodies too), a package-qualified reference, any use of a declared
+    interface's name (through any modport, as a port type, as an instance) and
+    an `include of a file that declares a unit all add that unit's file.
     """
     start = module_file(top)
     if start is None:
-        return {}, {top}
-    seen, unresolved, queue = {}, set(), [(top, start)]
+        return Closure({}, {top}, [])
+    index = declaration_index()
+    interfaces = [n for n, (kind, _p) in index.items() if kind == "interface"]
+    seen, unresolved, bad_includes, queue = {}, set(), [], [(top, start)]
     while queue:
         name, path = queue.pop()
         if name in seen:
             continue
         seen[name] = path.relative_to(REPO).as_posix()
-        text = path.read_text(errors="replace")
+        text, included, missing_inc = spliced(path)
+        bad_includes.extend((name, inc) for inc in missing_inc)
         children = set(INST_RE.findall(text))
-        children |= {name for name in PACKAGE_REF_RE.findall(text)
-                     if declaration_index().get(name, (None,))[0] == "package"}
-        children |= {name for name in INTERFACE_REF_RE.findall(text)
-                     if declaration_index().get(name, (None,))[0] == "interface"}
+        children |= {n for n in PACKAGE_REF_RE.findall(text)
+                     if index.get(n, (None,))[0] == "package"}
+        children |= {n for n in interfaces
+                     if re.search(r"\b" + re.escape(n) + r"\b", text)}
+        for inc in included:
+            children |= set(units_by_file().get(inc.resolve(), ()))
         for child in children:
             if child in seen:
                 continue
@@ -152,12 +217,18 @@ def closure(top="milan_datapath"):
                     unresolved.add(child)
             else:
                 queue.append((child, child_path))
-    return seen, unresolved
+    return Closure(seen, unresolved, bad_includes)
 
 
 # ---------------------------------------------------------------------------
 # consumers - each ASKS its own tooling for the expansion it will really use
 # ---------------------------------------------------------------------------
+class Answer(NamedTuple):
+    files: object   # the repo-relative files the consumer will compile, or None
+    kind: str       # "ok" | "unanswered" (could not ask) | "defect" (diagnosed)
+    why: object     # the reason, when kind is not "ok"
+
+
 def _repo_rel(tokens, cwd):
     """Resolve a consumer's own path tokens to repo-relative posix paths.
 
@@ -184,12 +255,13 @@ def _run(cmd, cwd):
     except (OSError, subprocess.SubprocessError) as exc:
         return None, f"{cmd[0]}: {exc}"
     if out.returncode != 0:
-        return None, f"{' '.join(cmd)} exited {out.returncode}"
+        return None, f"{' '.join(str(c) for c in cmd)} exited {out.returncode}"
     return out.stdout, None
 
 
-def default_goal_is_print_srcs(directory):
-    """True when a bare `make` in `directory` would print the source list.
+def default_goal_is_print_srcs(directory, makefile="Makefile"):
+    """True when a bare `make` in `directory` would print the source list,
+    False when it would not, None when make could not say.
 
     Adding a `print-srcs` target ABOVE a makefile's first real target makes it
     the default goal, so the suite stops running and prints a file list. The
@@ -203,71 +275,106 @@ def default_goal_is_print_srcs(directory):
     makefile syntax. Comparing a dry run to the printed list does not work: an
     `@`-prefixed recipe makes `-n` print the command, not run it.
     """
-    import tempfile
     with tempfile.TemporaryDirectory() as td:
         probe = Path(td) / "probe.mk"
         probe.write_text("__kl_show_default_goal:\n\t@echo $(.DEFAULT_GOAL)\n")
-        out, err = _run(["make", "-s", "-f", "Makefile", "-f", str(probe),
-                         "__kl_show_default_goal"], directory)
-    if out is None:
-        return False
-    return out.strip().splitlines()[-1].strip() == "print-srcs" if out.strip() else False
+        out, _err = _run(["make", "-s", "-f", str(makefile), "-f", str(probe),
+                          "__kl_show_default_goal"], directory)
+    if out is None or not out.strip():
+        return None
+    return out.strip().splitlines()[-1].strip() == "print-srcs"
 
 
-def _from_make(suite):
+def _from_make(suite, makefile=None):
+    """`make -s print-srcs` in the suite directory. A copy of the Makefile is
+    fed with `-f` and still runs from the suite directory, so its relative
+    paths and `$(CURDIR)` resolve exactly as the original's do."""
     d = REPO / "tb/verilator" / suite
-    if not (d / "Makefile").is_file():
-        return None, f"tb/verilator/{suite}/Makefile is absent"
-    text, err = _run(["make", "-s", "print-srcs"], d)
+    mk = Path(makefile) if makefile else d / "Makefile"
+    if not mk.is_file():
+        return Answer(None, "unanswered", f"{_rel(mk)} is absent")
+    text, err = _run(["make", "-s", "-f", str(mk), "print-srcs"], d)
     if text is None:
-        return None, err
-    if default_goal_is_print_srcs(d):
-        return None, (f"tb/verilator/{suite}: a bare `make` prints the source "
-                      f"list instead of running the suite - print-srcs has "
-                      f"become the default goal")
-    return _repo_rel(text.split(), d), None
+        return Answer(None, "unanswered", err)
+    goal = default_goal_is_print_srcs(d, mk)
+    if goal is None:
+        return Answer(None, "unanswered",
+                      f"tb/verilator/{suite}: make could not report its default goal")
+    if goal:
+        return Answer(None, "defect",
+                      f"tb/verilator/{suite}: a bare `make` prints the source list "
+                      f"instead of running the suite - print-srcs has become the "
+                      f"default goal")
+    return Answer(_repo_rel(text.split(), d), "ok", None)
 
 
-def _from_yosys_run():
-    text, err = _run(["./run.sh", "--emit", "milan_datapath"], REPO / "syn/yosys")
+def _from_yosys_run(script=None):
+    """`run.sh --emit milan_datapath`, the record bash prints from its own
+    expansion of the `tops` row. A copy must sit beside the original: the
+    script resolves the repository from `$0`."""
+    s = Path(script) if script else REPO / "syn/yosys/run.sh"
+    if not s.is_file():
+        return Answer(None, "unanswered", f"{_rel(s)} is absent")
+    text, err = _run([str(s), "--emit", "milan_datapath"], s.parent)
     if text is None:
-        return None, err
+        return Answer(None, "unanswered", err)
     names = set()
     for line in text.splitlines():
         if line.startswith("src="):
-            names |= _repo_rel(line[4:].split(), REPO / "syn/yosys")
-    return names, None
+            names |= _repo_rel(line[4:].split(), s.parent)
+    return Answer(names, "ok", None)
 
 
-def _from_yosys_ooc():
-    text, err = _run(["./ooc.sh", "--emit-dp"], REPO / "syn/yosys")
+def _from_yosys_ooc(script=None):
+    """`ooc.sh --emit-dp`, bash's own expansion of `DP_SRCS`."""
+    s = Path(script) if script else REPO / "syn/yosys/ooc.sh"
+    if not s.is_file():
+        return Answer(None, "unanswered", f"{_rel(s)} is absent")
+    text, err = _run([str(s), "--emit-dp"], s.parent)
     if text is None:
-        return None, err
-    return _repo_rel(text.split(), REPO / "syn/yosys"), None
+        return Answer(None, "unanswered", err)
+    return Answer(_repo_rel(text.split(), s.parent), "ok", None)
 
 
-#: every quoted source path in milan_soc.py's curated superproject list. The
-#: protocol-processor half is expanded by `_pp_sources()` at import time, so it
-#: is asked through the same `pp_srcs.py` authority rather than guessed from
-#: Python syntax. This gate grades FILE coverage and the vendored `.v` entries
-#: count too.
-_VIVADO_SRC_RE = re.compile(r'"((?:[\w.-]+/)+[\w.-]+\.(?:sv|v))"')
+def _from_vivado_list(soc=None):
+    """The source paths `milan_soc.py` registers, read as Python reads them
+    (check_soc_sources.vivado_sources), with the starred `_pp_sources()` entry
+    expanded through the same `pp_srcs.py` the SoC calls - and only when that
+    entry is still there."""
+    s = Path(soc) if soc else SOC
+    if not s.is_file():
+        return Answer(None, "unanswered", f"{_rel(s)} is absent")
+    paths, derived, why = vivado_sources(s)
+    if paths is None:
+        return Answer(None, "unanswered", why)
+    tokens = list(paths)
+    if "_pp_sources" in derived:
+        tokens += pp_sources()
+    return Answer(_repo_rel(tokens, REPO), "ok", None)
 
 
-def _from_vivado_list():
-    soc = REPO / "sw/litex/milan_soc.py"
-    if not soc.is_file():
-        return None, "sw/litex/milan_soc.py is absent"
-    tokens = _VIVADO_SRC_RE.findall(soc.read_text()) + pp_sources()
-    return _repo_rel(tokens, REPO), None
+class Consumer(NamedTuple):
+    label: str
+    fetch: object        # fetch() -> Answer for the real consumer;
+                         # fetch(copy) -> the same emit path over a copy
+    source: str          # the consumer file, repo-relative
+    copy_beside: bool    # a copy must live in the consumer's own directory
+                         # because the script resolves the repository from $0
 
 
 CONSUMERS = (
-    ("Vivado sources (sw/litex/milan_soc.py)", _from_vivado_list),
-    ("Yosys milan_datapath row (syn/yosys/run.sh)", _from_yosys_run),
-    ("Yosys DP_SRCS (syn/yosys/ooc.sh)", _from_yosys_ooc),
-    ("Verilator milan_dp (tb/verilator/milan_dp)", lambda: _from_make("milan_dp")),
-    ("Verilator hostplane (tb/verilator/hostplane)", lambda: _from_make("hostplane")),
+    Consumer("Vivado sources (sw/litex/milan_soc.py)", _from_vivado_list,
+             "sw/litex/milan_soc.py", False),
+    Consumer("Yosys milan_datapath row (syn/yosys/run.sh)", _from_yosys_run,
+             "syn/yosys/run.sh", True),
+    Consumer("Yosys DP_SRCS (syn/yosys/ooc.sh)", _from_yosys_ooc,
+             "syn/yosys/ooc.sh", True),
+    Consumer("Verilator milan_dp (tb/verilator/milan_dp)",
+             lambda copy=None: _from_make("milan_dp", copy),
+             "tb/verilator/milan_dp/Makefile", False),
+    Consumer("Verilator hostplane (tb/verilator/hostplane)",
+             lambda copy=None: _from_make("hostplane", copy),
+             "tb/verilator/hostplane/Makefile", False),
 )
 
 
@@ -351,43 +458,195 @@ def processor_tops_audit():
     return rows
 
 
-def audit():
-    """Returns (need, unresolved, results) with results as
-    [(label, missing_sorted_or_None, skip_reason_or_None)]."""
-    modules, unresolved = closure()
-    need = set(modules.values())
-    results = []
-    for label, fetch in CONSUMERS:
-        have, why = fetch()
-        if have is None:
-            results.append((label, None, why))
+# ---------------------------------------------------------------------------
+# the comparison and the verdict
+# ---------------------------------------------------------------------------
+class Row(NamedTuple):
+    label: str
+    kind: str        # "ok" | "unanswered" | "defect"
+    missing: list    # closure files the consumer does not carry
+    extra: list      # files the consumer carries that the closure does not need
+    why: object
+
+
+def audit(consumers=CONSUMERS, top="milan_datapath"):
+    """(closure, need, rows) - one Row per consumer."""
+    cl = closure(top)
+    need = set(cl.units.values())
+    rows = []
+    for c in consumers:
+        answer = c.fetch()
+        if answer.kind != "ok":
+            rows.append(Row(c.label, answer.kind, [], [], answer.why))
         else:
-            results.append((label, sorted(need - have), None))
-    return modules, need, unresolved, results
+            rows.append(Row(c.label, "ok", sorted(need - answer.files),
+                            sorted(answer.files - need), None))
+    return cl, need, rows
+
+
+def verdict(cl, need, rows, tops_rows, allow_skip=False, list_mode=False):
+    """(rc, lines). The exit code is decided here and nowhere else.
+
+    0: every consumer answered and is complete, the tops audit is clean.
+    1: a finding - a missing file, a default-goal defect, tops drift or a stale
+       record. Never skippable.
+    2: a consumer could not be asked and --allow-skip was not given, or every
+       consumer was skipped (a run that checked nothing proves nothing).
+    """
+    lines = []
+    findings = skipped = unanswered = answered = 0
+    for row in rows:
+        if row.kind == "unanswered":
+            if allow_skip:
+                skipped += 1
+                lines.append(f"!! SKIPPED (--allow-skip)  {row.label}: {row.why}  "
+                             f"-- NOT COVERED by this verdict")
+            else:
+                unanswered += 1
+                lines.append(f"CANNOT ASK  {row.label}: {row.why} -> this consumer "
+                             f"was not checked; pass --allow-skip to accept that "
+                             f"on a host without the tooling")
+            continue
+        if row.kind == "defect":
+            findings += 1
+            lines.append(f"DEFAULT GOAL: {row.why} -> fix the makefile "
+                         f"(.DEFAULT_GOAL := all, or the real target first)")
+            continue
+        answered += 1
+        for path in row.missing:
+            findings += 1
+            names = sorted(m for m, p in cl.units.items() if p == path)
+            lines.append(f"MISSING SOURCE: {row.label} does not carry '{path}' "
+                         f"(declares {', '.join(names)}), which milan_datapath "
+                         f"needs -> that consumer cannot build")
+        if list_mode:
+            if not row.missing:
+                lines.append(f"ok       {row.label}")
+            if row.extra:
+                lines.append(f"extra    {row.label}: {len(row.extra)} file(s) the "
+                             f"closure does not need: {', '.join(row.extra)}")
+
+    tops_note = []
+    for sub, script, tops, declared, recorded, unrecorded, stale, why in tops_rows:
+        if why is not None:
+            if allow_skip:
+                skipped += 1
+                lines.append(f"!! SKIPPED (--allow-skip)  {sub} native tops list: "
+                             f"{why}  -- NOT COVERED by this verdict")
+            else:
+                unanswered += 1
+                lines.append(f"CANNOT ASK  {sub} native tops list: {why}")
+            continue
+        for name in unrecorded:
+            findings += 1
+            lines.append(f"TOPS DRIFT: {sub}/{script} does not elaborate declared "
+                         f"module '{name}' as a top and "
+                         f"scripts/processor_yosys_tops.budget does not record why "
+                         f"-> its portability is unproven")
+        for name in stale:
+            findings += 1
+            lines.append(f"STALE RECORD: scripts/processor_yosys_tops.budget names "
+                         f"'{name}' but {sub}/{script} elaborates it (or nothing "
+                         f"declares it) -> remove the line")
+        if list_mode or recorded:
+            lines.append(f"{sub} native tops list ({script}): {len(tops)} top(s) for "
+                         f"{len(declared)} declared module(s); {len(recorded)} "
+                         f"recorded omission(s) at this pin: {', '.join(recorded) or '-'}")
+        tops_note.append(f"{sub} {len(tops)}/{len(declared)} tops, {len(recorded)} recorded")
+
+    if list_mode:
+        gptp = {p for p in cl.units.values() if p.startswith("gptp-processor/")}
+        lines.append(f"gptp-processor keeps no native tops list; the closure walk "
+                     f"reaches {len(gptp)} of its file(s)")
+
+    if unanswered:
+        lines.append(f"RTL source-list gate: NOT CHECKED - {unanswered} consumer(s) "
+                     f"could not be asked ({findings} finding(s) among the rest)")
+        return 2, lines
+    if findings:
+        return 1, lines
+    if not answered:
+        lines.append("RTL source-list gate: NOT CHECKED - every consumer was skipped, "
+                     "so this run proved nothing")
+        return 2, lines
+    text = (f"RTL source-list gate: OK ({len(need)} files in the milan_datapath "
+            f"closure, {answered} of {len(rows)} consumer list(s) carry all of them; "
+            f"{'; '.join(tops_note) or 'no processor tops list reachable'}")
+    lines.append(text + (f"; {skipped} SKIPPED by --allow-skip and NOT covered by "
+                         f"this verdict)" if skipped else ")"))
+    return 0, lines
+
+
+# ---------------------------------------------------------------------------
+# self-test support: a mutated COPY of a consumer, asked through its own path
+# ---------------------------------------------------------------------------
+def drop_source_token(text, basename):
+    """The consumer text with every path token ending in `/basename` removed:
+    a quoted Python row (with its comma) or a bare shell/make word."""
+    b = re.escape(basename)
+    return re.sub(r'"[^"\s]*/' + b + r'"\s*,?'
+                  r'|(?<=[\s|="])\S*/' + b + r'(?=\s|$|")', "", text)
+
+
+@contextmanager
+def mutated_copy(consumer, basename):
+    """A copy of the consumer file with one source removed, placed where its
+    emit path can run: beside the original under a temporary name when the
+    script resolves the repository from `$0`, in a temporary directory
+    otherwise. Deleted on the way out, whatever happened."""
+    src = REPO / consumer.source
+    text = src.read_text()
+    mutated = drop_source_token(text, basename)
+    if mutated == text:
+        yield None
+        return
+    td = None
+    if consumer.copy_beside:
+        copy = src.parent / f".selftest-{os.getpid()}-{src.name}"
+    else:
+        td = tempfile.mkdtemp()
+        copy = Path(td) / src.name
+    try:
+        copy.write_text(mutated)
+        shutil.copymode(src, copy)
+        yield copy
+    finally:
+        copy.unlink(missing_ok=True)
+        if td is not None:
+            shutil.rmtree(td, ignore_errors=True)
 
 
 def selftest():
-    """Mutation arms. Every one removes something and demands a complaint."""
-    failures = 0
+    """Mutation arms. Every one removes or breaks something and demands the
+    right complaint; each fails when the defect it guards is put back."""
+    failures = checks = 0
 
     def ck(name, ok, detail=""):
-        nonlocal failures
+        nonlocal failures, checks
+        checks += 1
         if ok:
             print(f"[PASS] {name}")
         else:
             failures += 1
             print(f"[FAIL] {name}{': ' + detail if detail else ''}")
 
-    modules, need, unresolved, results = audit()
+    cl, need, rows = audit()
+    modules = cl.units
     ck("the closure is non-empty", len(need) > 5, f"got {len(need)} file(s)")
-    ck("the closure resolves every module it names", not unresolved,
-       f"unresolved: {sorted(unresolved)}")
+    ck("the closure resolves every module it names", not cl.unresolved,
+       f"unresolved: {sorted(cl.unresolved)}")
+    ck("every `include in the closure resolves to a file", not cl.bad_includes,
+       f"unresolved includes: {cl.bad_includes}")
     ck("the closure is transitive, not one hop",
        "KL_aaf_latency_taps" in modules,
        "a module instantiated by a CHILD of milan_datapath must be in the closure")
     ck("a declared child needs no approved naming prefix",
        "credit_based_shaper" in modules,
        "the closure must follow declarations, not silently omit a new name family")
+    ck("a column-0 instantiation is followed (traffic_class_map, the shape the tree has)",
+       "traffic_class_map" in modules
+       and modules.get("traffic_class_map") == "hdl/ieee8021q/ts/traffic_class_map.sv",
+       "traffic_classifier.sv instantiates traffic_class_map at column 0")
     ck("package dependencies are part of the file closure",
        "pp_pkg" in modules and "ethernet_packet_pkg" in modules,
        "removing a package-only source must fail before compilation")
@@ -399,26 +658,103 @@ def selftest():
        and modules.get("KL_aaf_latency_chain") is not None,
        "two modules in one file must resolve to ONE required file")
 
-    reached = [r for r in results if r[2] is None]
-    ck("at least one consumer was reachable", bool(reached),
-       "every consumer skipped - this run would prove nothing")
+    # THE SHAPES, on a copy of the live datapath: each probe is the exact
+    # instantiation shape the round-2 review inserted, and the walk over the
+    # copy must reach the probed module. The probes name real declared modules
+    # that milan_datapath does not otherwise reach.
+    dp = REPO / "hdl/milan/milan_datapath.sv"
+    base = dp.read_text()
+    end = base.rfind("endmodule")
+    probes = (
+        ("a column-0 instantiation under a non-blank line is followed",
+         "\nassign zz_probe_a = 1'b0;\nKL_aes3_tx u_zz_col0 ();\n", "KL_aes3_tx"),
+        ("a tab-indented instantiation under a non-blank line is followed",
+         "\nassign zz_probe_b = 1'b0;\n\tKL_aes3_rx u_zz_tab ();\n", "KL_aes3_rx"),
+        ("an arrayed instance is followed",
+         "\n  KL_lat_history_ring u_zz_arr [1:0] ();\n", "KL_lat_history_ring"),
+        ("an interface used through a modport not named master/slave/monitor is followed",
+         "\n  zz_probe_if.tx zz_bus2;\n", "zz_probe_if"),
+    )
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "zz_probe_if.sv").write_text(
+            "interface zz_probe_if;\n  logic x;\n  modport tx (output x);\nendinterface\n")
+        (d / "zz_probe_body.svh").write_text("KL_aes3_tx u_zz_inc ();\n")
+        for name, insert, want in probes:
+            (d / "milan_datapath.sv").write_text(base[:end] + insert + base[end:])
+            got = _probe_children(d / "milan_datapath.sv", extra_index={
+                "zz_probe_if": ("interface", d / "zz_probe_if.sv")})
+            ck(name, want in got, f"the walk over the copy reached {sorted(got & {want})}")
+            ok_decl = want == "zz_probe_if" or module_file(want) is not None
+            if not ok_decl:
+                ck(f"probe module {want} is declared in the tree", False)
+        (d / "milan_datapath.sv").write_text(
+            base[:end] + "\n`include \"zz_probe_body.svh\"\n" + base[end:])
+        got = _probe_children(d / "milan_datapath.sv")
+        ck("an instantiation inside an included body is followed",
+           "KL_aes3_tx" in got, f"got {sorted(got)}")
 
-    # THE MUTATION. Take a real consumer's real list, remove one file the
-    # closure needs, and demand the comparison complains. An arm that only ever
-    # sees complete lists cannot tell a working gate from an inert one.
-    bitten = 0
-    for label, fetch in CONSUMERS:
-        have, why = fetch()
-        if have is None:
+    reached = [r for r in rows if r.kind == "ok"]
+    ck("every consumer answered, so the arms below grade all of them",
+       len(reached) == len(rows),
+       "; ".join(f"{r.label}: {r.why}" for r in rows if r.kind != "ok"))
+
+    # THE MUTATION, through each consumer's OWN emit path. Copy the consumer,
+    # remove one closure file from the copy, ask the copy. Set arithmetic on
+    # an already-fetched list would pass with every fetcher stubbed to return
+    # the closure; this cannot.
+    before = {c.source: (REPO / c.source).read_bytes() for c in CONSUMERS}
+    bitten, reasons = [], []
+    for c in CONSUMERS:
+        real = c.fetch()
+        if real.kind != "ok":
             continue
-        victim = sorted(need & have)[0]
-        if sorted(need - (have - {victim})) == [victim]:
-            bitten += 1
-    ck("removing one file from a live list is detected", bitten == len(reached),
-       f"{bitten} of {len(reached)} reachable consumers reported the removal")
+        text = (REPO / c.source).read_text()
+        victim = next((f for f in sorted(need & real.files)
+                       if drop_source_token(text, Path(f).name) != text), None)
+        if victim is None:
+            reasons.append(f"{c.label}: no closure file is literal in {c.source}")
+            continue
+        with mutated_copy(c, Path(victim).name) as copy:
+            mutated = c.fetch(copy) if copy else None
+        if mutated is None or mutated.kind != "ok":
+            reasons.append(f"{c.label}: the mutated copy could not answer: "
+                           f"{mutated.why if mutated else 'no copy'}")
+        elif victim in mutated.files:
+            reasons.append(f"{c.label}: removed '{victim}' from a copy of {c.source} "
+                           f"and its emit path still lists it")
+        elif mutated.files | {victim} != real.files:
+            reasons.append(f"{c.label}: the removal was not surgical, differs in "
+                           f"{sorted((mutated.files ^ real.files) - {victim})}")
+        else:
+            bitten.append(c.label)
+    ck("removing one file from a COPY of each consumer is reported by that consumer's own emit path",
+       len(bitten) == len(reached) and not reasons, "; ".join(reasons))
+    stray = [p.name for p in (REPO / "syn/yosys").iterdir() if p.name.startswith(".selftest-")]
+    ck("the mutation arm left every consumer byte-identical and no copy behind",
+       all((REPO / c.source).read_bytes() == before[c.source] for c in CONSUMERS)
+       and not stray, f"stray {stray}")
 
-    # asking a consumer for its list must not become what the consumer DOES
-    import tempfile
+    # the Vivado escape class the round-2 review ran: a row commented out is
+    # still text, and a text regex still counted it. The reader is imported
+    # from check_soc_sources.py; this arm proves the consumer above it uses it.
+    soc_text = SOC.read_text()
+    row = next((l for l in soc_text.splitlines()
+                if '"hdl/common/cdc_handshake.sv"' in l), None)
+    with tempfile.TemporaryDirectory() as td:
+        copy = Path(td) / "milan_soc.py"
+        copy.write_text(soc_text.replace(row, "#" + row, 1) if row else soc_text)
+        answer = _from_vivado_list(copy)
+    ck("commenting out a row of the Vivado list removes its files from what the consumer carries",
+       row is not None and answer.kind == "ok"
+       and "hdl/common/cdc_handshake.sv" in need
+       and "hdl/common/cdc_handshake.sv" not in answer.files,
+       f"row {row!r}, kind {answer.kind}, carried "
+       f"{'hdl/common/cdc_handshake.sv' in (answer.files or set())}")
+
+    # ASKING must not become DOING, and a consumer that cannot answer, or that
+    # answers with a defect, must reach the exit code. Fixture makefiles run
+    # through the real _from_make and the real verdict.
     with tempfile.TemporaryDirectory() as td:
         good = Path(td) / "good"; good.mkdir()
         (good / "Makefile").write_text(
@@ -426,11 +762,50 @@ def selftest():
         bad = Path(td) / "bad"; bad.mkdir()
         (bad / "Makefile").write_text(
             ".PHONY: all print-srcs\nprint-srcs:\n\t@echo a.sv\nall:\n\t@echo ran\n")
+        broken = Path(td) / "broken"; broken.mkdir()
+        (broken / "Makefile").write_text(
+            ".PHONY: all print-srcs\nall:\n\t@echo ran\nprint-srcs:\n\t@false\n")
         ck("a correctly ordered makefile is accepted",
-           not default_goal_is_print_srcs(good))
+           default_goal_is_print_srcs(good, good / "Makefile") is False)
         ck("print-srcs as the default goal is caught",
-           default_goal_is_print_srcs(bad),
+           default_goal_is_print_srcs(bad, bad / "Makefile") is True,
            "a bare make would print the list instead of running the suite")
+        complete = Consumer("fixture complete list",
+                            lambda copy=None: Answer(set(need), "ok", None), "-", False)
+        goal = Consumer("fixture default-goal suite",
+                        lambda copy=None: _from_make("milan_dp", bad / "Makefile"),
+                        "-", False)
+        dead = Consumer("fixture emit path that fails",
+                        lambda copy=None: _from_make("milan_dp", broken / "Makefile"),
+                        "-", False)
+        _cl, _need, r_goal = audit((complete, goal))
+        rc, lines = verdict(cl, need, r_goal, [])
+        ck("a default-goal regression through the real emit path exits 1",
+           rc == 1 and any(l.startswith("DEFAULT GOAL") for l in lines),
+           f"rc {rc}: {lines}")
+        rc, _ = verdict(cl, need, r_goal, [], allow_skip=True)
+        ck("a diagnosed defect is never skippable", rc == 1, f"rc {rc}")
+        _cl, _need, r_dead = audit((complete, dead))
+        rc, lines = verdict(cl, need, r_dead, [])
+        ck("an emit path that fails exits 2 by default",
+           rc == 2 and any(l.startswith("CANNOT ASK") for l in lines),
+           f"rc {rc}: {lines}")
+        rc, lines = verdict(cl, need, r_dead, [], allow_skip=True)
+        ck("--allow-skip turns it into a loud SKIPPED marker and a covered verdict",
+           rc == 0 and any(l.startswith("!! SKIPPED") for l in lines)
+           and any("NOT covered" in l for l in lines), f"rc {rc}: {lines}")
+        _cl, _need, r_only_dead = audit((dead,))
+        rc, _ = verdict(cl, need, r_only_dead, [], allow_skip=True)
+        ck("a run in which every consumer was skipped is not a pass", rc == 2, f"rc {rc}")
+        _cl, _need, r_complete = audit((complete,))
+        tops_gone = [("protocol-processor", "syn/yosys/run.sh", set(), set(), [], [], [],
+                      "protocol-processor/syn/yosys/run.sh is absent at this pin")]
+        rc, lines = verdict(cl, need, r_complete, tops_gone)
+        ck("a processor tops list that cannot be read exits 2 by default",
+           rc == 2 and any(l.startswith("CANNOT ASK") for l in lines), f"rc {rc}: {lines}")
+        rc, lines = verdict(cl, need, r_complete, tops_gone, allow_skip=True)
+        ck("--allow-skip skips an unreadable tops list loudly and covers the rest",
+           rc == 0 and any(l.startswith("!! SKIPPED") for l in lines), f"rc {rc}: {lines}")
 
     # the closure is a WALK: it must not be every file in the tree
     every = {p.relative_to(REPO).as_posix() for p in (REPO / "hdl").rglob("*.sv")}
@@ -479,92 +854,81 @@ def selftest():
            mutated[0] == ["KL_zz_probe"], f"got {mutated}")
     else:
         failures += 3
+        checks += 3
 
-    total = 24
-    print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
+    print(f"\n{checks} checks: {checks - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
+
+
+def _probe_children(path, extra_index=None):
+    """The direct children the walk derives from one unit file - the same
+    derivation `closure()` applies at every node, run on a copy so the tree is
+    never edited. `extra_index` adds fixture declarations to the lookup."""
+    index = dict(declaration_index())
+    index.update(extra_index or {})
+    interfaces = [n for n, (kind, _p) in index.items() if kind == "interface"]
+    text, included, _bad = spliced(Path(path))
+    children = set(INST_RE.findall(text))
+    children |= {n for n in PACKAGE_REF_RE.findall(text)
+                 if index.get(n, (None,))[0] == "package"}
+    children |= {n for n in interfaces if re.search(r"\b" + re.escape(n) + r"\b", text)}
+    for inc in included:
+        children |= set(units_by_file().get(inc.resolve(), ()))
+    return {c for c in children if c in index}
 
 
 def main():
     args = sys.argv[1:]
+    unknown = [a for a in args
+               if a not in ("--list", "--files", "--selftest", "--allow-skip")]
+    if unknown:
+        print(f"unknown option(s): {' '.join(unknown)}", file=sys.stderr)
+        print(__doc__.split("Usage:")[1].split("Exit 0")[0], file=sys.stderr)
+        return 2
     if "--selftest" in args:
         return selftest()
 
-    modules, need, unresolved, results = audit()
     gone = absent_roots()
     if gone:
         print(f"CANNOT BUILD THE CLOSURE: source root(s) {', '.join(gone)} are "
               f"not checked out, so an unresolved module cannot be told apart "
               f"from a missing tree. Run `git submodule update --init`.")
         return 2
-    if not need or unresolved:
-        for name in sorted(unresolved):
+    cl, need, rows = audit()
+    if not need or cl.unresolved or cl.bad_includes:
+        for name in sorted(cl.unresolved):
             print(f"UNRESOLVED MODULE: '{name}' is instantiated but no source in "
                   f"{', '.join(SEARCH_ROOTS)} declares it")
+        for unit, inc in cl.bad_includes:
+            print(f"UNRESOLVED INCLUDE: {unit} `include's '{inc}' but no file under "
+                  f"{', '.join(SEARCH_ROOTS)} answers to it, so its body could not "
+                  f"be walked")
         if not need:
             print("CLOSURE EMPTY: milan_datapath could not be read")
         return 2
 
-    if "--list" in args:
+    if "--files" in args:
+        # the closure as a front end wants it: packages first, one path per line
+        packages = {p for u, p in cl.units.items()
+                    if declaration_index()[u][0] == "package"}
+        for path in sorted(packages) + sorted(need - packages):
+            print(path)
+        return 0
+
+    list_mode = "--list" in args
+    if list_mode:
         print(f"file closure of milan_datapath ({len(need)} file(s), "
-              f"{len(modules)} module/package/interface unit(s)):")
+              f"{len(cl.units)} module/package/interface unit(s)):")
         for path in sorted(need):
-            names = sorted(m for m, p in modules.items() if p == path)
+            names = sorted(m for m, p in cl.units.items() if p == path)
             print(f"   {path}  [{', '.join(names)}]")
         print()
 
-    bad = skipped = 0
-    for label, missing, why in results:
-        if why is not None:
-            skipped += 1
-            print(f"SKIPPED  {label}: {why}")
-            continue
-        if missing:
-            bad += 1
-            for path in missing:
-                names = sorted(m for m, p in modules.items() if p == path)
-                print(f"MISSING SOURCE: {label} does not carry '{path}' "
-                      f"(declares {', '.join(names)}), which milan_datapath "
-                      f"needs -> that consumer cannot build")
-        elif "--list" in args:
-            print(f"ok       {label}")
-
-    tops_bad = 0
-    tops_note = []
-    for sub, script, tops, declared, recorded, unrecorded, stale, why in processor_tops_audit():
-        if why is not None:
-            skipped += 1
-            print(f"SKIPPED  {sub} native tops list: {why}")
-            continue
-        for name in unrecorded:
-            tops_bad += 1
-            print(f"TOPS DRIFT: {sub}/{script} does not elaborate declared module "
-                  f"'{name}' as a top and scripts/processor_yosys_tops.budget does "
-                  f"not record why -> its portability is unproven")
-        for name in stale:
-            tops_bad += 1
-            print(f"STALE RECORD: scripts/processor_yosys_tops.budget names '{name}' "
-                  f"but {sub}/{script} elaborates it (or nothing declares it) -> "
-                  f"remove the line")
-        if "--list" in args or recorded:
-            print(f"{sub} native tops list ({script}): {len(tops)} top(s) for "
-                  f"{len(declared)} declared module(s); {len(recorded)} recorded "
-                  f"omission(s) at this pin: {', '.join(recorded) or '-'}")
-        tops_note.append(f"{sub} {len(tops)}/{len(declared)} tops, {len(recorded)} recorded")
-    gptp = [m for m in modules.values() if m.startswith("gptp-processor/")]
-    if "--list" in args:
-        print(f"gptp-processor keeps no native tops list; the closure walk reaches "
-              f"{len(set(gptp))} of its file(s)")
-
-    if bad or tops_bad:
-        return 1
-    verdict = (f"RTL source-list gate: OK ({len(need)} files in the "
-               f"milan_datapath closure, {len(results) - skipped} of "
-               f"{len(results)} consumer list(s) carry all of them; "
-               f"{'; '.join(tops_note) or 'no processor tops list reachable'}")
-    print(verdict + (f"; {skipped} SKIPPED and NOT covered by this verdict)"
-                     if skipped else ")"))
-    return 0
+    rc, lines = verdict(cl, need, rows, processor_tops_audit(),
+                        allow_skip="--allow-skip" in args, list_mode=list_mode)
+    for line in lines:
+        print(line)
+    return rc
 
 
 if __name__ == "__main__":

--- a/scripts/check_rtl_source_lists.py
+++ b/scripts/check_rtl_source_lists.py
@@ -30,9 +30,11 @@ own expansion (`make -s print-srcs`, `syn/yosys/run.sh --emit`) and this gate
 reads that. The Vivado list is the exception: it is a Python literal with no
 expansion step, and `check_soc_sources.py` owns reading it.
 
-A consumer whose tooling is absent is reported SKIPPED, by name, and the
-verdict says so. A gate that silently drops a consumer it could not reach is
-how a list goes unchecked for months.
+The Vivado consumer combines its quoted superproject entries with the
+`pp_srcs.py` expansion that `milan_soc.py` itself uses for the project-owned
+protocol-processor submodule. A consumer whose tooling is absent is reported
+SKIPPED, by name, and the verdict says so. A gate that silently drops a
+consumer it could not reach is how a list goes unchecked for months.
 
 Usage:
     python3 scripts/check_rtl_source_lists.py            # gate
@@ -47,6 +49,7 @@ Exit 2 = the closure itself could not be built.
 import re
 import subprocess
 import sys
+from functools import lru_cache
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -55,6 +58,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 #: the first-hop derivation is OWNED by check_soc_sources.py. Importing it is
 #: the point of this gate: two instantiation parsers would be two truths.
 from check_soc_sources import INST_RE, PREFIXES
+from pp_srcs import pp_sources
 
 #: Trees a source list may legitimately draw from. The vendored AXI-stream
 #: RTL is here because every consumer must carry it too - it is Verilog, not
@@ -68,26 +72,44 @@ def absent_roots():
     return [r for r in SEARCH_ROOTS if not (REPO / r).is_dir()]
 
 
-def module_file(name):
-    """The source file declaring `name`, or None. Found by declaration, not by
-    filename: a module may live in a file named for something else."""
+@lru_cache(maxsize=1)
+def declaration_index():
+    """Every module/package/interface declaration, indexed by unit name."""
+    found = {}
     for root in SEARCH_ROOTS:
         base = REPO / root
         if not base.is_dir():
             continue
         for path in sorted(list(base.rglob("*.sv")) + list(base.rglob("*.v"))):
-            if re.search(r"^\s*module\s+%s\b" % re.escape(name),
-                         path.read_text(errors="replace"), re.M):
-                return path
-    return None
+            text = path.read_text(errors="replace")
+            for kind, name in re.findall(
+                    r"^\s*(module|package|interface)\s+([A-Za-z_]\w*)\b",
+                    text, re.M):
+                found.setdefault(name, (kind, path))
+    return found
+
+
+def module_file(name):
+    """The source file declaring `name`, or None.
+
+    Declaration membership, not a naming prefix, decides whether a child is
+    first-party/project RTL. Prefixes are retained only to turn a misspelled
+    project-looking child into an unresolved error.
+    """
+    item = declaration_index().get(name)
+    return item[1] if item else None
+
+
+PACKAGE_REF_RE = re.compile(r"\b([A-Za-z_]\w*)::")
+INTERFACE_REF_RE = re.compile(r"\b([A-Za-z_]\w*)\.(?:master|slave|monitor)\b")
 
 
 def closure(top="milan_datapath"):
-    """Every project module reachable from `top` by instantiation.
+    """Every project compilation unit reachable from `top`.
 
-    Returns (modules, unresolved): the module names, and the ones whose source
-    file could not be found. An unresolved name is not silently dropped - a
-    list cannot be checked for a module nobody can locate.
+    Module instantiations, package-qualified references and interface/modport
+    types all add their declaring file. Returns (units, unresolved): the unit
+    names, and project-looking module names whose source could not be found.
     """
     start = module_file(top)
     if start is None:
@@ -99,12 +121,18 @@ def closure(top="milan_datapath"):
             continue
         seen[name] = path.relative_to(REPO).as_posix()
         text = path.read_text(errors="replace")
-        for child in {m for m in INST_RE.findall(text) if m.startswith(PREFIXES)}:
+        children = set(INST_RE.findall(text))
+        children |= {name for name in PACKAGE_REF_RE.findall(text)
+                     if declaration_index().get(name, (None,))[0] == "package"}
+        children |= {name for name in INTERFACE_REF_RE.findall(text)
+                     if declaration_index().get(name, (None,))[0] == "interface"}
+        for child in children:
             if child in seen:
                 continue
             child_path = module_file(child)
             if child_path is None:
-                unresolved.add(child)
+                if child.startswith(PREFIXES):
+                    unresolved.add(child)
             else:
                 queue.append((child, child_path))
     return seen, unresolved
@@ -201,9 +229,11 @@ def _from_yosys_ooc():
     return _repo_rel(text.split(), REPO / "syn/yosys"), None
 
 
-#: every quoted source path in milan_soc.py's curated list. check_soc_sources.py
-#: reads only the `hdl/` half, because it grades module registration; this gate
-#: grades FILE coverage and the vendored `.v` entries count too.
+#: every quoted source path in milan_soc.py's curated superproject list. The
+#: protocol-processor half is expanded by `_pp_sources()` at import time, so it
+#: is asked through the same `pp_srcs.py` authority rather than guessed from
+#: Python syntax. This gate grades FILE coverage and the vendored `.v` entries
+#: count too.
 _VIVADO_SRC_RE = re.compile(r'"((?:[\w.-]+/)+[\w.-]+\.(?:sv|v))"')
 
 
@@ -211,7 +241,8 @@ def _from_vivado_list():
     soc = REPO / "sw/litex/milan_soc.py"
     if not soc.is_file():
         return None, "sw/litex/milan_soc.py is absent"
-    return _repo_rel(_VIVADO_SRC_RE.findall(soc.read_text()), REPO), None
+    tokens = _VIVADO_SRC_RE.findall(soc.read_text()) + pp_sources()
+    return _repo_rel(tokens, REPO), None
 
 
 CONSUMERS = (
@@ -257,6 +288,15 @@ def selftest():
     ck("the closure is transitive, not one hop",
        "KL_aaf_latency_taps" in modules,
        "a module instantiated by a CHILD of milan_datapath must be in the closure")
+    ck("a declared child needs no approved naming prefix",
+       "credit_based_shaper" in modules,
+       "the closure must follow declarations, not silently omit a new name family")
+    ck("package dependencies are part of the file closure",
+       "pp_pkg" in modules and "ethernet_packet_pkg" in modules,
+       "removing a package-only source must fail before compilation")
+    ck("interface dependencies are part of the file closure",
+       "axi_stream_if" in modules,
+       "an interface declaration is a source dependency even though it is not a module")
     ck("a module sharing another module's file needs no entry of its own",
        modules.get("KL_aaf_latency_chain") == modules.get("KL_aaf_latency_taps")
        and modules.get("KL_aaf_latency_chain") is not None,
@@ -300,7 +340,7 @@ def selftest():
     ck("the closure is a walk, not a directory listing", bool(every - need),
        "the closure covers every .sv under hdl/ - the instantiation walk is inert")
 
-    total = 9
+    total = 12
     print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -327,7 +367,7 @@ def main():
 
     if "--list" in args:
         print(f"file closure of milan_datapath ({len(need)} file(s), "
-              f"{len(modules)} module(s)):")
+              f"{len(modules)} module/package/interface unit(s)):")
         for path in sorted(need):
             names = sorted(m for m, p in modules.items() if p == path)
             print(f"   {path}  [{', '.join(names)}]")

--- a/scripts/check_rtl_source_lists.py
+++ b/scripts/check_rtl_source_lists.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Gate: every list that compiles `milan_datapath` carries every module it needs.
+
+Why this exists, with the receipts. There are FIVE independent lists of the
+same RTL - the Vivado sources in `sw/litex/milan_soc.py`, the `milan_datapath`
+row in `syn/yosys/run.sh`, `DP_SRCS` in `syn/yosys/ooc.sh`, and the source
+lists in `tb/verilator/milan_dp/Makefile` and `tb/verilator/hostplane/Makefile`.
+`scripts/check_soc_sources.py` has guarded exactly one of them since a missing
+`KL_i2s_feed_mux` entry killed three Vivado runs forty minutes in. The other
+four were unguarded, and extracting one module into
+`hdl/ieee1722/aaf/KL_aaf_latency_tap_bank.sv` broke three Verilator suites at
+once, each with the same "Cannot find file containing module" - one per list
+that nobody had told.
+
+THE AUTHORITY IS THE RTL, NOT ANOTHER LIST. This gate walks the module closure
+of `milan_datapath` through the sources themselves: what the datapath
+instantiates, what those modules instantiate, transitively. Checking one list
+against another would let all five agree and all five be wrong, which is the
+same defect wearing a different hat. `scripts/check_soc_sources.py` already
+derives the first hop this way, and this gate imports its derivation rather
+than writing a second copy of it - a gate about single sources of truth that
+forked its own instantiation parser would be self-refuting.
+
+AND THE CONSUMERS ARE ASKED, NOT PARSED. A recogniser accepts what it has
+modelled, and `make` and `bash` accept something else - the lesson
+`syn/ooc/dp_srcs.py` records after four escapes. So each consumer prints its
+own expansion (`make -s print-srcs`, `syn/yosys/run.sh --emit`) and this gate
+reads that. The Vivado list is the exception: it is a Python literal with no
+expansion step, and `check_soc_sources.py` owns reading it.
+
+A consumer whose tooling is absent is reported SKIPPED, by name, and the
+verdict says so. A gate that silently drops a consumer it could not reach is
+how a list goes unchecked for months.
+
+Usage:
+    python3 scripts/check_rtl_source_lists.py            # gate
+    python3 scripts/check_rtl_source_lists.py --list     # closure + per list
+    python3 scripts/check_rtl_source_lists.py --selftest # mutation arms
+
+Exit 0 = every reachable consumer carries the whole closure.
+Exit 1 = a consumer is missing a module.
+Exit 2 = the closure itself could not be built.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+#: the first-hop derivation is OWNED by check_soc_sources.py. Importing it is
+#: the point of this gate: two instantiation parsers would be two truths.
+from check_soc_sources import INST_RE, PREFIXES
+
+#: Trees a source list may legitimately draw from. The vendored AXI-stream
+#: RTL is here because every consumer must carry it too - it is Verilog, not
+#: SystemVerilog, which is why both suffixes are searched. A missing root is a
+#: SKIP with its name, never a silently smaller closure.
+SEARCH_ROOTS = ("hdl", "protocol-processor/hdl", "gptp-processor/hdl",
+                "third_party/verilog-axis/rtl")
+
+
+def absent_roots():
+    return [r for r in SEARCH_ROOTS if not (REPO / r).is_dir()]
+
+
+def module_file(name):
+    """The source file declaring `name`, or None. Found by declaration, not by
+    filename: a module may live in a file named for something else."""
+    for root in SEARCH_ROOTS:
+        base = REPO / root
+        if not base.is_dir():
+            continue
+        for path in sorted(list(base.rglob("*.sv")) + list(base.rglob("*.v"))):
+            if re.search(r"^\s*module\s+%s\b" % re.escape(name),
+                         path.read_text(errors="replace"), re.M):
+                return path
+    return None
+
+
+def closure(top="milan_datapath"):
+    """Every project module reachable from `top` by instantiation.
+
+    Returns (modules, unresolved): the module names, and the ones whose source
+    file could not be found. An unresolved name is not silently dropped - a
+    list cannot be checked for a module nobody can locate.
+    """
+    start = module_file(top)
+    if start is None:
+        return {}, {top}
+    seen, unresolved, queue = {}, set(), [(top, start)]
+    while queue:
+        name, path = queue.pop()
+        if name in seen:
+            continue
+        seen[name] = path.relative_to(REPO).as_posix()
+        text = path.read_text(errors="replace")
+        for child in {m for m in INST_RE.findall(text) if m.startswith(PREFIXES)}:
+            if child in seen:
+                continue
+            child_path = module_file(child)
+            if child_path is None:
+                unresolved.add(child)
+            else:
+                queue.append((child, child_path))
+    return seen, unresolved
+
+
+# ---------------------------------------------------------------------------
+# consumers - each ASKS its own tooling for the expansion it will really use
+# ---------------------------------------------------------------------------
+def _repo_rel(tokens, cwd):
+    """Resolve a consumer's own path tokens to repo-relative posix paths.
+
+    A source list is a list of FILES, and one file may declare several modules
+    (`KL_aaf_latency_chain` lives inside `KL_aaf_latency_taps.sv`,
+    `event_counter` beside `ethernet_events`). Comparing module names to file
+    stems would demand entries that must not exist, so the comparison is made
+    where the lists actually live: on files."""
+    out = set()
+    for tok in tokens:
+        if not tok.endswith((".sv", ".v")):
+            continue
+        try:
+            out.add((cwd / tok).resolve().relative_to(REPO).as_posix())
+        except ValueError:
+            continue          # outside the repo: not something a gate can own
+    return out
+
+
+def _run(cmd, cwd):
+    try:
+        out = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                             timeout=300)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"{cmd[0]}: {exc}"
+    if out.returncode != 0:
+        return None, f"{' '.join(cmd)} exited {out.returncode}"
+    return out.stdout, None
+
+
+def _from_make(suite):
+    d = REPO / "tb/verilator" / suite
+    if not (d / "Makefile").is_file():
+        return None, f"tb/verilator/{suite}/Makefile is absent"
+    text, err = _run(["make", "-s", "print-srcs"], d)
+    if text is None:
+        return None, err
+    return _repo_rel(text.split(), d), None
+
+
+def _from_yosys_run():
+    text, err = _run(["./run.sh", "--emit", "milan_datapath"], REPO / "syn/yosys")
+    if text is None:
+        return None, err
+    names = set()
+    for line in text.splitlines():
+        if line.startswith("src="):
+            names |= _repo_rel(line[4:].split(), REPO / "syn/yosys")
+    return names, None
+
+
+def _from_yosys_ooc():
+    text, err = _run(["./ooc.sh", "--emit-dp"], REPO / "syn/yosys")
+    if text is None:
+        return None, err
+    return _repo_rel(text.split(), REPO / "syn/yosys"), None
+
+
+#: every quoted source path in milan_soc.py's curated list. check_soc_sources.py
+#: reads only the `hdl/` half, because it grades module registration; this gate
+#: grades FILE coverage and the vendored `.v` entries count too.
+_VIVADO_SRC_RE = re.compile(r'"((?:[\w.-]+/)+[\w.-]+\.(?:sv|v))"')
+
+
+def _from_vivado_list():
+    soc = REPO / "sw/litex/milan_soc.py"
+    if not soc.is_file():
+        return None, "sw/litex/milan_soc.py is absent"
+    return _repo_rel(_VIVADO_SRC_RE.findall(soc.read_text()), REPO), None
+
+
+CONSUMERS = (
+    ("Vivado sources (sw/litex/milan_soc.py)", _from_vivado_list),
+    ("Yosys milan_datapath row (syn/yosys/run.sh)", _from_yosys_run),
+    ("Yosys DP_SRCS (syn/yosys/ooc.sh)", _from_yosys_ooc),
+    ("Verilator milan_dp (tb/verilator/milan_dp)", lambda: _from_make("milan_dp")),
+    ("Verilator hostplane (tb/verilator/hostplane)", lambda: _from_make("hostplane")),
+)
+
+
+def audit():
+    """Returns (need, unresolved, results) with results as
+    [(label, missing_sorted_or_None, skip_reason_or_None)]."""
+    modules, unresolved = closure()
+    need = set(modules.values())
+    results = []
+    for label, fetch in CONSUMERS:
+        have, why = fetch()
+        if have is None:
+            results.append((label, None, why))
+        else:
+            results.append((label, sorted(need - have), None))
+    return modules, need, unresolved, results
+
+
+def selftest():
+    """Mutation arms. Every one removes something and demands a complaint."""
+    failures = 0
+
+    def ck(name, ok, detail=""):
+        nonlocal failures
+        if ok:
+            print(f"[PASS] {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] {name}{': ' + detail if detail else ''}")
+
+    modules, need, unresolved, results = audit()
+    ck("the closure is non-empty", len(need) > 5, f"got {len(need)} file(s)")
+    ck("the closure resolves every module it names", not unresolved,
+       f"unresolved: {sorted(unresolved)}")
+    ck("the closure is transitive, not one hop",
+       "KL_aaf_latency_taps" in modules,
+       "a module instantiated by a CHILD of milan_datapath must be in the closure")
+    ck("a module sharing another module's file needs no entry of its own",
+       modules.get("KL_aaf_latency_chain") == modules.get("KL_aaf_latency_taps")
+       and modules.get("KL_aaf_latency_chain") is not None,
+       "two modules in one file must resolve to ONE required file")
+
+    reached = [r for r in results if r[2] is None]
+    ck("at least one consumer was reachable", bool(reached),
+       "every consumer skipped - this run would prove nothing")
+
+    # THE MUTATION. Take a real consumer's real list, remove one file the
+    # closure needs, and demand the comparison complains. An arm that only ever
+    # sees complete lists cannot tell a working gate from an inert one.
+    bitten = 0
+    for label, fetch in CONSUMERS:
+        have, why = fetch()
+        if have is None:
+            continue
+        victim = sorted(need & have)[0]
+        if sorted(need - (have - {victim})) == [victim]:
+            bitten += 1
+    ck("removing one file from a live list is detected", bitten == len(reached),
+       f"{bitten} of {len(reached)} reachable consumers reported the removal")
+
+    # the closure is a WALK: it must not be every file in the tree
+    every = {p.relative_to(REPO).as_posix() for p in (REPO / "hdl").rglob("*.sv")}
+    ck("the closure is a walk, not a directory listing", bool(every - need),
+       "the closure covers every .sv under hdl/ - the instantiation walk is inert")
+
+    total = 7
+    print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
+
+
+def main():
+    args = sys.argv[1:]
+    if "--selftest" in args:
+        return selftest()
+
+    modules, need, unresolved, results = audit()
+    gone = absent_roots()
+    if gone:
+        print(f"CANNOT BUILD THE CLOSURE: source root(s) {', '.join(gone)} are "
+              f"not checked out, so an unresolved module cannot be told apart "
+              f"from a missing tree. Run `git submodule update --init`.")
+        return 2
+    if not need or unresolved:
+        for name in sorted(unresolved):
+            print(f"UNRESOLVED MODULE: '{name}' is instantiated but no source in "
+                  f"{', '.join(SEARCH_ROOTS)} declares it")
+        if not need:
+            print("CLOSURE EMPTY: milan_datapath could not be read")
+        return 2
+
+    if "--list" in args:
+        print(f"file closure of milan_datapath ({len(need)} file(s), "
+              f"{len(modules)} module(s)):")
+        for path in sorted(need):
+            names = sorted(m for m, p in modules.items() if p == path)
+            print(f"   {path}  [{', '.join(names)}]")
+        print()
+
+    bad = skipped = 0
+    for label, missing, why in results:
+        if why is not None:
+            skipped += 1
+            print(f"SKIPPED  {label}: {why}")
+            continue
+        if missing:
+            bad += 1
+            for path in missing:
+                names = sorted(m for m, p in modules.items() if p == path)
+                print(f"MISSING SOURCE: {label} does not carry '{path}' "
+                      f"(declares {', '.join(names)}), which milan_datapath "
+                      f"needs -> that consumer cannot build")
+        elif "--list" in args:
+            print(f"ok       {label}")
+
+    if bad:
+        return 1
+    verdict = (f"RTL source-list gate: OK ({len(need)} files in the "
+               f"milan_datapath closure, {len(results) - skipped} of "
+               f"{len(results)} consumer list(s) carry all of them")
+    print(verdict + (f"; {skipped} SKIPPED and NOT covered by this verdict)"
+                     if skipped else ")"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_rtl_source_lists.py
+++ b/scripts/check_rtl_source_lists.py
@@ -143,6 +143,32 @@ def _run(cmd, cwd):
     return out.stdout, None
 
 
+def default_goal_is_print_srcs(directory):
+    """True when a bare `make` in `directory` would print the source list.
+
+    Adding a `print-srcs` target ABOVE a makefile's first real target makes it
+    the default goal, so the suite stops running and prints a file list. The
+    tally gate then reports NOCOUNT rather than a failure, which is a suite
+    that measured nothing wearing the costume of a suite that passed. This
+    happened here the moment print-srcs was added to the hostplane suite.
+
+    MAKE ASKS ITSELF. A second makefile adds one target that echoes
+    `.DEFAULT_GOAL`, which make has already resolved from the FIRST target of
+    the first makefile - so this reads make's own answer rather than a model of
+    makefile syntax. Comparing a dry run to the printed list does not work: an
+    `@`-prefixed recipe makes `-n` print the command, not run it.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        probe = Path(td) / "probe.mk"
+        probe.write_text("__kl_show_default_goal:\n\t@echo $(.DEFAULT_GOAL)\n")
+        out, err = _run(["make", "-s", "-f", "Makefile", "-f", str(probe),
+                         "__kl_show_default_goal"], directory)
+    if out is None:
+        return False
+    return out.strip().splitlines()[-1].strip() == "print-srcs" if out.strip() else False
+
+
 def _from_make(suite):
     d = REPO / "tb/verilator" / suite
     if not (d / "Makefile").is_file():
@@ -150,6 +176,10 @@ def _from_make(suite):
     text, err = _run(["make", "-s", "print-srcs"], d)
     if text is None:
         return None, err
+    if default_goal_is_print_srcs(d):
+        return None, (f"tb/verilator/{suite}: a bare `make` prints the source "
+                      f"list instead of running the suite - print-srcs has "
+                      f"become the default goal")
     return _repo_rel(text.split(), d), None
 
 
@@ -250,12 +280,27 @@ def selftest():
     ck("removing one file from a live list is detected", bitten == len(reached),
        f"{bitten} of {len(reached)} reachable consumers reported the removal")
 
+    # asking a consumer for its list must not become what the consumer DOES
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        good = Path(td) / "good"; good.mkdir()
+        (good / "Makefile").write_text(
+            ".PHONY: all print-srcs\nall:\n\t@echo ran\nprint-srcs:\n\t@echo a.sv\n")
+        bad = Path(td) / "bad"; bad.mkdir()
+        (bad / "Makefile").write_text(
+            ".PHONY: all print-srcs\nprint-srcs:\n\t@echo a.sv\nall:\n\t@echo ran\n")
+        ck("a correctly ordered makefile is accepted",
+           not default_goal_is_print_srcs(good))
+        ck("print-srcs as the default goal is caught",
+           default_goal_is_print_srcs(bad),
+           "a bare make would print the list instead of running the suite")
+
     # the closure is a WALK: it must not be every file in the tree
     every = {p.relative_to(REPO).as_posix() for p in (REPO / "hdl").rglob("*.sv")}
     ck("the closure is a walk, not a directory listing", bool(every - need),
        "the closure covers every .sv under hdl/ - the instantiation walk is inert")
 
-    total = 7
+    total = 9
     print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 

--- a/scripts/check_rtl_source_lists.py
+++ b/scripts/check_rtl_source_lists.py
@@ -36,13 +36,30 @@ protocol-processor submodule. A consumer whose tooling is absent is reported
 SKIPPED, by name, and the verdict says so. A gate that silently drops a
 consumer it could not reach is how a list goes unchecked for months.
 
+THE PROCESSOR'S OWN LIST IS A SIXTH CONSUMER, OF A DIFFERENT AUTHORITY. The
+protocol processor's portability gate (`protocol-processor/syn/yosys/run.sh`)
+keeps a hand-written `tops` array that its `hdl/README.md` rule 2 says must
+name every module, so each is elaborated as a Yosys top. It is not one of the
+five milan_datapath lists and `pp_srcs.py` does not feed it, so the closure
+walk above cannot see it drift - and at pin 3770ae02 it had: six declared
+modules were absent and both repositories reported the processor as covered.
+Here the authority is the set of modules DECLARED under `protocol-processor/hdl`;
+every one must be a top, or be named in `scripts/processor_yosys_tops.budget`
+with the reason it is not. An omission that is not recorded is refused; a
+recorded name that has become a top is refused as stale, so the record cannot
+outlive the debt it describes. The gPTP processor keeps no native list: its
+portability coverage is the closure walk itself, and the inventory prints how
+many of its files that walk reaches.
+
 Usage:
     python3 scripts/check_rtl_source_lists.py            # gate
     python3 scripts/check_rtl_source_lists.py --list     # closure + per list
     python3 scripts/check_rtl_source_lists.py --selftest # mutation arms
 
-Exit 0 = every reachable consumer carries the whole closure.
-Exit 1 = a consumer is missing a module.
+Exit 0 = every reachable consumer carries the whole closure, and the processor
+         tops array names every declared module that the budget does not.
+Exit 1 = a consumer is missing a module, or the processor tops array has an
+         unrecorded omission or a stale record.
 Exit 2 = the closure itself could not be built.
 """
 
@@ -254,6 +271,86 @@ CONSUMERS = (
 )
 
 
+# ---------------------------------------------------------------------------
+# the processor-native Yosys tops list - declared modules are the authority
+# ---------------------------------------------------------------------------
+#: (submodule, its portability script, the RTL root whose declarations it must
+#: name). One entry today; a second processor that grows a native tops list is
+#: added here and nowhere else.
+PROCESSOR_TOPS = (("protocol-processor", "syn/yosys/run.sh", "hdl"),)
+TOPS_BUDGET = REPO / "scripts/processor_yosys_tops.budget"
+_TOPS_ARRAY_RE = re.compile(r"\btops=\(([^)]*)\)", re.S)
+
+
+def parse_tops_array(text):
+    """The names in a bash `tops=( ... )` array, or None when there is none."""
+    m = _TOPS_ARRAY_RE.search(text)
+    if m is None:
+        return None
+    return set(m.group(1).split())
+
+
+def declared_modules(text):
+    """Module names declared in one SystemVerilog source (packages and
+    interfaces are not tops and are not counted)."""
+    return set(re.findall(r"^\s*module\s+([A-Za-z_]\w*)\b", text, re.M))
+
+
+def read_tops_budget(text):
+    """`name  reason` per line; `#` starts a comment. Returns {name: reason}."""
+    out = {}
+    for line in text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        name, _, reason = line.partition(" ")
+        out[name] = reason.strip()
+    return out
+
+
+def compare_tops(tops, declared, recorded):
+    """(unrecorded, stale) - the two refusals.
+
+    `unrecorded`: declared modules that are neither tops nor in the budget.
+    `stale`: budget names that are tops now (the debt was paid upstream and the
+    record must go) or that no source declares any more."""
+    missing = declared - tops
+    unrecorded = sorted(missing - set(recorded))
+    stale = sorted(n for n in recorded if n not in missing)
+    return unrecorded, stale
+
+
+def processor_tops_audit():
+    """[(submodule, script, tops, declared, recorded_missing, unrecorded,
+    stale, skip_reason)] - one row per PROCESSOR_TOPS entry."""
+    recorded = read_tops_budget(TOPS_BUDGET.read_text()) if TOPS_BUDGET.is_file() else {}
+    rows = []
+    for sub, script, hdl in PROCESSOR_TOPS:
+        path = REPO / sub / script
+        root = REPO / sub / hdl
+        if not root.is_dir():
+            rows.append((sub, script, set(), set(), [], [], [],
+                         f"{sub}/{hdl} is not checked out"))
+            continue
+        if not path.is_file():
+            rows.append((sub, script, set(), set(), [], [], [],
+                         f"{sub}/{script} is absent at this pin"))
+            continue
+        tops = parse_tops_array(path.read_text(errors="replace"))
+        if tops is None:
+            rows.append((sub, script, set(), set(), [], [], [],
+                         f"{sub}/{script} carries no tops=( ... ) array"))
+            continue
+        declared = set()
+        for src in sorted(root.rglob("*.sv")):
+            declared |= declared_modules(src.read_text(errors="replace"))
+        unrecorded, stale = compare_tops(tops, declared, recorded)
+        recorded_missing = sorted((declared - tops) & set(recorded))
+        rows.append((sub, script, tops, declared, recorded_missing, unrecorded,
+                     stale, None))
+    return rows
+
+
 def audit():
     """Returns (need, unresolved, results) with results as
     [(label, missing_sorted_or_None, skip_reason_or_None)]."""
@@ -340,7 +437,50 @@ def selftest():
     ck("the closure is a walk, not a directory listing", bool(every - need),
        "the closure covers every .sv under hdl/ - the instantiation walk is inert")
 
-    total = 12
+    # THE PROCESSOR-NATIVE LIST. Fixtures whose answer is known by construction,
+    # then the live pin, where the budget must name exactly the drift and
+    # nothing else.
+    tops = parse_tops_array("set -eu\ntops=(KL_a KL_b\n      KL_c)\nwork=x\n")
+    ck("a multi-line tops array is read whole", tops == {"KL_a", "KL_b", "KL_c"},
+       f"got {tops}")
+    ck("a script without a tops array is told apart from an empty one",
+       parse_tops_array("set -eu\nfor t in a b; do :; done\n") is None)
+    declared = declared_modules(
+        "package p_pkg; endpackage\nmodule KL_a; endmodule\n"
+        "interface bus_if; endinterface\n  module KL_new #(parameter W=1)(); endmodule\n")
+    ck("declarations are modules only - packages and interfaces are not tops",
+       declared == {"KL_a", "KL_new"}, f"got {declared}")
+    ck("adding a declared module that the tops array does not name is refused",
+       compare_tops({"KL_a"}, {"KL_a", "KL_new"}, {}) == (["KL_new"], []))
+    ck("a recorded omission is debt, not a refusal",
+       compare_tops({"KL_a"}, {"KL_a", "KL_new"}, {"KL_new": "drift"}) == ([], []))
+    ck("a recorded name that became a top is refused as stale",
+       compare_tops({"KL_a", "KL_new"}, {"KL_a", "KL_new"}, {"KL_new": "drift"})
+       == ([], ["KL_new"]))
+    ck("removing a declared module from the tops array is refused",
+       compare_tops({"KL_a"}, {"KL_a", "KL_b"}, {}) == (["KL_b"], []),
+       "a top dropped from the array is exactly the drift the gate exists for")
+    budget = read_tops_budget("# c\nKL_x  why x\n\nKL_y why y # trailing\n")
+    ck("the budget names each omission with its reason",
+       budget == {"KL_x": "why x", "KL_y": "why y"}, f"got {budget}")
+    live = [r for r in processor_tops_audit() if r[7] is None]
+    ck("the live processor tops array was read", bool(live) and len(live[0][2]) >= 30,
+       "no PROCESSOR_TOPS entry was reachable, or the array parsed as nearly empty")
+    if live:
+        sub, script, l_tops, l_decl, l_rec, l_unrec, l_stale, _ = live[0]
+        ck("every recorded omission is real drift at this pin, and every drift is recorded",
+           not l_unrec and not l_stale,
+           f"unrecorded {l_unrec}, stale {l_stale}")
+        ck("the record is non-empty at this pin, so the refusal arms grade a live population",
+           bool(l_rec), "an empty record would make the stale/unrecorded arms vacuous here")
+        mutated = compare_tops(l_tops, l_decl | {"KL_zz_probe"},
+                               read_tops_budget(TOPS_BUDGET.read_text()))
+        ck("a new declared processor module is refused by the live comparison",
+           mutated[0] == ["KL_zz_probe"], f"got {mutated}")
+    else:
+        failures += 3
+
+    total = 24
     print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -389,11 +529,39 @@ def main():
         elif "--list" in args:
             print(f"ok       {label}")
 
-    if bad:
+    tops_bad = 0
+    tops_note = []
+    for sub, script, tops, declared, recorded, unrecorded, stale, why in processor_tops_audit():
+        if why is not None:
+            skipped += 1
+            print(f"SKIPPED  {sub} native tops list: {why}")
+            continue
+        for name in unrecorded:
+            tops_bad += 1
+            print(f"TOPS DRIFT: {sub}/{script} does not elaborate declared module "
+                  f"'{name}' as a top and scripts/processor_yosys_tops.budget does "
+                  f"not record why -> its portability is unproven")
+        for name in stale:
+            tops_bad += 1
+            print(f"STALE RECORD: scripts/processor_yosys_tops.budget names '{name}' "
+                  f"but {sub}/{script} elaborates it (or nothing declares it) -> "
+                  f"remove the line")
+        if "--list" in args or recorded:
+            print(f"{sub} native tops list ({script}): {len(tops)} top(s) for "
+                  f"{len(declared)} declared module(s); {len(recorded)} recorded "
+                  f"omission(s) at this pin: {', '.join(recorded) or '-'}")
+        tops_note.append(f"{sub} {len(tops)}/{len(declared)} tops, {len(recorded)} recorded")
+    gptp = [m for m in modules.values() if m.startswith("gptp-processor/")]
+    if "--list" in args:
+        print(f"gptp-processor keeps no native tops list; the closure walk reaches "
+              f"{len(set(gptp))} of its file(s)")
+
+    if bad or tops_bad:
         return 1
     verdict = (f"RTL source-list gate: OK ({len(need)} files in the "
                f"milan_datapath closure, {len(results) - skipped} of "
-               f"{len(results)} consumer list(s) carry all of them")
+               f"{len(results)} consumer list(s) carry all of them; "
+               f"{'; '.join(tops_note) or 'no processor tops list reachable'}")
     print(verdict + (f"; {skipped} SKIPPED and NOT covered by this verdict)"
                      if skipped else ")"))
     return 0

--- a/scripts/check_rtl_source_lists.py
+++ b/scripts/check_rtl_source_lists.py
@@ -72,6 +72,10 @@ name every module, so each is elaborated as a Yosys top. It is not one of the
 five milan_datapath lists and `pp_srcs.py` does not feed it, so the closure
 walk above cannot see it drift - and at pin 3770ae02 it had: six declared
 modules were absent and both repositories reported the processor as covered.
+This list is read, not asked, because its only expansion path runs Yosys; so
+it is read the way bash reads it - `#` at the start of a word is a comment to
+the end of the line, quotes are unquoted - since splitting the raw text
+credited a commented-out top as elaborated.
 Here the authority is the set of modules DECLARED under `protocol-processor/hdl`;
 every one must be a top, or be named in `scripts/processor_yosys_tops.budget`
 with the reason it is not. An omission that is not recorded is refused; a
@@ -386,15 +390,80 @@ CONSUMERS = (
 #: added here and nowhere else.
 PROCESSOR_TOPS = (("protocol-processor", "syn/yosys/run.sh", "hdl"),)
 TOPS_BUDGET = REPO / "scripts/processor_yosys_tops.budget"
-_TOPS_ARRAY_RE = re.compile(r"\btops=\(([^)]*)\)", re.S)
+_TOPS_ARRAY_RE = re.compile(r"\btops=\(")
+
+
+def bash_array_words(text, pos):
+    """The words of a bash `( ... )` array literal whose body starts at `pos`,
+    read the way bash reads it: `#` at the start of a word opens a comment to
+    the end of the line; `'...'` is literal; `"..."` is literal except that a
+    backslash quotes a following `"`, `\\`, `$`, backquote or newline; an
+    unquoted backslash quotes the next character; and the literal ends at the
+    first `)` that is none of those. Nothing is expanded - the entries are
+    plain module names, and a `$var` here stays the word `$var`, which names
+    no declared module and so is refused rather than credited. Returns
+    (words, index after the `)`), or None when the literal is never closed.
+
+    The array cannot be ASKED like the other consumers: the script's only
+    expansion path elaborates every top through Yosys. Reading its raw text
+    with split() credited a commented-out top as elaborated, since `# KL_b`
+    became the words `#` and `KL_b` (PR #277 review)."""
+    words, word, in_word = [], [], False
+    n = len(text)
+    while pos < n:
+        c = text[pos]
+        if c in " \t\n":
+            if in_word:
+                words.append("".join(word))
+                word, in_word = [], False
+            pos += 1
+        elif c == "#" and not in_word:
+            nl = text.find("\n", pos)
+            pos = n if nl < 0 else nl + 1
+        elif c == ")":
+            if in_word:
+                words.append("".join(word))
+            return words, pos + 1
+        elif c == "'":
+            end = text.find("'", pos + 1)
+            if end < 0:
+                return None
+            word.append(text[pos + 1:end])
+            in_word, pos = True, end + 1
+        elif c == '"':
+            in_word, pos = True, pos + 1
+            while pos < n and text[pos] != '"':
+                if text[pos] == "\\" and pos + 1 < n and text[pos + 1] in '"\\$`\n':
+                    if text[pos + 1] != "\n":
+                        word.append(text[pos + 1])
+                    pos += 2
+                else:
+                    word.append(text[pos])
+                    pos += 1
+            if pos >= n:
+                return None
+            pos += 1
+        elif c == "\\":
+            if pos + 1 >= n:
+                return None
+            if text[pos + 1] != "\n":
+                word.append(text[pos + 1])
+                in_word = True
+            pos += 2
+        else:
+            word.append(c)
+            in_word, pos = True, pos + 1
+    return None
 
 
 def parse_tops_array(text):
-    """The names in a bash `tops=( ... )` array, or None when there is none."""
+    """The names in a bash `tops=( ... )` array as bash would run them, or
+    None when there is no such array or it is never closed."""
     m = _TOPS_ARRAY_RE.search(text)
     if m is None:
         return None
-    return set(m.group(1).split())
+    parsed = bash_array_words(text, m.end())
+    return None if parsed is None else set(parsed[0])
 
 
 def declared_modules(text):
@@ -446,7 +515,7 @@ def processor_tops_audit():
         tops = parse_tops_array(path.read_text(errors="replace"))
         if tops is None:
             rows.append((sub, script, set(), set(), [], [], [],
-                         f"{sub}/{script} carries no tops=( ... ) array"))
+                         f"{sub}/{script} carries no closed tops=( ... ) array"))
             continue
         declared = set()
         for src in sorted(root.rglob("*.sv")):
@@ -820,6 +889,49 @@ def selftest():
        f"got {tops}")
     ck("a script without a tops array is told apart from an empty one",
        parse_tops_array("set -eu\nfor t in a b; do :; done\n") is None)
+    # THE ARRAY IS READ AS BASH READS IT. The fixture below is the PR #277
+    # review's: split() on the raw body returned `#`, `KL_a`, `KL_b`, bash runs
+    # only KL_a, and the commented-out top passed as covered. Each fixture's
+    # answer is known by construction, and bash itself is the oracle for all
+    # of them (the literals are constants here; the processor's script is
+    # never run, because its expansion path is Yosys).
+    bash_fixtures = (
+        ("a commented-out top is not covered: the review's fixture",
+         "tops=(KL_a\n # KL_b\n)\n", {"KL_a"}),
+        ("a quoted name is unquoted and covered",
+         "tops=('KL_a' \"KL_b\")\n", {"KL_a", "KL_b"}),
+        ("an inline comment after a name runs to the end of its line only",
+         "tops=(KL_a # KL_b retired\n KL_c)\n", {"KL_a", "KL_c"}),
+        ("a `#` that does not start a word is not a comment, quoted or bare",
+         "tops=(\"KL_a#x\" 'KL_b#y' KL_c#z)\n", {"KL_a#x", "KL_b#y", "KL_c#z"}),
+        ("a `)` inside a comment or quotes does not close the array",
+         "tops=(KL_a # (was KL_b)\n 'KL_c)' KL_d)\n", {"KL_a", "KL_c)", "KL_d"}),
+    )
+    for name, fixture, want in bash_fixtures:
+        got = parse_tops_array(fixture)
+        ck(name, got == want, f"got {got}")
+    fx_tops = parse_tops_array(bash_fixtures[0][1])
+    ck("the commented-out top is refused as unrecorded, not credited",
+       compare_tops(fx_tops, {"KL_a", "KL_b"}, {}) == (["KL_b"], []),
+       f"got {compare_tops(fx_tops, {'KL_a', 'KL_b'}, {})}")
+    fx_row = ("protocol-processor", "syn/yosys/run.sh", fx_tops, {"KL_a", "KL_b"},
+              [], *compare_tops(fx_tops, {"KL_a", "KL_b"}, {}), None)
+    rc, lines = verdict(cl, need, [Row("fixture complete list", "ok", [], [], None)],
+                        [fx_row])
+    ck("the commented-out top reaches the verdict as TOPS DRIFT and exit 1",
+       rc == 1 and any(l.startswith("TOPS DRIFT") and "KL_b" in l for l in lines),
+       f"rc {rc}: {lines}")
+    oracle = []
+    for name, fixture, want in bash_fixtures:
+        run = subprocess.run(["bash", "-c", fixture + 'printf "%s\\n" "${tops[@]}"'],
+                             capture_output=True, text=True)
+        said = set(run.stdout.splitlines()) if run.returncode == 0 else None
+        if said != want:
+            oracle.append(f"{name}: bash said {said}, the fixture expects {want}")
+    ck("bash itself reads every fixture the way the parser does",
+       not oracle, "; ".join(oracle))
+    ck("an array that is never closed is refused, not read to the end of the file",
+       parse_tops_array("tops=(KL_a\n # KL_b)\n") is None)
     declared = declared_modules(
         "package p_pkg; endpackage\nmodule KL_a; endmodule\n"
         "interface bus_if; endinterface\n  module KL_new #(parameter W=1)(); endmodule\n")

--- a/scripts/check_soc_sources.py
+++ b/scripts/check_soc_sources.py
@@ -22,17 +22,53 @@ top, and 55/55 green - and three parallel Vivado runs all died on it.
 
 This gate closes the gap in under a second, with no toolchain at all.
 
+WHAT IT MEASURES, AND HOW IT READS. Both sides of the comparison are read the
+way the tools that consume them read them, because the first version read
+both as text and missed a real defect on each side:
+
+  * The RTL side is `instantiations()`: every instantiation shape the front
+    ends accept - at ANY indentation (the tree has one at column 0,
+    `traffic_class_map` in `traffic_classifier.sv`, and a regex that needed
+    two leading spaces walked past it), tab-indented, `X #(` with or without
+    the space, and an arrayed instance `X u [1:0] (`. Comments are blanked
+    first, so a commented-out instantiation is not one. Every
+    `include`d body is spliced in the way the preprocessor does, so an
+    instantiation living in a header is seen. This first hop is what
+    `scripts/check_rtl_source_lists.py` imports and walks transitively; a
+    hole here is a hole in the whole closure, which is why it lives here once.
+  * The Vivado side is `vivado_sources()`: the `_MILAN_DATAPATH_SOURCES`
+    literal and the source-path strings registered beside it, read through
+    `ast` - the tree Python evaluates, in which a comment does not exist. A
+    regex over the file's text counted a commented-out row as a registered
+    source; three files left the list that way with this gate green.
+
 Usage:
-    python3 scripts/check_soc_sources.py          # gate (exit 1 on a miss)
-    python3 scripts/check_soc_sources.py --list   # show the resolved sets
+    python3 scripts/check_soc_sources.py             # gate (exit 1 on a miss)
+    python3 scripts/check_soc_sources.py --list      # show the resolved sets
+    python3 scripts/check_soc_sources.py --selftest  # fixture arms
+
+Exit 0 = every instantiated module is registered and every registered file
+         exists. Exit 1 = a finding. Exit 2 = a side could not be read.
 """
+import ast
 import re
 import sys
+import tempfile
+from functools import lru_cache
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 DATAPATH = REPO / "hdl/milan/milan_datapath.sv"
 SOC = REPO / "sw/litex/milan_soc.py"
+#: the list literal in milan_soc.py that `add_source` walks
+SOC_LIST = "_MILAN_DATAPATH_SOURCES"
+
+#: Trees a source list may legitimately draw from, and where a `include is
+#: looked up. The vendored AXI-stream RTL is here because every consumer must
+#: carry it too. check_rtl_source_lists.py imports this rather than keeping a
+#: second copy.
+SEARCH_ROOTS = ("hdl", "protocol-processor/hdl", "gptp-processor/hdl",
+                "third_party/verilog-axis/rtl")
 
 #: instantiation names we care about - project RTL, not language keywords or
 #: generate-block labels. Anything matching a project prefix must be a real
@@ -42,35 +78,318 @@ PREFIXES = ("KL_", "avtp_", "adp_", "acmp_", "aaf_", "traffic_", "ptp_",
             "cdc_", "tcam", "rx_", "tx_", "axis_", "timestamp_",
             "ethernet_", "event_", "milan_")
 
-#: `X #(...) inst (` or `X inst (` at an indent (module instantiation shape)
-INST_RE = re.compile(r"^\s{2,}([A-Za-z_]\w*)\s+(?:#\s*\(|\w+\s*\()", re.M)
-SRC_RE = re.compile(
-    r'"((?:(?:protocol|gptp)-processor/)?hdl/[^"]*/([A-Za-z_]\w*)\.sv)"')
+#: The instantiation shapes a front end accepts: `X #(`, `X u (`, `X u [N:0] (`
+#: at ANY indentation. Keywords that share the shape (`else if (`, `module X (`)
+#: are matched too and discarded by the callers, which only keep names a
+#: source declares or a project prefix claims; a shape the regex does not see
+#: is a module no consumer is told about, so the net is wide on purpose.
+INST_RE = re.compile(
+    r"^[ \t]*([A-Za-z_]\w*)"                         # the module, any indent
+    r"(?:\s*#\s*\("                                   # `X #(`  (space optional)
+    r"|\s+[A-Za-z_]\w*\s*(?:\[[^\]]*\]\s*)*\()",      # `X u (`, `X u [1:0] (`
+    re.M)
+INCLUDE_RE = re.compile(r'^[ \t]*`include\s+"([^"]+)"', re.M)
+_COMMENT_OR_STRING_RE = re.compile(
+    r'"(?:\\.|[^"\\\n])*"|//[^\n]*|/\*.*?\*/', re.S)
+#: a whole string that is a repository-relative source path
+_SOURCE_PATH_RE = re.compile(r"^(?:[\w.-]+/)+[\w.-]+\.(?:sv|v)$")
 
 
-def instantiated():
-    text = DATAPATH.read_text()
-    return {m for m in INST_RE.findall(text) if m.startswith(PREFIXES)}
+def strip_comments(text):
+    """Blank every comment, keeping the line structure so line-anchored
+    patterns still see the same lines. String literals are stepped over, not
+    blanked: a `//` inside one is not a comment, and an `include names its
+    file in one."""
+    def blank(match):
+        token = match.group(0)
+        if token.startswith('"'):
+            return token
+        return re.sub(r"[^\n]", " ", token)
+    return _COMMENT_OR_STRING_RE.sub(blank, text)
 
 
-def registered():
-    return {name: path for path, name in SRC_RE.findall(SOC.read_text())}
+@lru_cache(maxsize=None)
+def _under_roots(name):
+    """The first file under SEARCH_ROOTS whose path ends with `name`, so an
+    include with a directory part (`gen/x.svh`) finds a `gen/` directory."""
+    for root in SEARCH_ROOTS:
+        base = REPO / root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob(Path(name).name)):
+            if path.is_file() and path.as_posix().endswith("/" + name):
+                return path
+    return None
+
+
+def resolve_include(name, includer):
+    """The file `include "name"` opens: beside the includer first, then the
+    search roots. None when no file answers."""
+    beside = includer.parent / name
+    if beside.is_file():
+        return beside
+    return _under_roots(name)
+
+
+def spliced(path, _seen=None):
+    """(text, included, unresolved): the unit's text as the front end sees it.
+
+    Every `include body is spliced in at its line, recursively, each file at
+    most once (a guarded header including itself ends); comments and strings
+    are blanked. `included` lists the files spliced, `unresolved` the include
+    names no file answered to - the caller decides what that means.
+    """
+    seen = set() if _seen is None else _seen
+    seen.add(path.resolve())
+    included, unresolved = [], []
+
+    def splice(match):
+        name = match.group(1)
+        target = resolve_include(name, path)
+        if target is None:
+            unresolved.append(name)
+            return ""
+        if target.resolve() in seen:
+            return ""
+        included.append(target)
+        body, inc, bad = spliced(target, seen)
+        included.extend(inc)
+        unresolved.extend(bad)
+        return body
+
+    text = INCLUDE_RE.sub(splice, strip_comments(path.read_text(errors="replace")))
+    return text, included, unresolved
+
+
+def instantiations(path):
+    """Module names instantiated by the unit in `path` - includes followed,
+    comments ignored. The FIRST HOP; check_rtl_source_lists.py walks it."""
+    text, _included, _unresolved = spliced(Path(path))
+    return set(INST_RE.findall(text))
+
+
+def instantiated(datapath=DATAPATH):
+    return {m for m in instantiations(datapath) if m.startswith(PREFIXES)}
+
+
+def vivado_sources(soc=SOC):
+    """(paths, derived, why): the source paths milan_soc.py registers, read the
+    way Python reads the file.
+
+    `paths` are the string constants that are repository-relative source
+    paths: the rows of the `_MILAN_DATAPATH_SOURCES` literal and the
+    conditional registrations beside it (`srcs.append("...KL_pcm_tx.sv")`).
+    A comment is not in the tree Python evaluates, so a commented-out row is
+    not a row. `derived` names the starred calls inside the literal
+    (`*_pp_sources()`); their expansion belongs to the caller. `why` is set,
+    and the others None, when the file or the list cannot be read.
+    """
+    soc = Path(soc)
+    try:
+        tree = ast.parse(soc.read_text(), filename=str(soc))
+    except (OSError, SyntaxError) as exc:
+        return None, None, f"{soc.name}: {exc}"
+    literal = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == SOC_LIST for t in node.targets):
+            literal = node.value
+    if not isinstance(literal, ast.List):
+        return None, None, f"{soc.name}: no `{SOC_LIST} = [...]` list literal"
+    derived = []
+    for elt in literal.elts:
+        if isinstance(elt, ast.Starred) and isinstance(elt.value, ast.Call):
+            derived.append(ast.unparse(elt.value.func))
+        elif not (isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                  and _SOURCE_PATH_RE.match(elt.value)):
+            return None, None, (f"{soc.name}:{elt.lineno}: {SOC_LIST} holds an "
+                                f"entry that is neither a source path nor a "
+                                f"derived expansion")
+    paths = []
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and _SOURCE_PATH_RE.match(node.value) and node.value not in paths):
+            paths.append(node.value)
+    return paths, derived, None
+
+
+def registered(soc=SOC):
+    """({module-name-by-stem: path}, None), or (None, why)."""
+    paths, _derived, why = vivado_sources(soc)
+    if paths is None:
+        return None, why
+    return {Path(p).stem: p for p in paths}, None
+
+
+def audit(datapath=DATAPATH, soc=SOC):
+    """(inst, reg, missing, gone, why) - the whole comparison, injectable so
+    the self-test grades copies rather than editing the tree."""
+    inst = instantiated(datapath)
+    reg, why = registered(soc)
+    if reg is None:
+        return inst, {}, [], [], why
+    missing = sorted(inst - set(reg))
+    # A source file that no longer exists is the mirror-image defect: Vivado
+    # would fail on a missing file rather than a missing module.
+    gone = sorted(p for p in reg.values() if not (REPO / p).is_file())
+    return inst, reg, missing, gone, None
+
+
+def selftest():
+    """Fixture arms, each known by construction and each red when the defect
+    it guards is put back (the two-space regex, the text-regex list reader)."""
+    failures = checks = 0
+
+    def ck(name, ok, detail=""):
+        nonlocal failures, checks
+        checks += 1
+        if ok:
+            print(f"[PASS] {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] {name}{': ' + detail if detail else ''}")
+
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        # 1. the instantiation shapes the front ends accept, and the lines
+        #    that share the shape without being one
+        (d / "shapes.sv").write_text(
+            "module KL_top #(parameter W = 1) (\n  input logic clk\n);\n"
+            "  KL_two u_two (.clk(clk));\n"
+            "KL_col0 u_col0 (.clk(clk));\n"
+            "\tKL_tab u_tab (.clk(clk));\n"
+            "  KL_param #(.W(W)) u_p (.clk(clk));\n"
+            "  KL_tight#(.W(W)) u_t (.clk(clk));\n"
+            "  KL_arr u_arr [1:0] (.clk(clk));\n"
+            "  KL_arr2 u_arr2[3:0](.clk(clk));\n"
+            "  KL_split\n    #(.W(W)) u_s (.clk(clk));\n"
+            "  // KL_ghost u_g (.clk(clk));\n"
+            "  /* KL_ghost2 u_g2 (.clk(clk)); */\n"
+            "  /*\n  KL_ghost3 u_g3 (.clk(clk));\n  */\n"
+            "  assign x = KL_func(clk);\n"
+            "  KL_task(clk);\n"
+            "  initial $display(\"KL_str u_s (\");\n"
+            "endmodule\n")
+        got = instantiations(d / "shapes.sv")
+        ck("a two-space instantiation is seen", "KL_two" in got, f"got {sorted(got)}")
+        ck("a column-0 instantiation is seen", "KL_col0" in got, f"got {sorted(got)}")
+        ck("a tab-indented instantiation is seen", "KL_tab" in got, f"got {sorted(got)}")
+        ck("a parameterised instantiation is seen with or without the space before #",
+           {"KL_param", "KL_tight"} <= got, f"got {sorted(got)}")
+        ck("an arrayed instance is seen", {"KL_arr", "KL_arr2"} <= got, f"got {sorted(got)}")
+        ck("an instantiation whose #( starts on the next line is seen", "KL_split" in got,
+           f"got {sorted(got)}")
+        ck("a commented-out instantiation is not one",
+           not {"KL_ghost", "KL_ghost2", "KL_ghost3"} & got, f"got {sorted(got)}")
+        ck("a function call, a task call and a string are not instantiations",
+           not {"KL_func", "KL_task", "KL_str", "KL_top"} & got, f"got {sorted(got)}")
+
+        # 2. `include: the body is part of the unit, recursively, once
+        (d / "gen").mkdir()
+        (d / "top.sv").write_text(
+            "module KL_t;\n`include \"body.svh\"\n`include \"gen/shape.svh\"\n"
+            "`include \"missing.svh\"\nendmodule\n")
+        (d / "body.svh").write_text(
+            "`include \"nested.svh\"\nKL_inc u_inc (.a(a));\n")
+        (d / "nested.svh").write_text(
+            "`include \"body.svh\"\n  KL_nested u_n (.a(a));\n")
+        (d / "gen" / "shape.svh").write_text("  KL_gen u_g (.a(a));\n")
+        got = instantiations(d / "top.sv")
+        _text, included, unresolved = spliced(d / "top.sv")
+        ck("an instantiation inside an included body is seen", "KL_inc" in got,
+           f"got {sorted(got)}")
+        ck("a nested include is followed and a header including itself ends",
+           "KL_nested" in got and len(included) == 3,
+           f"got {sorted(got)}, spliced {[p.name for p in included]}")
+        ck("an include with a directory part resolves beside the includer",
+           "KL_gen" in got, f"got {sorted(got)}")
+        ck("an include no file answers to is reported by name",
+           unresolved == ["missing.svh"], f"got {unresolved}")
+        ck("a header under the search roots resolves from anywhere",
+           resolve_include("gen/adp_shape_defaults.svh", d / "top.sv") is not None
+           and resolve_include("ethernet_events.svh", d / "top.sv") is not None)
+
+        # 3. the Vivado list is read as Python reads it
+        (d / "soc.py").write_text(
+            '"""Not a list: hdl/a/KL_doc.sv is prose."""\n'
+            "def _pp_sources():\n    return []\n"
+            f"{SOC_LIST} = [\n"
+            "    *_pp_sources(),\n"
+            '    "hdl/a/KL_live.sv",  # "hdl/a/KL_trailing.sv"\n'
+            '    # "hdl/a/KL_dead.sv",\n'
+            '    "third_party/verilog-axis/rtl/axis_fifo.v",\n'
+            "]\n"
+            "def add(platform, cond):\n"
+            f"    srcs = list({SOC_LIST})\n"
+            "    if cond:\n"
+            '        srcs.append("hdl/a/KL_cond.sv")\n'
+            '    print("see hdl/a/KL_msg.sv for details")\n'
+            "    return srcs\n")
+        paths, derived, why = vivado_sources(d / "soc.py")
+        ck("a live row is a row", paths is not None and "hdl/a/KL_live.sv" in paths, f"{paths} {why}")
+        ck("a commented-out row is not a row",
+           paths is not None and "hdl/a/KL_dead.sv" not in paths, f"{paths}")
+        ck("a path in a trailing comment or a docstring is not a row",
+           paths is not None and not {"hdl/a/KL_trailing.sv", "hdl/a/KL_doc.sv"} & set(paths),
+           f"{paths}")
+        ck("a conditional registration beside the list is read",
+           paths is not None and "hdl/a/KL_cond.sv" in paths, f"{paths}")
+        ck("a path inside a message string is not a registration",
+           paths is not None and not any("KL_msg" in p for p in paths), f"{paths}")
+        ck("the derived half is reported as the starred call, not guessed from syntax",
+           derived == ["_pp_sources"], f"{derived}")
+        ck("a vendored .v entry counts as a source", paths is not None
+           and "third_party/verilog-axis/rtl/axis_fifo.v" in paths, f"{paths}")
+        (d / "nolist.py").write_text("x = 1\n")
+        ck("a file without the list is refused, not read as empty",
+           vivado_sources(d / "nolist.py")[0] is None)
+        (d / "badrow.py").write_text(f"{SOC_LIST} = ['hdl/a/b.sv', 42]\n")
+        ck("a row that is neither a path nor a derived expansion is refused",
+           vivado_sources(d / "badrow.py")[0] is None)
+
+        # 4. the live tree, then the two mutations the round-2 review ran
+        inst, reg, missing, gone, why = audit()
+        ck("the live datapath's first hop is registered and present",
+           why is None and not missing and not gone and len(inst) >= 30,
+           f"missing {missing} gone {gone} why {why} ({len(inst)} modules)")
+        soc_text = SOC.read_text()
+        row = next((l for l in soc_text.splitlines()
+                    if '"hdl/common/cdc_pulse.sv"' in l), None)
+        mutated = soc_text.replace(row, "#" + row, 1) if row else soc_text
+        (d / "milan_soc.py").write_text(mutated)
+        _i, _r, m2, _g, w2 = audit(soc=d / "milan_soc.py")
+        ck("commenting out the live row that carries cdc_pulse.sv is a MISSING SOURCE",
+           row is not None and w2 is None and "cdc_pulse" in m2,
+           f"row {row!r} missing {m2} why {w2}")
+        dp = DATAPATH.read_text()
+        end = dp.rfind("endmodule")
+        (d / "milan_datapath.sv").write_text(
+            dp[:end] + "\nKL_zz_col0 u_zz_col0 ();\n" + dp[end:])
+        ck("a column-0 instantiation added to the live datapath reaches the first hop",
+           "KL_zz_col0" in instantiated(d / "milan_datapath.sv"))
+
+    print(f"\n{checks} checks: {checks - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
 
 
 def main():
-    inst = instantiated()
-    reg = registered()
-    missing = sorted(inst - set(reg))
+    args = sys.argv[1:]
+    if "--selftest" in args:
+        return selftest()
+    inst, reg, missing, gone, why = audit()
+    if why is not None:
+        print(f"CANNOT READ THE VIVADO LIST: {why}")
+        return 2
+    if not inst:
+        print("CANNOT READ milan_datapath: no instantiation found, and an empty "
+              "first hop would prove nothing")
+        return 2
 
-    if "--list" in sys.argv[1:]:
+    if "--list" in args:
         print(f"instantiated by milan_datapath ({len(inst)}):")
         for m in sorted(inst):
             print(f"   {'ok ' if m in reg else 'MISS'}  {m}")
         print(f"\nregistered for Vivado ({len(reg)})")
-
-    # A source file that no longer exists is the mirror-image defect: Vivado
-    # would fail on a missing file rather than a missing module.
-    gone = sorted(p for p in reg.values() if not (REPO / p).is_file())
 
     if missing or gone:
         for m in missing:

--- a/scripts/processor_yosys_tops.budget
+++ b/scripts/processor_yosys_tops.budget
@@ -1,0 +1,18 @@
+# Modules declared under protocol-processor/hdl that the processor's OWN Yosys
+# portability gate (protocol-processor/syn/yosys/run.sh, the `tops` array) does
+# not elaborate as a top, by NAME. Read by scripts/check_rtl_source_lists.py.
+#
+# Its hdl/README.md rule 2 says every module must elaborate; these six are
+# drift at pin 3770ae02, not helper-module exceptions - each elaborates when
+# asked. The fix is upstream (name them in the tops array); the pin bump that
+# brings it in deletes the line here, because a name that has become a top is
+# refused as STALE, and an omission that is not on this list is refused
+# outright. Entries are never added to hide new drift.
+#
+# <module>  <reason>
+KL_acmp_nvm_shadow      drift at pin 3770ae02: declared in hdl/acmp, absent from the tops array
+KL_mrp_strip            drift at pin 3770ae02: declared in hdl/top, absent from the tops array
+KL_pp_dispatch_fifo     drift at pin 3770ae02: declared in hdl/packet_engine, absent from the tops array
+KL_srp_admission        drift at pin 3770ae02: declared in hdl/srp, absent from the tops array
+KL_srp_top              drift at pin 3770ae02: declared in hdl/srp, absent from the tops array
+protocol_processor_top  drift at pin 3770ae02: declared in hdl/top, absent from the tops array

--- a/sw/litex/milan_soc.py
+++ b/sw/litex/milan_soc.py
@@ -516,9 +516,11 @@ _MILAN_DATAPATH_SOURCES = [
     "hdl/milan/KL_pp_shadow.sv", "hdl/milan/KL_pp_maap_shim.sv",
     # the gPTP plane (#114): milan_datapath instantiates KL_gptp_shadow and
     # KL_gptp_txstamp under GPTP_PLANE_EN_P (product default ON), so Vivado must see
-    # the wrappers and the gptp-processor engine they wrap. Order mirrors the
-    # authoritative GPTP_SRCS in tb/verilator/milan_dp/Makefile: the package
-    # first, its importers after.
+    # the wrappers and the gptp-processor engine they wrap. No copy of this
+    # list is authoritative - not this one, and not GPTP_SRCS in the milan_dp
+    # Verilator Makefile, which this comment once called so: the RTL is, and
+    # scripts/check_rtl_source_lists.py checks every copy against the engine
+    # files the datapath really reaches. The package first, its importers after.
     "gptp-processor/hdl/ucpu/gptp_ucpu_pkg.sv", "gptp-processor/hdl/ucpu/KL_gptp_ucpu.sv",
     "gptp-processor/hdl/wire/KL_gptp_rx_parser.sv", "gptp-processor/hdl/wire/KL_gptp_tx_slot.sv",
     "gptp-processor/hdl/common/KL_gptp_timer.sv", "gptp-processor/hdl/top/KL_gptp_engine.sv",

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -123,6 +123,15 @@ tops=(
   "KL_nvm_backend_sizer|$R/syn/ooc/sizing/KL_nvm_backend_sizer.sv"
 )
 
+# Print bash's own expansion of DP_SRCS and exit. scripts/check_rtl_source_lists.py
+# grades what this script will really read, not a model of this file: a
+# recogniser accepts what it has modelled and bash accepts something else
+# (syn/ooc/dp_srcs.py records four escapes that worked exactly that way).
+if [ "${1:-}" = "--emit-dp" ]; then
+  printf '%s\n' $DP_SRCS
+  exit 0
+fi
+
 RECORD=0
 if [ "${1:-}" = "--record-rom-digests" ]; then RECORD=1; shift; fi
 want=("$@")

--- a/tb/verilator/hostplane/Makefile
+++ b/tb/verilator/hostplane/Makefile
@@ -137,14 +137,20 @@ SRCS = $(PP_SRCS) $(GPTP_SRCS) $(C)/ethernet_packet_pkg.sv $(C)/axi_stream_if.sv
 
 .PHONY: all run build clean banner print-srcs
 
+# PINNED, because getting this wrong is invisible until CI: make takes the
+# FIRST target in the file as its default goal, so adding print-srcs above
+# `all` silently turned a bare `make` into a source-list dump - the suite ran
+# nothing and the tally gate reported NOCOUNT rather than a failure.
+.DEFAULT_GOAL := all
+
+
+all: run
+
 # The list this suite will really compile, printed rather than described, so
 # scripts/check_rtl_source_lists.py grades bash's own expansion instead of a
 # model of it. Paths are relative to this directory.
 print-srcs:
 	@echo $(SRCS)
-
-
-all: run
 
 banner:
 	@echo "======================================================================"

--- a/tb/verilator/hostplane/Makefile
+++ b/tb/verilator/hostplane/Makefile
@@ -135,7 +135,14 @@ SRCS = $(PP_SRCS) $(GPTP_SRCS) $(C)/ethernet_packet_pkg.sv $(C)/axi_stream_if.sv
        $(RTL_DIR)/common/csr/milan_csr.sv \
        $(RTL_DIR)/milan/milan_datapath.sv
 
-.PHONY: all run build clean banner
+.PHONY: all run build clean banner print-srcs
+
+# The list this suite will really compile, printed rather than described, so
+# scripts/check_rtl_source_lists.py grades bash's own expansion instead of a
+# model of it. Paths are relative to this directory.
+print-srcs:
+	@echo $(SRCS)
+
 
 all: run
 

--- a/tb/verilator/milan_dp/Makefile
+++ b/tb/verilator/milan_dp/Makefile
@@ -153,6 +153,7 @@ SRCS = $(PP_SRCS) $(GPTP_SRCS) $(C)/ethernet_packet_pkg.sv $(C)/axi_stream_if.sv
        $(RTL_DIR)/ieee1722/aaf/KL_media_adv.sv \
        $(RTL_DIR)/common/cdc_pair_fifo.sv \
        $(RTL_DIR)/common/eth_event_counter/ethernet_events.sv \
+       $(RTL_DIR)/common/eth_event_counter/event_counter.sv \
        $(RTL_DIR)/common/csr/milan_csr.sv \
        $(RTL_DIR)/milan/milan_datapath.sv
 CPP  = sim_main.cpp


### PR DESCRIPTION
> [!IMPORTANT]
> **Post-review correction (2026-08-28, head `823bdc99`).** The source closure no longer depends on project naming prefixes: it follows every declared module instantiation plus package and interface/modport dependencies, including the processor submodules. The Vivado consumer now combines literal sources with the real `pp_srcs.py` expansion. Result: 108 files, 5/5 consumers complete, self-test 12/12. Earlier 61-file and 7-arm figures below are superseded.

Closes #251

Rule 3 of the #248 contract. **Stacked on #276 (Rule 2), which is stacked on #275 (Rule 1) — review in that order; this PR's diff is incremental.**

## What changed

| Area | Change |
|---|---|
| Guide | Rule 3 section in `docs/development/CODE_QUALITY.md`: the single-definition rule, the independent-oracle exception, the classified duplication inventory, worked example, review checklist. |
| Consolidation | `scripts/check_rtl_source_lists.py` — new gate. The RTL is the authority; all five source lists are derived consumers. |
| Emit paths | `syn/yosys/ooc.sh --emit-dp` and a `print-srcs` target in `tb/verilator/hostplane/Makefile`, so those two consumers can be *asked* instead of parsed. |
| Named constant | `milan_datapath` passed `16'h88F7` to `ptp_ts_top`'s `ETH_TYPE` while already importing the package that defines it as `ETH_TYPE_PTP`. |
| Completeness | `tb/verilator/milan_dp` now lists `event_counter.sv` explicitly instead of relying on a `+incdir+` side effect. |
| CI | The gate and its self-test run in `docs.yml`, beside the Vivado source-list gate. |

## The duplication, and the receipts

The set of files needed to compile `milan_datapath` was written out five times. Exactly one was guarded. The other four cost three broken Verilator suites the moment Rule 1 extracted a module — one failure per list nobody had told.

The gate walks the module closure of `milan_datapath` through the sources (transitively) and checks all five consumers carry every file in it: **61 files, 5 of 5 consumers.**

Two properties make it a source-of-truth gate and not a sixth copy:

- **It never checks one list against another.** All five could agree and all five be wrong. The first-hop instantiation parser is *imported* from `scripts/check_soc_sources.py` rather than re-written — a gate about single sources of truth that forked its own parser would refute itself.
- **It asks each consumer, it does not parse it.** A recogniser accepts what it has modelled; `make` and `bash` accept something else, and `syn/ooc/dp_srcs.py` records four escapes that worked exactly that way. Each consumer prints the expansion it will really use.

The unit is the **file**, not the module, because that is what a source list carries and one file may declare several modules (`KL_aaf_latency_chain` lives inside `KL_aaf_latency_taps.sv`). A consumer whose tooling is absent is reported `SKIPPED` by name and the verdict says it is not covered.

## The oracle exception, proven by mutation

`tb/verilator/aaf_latency_tap_bank` takes every LTAP word offset and field split from the register map at base `0x870`, not from the packing expression in the RTL. Swapping the `max` and `last` halves of one word in `KL_aaf_latency_tap_bank.sv` makes the harness **fail** — on the check where a sample's maximum and its last value genuinely differ, which is the check that can see the swap. A harness that had imported the DUT's word order would have stayed green. The mutation was applied, observed, and reverted; it is not in the diff.

## Inventory

57 hexadecimal literals appear in four or more first-party files. Classified: drift where a named definition already exists (fixed here for the one site whose module already imports the package); structural rails like `0xFFFF` (not duplication); and deliberate independent oracles in tests and wire-truth tools (kept, with the reason).

Three further sites spell the same EtherTypes raw but do **not** import the package. Adding an import to three modules changes their compile dependencies, so that is a separate change with its own verification rather than a rider here.

## Evidence

- `scripts/check_rtl_source_lists.py` — **OK**, 61 files, 5 of 5 consumers.
- `scripts/check_rtl_source_lists.py --selftest` — **7/7**, including a live mutation that removes one file from each real consumer list and requires every one to be reported.
- `scripts/lint_rtl.py --check` — PASS, 99 ≤ ratchet 99.
- `syn/yosys/run.sh --mode elaborate --top milan_datapath` — PASS; tied-input PASS; TAP-PURITY PASS.
- `scripts/ci_events.py --check` — OK (222 contract items); `--selftest` — PASS (224 arms).
- `docs_check` 0 findings / `gen_toc --check` OK / `check_doc_paths` OK.
- `scripts/check_soc_sources.py` — OK.

## Not covered

- `tsn_fuzz` declared SKIP (tsn-gen absent); builder gate 23h pre-existing on this host and on a pristine `dev` checkout. Neither is touched by this branch.
- No Vivado run.
