### PR TITLE
[Code quality] Rule 4: put the unit in the name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,6 +100,15 @@ jobs:
           python3 scripts/check_rtl_source_lists.py
           python3 scripts/check_rtl_source_lists.py --selftest
 
+      # Rule 4 ratchet: a boundary port whose own //! comment names a unit the
+      # identifier does not carry. The three exclusion classes and the
+      # false-positive measurement behind them are in the script; the count may
+      # only go down.
+      - name: Boundary-unit naming ratchet
+        run: |
+          python3 scripts/measure_naming.py --check
+          python3 scripts/measure_naming.py --selftest
+
       # CI event and SHA contract gate (#174, #181): the four workflow files
       # and docs/testing/CI_WORKFLOWS.md must agree on the triggers, the cron
       # time, the public check names, cancel-in-progress and the one-SHA rule

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,10 @@ lane-per-worktree, every change grows the test suite, and nothing merges on
 - Ports documented **inline with `//!`** — the port list IS the spec.
 - Naming: `_r` registered, `_w` wire/comb, `_p` one-cycle pulse, `_S` FSM
   states, `_C`/`_P` params. Named `always_ff`/`always_comb` blocks
-  (`begin : name … end : name`).
+  (`begin : name … end : name`). A boundary whose value has a unit carries it
+  in the name beside these suffixes (`ring_len_bytes_i`, `timeout_cyc_c`);
+  the qualifier table is Rule 4 of the
+  [code quality guide](docs/development/CODE_QUALITY.md#rule-4-use-intention-revealing-names-and-explicit-units).
 - Reset: synchronous, active-low `rst_n`, every register reset. 2-space
   indent.
 - CDC: only via the blessed primitives (`cdc_pulse`, `cdc_handshake`,

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -791,6 +791,9 @@ The evidence is the port's own `//!` comment. Those comments say what the value
 is — "Egress latency correction, ns", "hiCredit clamp, signed bytes" — and when
 the comment names a unit and the identifier does not, the unit is known and
 simply missing from the name. A reader can check any finding in one line.
+The converse is measured too, and is the worse finding: when the identifier
+carries a unit and the comment documents a different one, the name is not
+vague, it is wrong.
 
 [`scripts/measure_naming.py`](../../scripts/measure_naming.py) does that scan.
 
@@ -821,15 +824,15 @@ processor reading as nearly clean can be told apart from one that is merely
 undocumented — the gPTP processor's 1 candidate sits beside its
 22 undocumented ports:
 
-| Tree | Files | Ports | Parameters | Documented | Undocumented | Unit in the name | Unit in the comment | Excluded | Candidates |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| superproject | 69 | 1791 | 263 | 1779 | 275 | 99 | 315 | 232 | 83 |
-| protocol-processor | 42 | 1548 | 270 | 1698 | 120 | 99 | 181 | 161 | 20 |
-| gptp-processor | 6 | 120 | 6 | 104 | 22 | 7 | 20 | 19 | 1 |
-| total | 117 | 3459 | 539 | 3581 | 417 | 205 | 516 | 412 | 104 |
+| Tree | Files | Ports | Parameters | Documented | Undocumented | Unit in the name | Unit in the comment | Excluded | Named for another unit | Candidates |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| superproject | 69 | 1791 | 263 | 1779 | 275 | 99 | 320 | 232 | 5 | 88 |
+| protocol-processor | 42 | 1548 | 270 | 1698 | 120 | 99 | 182 | 161 | 1 | 21 |
+| gptp-processor | 6 | 120 | 6 | 104 | 22 | 7 | 20 | 19 | 0 | 1 |
+| total | 117 | 3459 | 539 | 3581 | 417 | 205 | 522 | 412 | 6 | 110 |
 
 **The false positives were measured before anything was gated**, because the
-naive form of this check is mostly noise: 516 declarations match a unit
+naive form of this check is mostly noise: 522 declarations match a unit
 word in their comment and 412 of them are not findings. Four exclusion
 classes, each printed in full by `--excluded` with its reason:
 
@@ -847,18 +850,53 @@ ordinal "second" count only in a unit context ("hold time, us", "1 second"),
 and a unit word joined by a hyphen into an identifier or an adjective
 (`P-RX-SLOT-BYTES`, "byte-identical", "cycle-count width") is prose.
 
-That leaves **104 candidates**. The residual set still holds judgement
-calls — `now_i` on a module whose entire subject is nanoseconds is arguable —
-so this ships as a ratchet, not a verdict.
+That leaves **110 candidates**, **6** of them named for a different unit
+than they document. The residual set still holds judgement calls — `now_i` on
+a module whose entire subject is nanoseconds is arguable — so this ships as a
+ratchet, not a verdict.
+
+**A wrong unit is a candidate too.** The first form of this tool stopped as
+soon as the identifier carried any unit token, so `timeout_bytes_i //!
+timeout in cycles` satisfied a cycles contract and fell out of the ratchet;
+review caught it. Units are now compared by family, defined once in the tool:
+
+| Family | Spellings, in a comment or as a `_`-delimited token |
+|---|---|
+| time | `ns`, `us`, `µs`, `ms`, `nsec`, `usec`, `msec`, `sec`, `second(s)`, `nanosecond(s)`, `microsecond(s)`, `millisecond(s)` |
+| bytes | `byte(s)`, `octet(s)` |
+| cycles | `cyc`, `cycle(s)`, `clock cycle(s)`, a counted `clocks` ("in clocks", "6250 clocks") |
+| frequency | `hz`, `khz`, `mhz`, `ghz`, `hertz` |
+| ratio | `ppb`, `ppm` |
+| rate | `bps`, `kbps`, `mbps`, `gbps`, `bits/s`, `bits per second`, `bytes per second` |
+| samples | `smp`, `sample(s)` |
+
+so `_ns` satisfies "nanoseconds" and `_cyc` satisfies "clock cycles". A
+unit-named boundary is a candidate when its comment documents a unit of
+measure and never names the name's family at all — nouns count, so "tone
+generator sample" confirms `tone_smp_i` — or when the comment states the
+value as "X per Y" and the name carries only Y: `DIV_US_P //! clk cycles per
+1 µs tick` is a cycle count named for the tick it produces. Comparing against
+the first documented word alone was measured and rejected: it would have
+recorded `MILAN_CLK_FREQ_HZ_P` because "ns" appears in the second sentence of
+its comment and "125 MHz" in the fourth. Of the exclusion classes, *noun* and
+*shape* carry over, because they say the comment documents no unit of measure
+and there is nothing to compare; *protocol-fixed* carries over because the
+name is not ours to change; *single-bit* does not, because it excused a unit
+that was missing from a port with no quantity, and a unit that is present and
+wrong is a false statement at any width — `go_ns_i //! start, in cycles` is a
+candidate.
 
 **The ratchet is keyed on identity, not a count.**
 [`scripts/naming.budget`](../../scripts/naming.budget) names every candidate as
 `path:module:port` — a processor entry as `submodule:path:module:port`, the
 `xvlog.budget` spelling, so the generated record is never read as a
 hand-written copy of a processor source list. A candidate may leave the list
-only by being renamed with
-its unit or by being removed; a port still declared under the same name whose
-comment has merely lost the unit word is refused as *stripped*. Review found
+only by being renamed with its unit or by being removed — or, for a name that
+already carries a unit, by a comment that now names that unit's family,
+because the tool cannot tell a conversion (`SETTLE_CYC_C //! clean-clock hold
+(~21 ms)`) from a contradiction and the diff can; a port still declared under
+the same name whose comment has merely lost the unit word is refused as
+*stripped*. Review found
 the count-only form of this ratchet could be paid down by deleting units from
 documentation — the opposite of the rule — and reported it as a lowering. No
 new identity may appear either, in any of the three trees; the arms inject one

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -853,7 +853,10 @@ so this ships as a ratchet, not a verdict.
 
 **The ratchet is keyed on identity, not a count.**
 [`scripts/naming.budget`](../../scripts/naming.budget) names every candidate as
-`path:module:port`. A candidate may leave the list only by being renamed with
+`path:module:port` — a processor entry as `submodule:path:module:port`, the
+`xvlog.budget` spelling, so the generated record is never read as a
+hand-written copy of a processor source list. A candidate may leave the list
+only by being renamed with
 its unit or by being removed; a port still declared under the same name whose
 comment has merely lost the unit word is refused as *stripped*. Review found
 the count-only form of this ratchet could be paid down by deleting units from

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -792,8 +792,9 @@ python3 scripts/measure_naming.py --check     # the ratchet
 ```
 
 **The false positives were measured before anything was gated**, because the
-naive form of this check is mostly noise. 180 of 1,757 ports match a unit word
-in their comment. Three exclusion classes account for 100 of them:
+naive form of this check is mostly noise. Across the superproject and both
+project-owned processor submodules, 408 of 3,491 ports match a unit word in
+their comment. Three exclusion classes account for 255 of them:
 
 | Excluded | Count | Reason |
 |---|---:|---|
@@ -806,7 +807,7 @@ already explicit in the SystemVerilog type, and "word" is used in this tree both
 as a count and as a noun for the value itself, so it cannot separate a missing
 unit from ordinary prose.
 
-That leaves **80 candidates**, down from 91 before the rename above. The
+That leaves **153 candidates**, down from 164 before the rename above. The
 residual set still contains judgement calls — `now_i` on a module whose entire
 subject is nanoseconds is arguable — so this ships as a **ratchet**
 (`scripts/naming.budget`), not a verdict. The count may not rise; a new

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -26,6 +26,8 @@ shape rather than guess at it.
 - **[Rule 2: prefer simple and explicit control flow](#rule-2-prefer-simple-and-explicit-control-flow)** -- The KISS rule, what "explicit" means for a SystemVerilog priority chain versus a host-side parser, the worked simplification that took one function from four levels of nesting to two, a real FSM and a real combinational mux read against the same rule, the measured hotspots with their dispositions, and the review checklist.
 - **[Measuring control flow](#measuring-control-flow)** -- What `scripts/measure_control_flow.py` counts in each language -- nesting and decision points in Python, priority resolved by source order in RTL -- exactly which files and blocks it scans and what it refuses, why no threshold is proposed, and what the tree actually measures today.
 - **[Rule 3: keep one source of truth without weakening test oracles](#rule-3-keep-one-source-of-truth-without-weakening-test-oracles)** -- The single-definition rule and the exception that keeps a test honest, the five RTL source lists that had one authority and four unguarded copies, the drift gate that now derives all of them from the RTL, and the mutation that proves an independent oracle is really independent.
+- **[Rule 4: use intention-revealing names and explicit units](#rule-4-use-intention-revealing-names-and-explicit-units)** -- What a name must reveal, the unit and clock-domain qualifiers that extend the existing HDL suffixes rather than competing with them, cross-language equivalents, and the interface renamed end to end to prove it.
+- **[Measuring hidden units](#measuring-hidden-units)** -- The port's own documentation as the evidence, the three exclusion classes and the false positives that forced them, and why this ships as a ratchet instead of a verdict.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -704,14 +706,122 @@ have stayed green through the same mutation.
   rule cited?
 - Would a wrong implementation constant still make the test fail?
 
+## Rule 4: use intention-revealing names and explicit units
+
+> Names MUST reveal role and meaning; boundary types MUST make width,
+> signedness, direction and units explicit. Use the existing `_r`, `_w`, `_p`,
+> `_S`, `_C` and `_P` suffixes, and add a unit or domain qualifier — `_ns`,
+> `_cyc`, `_bytes`, `_bps`, or the clock domain — wherever confusion is
+> possible.
+
+This **extends** the house style in [CONTRIBUTING.md](../../CONTRIBUTING.md);
+it does not compete with it. The suffixes there say what a signal *is*
+(registered, wire, pulse, state, parameter). A unit qualifier says what its
+value *means*. A port can need both: `ring_len_bytes_i` is an input carrying a
+length in bytes.
+
+### The qualifier table
+
+| Concern | Qualifier | Example | Why the bare name is not enough |
+|---|---|---|---|
+| Time | `_ns`, `_us`, `_ms`, `_sec` | `pres_ofs_ns_i` | An offset in cycles and an offset in nanoseconds are the same 32 bits and a different value |
+| Cycle counts | `_cyc` | `timeout_cyc_c` | A cycle count is only meaningful beside its clock |
+| Size and position | `_bytes`, `_samples` | `ring_len_bytes_i` | A ring length in bytes and in records both fit; only one is right |
+| Rate | `_bps`, `_hz`, `_ppb` | `idle_slope_bps_i` | idleSlope is a rate; a bare number invites a per-frame reading |
+| Clock domain | domain name | `gtx_ts_ns_w` | The domain is the difference between a valid read and a metastable one |
+| Predicate | reads as a question | `is_talker_w`, `has_listener_w` | A boolean named for a noun does not say which way true points |
+| Event | `_p` (existing) | `arm_p` | A pulse and a level need different consumers |
+
+Cross-language, the concept keeps its name and its unit: a value that is
+`egress_lat_ns` in SystemVerilog is `egress_lat_ns` in the builder and in the
+harness. A rename that stops at the module boundary has moved the confusion
+rather than removed it.
+
+### What a qualifier is not for
+
+- Not for a signal whose width is its meaning. A port's bit width is already
+  in its type; `_bits` restates the declaration.
+- Not for pulse shape. "One-cycle strobe" is what `_p` already says, and
+  spelling it `_cyc` would make the two conventions disagree.
+- Not for identifiers a published protocol owns. `s_axi_awaddr` is documented
+  as a byte offset and keeps its name, because the name is AXI's contract, not
+  ours.
+
+### The interface renamed end to end
+
+The credit-based shaper's configuration interface carries three quantities with
+three different units, and none of them said so. It is renamed here through
+every hop it crosses — the CSR block, the datapath, the top level, the shaping
+core, the controller, the shaper itself, four testbench wrappers and their
+harnesses, and the register documentation:
+
+| Was | Now | Unit, from its own documentation |
+|---|---|---|
+| `o_cbs_hi_credit`, `hi_credit_i` | `o_cbs_hi_credit_bytes`, `hi_credit_bytes_i` | signed bytes |
+| `o_cbs_lo_credit`, `lo_credit_i` | `o_cbs_lo_credit_bytes`, `lo_credit_bytes_i` | signed bytes |
+| `o_cbs_idle_slope`, `idle_slope_i` | `o_cbs_idle_slope_bps`, `idle_slope_bps_i` | bits per second |
+
+`hiCredit` and `loCredit` are 802.1Q terms and keep their spelling; only the
+unit is added. The rename is pure — no logic moved — and the shaper's own
+harnesses grade the result, including the cycle-accurate reference model.
+
+### Review checklist
+
+- Does the name say what the value means, not just where it came from?
+- If the value has a unit, is the unit in the name or only in the comment?
+- Does a boolean read as a predicate, and is a pulse distinguishable from a
+  level?
+- At a cast, is the truncation or sign change documented — or is the cast
+  hiding a law nobody wrote down?
+- Does the concept keep its name across the module, the builder and the tests?
+
+## Measuring hidden units
+
+The evidence is the port's own `//!` comment. The house style already requires
+one on every port, and those comments say what the value is — "Egress latency
+correction, ns", "hiCredit clamp, signed bytes". When the comment names a unit
+and the identifier does not, the unit is known and simply missing from the
+name. No taste is involved and a reader can check any finding in one line.
+
+[`scripts/measure_naming.py`](../../scripts/measure_naming.py) does that scan.
+
+```
+python3 scripts/measure_naming.py             # the candidate list
+python3 scripts/measure_naming.py --excluded  # what was filtered, and why
+python3 scripts/measure_naming.py --check     # the ratchet
+```
+
+**The false positives were measured before anything was gated**, because the
+naive form of this check is mostly noise. 180 of 1,757 ports match a unit word
+in their comment. Three exclusion classes account for 100 of them:
+
+| Excluded | Count | Reason |
+|---|---:|---|
+| Single-bit ports | 94 | A one-bit port carries no quantity, so a unit cannot be missing from it |
+| Protocol-fixed identifiers | 4 | `s_axi_awaddr` is AXI's name; renaming it breaks what the name is for |
+| Shape, not unit | 2 | "1-cycle pulse" describes shape, which `_p` already encodes |
+
+`bit`, `bits` and `word` are not in the unit vocabulary at all: bit width is
+already explicit in the SystemVerilog type, and "word" is used in this tree both
+as a count and as a noun for the value itself, so it cannot separate a missing
+unit from ordinary prose.
+
+That leaves **80 candidates**, down from 91 before the rename above. The
+residual set still contains judgement calls — `now_i` on a module whose entire
+subject is nanoseconds is arguable — so this ships as a **ratchet**
+(`scripts/naming.budget`), not a verdict. The count may not rise; a new
+boundary states its unit, and existing debt is paid down deliberately.
+
+`--excluded` prints every filtered match with its reason, because a filter
+nobody can see is how a check quietly stops checking.
+
 ## Rules not yet landed
 
-The contract is ten rules. Rules 1, 2 and 3 are above; the rest keep these
+The contract is ten rules. Rules 1 to 4 are above; the rest keep these
 numbers so citations stay stable as they land:
 
 | Rule | Subject |
 |---|---|
-| 4 | Intention-revealing names and explicit units and types |
 | 5 | Explicit ports, contracts, ownership and side effects |
 | 6 | Fail fast and encode invariants |
 | 7 | Comments explain why; no dead or speculative code |

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -823,22 +823,22 @@ undocumented — the gPTP processor's 1 candidate sits beside its
 
 | Tree | Files | Ports | Parameters | Documented | Undocumented | Unit in the name | Unit in the comment | Excluded | Candidates |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| superproject | 69 | 1791 | 263 | 1779 | 275 | 99 | 315 | 231 | 84 |
+| superproject | 69 | 1791 | 263 | 1779 | 275 | 99 | 315 | 232 | 83 |
 | protocol-processor | 42 | 1548 | 270 | 1698 | 120 | 99 | 181 | 161 | 20 |
 | gptp-processor | 6 | 120 | 6 | 104 | 22 | 7 | 20 | 19 | 1 |
-| total | 117 | 3459 | 539 | 3581 | 417 | 205 | 516 | 411 | 105 |
+| total | 117 | 3459 | 539 | 3581 | 417 | 205 | 516 | 412 | 104 |
 
 **The false positives were measured before anything was gated**, because the
 naive form of this check is mostly noise: 516 declarations match a unit
-word in their comment and 411 of them are not findings. Four exclusion
+word in their comment and 412 of them are not findings. Four exclusion
 classes, each printed in full by `--excluded` with its reason:
 
 | Excluded | Count | Reason |
 |---|---:|---|
-| Noun for the value | 196 | "write byte", "subframe A sample", "(byte 0 = MSB)" name what the value *is*; a singular byte, octet or sample is a unit only after "in", "per" or "every" |
-| Single-bit ports | 152 | A one-bit port carries no quantity, so a unit cannot be missing from it |
+| Noun for the value, or timing prose | 313 | "write byte", "subframe A sample", "(byte 0 = MSB)" name what the value *is*, "applied on the cycle `en` is high" says *when*, and "1-cycle pulse" or "16-byte aligned" is an adjective; a singular byte, octet, sample or cycle is a unit only after "in", "per" or "every" |
+| Single-bit ports | 61 | A one-bit port carries no quantity, so a unit cannot be missing from it |
 | Protocol-fixed identifiers | 37 | The published AXI4/AXI-Stream signal names (`s_axi_awaddr`, `m_axis_tdata`) keep their names; a prefix alone earns no exemption |
-| Shape, not unit | 26 | "1-cycle pulse" describes shape, which `_p` already encodes; applied only when the matched unit is the cycle one, so "length in bytes, sampled every cycle" still counts |
+| Shape, not unit | 1 | "held 2 cycles", "per cycle" describe shape, which `_p` already encodes; applied only when the matched unit is the cycle one, so "length in bytes, sampled every cycle" still counts |
 
 `bit`, `bits` and `word` are not in the unit vocabulary at all: bit width is
 already explicit in the SystemVerilog type, and "word" is used in this tree
@@ -847,7 +847,7 @@ ordinal "second" count only in a unit context ("hold time, us", "1 second"),
 and a unit word joined by a hyphen into an identifier or an adjective
 (`P-RX-SLOT-BYTES`, "byte-identical", "cycle-count width") is prose.
 
-That leaves **105 candidates**. The residual set still holds judgement
+That leaves **104 candidates**. The residual set still holds judgement
 calls — `now_i` on a module whose entire subject is nanoseconds is arguable —
 so this ships as a ratchet, not a verdict.
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -731,11 +731,16 @@ length in bytes.
 | Clock domain | domain name | `gtx_ts_ns_w` | The domain is the difference between a valid read and a metastable one |
 | Predicate | reads as a question | `is_talker_w`, `has_listener_w` | A boolean named for a noun does not say which way true points |
 | Event | `_p` (existing) | `arm_p` | A pulse and a level need different consumers |
+| Boundary type | explicit width and sign in the declaration | `input logic signed [31:0] hi_credit_bytes_i` | A bare `[31:0]` on a credit that can go negative documents the width and hides the sign; the cast at the consumer then decides it silently |
+| C++ harness | the same qualifier on the field or argument | `int32_t idle_slope_bps;` in `cbs_ref_model.h`, `run_rate(…, uint32_t idle_slope_bps, …)` | The reference model is graded against the DUT in the same unit; a field called `idle_slope` beside a port called `idle_slope_bps_i` is the confusion moved one file over |
+| Python builder | the same qualifier on the key or argument | `egress_lat_ns`, `ring_len_bytes` | A builder key feeds a CSR default; a reader of the YAML has no type to fall back on, only the name |
 
 Cross-language, the concept keeps its name and its unit: a value that is
 `egress_lat_ns` in SystemVerilog is `egress_lat_ns` in the builder and in the
 harness. A rename that stops at the module boundary has moved the confusion
-rather than removed it.
+rather than removed it — which is why the shaper rename below reaches the
+reference model's fields and the harness helpers' arguments, not only the
+`dut->` bindings.
 
 ### What a qualifier is not for
 
@@ -763,7 +768,12 @@ harnesses, and the register documentation:
 
 `hiCredit` and `loCredit` are 802.1Q terms and keep their spelling; only the
 unit is added. The rename is pure — no logic moved — and the shaper's own
-harnesses grade the result, including the cycle-accurate reference model.
+harnesses grade the result, including the cycle-accurate reference model,
+whose `CbsConfig` fields and slope helpers carry the same qualifiers
+(`idle_slope_bps`, `hi_credit_bytes`, `lo_credit_bytes`). The package functions
+`calc_hi_credit`/`calc_lo_credit` in `ethernet_packet_pkg` keep their names:
+they are 802.1Q's formula names, and their arguments are typed `int` with the
+unit in the function's own `//!` line.
 
 ### Review checklist
 
@@ -777,44 +787,81 @@ harnesses grade the result, including the cycle-accurate reference model.
 
 ## Measuring hidden units
 
-The evidence is the port's own `//!` comment. The house style already requires
-one on every port, and those comments say what the value is — "Egress latency
-correction, ns", "hiCredit clamp, signed bytes". When the comment names a unit
-and the identifier does not, the unit is known and simply missing from the
-name. No taste is involved and a reader can check any finding in one line.
+The evidence is the port's own `//!` comment. Those comments say what the value
+is — "Egress latency correction, ns", "hiCredit clamp, signed bytes" — and when
+the comment names a unit and the identifier does not, the unit is known and
+simply missing from the name. A reader can check any finding in one line.
 
 [`scripts/measure_naming.py`](../../scripts/measure_naming.py) does that scan.
 
 ```
-python3 scripts/measure_naming.py             # the candidate list
-python3 scripts/measure_naming.py --excluded  # what was filtered, and why
-python3 scripts/measure_naming.py --check     # the ratchet
+python3 scripts/measure_naming.py                # candidates + the per-tree table
+python3 scripts/measure_naming.py --excluded     # every filtered match, and why
+python3 scripts/measure_naming.py --check        # the identity ratchet
+python3 scripts/measure_naming.py --write-budget # regenerate the budget after a rename
 ```
 
+**What is scanned, and what is not.** Every module header — ports and
+parameters — in first-party `.sv` under `hdl/` across the superproject and both
+project-owned processor submodules: 117 files, 3459 ports and 539
+parameters at this head. Declarations are parsed rather than pattern-matched,
+so `output reg`, `int`, package-typed and interface-modport ports, packed and
+unpacked dimensions, declarations split across lines and names sharing one
+declaration are all boundaries. Function and task arguments in module bodies
+are not boundaries and are not counted. Outside the scan, and said so here
+rather than left to be discovered: signals declared inside an `interface`
+body, and `hdl/milan/milan_dma_wrapper.v`, the generated Vivado wrapper the
+lint gate already excludes with its reason.
+
+**The blind spot has a size.** A port with no `//!` at all cannot be judged
+here, and the house style's "one on every port" is a rule with debt behind it:
+417 of the 3459 ports carry no comment. That population is Rule
+5's ratchet, not a Rule 4 finding, and the tool prints it per tree so a
+processor reading as nearly clean can be told apart from one that is merely
+undocumented — the gPTP processor's 1 candidate sits beside its
+22 undocumented ports:
+
+| Tree | Files | Ports | Parameters | Documented | Undocumented | Unit in the name | Unit in the comment | Excluded | Candidates |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| superproject | 69 | 1791 | 263 | 1779 | 275 | 99 | 315 | 231 | 84 |
+| protocol-processor | 42 | 1548 | 270 | 1698 | 120 | 99 | 181 | 161 | 20 |
+| gptp-processor | 6 | 120 | 6 | 104 | 22 | 7 | 20 | 19 | 1 |
+| total | 117 | 3459 | 539 | 3581 | 417 | 205 | 516 | 411 | 105 |
+
 **The false positives were measured before anything was gated**, because the
-naive form of this check is mostly noise. Across the superproject and both
-project-owned processor submodules, 408 of 3,491 ports match a unit word in
-their comment. Three exclusion classes account for 255 of them:
+naive form of this check is mostly noise: 516 declarations match a unit
+word in their comment and 411 of them are not findings. Four exclusion
+classes, each printed in full by `--excluded` with its reason:
 
 | Excluded | Count | Reason |
 |---|---:|---|
-| Single-bit ports | 94 | A one-bit port carries no quantity, so a unit cannot be missing from it |
-| Protocol-fixed identifiers | 4 | `s_axi_awaddr` is AXI's name; renaming it breaks what the name is for |
-| Shape, not unit | 2 | "1-cycle pulse" describes shape, which `_p` already encodes |
+| Noun for the value | 196 | "write byte", "subframe A sample", "(byte 0 = MSB)" name what the value *is*; a singular byte, octet or sample is a unit only after "in", "per" or "every" |
+| Single-bit ports | 152 | A one-bit port carries no quantity, so a unit cannot be missing from it |
+| Protocol-fixed identifiers | 37 | The published AXI4/AXI-Stream signal names (`s_axi_awaddr`, `m_axis_tdata`) keep their names; a prefix alone earns no exemption |
+| Shape, not unit | 26 | "1-cycle pulse" describes shape, which `_p` already encodes; applied only when the matched unit is the cycle one, so "length in bytes, sampled every cycle" still counts |
 
 `bit`, `bits` and `word` are not in the unit vocabulary at all: bit width is
-already explicit in the SystemVerilog type, and "word" is used in this tree both
-as a count and as a noun for the value itself, so it cannot separate a missing
-unit from ordinary prose.
+already explicit in the SystemVerilog type, and "word" is used in this tree
+both as a count and as a noun for the value itself. The pronoun "us" and the
+ordinal "second" count only in a unit context ("hold time, us", "1 second"),
+and a unit word joined by a hyphen into an identifier or an adjective
+(`P-RX-SLOT-BYTES`, "byte-identical", "cycle-count width") is prose.
 
-That leaves **153 candidates**, down from 164 before the rename above. The
-residual set still contains judgement calls — `now_i` on a module whose entire
-subject is nanoseconds is arguable — so this ships as a **ratchet**
-(`scripts/naming.budget`), not a verdict. The count may not rise; a new
-boundary states its unit, and existing debt is paid down deliberately.
+That leaves **105 candidates**. The residual set still holds judgement
+calls — `now_i` on a module whose entire subject is nanoseconds is arguable —
+so this ships as a ratchet, not a verdict.
 
-`--excluded` prints every filtered match with its reason, because a filter
-nobody can see is how a check quietly stops checking.
+**The ratchet is keyed on identity, not a count.**
+[`scripts/naming.budget`](../../scripts/naming.budget) names every candidate as
+`path:module:port`. A candidate may leave the list only by being renamed with
+its unit or by being removed; a port still declared under the same name whose
+comment has merely lost the unit word is refused as *stripped*. Review found
+the count-only form of this ratchet could be paid down by deleting units from
+documentation — the opposite of the rule — and reported it as a lowering. No
+new identity may appear either, in any of the three trees; the arms inject one
+into each processor and require the refusal. After a genuine rename,
+`--write-budget` regenerates the list and the diff shows exactly which
+boundary gained its unit.
 
 ## Rules not yet landed
 

--- a/hdl/common/csr/doc/milan_csr.md
+++ b/hdl/common/csr/doc/milan_csr.md
@@ -118,9 +118,9 @@ source for both groups rather than a second hand-written copy:
 | o_cls_pcp_tc_map    | output    | wire [23:0]             | Priority->traffic-class table (8x3)                  |
 | o_cls_prio_regen    | output    | wire [23:0]             | Priority regeneration table (8x3)                    |
 | o_cls_tc_queue_map  | output    | wire [31:0]             | Traffic-class->queue map                             |
-| o_cbs_idle_slope_bps    | output    | wire [32*NUM_QUEUES-1:0]| Per-queue idleSlope, bits/s                          |
-| o_cbs_hi_credit_bytes     | output    | wire [32*NUM_QUEUES-1:0]| Per-queue hiCredit, signed bytes                     |
-| o_cbs_lo_credit_bytes     | output    | wire [32*NUM_QUEUES-1:0]| Per-queue loCredit, signed bytes                     |
+| o_cbs_idle_slope_bps | output    | wire [32*NUM_QUEUES-1:0]| Per-queue idleSlope, bits/s                          |
+| o_cbs_hi_credit_bytes | output   | wire [32*NUM_QUEUES-1:0]| Per-queue hiCredit, signed bytes                     |
+| o_cbs_lo_credit_bytes | output   | wire [32*NUM_QUEUES-1:0]| Per-queue loCredit, signed bytes                     |
 | o_cbs_enable        | output    | wire [NUM_QUEUES-1:0]   | Per-queue shaped-enable; 0 = strict priority         |
 | o_ptp_enable        | output    | wire                    | PTP counter enable (PTP_CTRL[0])                    |
 | o_ptp_incr          | output    | wire [31:0]             | Nominal per-tick increment, ns.frac                  |

--- a/hdl/common/csr/doc/milan_csr.md
+++ b/hdl/common/csr/doc/milan_csr.md
@@ -118,9 +118,9 @@ source for both groups rather than a second hand-written copy:
 | o_cls_pcp_tc_map    | output    | wire [23:0]             | Priority->traffic-class table (8x3)                  |
 | o_cls_prio_regen    | output    | wire [23:0]             | Priority regeneration table (8x3)                    |
 | o_cls_tc_queue_map  | output    | wire [31:0]             | Traffic-class->queue map                             |
-| o_cbs_idle_slope    | output    | wire [32*NUM_QUEUES-1:0]| Per-queue idleSlope, bits/s                          |
-| o_cbs_hi_credit     | output    | wire [32*NUM_QUEUES-1:0]| Per-queue hiCredit, signed bytes                     |
-| o_cbs_lo_credit     | output    | wire [32*NUM_QUEUES-1:0]| Per-queue loCredit, signed bytes                     |
+| o_cbs_idle_slope_bps    | output    | wire [32*NUM_QUEUES-1:0]| Per-queue idleSlope, bits/s                          |
+| o_cbs_hi_credit_bytes     | output    | wire [32*NUM_QUEUES-1:0]| Per-queue hiCredit, signed bytes                     |
+| o_cbs_lo_credit_bytes     | output    | wire [32*NUM_QUEUES-1:0]| Per-queue loCredit, signed bytes                     |
 | o_cbs_enable        | output    | wire [NUM_QUEUES-1:0]   | Per-queue shaped-enable; 0 = strict priority         |
 | o_ptp_enable        | output    | wire                    | PTP counter enable (PTP_CTRL[0])                    |
 | o_ptp_incr          | output    | wire [31:0]             | Nominal per-tick increment, ns.frac                  |

--- a/hdl/common/csr/milan_csr.sv
+++ b/hdl/common/csr/milan_csr.sv
@@ -173,9 +173,9 @@ module milan_csr #(
   output wire [31:0]             o_cls_tc_queue_map, //! Traffic-class->queue map (CLS_TC_QUEUE_MAP)
 
   // ---- 802.1Qav CBS, per queue, packed [q*32 +: 32] (REQ-CBS-01..03) ----
-  output wire [32*NUM_QUEUES-1:0] o_cbs_idle_slope, //! Per-queue idleSlope, bits/s (CBS_IDLE_SLOPE)
-  output wire [32*NUM_QUEUES-1:0] o_cbs_hi_credit,  //! Per-queue hiCredit, signed bytes (CBS_HI_CREDIT)
-  output wire [32*NUM_QUEUES-1:0] o_cbs_lo_credit,  //! Per-queue loCredit, signed bytes (CBS_LO_CREDIT)
+  output wire [32*NUM_QUEUES-1:0] o_cbs_idle_slope_bps, //! Per-queue idleSlope, bits/s (CBS_IDLE_SLOPE)
+  output wire [32*NUM_QUEUES-1:0] o_cbs_hi_credit_bytes,  //! Per-queue hiCredit, signed bytes (CBS_HI_CREDIT)
+  output wire [32*NUM_QUEUES-1:0] o_cbs_lo_credit_bytes,  //! Per-queue loCredit, signed bytes (CBS_LO_CREDIT)
   output wire [NUM_QUEUES-1:0]    o_cbs_enable,     //! Per-queue shaped-enable; 0 = strict priority (CBS_CTRL[0])
 
   // ---- PTP hardware clock (REQ-PTP-01..04,06) ----
@@ -2590,9 +2590,9 @@ module milan_csr #(
   genvar g;
   generate
     for (g = 0; g < NUM_QUEUES; g = g + 1) begin : gen_cbs_out
-      assign o_cbs_idle_slope[g*32 +: 32] = cbs_idle[g];
-      assign o_cbs_hi_credit [g*32 +: 32] = cbs_hi[g];
-      assign o_cbs_lo_credit [g*32 +: 32] = cbs_lo[g];
+      assign o_cbs_idle_slope_bps[g*32 +: 32] = cbs_idle[g];
+      assign o_cbs_hi_credit_bytes [g*32 +: 32] = cbs_hi[g];
+      assign o_cbs_lo_credit_bytes [g*32 +: 32] = cbs_lo[g];
       assign o_cbs_enable[g]              = cbs_en[g];
     end
   endgenerate

--- a/hdl/ieee8021q/ts/credit_based_shaper.sv
+++ b/hdl/ieee8021q/ts/credit_based_shaper.sv
@@ -87,9 +87,9 @@ module credit_based_shaper #(
 
   //! --- runtime configuration (from milan_csr CBS register group, REQ-CBS-01) ---
   input  wire        shaped_i,              //! 1 = apply CBS; 0 = strict priority (always eligible)
-  input  wire [31:0] idle_slope_i,          //! idleSlope for the current link rate, bits/s
-  input  wire signed [31:0] hi_credit_i,    //! hiCredit clamp, signed bytes
-  input  wire signed [31:0] lo_credit_i,    //! loCredit clamp, signed bytes
+  input  wire [31:0] idle_slope_bps_i,          //! idleSlope for the current link rate, bits/s
+  input  wire signed [31:0] hi_credit_bytes_i,    //! hiCredit clamp, signed bytes
+  input  wire signed [31:0] lo_credit_bytes_i,    //! loCredit clamp, signed bytes
 
   //! --- datapath status ---
   input  wire        queue_has_data_i,      //! Queue has a frame ready to send
@@ -121,7 +121,7 @@ module credit_based_shaper #(
   //  idle_slope_per_cycle_r = (idle_slope <<< 16) / CLK_FREQ_HZ / BYTE_TO_BIT
   //  send_slope_per_byte_r  = ((idle_slope - link_rate) <<< 16) / link_rate
   //
-  //  Both terms are functions ONLY of quasi-static config (idle_slope_i,
+  //  Both terms are functions ONLY of quasi-static config (idle_slope_bps_i,
   //  is_1g_i). The 2026-07-01 rework computed them with per-cycle combinational
   //  constant-divisor cones; measured on xc7a100t 2026-07-11 those cost ~2.3K
   //  LUTs per queue (~9.3K over 4 queues, 18 percent of the SoC, partly
@@ -130,7 +130,7 @@ module credit_based_shaper #(
   //  31-bit serial restoring divider, 1 bit per cycle, on a FIXED 100-cycle
   //  cadence (data-independent, free-running):
   //
-  //    cnt 0        sample idle_slope_i / is_1g_i
+  //    cnt 0        sample idle_slope_bps_i / is_1g_i
   //    cnt 1        load dividend |idle_slope <<< 16|, divisor CLK_FREQ_HZ*8
   //    cnt 2..49    48 divide iterations -> idle_slope_per_cycle quotient
   //    cnt 50       stash quotient 1; load |send_slope <<< 16|, divisor link
@@ -159,7 +159,7 @@ module credit_based_shaper #(
   localparam logic [30:0] SLOPE_DEN1 = 31'(CLK_FREQ_HZ * BYTE_TO_BIT);
 
   logic [6:0]         eng_cnt;    //! engine cadence counter, 0..99
-  logic signed [47:0] eng_idle_s; //! sampled idle_slope_i (sign extended)
+  logic signed [47:0] eng_idle_s; //! sampled idle_slope_bps_i (sign extended)
   logic               eng_is1g_s; //! sampled link-rate select
   logic               eng_sign;   //! dividend sign of the divide in flight
   logic [47:0]        eng_num;    //! dividend magnitude shift register
@@ -220,8 +220,8 @@ module credit_based_shaper #(
   //! reconfiguration that lowers hiCredit shrinks the burst allowance on the
   //! very next cycle, REQ-CBS-01).
   always_comb begin : clamp_calc
-    hi_credit_q16 = 48'(signed'(hi_credit_i)) <<< FP_DECIMAL_POINT;
-    lo_credit_q16 = 48'(signed'(lo_credit_i)) <<< FP_DECIMAL_POINT;
+    hi_credit_q16 = 48'(signed'(hi_credit_bytes_i)) <<< FP_DECIMAL_POINT;
+    lo_credit_q16 = 48'(signed'(lo_credit_bytes_i)) <<< FP_DECIMAL_POINT;
   end
 
   //! Slope engine combinational helpers: dividend selection (with the same
@@ -273,7 +273,7 @@ module credit_based_shaper #(
     end else begin
       eng_cnt <= (eng_cnt == 7'd99) ? 7'd0 : (eng_cnt + 7'd1);
       if (eng_cnt == 7'd0) begin
-        eng_idle_s <= 48'(signed'(idle_slope_i));
+        eng_idle_s <= 48'(signed'(idle_slope_bps_i));
         eng_is1g_s <= is_1g_i;
       end else if (eng_cnt == 7'd1 || eng_cnt == 7'd50) begin
         if (eng_cnt == 7'd50) eng_q1 <= eng_quo_s;

--- a/hdl/ieee8021q/ts/traffic_controller_802_1q.sv
+++ b/hdl/ieee8021q/ts/traffic_controller_802_1q.sv
@@ -58,9 +58,9 @@ module traffic_controller_802_1q #(
   input wire [31:0] cls_tc_queue_map_i,       //! Traffic-class->queue map, 8x4 bits
 
   //! --- per-queue CBS runtime config, packed [q*32 +: 32] (from milan_csr) ---
-  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_idle_slope_i, //! idleSlope per queue, bits/s
-  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_hi_credit_i,  //! hiCredit per queue, signed bytes
-  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_lo_credit_i,  //! loCredit per queue, signed bytes
+  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_idle_slope_bps_i, //! idleSlope per queue, bits/s
+  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_hi_credit_bytes_i,  //! hiCredit per queue, signed bytes
+  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_lo_credit_bytes_i,  //! loCredit per queue, signed bytes
   input wire [NUMBER_OF_QUEUES-1:0]    cbs_shaped_i,     //! 1 = shaped, 0 = strict priority
 
   axi_stream_if.slave s_axis,                 //! slave interface of AXIS
@@ -136,9 +136,9 @@ module traffic_controller_802_1q #(
     .resetn(resetn),
     .queue_has_data_i(queue_has_data),
     .is_1g_i(is_1g_i),
-    .cbs_idle_slope_i(cbs_idle_slope_i),
-    .cbs_hi_credit_i(cbs_hi_credit_i),
-    .cbs_lo_credit_i(cbs_lo_credit_i),
+    .cbs_idle_slope_bps_i(cbs_idle_slope_bps_i),
+    .cbs_hi_credit_bytes_i(cbs_hi_credit_bytes_i),
+    .cbs_lo_credit_bytes_i(cbs_lo_credit_bytes_i),
     .cbs_shaped_i(cbs_shaped_i),
     .grant_queue_o(queue_grant),
     .s_axis(queue_to_shaper),

--- a/hdl/ieee8021q/ts/traffic_shaping_core.sv
+++ b/hdl/ieee8021q/ts/traffic_shaping_core.sv
@@ -65,9 +65,9 @@ module traffic_shaping_core #(
   input wire is_1g_i,                 //! High when the link rate is 1GBps
 
   //! --- per-queue CBS runtime config, packed [q*32 +: 32] (from milan_csr) ---
-  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_idle_slope_i, //! idleSlope per queue, bits/s
-  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_hi_credit_i,  //! hiCredit per queue, signed bytes
-  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_lo_credit_i,  //! loCredit per queue, signed bytes
+  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_idle_slope_bps_i, //! idleSlope per queue, bits/s
+  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_hi_credit_bytes_i,  //! hiCredit per queue, signed bytes
+  input wire [32*NUMBER_OF_QUEUES-1:0] cbs_lo_credit_bytes_i,  //! loCredit per queue, signed bytes
   input wire [NUMBER_OF_QUEUES-1:0]    cbs_shaped_i,     //! 1 = shaped, 0 = strict priority
 
   //! One-hot: indicates which queue is granted
@@ -114,9 +114,9 @@ module traffic_shaping_core #(
         .clk               (clk),
         .resetn            (resetn),
         .shaped_i          (cbs_shaped_i[i]),
-        .idle_slope_i      (cbs_idle_slope_i[i*32 +: 32]),
-        .hi_credit_i       (cbs_hi_credit_i[i*32 +: 32]),
-        .lo_credit_i       (cbs_lo_credit_i[i*32 +: 32]),
+        .idle_slope_bps_i      (cbs_idle_slope_bps_i[i*32 +: 32]),
+        .hi_credit_bytes_i       (cbs_hi_credit_bytes_i[i*32 +: 32]),
+        .lo_credit_bytes_i       (cbs_lo_credit_bytes_i[i*32 +: 32]),
         .queue_has_data_i  (queue_has_data_i[i]),
         .is_1g_i           (is_1g_i),
         .is_transmitting_i (is_transmitting[i]),

--- a/hdl/milan/milan_datapath.sv
+++ b/hdl/milan/milan_datapath.sv
@@ -1438,7 +1438,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   wire [23:0] cfg_cls_pcp_tc_map, cfg_cls_prio_regen;
   wire [31:0] cfg_cls_tc_queue_map;
 
-  wire [32*NUM_QUEUES-1:0] cfg_cbs_idle_slope, cfg_cbs_hi_credit, cfg_cbs_lo_credit;
+  wire [32*NUM_QUEUES-1:0] cfg_cbs_idle_slope_bps, cfg_cbs_hi_credit_bytes, cfg_cbs_lo_credit_bytes;
   wire [NUM_QUEUES-1:0]    cfg_cbs_enable;
 
   wire        cfg_ptp_enable;
@@ -2377,9 +2377,9 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     .o_cls_prio_regen  (cfg_cls_prio_regen),
     .o_cls_tc_queue_map(cfg_cls_tc_queue_map),
     // CBS
-    .o_cbs_idle_slope(cfg_cbs_idle_slope),
-    .o_cbs_hi_credit (cfg_cbs_hi_credit),
-    .o_cbs_lo_credit (cfg_cbs_lo_credit),
+    .o_cbs_idle_slope_bps(cfg_cbs_idle_slope_bps),
+    .o_cbs_hi_credit_bytes (cfg_cbs_hi_credit_bytes),
+    .o_cbs_lo_credit_bytes (cfg_cbs_lo_credit_bytes),
     .o_cbs_enable    (cfg_cbs_enable),
     // PTP
     .o_ptp_enable      (cfg_ptp_enable),
@@ -2726,7 +2726,7 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
   //! instead of corrupting a neighbouring queue's slope.
   wire lwsrp_qidx_ok_w = (32'(cfg_lwsrp_qidx) < NUM_QUEUES);
   always_comb begin
-    cbs_idle_slope_mux = cfg_cbs_idle_slope;
+    cbs_idle_slope_mux = cfg_cbs_idle_slope_bps;
     cbs_enable_mux     = cfg_cbs_enable;
     if (lwsrp_slope_en && lwsrp_qidx_ok_w) begin
       cbs_idle_slope_mux[32*cfg_lwsrp_qidx +: 32] = lwsrp_idle_slope;
@@ -2750,9 +2750,9 @@ parameter int PB_PREFILL_C = 0,    //! playback prefill release (0 = midpoint;
     .cls_pcp_tc_map_i  (cfg_cls_pcp_tc_map),
     .cls_prio_regen_i  (cfg_cls_prio_regen),
     .cls_tc_queue_map_i(cfg_cls_tc_queue_map),
-    .cbs_idle_slope_i  (cbs_idle_slope_mux),
-    .cbs_hi_credit_i   (cfg_cbs_hi_credit),
-    .cbs_lo_credit_i   (cfg_cbs_lo_credit),
+    .cbs_idle_slope_bps_i  (cbs_idle_slope_mux),
+    .cbs_hi_credit_bytes_i   (cfg_cbs_hi_credit_bytes),
+    .cbs_lo_credit_bytes_i   (cfg_cbs_lo_credit_bytes),
     .cbs_shaped_i      (cbs_enable_mux),
     .s_axis(tx_axis_to_shaper),
     .m_axis(tx_axis_shaper_to_ts)

--- a/hdl/milan/milan_top.sv
+++ b/hdl/milan/milan_top.sv
@@ -241,7 +241,7 @@ module milan_top import ethernet_packet_pkg::*; #(
   wire [31:0] cfg_cls_tc_queue_map;
 
   //! CBS config (packed per queue)
-  wire [32*NUM_QUEUES-1:0] cfg_cbs_idle_slope, cfg_cbs_hi_credit, cfg_cbs_lo_credit;
+  wire [32*NUM_QUEUES-1:0] cfg_cbs_idle_slope_bps, cfg_cbs_hi_credit_bytes, cfg_cbs_lo_credit_bytes;
   wire [NUM_QUEUES-1:0]    cfg_cbs_enable;
 
   //! PTP config / status
@@ -459,9 +459,9 @@ module milan_top import ethernet_packet_pkg::*; #(
     .o_cls_prio_regen  (cfg_cls_prio_regen),
     .o_cls_tc_queue_map(cfg_cls_tc_queue_map),
     // CBS
-    .o_cbs_idle_slope(cfg_cbs_idle_slope),
-    .o_cbs_hi_credit (cfg_cbs_hi_credit),
-    .o_cbs_lo_credit (cfg_cbs_lo_credit),
+    .o_cbs_idle_slope_bps(cfg_cbs_idle_slope_bps),
+    .o_cbs_hi_credit_bytes (cfg_cbs_hi_credit_bytes),
+    .o_cbs_lo_credit_bytes (cfg_cbs_lo_credit_bytes),
     .o_cbs_enable    (cfg_cbs_enable),
     // PTP
     .o_ptp_enable      (cfg_ptp_enable),
@@ -598,9 +598,9 @@ module milan_top import ethernet_packet_pkg::*; #(
     .cls_pcp_tc_map_i  (cfg_cls_pcp_tc_map),
     .cls_prio_regen_i  (cfg_cls_prio_regen),
     .cls_tc_queue_map_i(cfg_cls_tc_queue_map),
-    .cbs_idle_slope_i  (cfg_cbs_idle_slope),
-    .cbs_hi_credit_i   (cfg_cbs_hi_credit),
-    .cbs_lo_credit_i   (cfg_cbs_lo_credit),
+    .cbs_idle_slope_bps_i  (cfg_cbs_idle_slope_bps),
+    .cbs_hi_credit_bytes_i   (cfg_cbs_hi_credit_bytes),
+    .cbs_lo_credit_bytes_i   (cfg_cbs_lo_credit_bytes),
     .cbs_shaped_i      (cfg_cbs_enable),
     .s_axis(tx_axis_to_shaper),
     .m_axis(tx_axis_shaper_to_ts)

--- a/scripts/measure_naming.py
+++ b/scripts/measure_naming.py
@@ -92,8 +92,10 @@ UNIT = re.compile(r"\b(" + _UNIT_WORDS + r")\b", re.I)
 _CONTEXT_UNIT = re.compile(
     r"(?:(?<=\d)\s*|(?<=[(,/])\s*|\b(?:in|per|every)\s+|^\s*)(us|seconds?)\b", re.I)
 #: singular nouns that are a unit only after "in", "per" or "every" ("in byte
-#: units"); "frame byte", "channel 0 sample", "(byte 0 = MSB)" name the value
-_NOUN_SINGULAR = re.compile(r"^(byte|octet|sample)$", re.I)
+#: units"); "frame byte", "channel 0 sample", "(byte 0 = MSB)" name the value,
+#: and a singular "cycle" outside a count ("applied on the cycle en is high",
+#: "the next cycle") is timing prose, not a quantity measured in cycles
+_NOUN_SINGULAR = re.compile(r"^(byte|octet|sample|cycle|clock)$", re.I)
 _COUNT_CONTEXT = re.compile(r"\b(?:in|per|every)\s+$", re.I)
 #: a unit word joined by a hyphen or underscore is part of an identifier or a
 #: compound adjective (P-RX-SLOT-BYTES, byte-identical, cycle-count), not a unit
@@ -106,8 +108,13 @@ NAME_UNIT = re.compile(
 
 #: SHAPE phrasing - `_p` already encodes this. Only meaningful for the cycle
 #: unit; "frame length in bytes, sampled every cycle" documents a real unit.
+#: A plural count is a shape only when it is the signal's own duration
+#: ("held 2 cycles", "asserted for 3 clocks", "2 cycles wide"); "latency,
+#: 3 cycles after the strobe" is a quantity the port carries.
 SHAPE = re.compile(
     r"\b\d+\s*-?\s*(cycle|clock)\b|\bone[- ]cycle\b|\bsingle[- ]cycle\b"
+    r"|\b(held|asserted|driven|high|low|stays?)\s+(for\s+)?\d+\s*(cycles|clocks)\b"
+    r"|\b\d+\s*(cycles|clocks)\s+(wide|long)\b"
     r"|\bper[- ]cycle\b|\bevery\b[^,;]*\bcycle\b", re.I)
 _CYCLE = re.compile(r"cycle|clock", re.I)
 
@@ -143,7 +150,7 @@ def unit_in(doc):
             if not _CONTEXT_UNIT.search(doc[:m.end()]):
                 continue
         if _NOUN_SINGULAR.match(word) and not _COUNT_CONTEXT.search(doc[:m.start()]):
-            noun = noun or word
+            noun = noun or word          # "16-byte aligned", "1-cycle pulse": adjectives
             continue
         return word, "unit"
     return (noun, "noun") if noun else (None, "")
@@ -155,7 +162,7 @@ def classify(name, doc, multibit):
     if not unit or NAME_UNIT.search(name):
         return None, unit, ""
     if kind == "noun":
-        return "excluded", unit, "noun for the value, not a unit of measure"
+        return "excluded", unit, "noun for the value or timing prose, not a unit of measure"
     if PROTOCOL.search(name):
         return "excluded", unit, "protocol-fixed identifier"
     if not multibit:
@@ -322,8 +329,10 @@ FIXTURES = [
      _wrap("  input wire [31:0] pres_ofs_i,  //! presentation offset ns"), 1, 0),
     ("a name that already carries the unit is not",
      _wrap("  input wire [31:0] pres_ofs_ns_i,  //! presentation offset ns"), 0, 0),
-    ("a one-cycle pulse is a shape, not a unit",
+    ("a 1-cycle pulse is timing prose, not a unit",
      _wrap("  input wire [3:0] arm_i,  //! 1-cycle pulse: arm the chain"), 0, 1),
+    ("a strobe held for N cycles is a shape, not a unit",
+     _wrap("  input wire [3:0] arm_i,  //! arm the chain, held 2 cycles"), 0, 1),
     ("shape phrasing does not swallow a real unit",
      _wrap("  input wire [15:0] len_i,  //! frame length in bytes, sampled every cycle"), 1, 0),
     ("a single-bit port carries no quantity",
@@ -360,6 +369,9 @@ FIXTURES = [
     ("a position noun with a number after it is a noun, not a count",
      _wrap("  input wire [47:0] mac_i, //! MSB-first (byte 0 in [47:40])\n"
            "  input wire [23:0] ph_i, //! phys channel 0 sample"), 0, 2),
+    ("a singular cycle in timing prose is not a quantity in cycles",
+     _wrap("  input wire [47:0] tcam_wr_key_i, //! TCAM entry write port. Applied on the cycle en is high\n"
+           "  input wire [7:0] lat_i, //! latency, 3 cycles after the strobe"), 1, 1),
     ("a unit word joined by a hyphen is an identifier or an adjective, not a unit",
      _wrap("  input wire [7:0] a_i, //! P-RX-SLOTS / P-RX-SLOT-BYTES (F01.5)\n"
            "  input wire [7:0] b_i, //! stereo framer, byte-identical\n"
@@ -419,8 +431,11 @@ def selftest():
            f"got {len(c)} candidate(s) {[(x[1], x[2]) for x in c]} / {len(e)} excluded "
            f"{[(x[1], x[3]) for x in e]}, want {want_c} / {want_e}")
 
-    _c, e, _s = scan_text(FIXTURES[2][1])
+    _c, e, _s = scan_text(FIXTURES[3][1])
     ck("an exclusion names its reason", bool(e) and e[0][3].startswith("shape"), f"{e}")
+    _c, e2, _s = scan_text(FIXTURES[2][1])
+    ck("timing prose is excluded under its own reason",
+       bool(e2) and e2[0][3].startswith("noun"), f"{e2}")
 
     _c, _e, st = scan_text(_wrap("  input wire [31:0] a_i,\n  input wire [31:0] b_i, //! x"))
     ck("undocumented ports are counted, not silently skipped",
@@ -474,7 +489,7 @@ def selftest():
        recorded_live is not None and all(":" in i for i in recorded_live),
        "scripts/naming.budget must list path:module:name lines")
 
-    n = len(FIXTURES) + 11
+    n = len(FIXTURES) + 12
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 

--- a/scripts/measure_naming.py
+++ b/scripts/measure_naming.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Measure boundary names that hide a unit, and hold the count down.
+
+Why this exists. Rule 4 of the maintainability guide
+(docs/development/CODE_QUALITY.md) asks that boundary types make width,
+signedness, direction and units explicit. A general naming linter cannot help
+here: it would fight the `_r` / `_w` / `_p` / `_S` / `_C` / `_P` suffixes
+`CONTRIBUTING.md` mandates, and it has no idea what a signal means.
+
+So the evidence is the port's OWN documentation. The house style requires every
+port to be documented inline with `//!`, and those comments say what the value
+IS - "Egress latency correction, ns", "hiCredit clamp, signed bytes". When the
+comment names a unit of measure and the identifier does not, the unit is known
+and simply absent from the name. That is a finding a reader can check in one
+line, and it needs no taste.
+
+FALSE POSITIVES WERE MEASURED BEFORE ANY GATE, and they dominated the naive
+form of this check: 180 of 1757 ports matched a unit word in their comment, and
+most were not findings at all. Three exclusion classes, each with a reason:
+
+  * SHAPE, not unit. "1-cycle pulse", "single-cycle strobe", "flips every
+    eth_rx cycle" describe the SHAPE of a signal. That is what the `_p` suffix
+    already encodes, and demanding `_cyc` on a pulse would fight the house
+    convention Rule 4 explicitly defers to.
+  * PROTOCOL-FIXED identifiers. `s_axi_awaddr` is documented as a byte offset
+    and must keep its name: it is AXI's, not ours. Renaming it would break the
+    thing the name exists for.
+  * SINGLE-BIT ports. A one-bit port carries no quantity, so a unit cannot be
+    missing from it.
+
+Applying those three excludes 100 of the 180 and leaves 80 candidates. The
+residual set still contains judgement calls - `now_i` on a module whose entire
+subject is nanoseconds is arguable - so this is a RATCHET and not a verdict.
+The count may not rise. New boundaries state their units; existing debt is
+inventoried and paid down deliberately.
+
+`--excluded` prints every filtered match with its reason, because a filter
+nobody can see is how a check quietly stops checking.
+
+Usage:
+    python3 scripts/measure_naming.py             # the candidate list
+    python3 scripts/measure_naming.py --check     # ratchet (exit 1 if it rose)
+    python3 scripts/measure_naming.py --excluded  # what was filtered, and why
+    python3 scripts/measure_naming.py --selftest  # fixture arms
+
+Exit 0 = at or under the ratchet.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BUDGET = Path(__file__).resolve().parent / "naming.budget"
+
+EXCLUDED_PREFIXES = ("third_party/", "external/", "protocol-processor/",
+                     "gptp-processor/", "gen/", "build/")
+
+#: A UNIT OF MEASURE, as written in a port's own `//!` comment. Singular forms
+#: are included deliberately: they are most of what the exclusion classes below
+#: have to filter, and a vocabulary too narrow to SEE a false positive cannot
+#: be said to have measured any.
+#:
+#: `bit`, `bits` and `word` are deliberately NOT units here. A port's bit width
+#: is already explicit in its SystemVerilog type, so "8x3 bits" in a comment is
+#: describing the declared width or a table shape, never a unit of the value;
+#: and "word" is used in this tree both as a count ("31 words") and as a noun
+#: for the value itself ("configuration word"), so it cannot distinguish a
+#: missing unit from ordinary prose.
+UNIT = re.compile(
+    r"\b(nanoseconds?|microseconds?|milliseconds?|ns|us|cycles?|bytes?|octets?"
+    r"|hertz|Hz|ppb|ppm|samples?|seconds?|bits/s|bit/s|bps)\b")
+
+#: the same unit, already carried by the identifier
+NAME_UNIT = re.compile(
+    r"(^|_)(ns|us|ms|cyc|cycles|bytes?|hz|ppb|ppm|smp|samples?|sec|secs|bps)(_|$)",
+    re.I)
+
+#: SHAPE phrasing - `_p` already encodes this, and Rule 4 defers to the
+#: existing suffix convention rather than competing with it.
+SHAPE = re.compile(
+    r"\b\d+\s*-?\s*(cycle|clock)\b|\bone[- ]cycle\b|\bsingle[- ]cycle\b"
+    r"|\bper[- ]cycle\b|\bevery\b.*\bcycle\b", re.I)
+
+#: identifiers a published protocol owns. Renaming these breaks the contract
+#: the name exists to state.
+PROTOCOL = re.compile(
+    r"^(s_axi|m_axi|s_axis|m_axis)_"
+    r"|_(tvalid|tready|tlast|tdata|tkeep|tuser|tdest|tstrb)$")
+
+PORT = re.compile(
+    r"^\s*(input|output|inout)\s+(?:wire|logic|var)?\s*(?:signed\s+)?"
+    r"(\[[^\]]*\]\s*)?(\w+)")
+
+
+def sources():
+    out = subprocess.run(["git", "ls-files", "hdl"], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout.split()
+    return [p for p in out if p.endswith(".sv") and not p.startswith(EXCLUDED_PREFIXES)]
+
+
+def scan_text(text):
+    """Return (candidates, excluded, total_ports) for one source.
+
+    candidates: [(name, unit, doc)] - documented unit missing from the name.
+    excluded:   [(name, unit, reason)] - matched, then filtered, with why.
+    """
+    candidates, excluded, total = [], [], 0
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        m = PORT.match(line)
+        if not m:
+            continue
+        total += 1
+        width, name = m.group(2), m.group(3)
+        same = re.search(r"//!(.*)$", line)
+        if same:
+            doc = same.group(1)
+        elif i and "//!" in lines[i - 1]:
+            doc = lines[i - 1].split("//!", 1)[1]
+        else:
+            doc = ""
+        unit = UNIT.search(doc)
+        if not unit or NAME_UNIT.search(name):
+            continue
+        if PROTOCOL.search(name):
+            excluded.append((name, unit.group(0), "protocol-fixed identifier"))
+        elif not width:
+            excluded.append((name, unit.group(0), "single-bit port carries no quantity"))
+        elif SHAPE.search(doc):
+            excluded.append((name, unit.group(0), "shape, not a unit (the _p suffix owns this)"))
+        else:
+            candidates.append((name, unit.group(0), doc.strip()))
+    return candidates, excluded, total
+
+
+def scan_repo():
+    rows, drops, total = [], [], 0
+    for rel in sources():
+        c, e, n = scan_text((REPO / rel).read_text(errors="replace"))
+        total += n
+        rows += [(rel,) + r for r in c]
+        drops += [(rel,) + r for r in e]
+    return rows, drops, total
+
+
+def read_budget():
+    if not BUDGET.is_file():
+        return None
+    for line in BUDGET.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line.isdigit():
+            return int(line)
+    return None
+
+
+FIXTURES = [
+    ("a documented unit missing from the name is a candidate",
+     "  input wire [31:0] pres_ofs_i,  //! presentation offset ns", 1, 0),
+    ("a name that already carries the unit is not",
+     "  input wire [31:0] pres_ofs_ns_i,  //! presentation offset ns", 0, 0),
+    ("a one-cycle pulse is a shape, not a unit",
+     "  input wire [3:0] arm_i,  //! 1-cycle pulse: arm the chain", 0, 1),
+    ("a single-bit port carries no quantity",
+     "  input wire go_i,  //! start, ns aligned", 0, 1),
+    ("a protocol-fixed identifier is left alone",
+     "  input wire [11:0] s_axi_awaddr,  //! Write address (byte offset)", 0, 1),
+    ("a port with no unit in its comment is not a candidate",
+     "  input wire [31:0] thing_i,  //! some opaque configuration word", 0, 0),
+    ("an undocumented port is not a candidate",
+     "  input wire [31:0] thing_i,", 0, 0),
+    ("the comment may sit on the line above",
+     "  //! ring size (bytes)\n  input wire [31:0] ring_len_i,", 1, 0),
+]
+
+
+def selftest():
+    failures = 0
+    for name, src, want_c, want_e in FIXTURES:
+        c, e, _ = scan_text(src)
+        if len(c) == want_c and len(e) == want_e:
+            print(f"[PASS] {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] {name}: got {len(c)} candidate(s) / {len(e)} excluded, "
+                  f"want {want_c} / {want_e}")
+
+    # the exclusions must be REPORTED, not silently dropped: a filter nobody
+    # can see is how a check quietly stops checking
+    _c, e, _n = scan_text(FIXTURES[2][1])
+    if e and e[0][2].startswith("shape"):
+        print("[PASS] an exclusion names its reason")
+    else:
+        failures += 1
+        print(f"[FAIL] an exclusion names its reason: {e}")
+
+    # and the scan must find something in the real tree - an inert scan would
+    # ratchet to zero and stay green forever
+    rows, drops, total = scan_repo()
+    if total > 500 and rows:
+        print(f"[PASS] the live scan reads the tree ({total} ports)")
+    else:
+        failures += 1
+        print(f"[FAIL] the live scan reads the tree: {total} ports, {len(rows)} candidates")
+
+    n = len(FIXTURES) + 2
+    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--check", action="store_true", help="ratchet: fail if the count rose")
+    ap.add_argument("--excluded", action="store_true", help="show what was filtered, and why")
+    ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    rows, drops, total = scan_repo()
+
+    if args.excluded:
+        print(f"{len(drops)} match(es) filtered, by reason:")
+        for reason in sorted({d[3] for d in drops}):
+            group = [d for d in drops if d[3] == reason]
+            print(f"\n  {reason} ({len(group)}):")
+            for rel, name, unit, _r in group[:12]:
+                print(f"    {name:<28} [{unit}]  {rel}")
+            if len(group) > 12:
+                print(f"    ... and {len(group) - 12} more")
+        return 0
+
+    for rel, name, unit, doc in rows:
+        print(f"{rel}: {name} — documented in {unit}, not named for it: {doc}")
+
+    budget = read_budget()
+    tail = (f"{len(rows)} boundary name(s) hide a documented unit "
+            f"({total} ports scanned, {len(drops)} match(es) excluded with a reason)")
+    if not args.check:
+        print(f"\n{tail}")
+        return 0
+
+    if budget is None:
+        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} is missing or unreadable")
+        return 1
+    if len(rows) > budget:
+        print(f"\nNAMING RATCHET: FAIL ({len(rows)} > ratchet {budget}). A new "
+              f"boundary must state its unit in its name.")
+        return 1
+    print(f"\nNAMING RATCHET: PASS ({tail}; ratchet {budget})")
+    if len(rows) < budget:
+        print(f"  the ratchet can be lowered to {len(rows)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_naming.py
+++ b/scripts/measure_naming.py
@@ -14,7 +14,11 @@ port to be documented inline with `//!`, and those comments say what the value
 IS - "Egress latency correction, ns", "hiCredit clamp, signed bytes". When the
 comment names a unit of measure and the identifier does not, the unit is known
 and simply absent from the name. That is a finding a reader can check in one
-line.
+line. The converse is worse and is measured too: when the identifier carries
+a unit token and the comment documents a different family - `timeout_bytes_i
+//! timeout in cycles` - the name is not vague, it is wrong. Review found the
+first form of this tool stopped at "the name has a unit token", so a
+misleading `_bytes` satisfied a cycles contract and fell out of the ratchet.
 
 WHAT IS SCANNED. Every module header - ports and parameters - in first-party
 `.sv` under `hdl/` across the superproject and both project-owned processor
@@ -41,14 +45,30 @@ with a reason, and each printed in full by `--excluded`:
     word" name what the value IS, not what it is measured in. A singular
     byte/sample/octet with no count, "in", "per" or comma before it is prose.
 
+UNITS ARE COMPARED BY FAMILY, DEFINED ONCE. `FAMILIES` maps every spelling the
+tool knows - in a comment or as an identifier token - to time, bytes, cycles,
+frequency, ratio, rate or samples, so `_ns` satisfies "nanoseconds", `_cyc`
+satisfies "clock cycles" and `_bps` satisfies "bits per second". A unit-named
+boundary is a candidate when the comment documents a unit of measure and never
+names the name's family at all (nouns count: "tone sample" confirms `_smp`),
+or when it states the value as "X per Y" and the name carries only Y - a cycle
+count named for the tick it produces. The NOUN and SHAPE exclusions carry over
+because they say the comment documents no unit; PROTOCOL carries over because
+the name is not ours; SINGLE-BIT does not, because it excused a unit that was
+missing from a port with no quantity, and a unit that is present and wrong is
+a false statement at any width.
+
 THE RATCHET IS KEYED ON IDENTITY, NOT A COUNT. `scripts/naming.budget` names
 every candidate as `path:module:port`. A candidate may leave the list only by
-being renamed with its unit or by being removed; a port that is still there
-under the same name and has merely lost the unit word from its comment is
-refused - the cheapest way to lower a count would otherwise be to strip the
-documentation, which is the opposite of the rule. No new identity may appear.
-`--write-budget` regenerates the list after a rename, so lowering is a normal
-commit and the diff shows exactly which boundary gained its unit.
+being renamed with its unit or by being removed - or, for a name that already
+carries a unit, by a comment that now names that family, since the tool cannot
+tell a conversion ("~21 ms" on a cycle count) from a contradiction and the diff
+can; a port that is still there under the same name and has merely lost the
+unit word from its comment is refused - the cheapest way to lower a count would
+otherwise be to strip the documentation, which is the opposite of the rule. No
+new identity may appear. `--write-budget` regenerates the list after a rename,
+so lowering is a normal commit and the diff shows exactly which boundary gained
+its unit.
 
 Usage:
     python3 scripts/measure_naming.py                # candidates + per-tree table
@@ -76,17 +96,58 @@ from sv_ports import declarations, module_headers
 # ---------------------------------------------------------------------------
 # vocabulary
 # ---------------------------------------------------------------------------
+#: THE UNIT FAMILIES, defined once. Every unit spelling the tool knows - as
+#: written in a `//!` comment or carried as a `_`-delimited identifier token -
+#: belongs to exactly one family, and two spellings agree when their families
+#: do. `bit`, `bits` and `word` are deliberately absent: bit width is already
+#: in the type, and "word" is a noun for the value in this tree
+#: ("configuration word").
+FAMILIES = {
+    "time": ("ns", "us", "µs", "μs", "ms", "nsec", "usec", "msec", "sec", "secs",
+             "second", "seconds", "nanosecond", "nanoseconds", "microsecond",
+             "microseconds", "millisecond", "milliseconds"),
+    "bytes": ("byte", "bytes", "octet", "octets"),
+    "cycles": ("cyc", "cycle", "cycles", "clock cycle", "clock cycles", "clock", "clocks"),
+    "frequency": ("hz", "khz", "mhz", "ghz", "hertz"),
+    "ratio": ("ppb", "ppm"),
+    "rate": ("bps", "kbps", "mbps", "gbps", "bit/s", "bits/s", "bit per second",
+             "bits per second", "byte per second", "bytes per second"),
+    "samples": ("smp", "sample", "samples"),
+}
+_FAMILY_OF = {alias: fam for fam, aliases in FAMILIES.items() for alias in aliases}
+#: spellings a comment never uses as a unit: the identifier abbreviations
+#: ("1-cyc strobe" is shape) and the singular clock, which is the signal or
+#: timing prose ("per Clock Domain", "every clock") - the counted plural is
+#: the unit ("in clocks", "6250 clocks per 3 samples")
+_NOT_IN_PROSE = frozenset({"cyc", "smp", "clock"})
+#: the tokens an identifier carries: the abbreviations and plain words, not
+#: the English long forms, the compounds or the non-ASCII spellings, and not
+#: `clock` (`clock_en_i` is a signal, not a count) or `second` (`second_stage_r`)
+_NAME_TOKENS = ("ns", "us", "ms", "nsec", "usec", "msec", "cyc", "cycle", "cycles",
+                "byte", "bytes", "octet", "octets", "hz", "khz", "mhz", "ghz", "ppb",
+                "ppm", "smp", "sample", "samples", "sec", "secs", "bps", "kbps",
+                "mbps", "gbps")
+
+
+def family(word):
+    """The family of a unit spelling from either vocabulary, or None."""
+    return _FAMILY_OF.get(re.sub(r"\s*/\s*", "/", re.sub(r"\s+", " ", word.lower().strip())))
+
+
+def _alternation(words):
+    """A regex alternation of unit spellings, longest first so "clock cycles"
+    beats "cycles" and "bytes per second" beats "bytes"; a space matches any
+    whitespace and a slash tolerates spaces around it."""
+    def pat(w):
+        return r"\s+".join(r"\s*/\s*".join(re.escape(p) for p in tok.split("/"))
+                           for tok in w.split(" "))
+    return "|".join(pat(w) for w in sorted(words, key=len, reverse=True))
+
+
+_DOC_ALT = _alternation(w for w in _FAMILY_OF if w not in _NOT_IN_PROSE)
 #: A UNIT OF MEASURE as written in a `//!` comment. Case-insensitive except
-#: where case is the unit (Hz/MHz vs the pronoun "us"). `bit`, `bits` and
-#: `word` are deliberately absent: bit width is already in the type, and
-#: "word" is a noun for the value in this tree ("configuration word").
-_UNIT_WORDS = (
-    r"nanoseconds?|microseconds?|milliseconds?|nsec|usec|msec|ns|us|ms"
-    r"|clock\s+cycles?|cycles?|bytes?|octets?|samples?"
-    r"|hertz|k?hz|mhz|ghz|ppb|ppm|secs?|seconds?"
-    r"|bits?\s*/\s*s|bits?\s+per\s+second|bytes?\s+per\s+second|[kmg]?bps"
-)
-UNIT = re.compile(r"\b(" + _UNIT_WORDS + r")\b", re.I)
+#: where case is the unit (Hz/MHz vs the pronoun "us").
+UNIT = re.compile(r"\b(" + _DOC_ALT + r")\b", re.I)
 #: `us` is also a pronoun and `second` an ordinal: both need a unit context -
 #: a count, a bracket, a comma, "in" or "per" in front.
 _CONTEXT_UNIT = re.compile(
@@ -97,14 +158,19 @@ _CONTEXT_UNIT = re.compile(
 #: "the next cycle") is timing prose, not a quantity measured in cycles
 _NOUN_SINGULAR = re.compile(r"^(byte|octet|sample|cycle|clock)$", re.I)
 _COUNT_CONTEXT = re.compile(r"\b(?:in|per|every)\s+$", re.I)
+#: clocks are a unit only when counted ("in clocks", "6250 clocks per 3
+#: samples"); elsewhere the word is the verb or the signals ("clocks alive",
+#: "the ADC clocks are") and is not even a noun for the value
+_COUNTED_ONLY = re.compile(r"^clocks$", re.I)
+_COUNTED_BEFORE = re.compile(r"(?:\d\s*-?\s*|\b(?:in|per|every)\s+)$", re.I)
+#: "X per Y": a value stated as a rate whose denominator is Y
+_PER = re.compile(r"\b(" + _DOC_ALT + r")\s+per\s+(?:\d+\s*)?(" + _DOC_ALT + r")\b", re.I)
 #: a unit word joined by a hyphen or underscore is part of an identifier or a
 #: compound adjective (P-RX-SLOT-BYTES, byte-identical, cycle-count), not a unit
 _JOINED = re.compile(r"[-_]")
 
-#: the same unit already carried by the identifier, as a `_`-delimited token
-NAME_UNIT = re.compile(
-    r"(^|_)(ns|us|ms|nsec|usec|msec|cyc|cycles?|bytes?|octets?|k?hz|mhz|ghz"
-    r"|ppb|ppm|smp|samples?|secs?|[kmg]?bps)(_|\d|$)", re.I)
+#: a unit carried by the identifier, as a `_`-delimited token
+NAME_UNIT = re.compile(r"(^|_)(" + "|".join(_NAME_TOKENS) + r")(?=_|\d|$)", re.I)
 
 #: SHAPE phrasing - `_p` already encodes this. Only meaningful for the cycle
 #: unit; "frame length in bytes, sampled every cycle" documents a real unit.
@@ -128,15 +194,14 @@ PROTOCOL = re.compile(
 # ---------------------------------------------------------------------------
 # classification
 # ---------------------------------------------------------------------------
-def unit_in(doc):
-    """(word, kind) for the first unit-looking word in a comment, or (None, '').
+def units_in(doc):
+    """Every unit-looking word in a comment, in order, as (word, kind).
 
-    kind is 'unit' for a unit of measure, 'noun' for a singular byte/octet/
-    sample used as a noun for the value (reported as an exclusion so the
-    class stays visible), or '' when no unit word is present at all. Words
-    joined by a hyphen or underscore into an identifier or adjective, the
-    pronoun `us` and the ordinal `second` are prose, not units."""
-    noun = None
+    kind is 'unit' for a unit of measure or 'noun' for a singular byte/octet/
+    sample/cycle used as a noun for the value. Words joined by a hyphen or
+    underscore into an identifier or adjective, the pronoun `us`, the ordinal
+    `second` and a clock outside a count are prose and are not listed."""
+    found = []
     for m in UNIT.finditer(doc):
         word = m.group(1)
         low = word.lower()
@@ -149,18 +214,73 @@ def unit_in(doc):
         if low == "us" or low.startswith("second"):
             if not _CONTEXT_UNIT.search(doc[:m.end()]):
                 continue
-        if _NOUN_SINGULAR.match(word) and not _COUNT_CONTEXT.search(doc[:m.start()]):
-            noun = noun or word          # "16-byte aligned", "1-cycle pulse": adjectives
+        if _COUNTED_ONLY.match(word) and not _COUNTED_BEFORE.search(doc[:m.start()]):
             continue
-        return word, "unit"
-    return (noun, "noun") if noun else (None, "")
+        if _NOUN_SINGULAR.match(word) and not _COUNT_CONTEXT.search(doc[:m.start()]):
+            found.append((word, "noun"))  # "16-byte aligned", "1-cycle pulse": adjectives
+            continue
+        found.append((word, "unit"))
+    return found
+
+
+def unit_in(doc):
+    """(word, kind) for the first unit of measure in a comment, else the first
+    noun for the value (reported as an exclusion so the class stays visible),
+    else (None, '') when no unit word is present at all."""
+    words = units_in(doc)
+    for word, kind in words:
+        if kind == "unit":
+            return word, kind
+    return (words[0][0], "noun") if words else (None, "")
+
+
+def name_families(name):
+    """The unit families an identifier carries as `_`-delimited tokens."""
+    return {family(m.group(2)) for m in NAME_UNIT.finditer(name)}
+
+
+MISMATCH = "named for a different unit than documented"
+
+
+def _classify_named(name, doc, unit, named):
+    """A boundary whose identifier already carries a unit.
+
+    Not a candidate when the comment agrees with the name; a candidate when
+    the comment documents a unit of measure and never names the name's family
+    (`timeout_bytes_i //! timeout in cycles`), or states the value as "X per
+    Y" with only Y in the name (`DIV_US_P //! clk cycles per 1 us tick` is a
+    cycle count named for the tick it produces).
+
+    Which exclusions carry over. NOUN and SHAPE describe the comment - "write
+    byte" and "held 2 cycles" document no unit of measure - so there is
+    nothing to compare and the name stands. PROTOCOL-fixed names are not ours
+    to rename either way. SINGLE-BIT does not carry over: it excused a unit
+    that was MISSING because a one-bit port carries no quantity, and a unit
+    that is present and wrong is a false statement at any width."""
+    words = units_in(doc)
+    documented = {family(w) for w, k in words if k == "unit"}
+    if SHAPE.search(doc):
+        documented.discard("cycles")
+    if not documented:
+        return None, unit, ""
+    if PROTOCOL.search(name):
+        return "excluded", unit, "protocol-fixed identifier"
+    for m in _PER.finditer(doc):
+        if family(m.group(1)) not in named and family(m.group(2)) in named:
+            return "candidate", m.group(1), MISMATCH
+    if named & {family(w) for w, _k in words}:
+        return None, unit, ""
+    return "candidate", unit, MISMATCH
 
 
 def classify(name, doc, multibit):
     """('candidate'|'excluded'|None, unit, reason)."""
     unit, kind = unit_in(doc)
-    if not unit or NAME_UNIT.search(name):
+    if not unit:
         return None, unit, ""
+    named = name_families(name)
+    if named:
+        return _classify_named(name, doc, unit, named)
     if kind == "noun":
         return "excluded", unit, "noun for the value or timing prose, not a unit of measure"
     if PROTOCOL.search(name):
@@ -175,11 +295,14 @@ def classify(name, doc, multibit):
 def scan_text(text):
     """(candidates, excluded, stats) for one source.
 
-    candidates: [(module, name, unit, doc)]
+    candidates: [(module, name, unit, doc, reason)] - reason is '' for a name
+                that hides its documented unit, MISMATCH for one named for
+                another
     excluded:   [(module, name, unit, reason)]
-    stats: dict(ports, documented, undocumented, named)."""
+    stats: dict(ports, params, documented, undocumented, named, mismatched)."""
     candidates, excluded = [], []
-    stats = {"ports": 0, "documented": 0, "undocumented": 0, "named": 0, "params": 0}
+    stats = {"ports": 0, "documented": 0, "undocumented": 0, "named": 0, "params": 0,
+             "mismatched": 0}
     for module, name, doc, multibit, kind in declarations(text):
         stats["params" if kind == "param" else "ports"] += 1
         if doc.strip():
@@ -190,7 +313,8 @@ def scan_text(text):
             stats["named"] += 1
         verdict, unit, reason = classify(name, doc, multibit)
         if verdict == "candidate":
-            candidates.append((module, name, unit, doc.strip()))
+            candidates.append((module, name, unit, doc.strip(), reason))
+            stats["mismatched"] += reason == MISMATCH
         elif verdict == "excluded":
             excluded.append((module, name, unit, reason))
     return candidates, excluded, stats
@@ -214,9 +338,10 @@ def scan_repo():
         t = per_tree.setdefault(tree_of(rel), {"files": 0, "ports": 0, "params": 0,
                                                "documented": 0, "undocumented": 0,
                                                "named": 0, "matches": 0,
-                                               "excluded": 0, "candidates": 0})
+                                               "excluded": 0, "mismatched": 0,
+                                               "candidates": 0})
         t["files"] += 1
-        for k in ("ports", "params", "documented", "undocumented", "named"):
+        for k in ("ports", "params", "documented", "undocumented", "named", "mismatched"):
             t[k] += st[k]
         t["matches"] += len(c) + len(e)
         t["excluded"] += len(e)
@@ -269,13 +394,25 @@ def read_budget():
     return ids
 
 
-def port_still_declared(rel, module, name):
-    """True when `module` in `rel` still declares a port/parameter called `name`."""
+def declared_as(rel, module, name):
+    """The `//!` comment when `module` in `rel` still declares a port or
+    parameter called `name`, else None."""
     path = REPO / rel
     if not path.is_file():
-        return False
-    return any(m == module and n == name
-               for m, n, _d, _mb, _k in declarations(path.read_text(errors="replace")))
+        return None
+    for m, n, doc, _mb, _k in declarations(path.read_text(errors="replace")):
+        if m == module and n == name:
+            return doc
+    return None
+
+
+def agrees(name, doc):
+    """True when the identifier carries a unit and the comment names that
+    family: the one way a unit-named record may leave the ratchet without a
+    rename, because the tool cannot tell a conversion ("~21 ms" on a cycle
+    count) from a contradiction, and the diff can."""
+    named = name_families(name)
+    return bool(named) and bool(named & {family(w) for w, _k in units_in(doc)})
 
 
 def ratchet(rows, recorded):
@@ -286,33 +423,44 @@ def ratchet(rows, recorded):
     stripped, left = [], []
     for ident in sorted(recorded - current):
         rel, module, name = identity_path(ident)
-        if port_still_declared(rel, module, name):
-            stripped.append(ident)
-        else:
+        doc = declared_as(rel, module, name)
+        if doc is None or agrees(name, doc):
             left.append(ident)
+        else:
+            stripped.append(ident)
     return new, stripped, left
 
 
 def write_budget(rows, per_tree):
     total = sum(t["candidates"] for t in per_tree.values())
+    mismatched = sum(t["mismatched"] for t in per_tree.values())
     head = [
         "# Rule 4 ratchet, keyed on IDENTITY: every boundary port or parameter whose",
         "# own //! comment names a unit of measure that the identifier does not carry,",
-        "# as path:module:name. A processor entry is spelled <submodule>:<path>:...",
-        "# (colon, not slash, after the submodule name - the scripts/xvlog.budget",
-        "# spelling) so this generated record is not a hand-written source list.",
+        "# or documents a unit of a different family than the one the identifier",
+        "# carries (marked `# " + MISMATCH + "`), as path:module:name.",
+        "# A processor entry is spelled <submodule>:<path>:... (colon, not slash,",
+        "# after the submodule name - the scripts/xvlog.budget spelling) so this",
+        "# generated record is not a hand-written source list.",
         "# See scripts/measure_naming.py.",
         "#",
         "# A line may leave this file only because the boundary was renamed with its",
-        "# unit or removed; a port still declared under the same name that has lost",
-        "# the unit word from its comment is refused, so the documentation cannot be",
-        "# stripped to lower the count. No line may be added. Regenerate with",
-        "# `python3 scripts/measure_naming.py --write-budget` after a rename.",
+        "# unit or removed - or, for a name that already carries a unit, because its",
+        "# comment now names that unit's family; a port still declared under the same",
+        "# name that has lost the unit word from its comment is refused, so the",
+        "# documentation cannot be stripped to lower the count. No line may be added.",
+        "# Regenerate with `python3 scripts/measure_naming.py --write-budget`.",
+        "#",
+        "# 2026-08-29: the mismatch lines arrived when the measurement began comparing",
+        "# the identifier's unit family to the documented one (PR #278 review,",
+        "# scripts/measure_naming.py classify): a unit token in the name no longer",
+        "# satisfies a comment that documents a different unit.",
         "#",
         f"# {total} candidate(s): " + ", ".join(
-            f"{k} {v['candidates']}" for k, v in sorted(per_tree.items())),
+            f"{k} {v['candidates']}" for k, v in sorted(per_tree.items()))
+        + f"; {mismatched} of them {MISMATCH}",
     ]
-    body = sorted(identity(r) for r in rows)
+    body = sorted(identity(r) + (f"  # {r[5]}" if r[5] else "") for r in rows)
     BUDGET.write_text("\n".join(head + body) + "\n")
 
 
@@ -411,6 +559,32 @@ FIXTURES = [
      "module f (\n  input wire clk_i //! clock\n);\n  function automatic int g(input int idle_slope); //! bits/s\n    return idle_slope;\n  endfunction\nendmodule\n", 0, 0),
     ("an interface modport port parses as one name",
      _wrap("  axi_stream_if.slave s_axis, //! ingress, bytes per beat"), 1, 0),
+    # the unit families: a name must agree with its documented unit, not just carry one
+    ("a name carrying a unit of a different family than documented is a candidate",
+     _wrap("  input wire [31:0] timeout_bytes_i,  //! timeout in cycles"), 1, 0),
+    ("a same-family alias in the comment agrees with the name",
+     _wrap("  input wire [31:0] hold_ns_i,  //! hold, nanoseconds\n"
+           "  input wire [31:0] guard_cyc_i,  //! guard, clock cycles\n"
+           "  input wire [31:0] slope_bps_i,  //! slope, bits per second\n"
+           "  input wire [31:0] len_octets_i,  //! length, bytes"), 0, 0),
+    ("a cycle count named for the tick it produces is the tree's own cross-family pair",
+     "module f #(\n  parameter int unsigned DIV_US_P = 100 //! clk cycles per 1 µs tick; override to compress time\n"
+     ") (\n  input wire clk_i //! clock\n);\nendmodule\n", 1, 0),
+    ("a single-bit port with a wrong-unit suffix is still misleading",
+     _wrap("  input wire go_ns_i,  //! start, in cycles"), 1, 0),
+    ("shape phrasing and a noun for the value do not contradict a unit-named port",
+     _wrap("  input wire [7:0] arm_ns_i,  //! arm delay, held 2 cycles\n"
+           "  input wire [23:0] tone_smp_i,  //! tone generator sample (live)"), 0, 0),
+    ("a name carrying several tokens agrees when any of them matches",
+     _wrap("  input wire [31:0] sample_lat_ns_i,  //! measured stage latency (ns or cycles)"), 0, 0),
+    ("a comment that names the name's family anywhere is not a contradiction",
+     "module f #(\n  //! PHC clock frequency. Sets the increment = the true clock period in ns\n"
+     "  //! (125 MHz -> 0x08000000)\n  parameter int unsigned CLK_FREQ_HZ_P = 125_000_000\n"
+     ") (\n  input wire clk_i //! clock\n);\nendmodule\n", 0, 0),
+    ("in clocks is a cycle count; clocks outside a count are the verb or the signals",
+     _wrap("  input wire [15:0] wdog_i,  //! no-progress watchdog, in clocks\n"
+           "  input wire [15:0] alive_i,  //! clocks alive, reinit released\n"
+           "  input wire [15:0] dom_i,  //! one setting per Clock Domain, every clock"), 1, 0),
 ]
 
 
@@ -436,6 +610,25 @@ def selftest():
     _c, e2, _s = scan_text(FIXTURES[2][1])
     ck("timing prose is excluded under its own reason",
        bool(e2) and e2[0][3].startswith("noun"), f"{e2}")
+
+    # the reviewer's reproduction, verbatim: a misleading suffix must not satisfy the contract
+    verdict, unit, reason = classify("timeout_bytes_i", "timeout in cycles", True)
+    ck("classify refuses a name whose unit family differs from the documented one",
+       verdict == "candidate" and unit == "cycles" and reason == MISMATCH,
+       f"{(verdict, unit, reason)}")
+    ck("classify accepts a same-family alias",
+       classify("hold_ns_i", "hold, nanoseconds", True) == (None, "nanoseconds", ""))
+    rows_mm = scan_text(_wrap("  input wire [31:0] timeout_bytes_i, //! timeout in cycles"))[0]
+    ck("a mismatch is reported under its own reason",
+       bool(rows_mm) and rows_mm[0][4] == MISMATCH, f"{rows_mm}")
+    ck("every spelling in both vocabularies has a family, and aliases share it",
+       all(family(w) for w in _NAME_TOKENS) and all(family(w) for w in _FAMILY_OF)
+       and _NOT_IN_PROSE <= set(_FAMILY_OF)
+       and family("clock  cycles") == family("CYC") == "cycles"
+       and family("Bits per second") == family("bits / s") == family("Mbps") == "rate"
+       and family("nanoseconds") == family("NS") == family("µs") == "time"
+       and family("octets") == family("byte") == "bytes" and family("word") is None,
+       f"{[w for w in _NAME_TOKENS if not family(w)]}")
 
     _c, _e, st = scan_text(_wrap("  input wire [31:0] a_i,\n  input wire [31:0] b_i, //! x"))
     ck("undocumented ports are counted, not silently skipped",
@@ -473,6 +666,21 @@ def selftest():
             (REPO / "x.sv").write_text(_wrap(""))
             ck("a recorded port that was removed has left legitimately",
                ratchet([], recorded) == ([], [], ["x.sv:f:pres_ofs_i"]))
+            # a recorded MISMATCH may also leave by a comment that names the name's family
+            wrong = {"x.sv:f:timeout_bytes_i"}
+            (REPO / "x.sv").write_text(_wrap("  input wire [31:0] timeout_bytes_i, //! timeout in cycles"))
+            ck("a recorded mismatch that is still one is neither new nor gone",
+               ratchet([("x.sv", "f", "timeout_bytes_i", "cycles", "timeout in cycles", MISMATCH)], wrong)
+               == ([], [], []))
+            (REPO / "x.sv").write_text(_wrap("  input wire [31:0] timeout_bytes_i, //! timeout in bytes"))
+            ck("a recorded mismatch whose comment now names the name's unit has left legitimately",
+               ratchet([], wrong) == ([], [], ["x.sv:f:timeout_bytes_i"]))
+            (REPO / "x.sv").write_text(_wrap("  input wire [31:0] timeout_bytes_i, //! timeout"))
+            ck("a recorded mismatch that merely lost the unit from its comment is refused as stripped",
+               ratchet([], wrong) == ([], ["x.sv:f:timeout_bytes_i"], []))
+            (REPO / "x.sv").write_text(_wrap("  input wire [31:0] pres_ofs_i, //! presentation offset"))
+            ck("a name without a unit still cannot leave by a comment edit",
+               ratchet([], recorded) == ([], ["x.sv:f:pres_ofs_i"], []))
         finally:
             REPO = real
 
@@ -489,7 +697,7 @@ def selftest():
        recorded_live is not None and all(":" in i for i in recorded_live),
        "scripts/naming.budget must list path:module:name lines")
 
-    n = len(FIXTURES) + 12
+    n = len(FIXTURES) + 20
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -522,22 +730,29 @@ def main():
         print(f"wrote {BUDGET.relative_to(REPO)}: {len(rows)} candidate(s)")
         return 0
 
-    for rel, module, name, unit, doc in rows:
-        print(f"{rel}:{module}: {name} — documented in {unit}, not named for it: {doc}")
+    for rel, module, name, unit, doc, reason in rows:
+        if reason == MISMATCH:
+            print(f"{rel}:{module}: {name} — named for a different unit "
+                  f"({', '.join(sorted(name_families(name)))}) than documented "
+                  f"({unit}, {family(unit)}): {doc}")
+        else:
+            print(f"{rel}:{module}: {name} — documented in {unit}, not named for it: {doc}")
 
     print(f"\n{'tree':<20}{'files':>6}{'ports':>7}{'params':>7}{'documented':>11}"
-          f"{'undocumented':>13}{'unit-named':>11}{'matches':>8}{'excluded':>9}{'candidates':>11}")
+          f"{'undocumented':>13}{'unit-named':>11}{'matches':>8}{'excluded':>9}"
+          f"{'mismatched':>11}{'candidates':>11}")
     for tree, t in sorted(per_tree.items()):
         print(f"{tree:<20}{t['files']:>6}{t['ports']:>7}{t['params']:>7}{t['documented']:>11}"
               f"{t['undocumented']:>13}{t['named']:>11}{t['matches']:>8}{t['excluded']:>9}"
-              f"{t['candidates']:>11}")
+              f"{t['mismatched']:>11}{t['candidates']:>11}")
     tot = {k: sum(t[k] for t in per_tree.values()) for k in
            ("files", "ports", "params", "documented", "undocumented", "named",
-            "matches", "excluded", "candidates")}
+            "matches", "excluded", "mismatched", "candidates")}
     print(f"{'total':<20}{tot['files']:>6}{tot['ports']:>7}{tot['params']:>7}{tot['documented']:>11}"
           f"{tot['undocumented']:>13}{tot['named']:>11}{tot['matches']:>8}{tot['excluded']:>9}"
-          f"{tot['candidates']:>11}")
-    print(f"\n{len(rows)} boundary name(s) hide a documented unit "
+          f"{tot['mismatched']:>11}{tot['candidates']:>11}")
+    print(f"\n{len(rows)} candidate(s): {len(rows) - tot['mismatched']} boundary name(s) hide "
+          f"a documented unit and {tot['mismatched']} are {MISMATCH} "
           f"({tot['ports']} ports and {tot['params']} parameters scanned, "
           f"{tot['undocumented']} with no //! and so not judged here, "
           f"{len(drops)} match(es) excluded with a reason)")
@@ -555,7 +770,8 @@ def main():
     for ident in stripped:
         print(f"\nSTRIPPED: {ident} is still declared under that name and is no longer a "
               f"candidate only because its comment no longer names the unit - restore the "
-              f"documentation or rename the boundary")
+              f"documentation, rename the boundary, or (for a name that carries a unit) "
+              f"document that unit")
     if new or stripped:
         print(f"\nNAMING RATCHET: FAIL ({len(new)} new, {len(stripped)} stripped)")
         return 1

--- a/scripts/measure_naming.py
+++ b/scripts/measure_naming.py
@@ -17,7 +17,8 @@ and simply absent from the name. That is a finding a reader can check in one
 line, and it needs no taste.
 
 FALSE POSITIVES WERE MEASURED BEFORE ANY GATE, and they dominated the naive
-form of this check: 180 of 1757 ports matched a unit word in their comment, and
+form of this check: 408 of 3,491 ports across the superproject and its two
+project-owned processor submodules matched a unit word in their comment, and
 most were not findings at all. Three exclusion classes, each with a reason:
 
   * SHAPE, not unit. "1-cycle pulse", "single-cycle strobe", "flips every
@@ -30,7 +31,7 @@ most were not findings at all. Three exclusion classes, each with a reason:
   * SINGLE-BIT ports. A one-bit port carries no quantity, so a unit cannot be
     missing from it.
 
-Applying those three excludes 100 of the 180 and leaves 80 candidates. The
+Applying those three excludes 255 of the 408 and leaves 153 candidates. The
 residual set still contains judgement calls - `now_i` on a module whose entire
 subject is nanoseconds is arguable - so this is a RATCHET and not a verdict.
 The count may not rise. New boundaries state their units; existing debt is
@@ -50,15 +51,14 @@ Exit 0 = at or under the ratchet.
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 BUDGET = Path(__file__).resolve().parent / "naming.budget"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-EXCLUDED_PREFIXES = ("third_party/", "external/", "protocol-processor/",
-                     "gptp-processor/", "gen/", "build/")
+from code_quality_scope import tracked
 
 #: A UNIT OF MEASURE, as written in a port's own `//!` comment. Singular forms
 #: are included deliberately: they are most of what the exclusion classes below
@@ -73,7 +73,7 @@ EXCLUDED_PREFIXES = ("third_party/", "external/", "protocol-processor/",
 #: missing unit from ordinary prose.
 UNIT = re.compile(
     r"\b(nanoseconds?|microseconds?|milliseconds?|ns|us|cycles?|bytes?|octets?"
-    r"|hertz|Hz|ppb|ppm|samples?|seconds?|bits/s|bit/s|bps)\b")
+    r"|hertz|Hz|ppb|ppm|samples?|seconds|secs?|bits/s|bit/s|bps)\b")
 
 #: the same unit, already carried by the identifier
 NAME_UNIT = re.compile(
@@ -98,9 +98,7 @@ PORT = re.compile(
 
 
 def sources():
-    out = subprocess.run(["git", "ls-files", "hdl"], cwd=REPO,
-                         capture_output=True, text=True, check=True).stdout.split()
-    return [p for p in out if p.endswith(".sv") and not p.startswith(EXCLUDED_PREFIXES)]
+    return [p for p in tracked("hdl") if p.endswith(".sv")]
 
 
 def scan_text(text):
@@ -173,6 +171,8 @@ FIXTURES = [
      "  input wire [31:0] thing_i,  //! some opaque configuration word", 0, 0),
     ("an undocumented port is not a candidate",
      "  input wire [31:0] thing_i,", 0, 0),
+    ("ordinary prose using second is not a time unit",
+     "  input wire [31:0] stream_id_i, //! avoids a second copy", 0, 0),
     ("the comment may sit on the line above",
      "  //! ring size (bytes)\n  input wire [31:0] ring_len_i,", 1, 0),
 ]

--- a/scripts/measure_naming.py
+++ b/scripts/measure_naming.py
@@ -219,9 +219,32 @@ def scan_repo():
     return rows, drops, per_tree
 
 
+#: A processor identity is spelled `<submodule>:<path>:<module>:<name>`, with a
+#: colon after the submodule name rather than a slash - the spelling
+#: scripts/xvlog.budget uses - so this generated record is never read as a
+#: hand-written copy of the submodule source list (scripts/pp_srcs.py --check
+#: refuses any tracked file that names a processor source literally).
+_SUBMODULE_PREFIXES = ("protocol-processor/", "gptp-processor/")
+
+
 def identity(row):
     rel, module, name = row[0], row[1], row[2]
+    for prefix in _SUBMODULE_PREFIXES:
+        if rel.startswith(prefix):
+            rel = prefix[:-1] + ":" + rel[len(prefix):]
+            break
     return f"{rel}:{module}:{name}"
+
+
+def identity_path(ident):
+    """(rel_path, module, name) from an identity, undoing the processor spelling."""
+    for prefix in _SUBMODULE_PREFIXES:
+        sub = prefix[:-1]
+        if ident.startswith(sub + ":"):
+            rest, module, name = ident[len(sub) + 1:].rsplit(":", 2)
+            return f"{sub}/{rest}", module, name
+    rel, module, name = ident.rsplit(":", 2)
+    return rel, module, name
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +278,7 @@ def ratchet(rows, recorded):
     new = sorted(current - recorded)
     stripped, left = [], []
     for ident in sorted(recorded - current):
-        rel, module, name = ident.split(":", 2)
+        rel, module, name = identity_path(ident)
         if port_still_declared(rel, module, name):
             stripped.append(ident)
         else:
@@ -268,7 +291,10 @@ def write_budget(rows, per_tree):
     head = [
         "# Rule 4 ratchet, keyed on IDENTITY: every boundary port or parameter whose",
         "# own //! comment names a unit of measure that the identifier does not carry,",
-        "# as path:module:name. See scripts/measure_naming.py.",
+        "# as path:module:name. A processor entry is spelled <submodule>:<path>:...",
+        "# (colon, not slash, after the submodule name - the scripts/xvlog.budget",
+        "# spelling) so this generated record is not a hand-written source list.",
+        "# See scripts/measure_naming.py.",
         "#",
         "# A line may leave this file only because the boundary was renamed with its",
         "# unit or removed; a port still declared under the same name that has lost",
@@ -407,6 +433,15 @@ def selftest():
        ratchet(rows_now, recorded) == ([], [], []))
     ck("a new identity is refused",
        ratchet(rows_now + [("x.sv", "f", "zz_i", "ns", "d ns")], recorded)[0] == ["x.sv:f:zz_i"])
+    # the processor path is ASSEMBLED, not spelled: pp_srcs.py --check refuses
+    # any tracked file that names a processor source literally, this one included
+    pp, tail = "protocol-processor", "hdl/srp/KL_srp_top.sv"
+    ck("a processor identity is spelled submodule:path, never as a source literal",
+       identity((f"{pp}/{tail}", "KL_srp_top", "wr_len_o", "b", "d"))
+       == f"{pp}:{tail}:KL_srp_top:wr_len_o"
+       and identity_path("gptp-processor:hdl/top/KL_gptp_engine.sv:KL_gptp_engine:pub_offset_o")
+       == ("gptp-processor/hdl/top/KL_gptp_engine.sv", "KL_gptp_engine", "pub_offset_o")
+       and identity_path("hdl/a.sv:m:p") == ("hdl/a.sv", "m", "p"))
 
     import tempfile
     with tempfile.TemporaryDirectory() as td:
@@ -439,7 +474,7 @@ def selftest():
        recorded_live is not None and all(":" in i for i in recorded_live),
        "scripts/naming.budget must list path:module:name lines")
 
-    n = len(FIXTURES) + 10
+    n = len(FIXTURES) + 11
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 

--- a/scripts/measure_naming.py
+++ b/scripts/measure_naming.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Kebag Logic
 # SPDX-License-Identifier: CERN-OHL-W-2.0
-"""Measure boundary names that hide a unit, and hold the count down.
+"""Measure boundary names that hide a unit, and hold the list down by identity.
 
 Why this exists. Rule 4 of the maintainability guide
 (docs/development/CODE_QUALITY.md) asks that boundary types make width,
@@ -14,39 +14,51 @@ port to be documented inline with `//!`, and those comments say what the value
 IS - "Egress latency correction, ns", "hiCredit clamp, signed bytes". When the
 comment names a unit of measure and the identifier does not, the unit is known
 and simply absent from the name. That is a finding a reader can check in one
-line, and it needs no taste.
+line.
 
-FALSE POSITIVES WERE MEASURED BEFORE ANY GATE, and they dominated the naive
-form of this check: 408 of 3,491 ports across the superproject and its two
-project-owned processor submodules matched a unit word in their comment, and
-most were not findings at all. Three exclusion classes, each with a reason:
+WHAT IS SCANNED. Every module header - ports and parameters - in first-party
+`.sv` under `hdl/` across the superproject and both project-owned processor
+submodules. A declaration is parsed, not pattern-matched: direction, any type
+(`wire`, `logic`, `reg`, `int`, a package type, an interface modport), packed
+and unpacked dimensions, and every name a declaration shares, across lines. A
+`//!` on the declaration's line documents every name on it; a standalone `//!`
+line documents the undocumented names that follow it until one carries its own
+comment, which is the bundle rule the port-contract gate uses. Function and
+task arguments in module bodies are not boundaries and are not counted. Ports
+with no `//!` at all cannot be judged here and are COUNTED SEPARATELY per tree,
+so the blind spot has a size; the port-contract gate owns that population.
+
+FALSE POSITIVES WERE MEASURED BEFORE ANY GATE. Three exclusion classes, each
+with a reason, and each printed in full by `--excluded`:
 
   * SHAPE, not unit. "1-cycle pulse", "single-cycle strobe", "flips every
-    eth_rx cycle" describe the SHAPE of a signal. That is what the `_p` suffix
-    already encodes, and demanding `_cyc` on a pulse would fight the house
-    convention Rule 4 explicitly defers to.
-  * PROTOCOL-FIXED identifiers. `s_axi_awaddr` is documented as a byte offset
-    and must keep its name: it is AXI's, not ours. Renaming it would break the
-    thing the name exists for.
-  * SINGLE-BIT ports. A one-bit port carries no quantity, so a unit cannot be
-    missing from it.
+    eth_rx cycle" describe the SHAPE of a signal - what the `_p` suffix
+    already encodes. Applied only when the matched unit is the cycle one.
+  * PROTOCOL-FIXED identifiers. `s_axi_awaddr` is AXI's name and keeps it.
+    The set is the published AXI/AXI-Stream signal names, not a prefix.
+  * SINGLE-BIT ports. A one-bit port carries no quantity.
+  * NOUN for the value. "write byte", "subframe A sample", "configuration
+    word" name what the value IS, not what it is measured in. A singular
+    byte/sample/octet with no count, "in", "per" or comma before it is prose.
 
-Applying those three excludes 255 of the 408 and leaves 153 candidates. The
-residual set still contains judgement calls - `now_i` on a module whose entire
-subject is nanoseconds is arguable - so this is a RATCHET and not a verdict.
-The count may not rise. New boundaries state their units; existing debt is
-inventoried and paid down deliberately.
-
-`--excluded` prints every filtered match with its reason, because a filter
-nobody can see is how a check quietly stops checking.
+THE RATCHET IS KEYED ON IDENTITY, NOT A COUNT. `scripts/naming.budget` names
+every candidate as `path:module:port`. A candidate may leave the list only by
+being renamed with its unit or by being removed; a port that is still there
+under the same name and has merely lost the unit word from its comment is
+refused - the cheapest way to lower a count would otherwise be to strip the
+documentation, which is the opposite of the rule. No new identity may appear.
+`--write-budget` regenerates the list after a rename, so lowering is a normal
+commit and the diff shows exactly which boundary gained its unit.
 
 Usage:
-    python3 scripts/measure_naming.py             # the candidate list
-    python3 scripts/measure_naming.py --check     # ratchet (exit 1 if it rose)
-    python3 scripts/measure_naming.py --excluded  # what was filtered, and why
-    python3 scripts/measure_naming.py --selftest  # fixture arms
+    python3 scripts/measure_naming.py                # candidates + per-tree table
+    python3 scripts/measure_naming.py --check        # the identity ratchet
+    python3 scripts/measure_naming.py --excluded     # every filtered match, and why
+    python3 scripts/measure_naming.py --write-budget # regenerate the budget
+    python3 scripts/measure_naming.py --selftest     # fixture arms
 
-Exit 0 = at or under the ratchet.
+Exit 0 = every candidate is recorded and no record left without a rename or
+removal.
 """
 
 import argparse
@@ -59,202 +71,449 @@ BUDGET = Path(__file__).resolve().parent / "naming.budget"
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from code_quality_scope import tracked
+from sv_ports import declarations, module_headers
 
-#: A UNIT OF MEASURE, as written in a port's own `//!` comment. Singular forms
-#: are included deliberately: they are most of what the exclusion classes below
-#: have to filter, and a vocabulary too narrow to SEE a false positive cannot
-#: be said to have measured any.
-#:
-#: `bit`, `bits` and `word` are deliberately NOT units here. A port's bit width
-#: is already explicit in its SystemVerilog type, so "8x3 bits" in a comment is
-#: describing the declared width or a table shape, never a unit of the value;
-#: and "word" is used in this tree both as a count ("31 words") and as a noun
-#: for the value itself ("configuration word"), so it cannot distinguish a
-#: missing unit from ordinary prose.
-UNIT = re.compile(
-    r"\b(nanoseconds?|microseconds?|milliseconds?|ns|us|cycles?|bytes?|octets?"
-    r"|hertz|Hz|ppb|ppm|samples?|seconds|secs?|bits/s|bit/s|bps)\b")
+# ---------------------------------------------------------------------------
+# vocabulary
+# ---------------------------------------------------------------------------
+#: A UNIT OF MEASURE as written in a `//!` comment. Case-insensitive except
+#: where case is the unit (Hz/MHz vs the pronoun "us"). `bit`, `bits` and
+#: `word` are deliberately absent: bit width is already in the type, and
+#: "word" is a noun for the value in this tree ("configuration word").
+_UNIT_WORDS = (
+    r"nanoseconds?|microseconds?|milliseconds?|nsec|usec|msec|ns|us|ms"
+    r"|clock\s+cycles?|cycles?|bytes?|octets?|samples?"
+    r"|hertz|k?hz|mhz|ghz|ppb|ppm|secs?|seconds?"
+    r"|bits?\s*/\s*s|bits?\s+per\s+second|bytes?\s+per\s+second|[kmg]?bps"
+)
+UNIT = re.compile(r"\b(" + _UNIT_WORDS + r")\b", re.I)
+#: `us` is also a pronoun and `second` an ordinal: both need a unit context -
+#: a count, a bracket, a comma, "in" or "per" in front.
+_CONTEXT_UNIT = re.compile(
+    r"(?:(?<=\d)\s*|(?<=[(,/])\s*|\b(?:in|per|every)\s+|^\s*)(us|seconds?)\b", re.I)
+#: singular nouns that are a unit only after "in", "per" or "every" ("in byte
+#: units"); "frame byte", "channel 0 sample", "(byte 0 = MSB)" name the value
+_NOUN_SINGULAR = re.compile(r"^(byte|octet|sample)$", re.I)
+_COUNT_CONTEXT = re.compile(r"\b(?:in|per|every)\s+$", re.I)
+#: a unit word joined by a hyphen or underscore is part of an identifier or a
+#: compound adjective (P-RX-SLOT-BYTES, byte-identical, cycle-count), not a unit
+_JOINED = re.compile(r"[-_]")
 
-#: the same unit, already carried by the identifier
+#: the same unit already carried by the identifier, as a `_`-delimited token
 NAME_UNIT = re.compile(
-    r"(^|_)(ns|us|ms|cyc|cycles|bytes?|hz|ppb|ppm|smp|samples?|sec|secs|bps)(_|$)",
-    re.I)
+    r"(^|_)(ns|us|ms|nsec|usec|msec|cyc|cycles?|bytes?|octets?|k?hz|mhz|ghz"
+    r"|ppb|ppm|smp|samples?|secs?|[kmg]?bps)(_|\d|$)", re.I)
 
-#: SHAPE phrasing - `_p` already encodes this, and Rule 4 defers to the
-#: existing suffix convention rather than competing with it.
+#: SHAPE phrasing - `_p` already encodes this. Only meaningful for the cycle
+#: unit; "frame length in bytes, sampled every cycle" documents a real unit.
 SHAPE = re.compile(
     r"\b\d+\s*-?\s*(cycle|clock)\b|\bone[- ]cycle\b|\bsingle[- ]cycle\b"
-    r"|\bper[- ]cycle\b|\bevery\b.*\bcycle\b", re.I)
+    r"|\bper[- ]cycle\b|\bevery\b[^,;]*\bcycle\b", re.I)
+_CYCLE = re.compile(r"cycle|clock", re.I)
 
-#: identifiers a published protocol owns. Renaming these breaks the contract
-#: the name exists to state.
+#: identifiers a published protocol owns: the AXI4/AXI4-Lite and AXI-Stream
+#: signal names, exactly, behind the house s_/m_ prefixes.
 PROTOCOL = re.compile(
-    r"^(s_axi|m_axi|s_axis|m_axis)_"
-    r"|_(tvalid|tready|tlast|tdata|tkeep|tuser|tdest|tstrb)$")
+    r"^[sm]_axis?_(?:aw|w|b|ar|r)?(?:addr|data|valid|ready|last|keep|strb|user"
+    r"|dest|id|resp|prot|len|size|burst|lock|cache|qos|region)$"
+    r"|_t(?:valid|ready|last|data|keep|user|dest|strb|id)$")
 
-PORT = re.compile(
-    r"^\s*(input|output|inout)\s+(?:wire|logic|var)?\s*(?:signed\s+)?"
-    r"(\[[^\]]*\]\s*)?(\w+)")
+# ---------------------------------------------------------------------------
+# classification
+# ---------------------------------------------------------------------------
+def unit_in(doc):
+    """(word, kind) for the first unit-looking word in a comment, or (None, '').
+
+    kind is 'unit' for a unit of measure, 'noun' for a singular byte/octet/
+    sample used as a noun for the value (reported as an exclusion so the
+    class stays visible), or '' when no unit word is present at all. Words
+    joined by a hyphen or underscore into an identifier or adjective, the
+    pronoun `us` and the ordinal `second` are prose, not units."""
+    noun = None
+    for m in UNIT.finditer(doc):
+        word = m.group(1)
+        low = word.lower()
+        before = doc[m.start() - 1] if m.start() else ""
+        after = doc[m.end():m.end() + 2]
+        count_hyphen = before == "-" and m.start() >= 2 and doc[m.start() - 2].isdigit()
+        if (_JOINED.match(before) and not count_hyphen) or \
+           (after[:1] == "-" and after[1:2].isalpha()):
+            continue
+        if low == "us" or low.startswith("second"):
+            if not _CONTEXT_UNIT.search(doc[:m.end()]):
+                continue
+        if _NOUN_SINGULAR.match(word) and not _COUNT_CONTEXT.search(doc[:m.start()]):
+            noun = noun or word
+            continue
+        return word, "unit"
+    return (noun, "noun") if noun else (None, "")
+
+
+def classify(name, doc, multibit):
+    """('candidate'|'excluded'|None, unit, reason)."""
+    unit, kind = unit_in(doc)
+    if not unit or NAME_UNIT.search(name):
+        return None, unit, ""
+    if kind == "noun":
+        return "excluded", unit, "noun for the value, not a unit of measure"
+    if PROTOCOL.search(name):
+        return "excluded", unit, "protocol-fixed identifier"
+    if not multibit:
+        return "excluded", unit, "single-bit port carries no quantity"
+    if _CYCLE.search(unit) and SHAPE.search(doc):
+        return "excluded", unit, "shape, not a unit (the _p suffix owns this)"
+    return "candidate", unit, ""
+
+
+def scan_text(text):
+    """(candidates, excluded, stats) for one source.
+
+    candidates: [(module, name, unit, doc)]
+    excluded:   [(module, name, unit, reason)]
+    stats: dict(ports, documented, undocumented, named)."""
+    candidates, excluded = [], []
+    stats = {"ports": 0, "documented": 0, "undocumented": 0, "named": 0, "params": 0}
+    for module, name, doc, multibit, kind in declarations(text):
+        stats["params" if kind == "param" else "ports"] += 1
+        if doc.strip():
+            stats["documented"] += 1
+        else:
+            stats["undocumented"] += 1
+        if multibit and NAME_UNIT.search(name):
+            stats["named"] += 1
+        verdict, unit, reason = classify(name, doc, multibit)
+        if verdict == "candidate":
+            candidates.append((module, name, unit, doc.strip()))
+        elif verdict == "excluded":
+            excluded.append((module, name, unit, reason))
+    return candidates, excluded, stats
+
+
+def tree_of(rel):
+    for sub in ("gptp-processor", "protocol-processor"):
+        if rel.startswith(sub + "/"):
+            return sub
+    return "superproject"
 
 
 def sources():
     return [p for p in tracked("hdl") if p.endswith(".sv")]
 
 
-def scan_text(text):
-    """Return (candidates, excluded, total_ports) for one source.
-
-    candidates: [(name, unit, doc)] - documented unit missing from the name.
-    excluded:   [(name, unit, reason)] - matched, then filtered, with why.
-    """
-    candidates, excluded, total = [], [], 0
-    lines = text.splitlines()
-    for i, line in enumerate(lines):
-        m = PORT.match(line)
-        if not m:
-            continue
-        total += 1
-        width, name = m.group(2), m.group(3)
-        same = re.search(r"//!(.*)$", line)
-        if same:
-            doc = same.group(1)
-        elif i and "//!" in lines[i - 1]:
-            doc = lines[i - 1].split("//!", 1)[1]
-        else:
-            doc = ""
-        unit = UNIT.search(doc)
-        if not unit or NAME_UNIT.search(name):
-            continue
-        if PROTOCOL.search(name):
-            excluded.append((name, unit.group(0), "protocol-fixed identifier"))
-        elif not width:
-            excluded.append((name, unit.group(0), "single-bit port carries no quantity"))
-        elif SHAPE.search(doc):
-            excluded.append((name, unit.group(0), "shape, not a unit (the _p suffix owns this)"))
-        else:
-            candidates.append((name, unit.group(0), doc.strip()))
-    return candidates, excluded, total
-
-
 def scan_repo():
-    rows, drops, total = [], [], 0
+    rows, drops, per_tree = [], [], {}
     for rel in sources():
-        c, e, n = scan_text((REPO / rel).read_text(errors="replace"))
-        total += n
+        c, e, st = scan_text((REPO / rel).read_text(errors="replace"))
+        t = per_tree.setdefault(tree_of(rel), {"files": 0, "ports": 0, "params": 0,
+                                               "documented": 0, "undocumented": 0,
+                                               "named": 0, "matches": 0,
+                                               "excluded": 0, "candidates": 0})
+        t["files"] += 1
+        for k in ("ports", "params", "documented", "undocumented", "named"):
+            t[k] += st[k]
+        t["matches"] += len(c) + len(e)
+        t["excluded"] += len(e)
+        t["candidates"] += len(c)
         rows += [(rel,) + r for r in c]
         drops += [(rel,) + r for r in e]
-    return rows, drops, total
+    return rows, drops, per_tree
 
 
+def identity(row):
+    rel, module, name = row[0], row[1], row[2]
+    return f"{rel}:{module}:{name}"
+
+
+# ---------------------------------------------------------------------------
+# the identity ratchet
+# ---------------------------------------------------------------------------
 def read_budget():
+    """{identity} recorded, or None when the file is missing/unreadable."""
     if not BUDGET.is_file():
         return None
+    ids = set()
     for line in BUDGET.read_text().splitlines():
         line = line.split("#", 1)[0].strip()
-        if line.isdigit():
-            return int(line)
-    return None
+        if line:
+            ids.add(line)
+    return ids
+
+
+def port_still_declared(rel, module, name):
+    """True when `module` in `rel` still declares a port/parameter called `name`."""
+    path = REPO / rel
+    if not path.is_file():
+        return False
+    return any(m == module and n == name
+               for m, n, _d, _mb, _k in declarations(path.read_text(errors="replace")))
+
+
+def ratchet(rows, recorded):
+    """(new, stripped, left) - new identities, records that lost their unit
+    word without a rename, and records that left legitimately."""
+    current = {identity(r) for r in rows}
+    new = sorted(current - recorded)
+    stripped, left = [], []
+    for ident in sorted(recorded - current):
+        rel, module, name = ident.split(":", 2)
+        if port_still_declared(rel, module, name):
+            stripped.append(ident)
+        else:
+            left.append(ident)
+    return new, stripped, left
+
+
+def write_budget(rows, per_tree):
+    total = sum(t["candidates"] for t in per_tree.values())
+    head = [
+        "# Rule 4 ratchet, keyed on IDENTITY: every boundary port or parameter whose",
+        "# own //! comment names a unit of measure that the identifier does not carry,",
+        "# as path:module:name. See scripts/measure_naming.py.",
+        "#",
+        "# A line may leave this file only because the boundary was renamed with its",
+        "# unit or removed; a port still declared under the same name that has lost",
+        "# the unit word from its comment is refused, so the documentation cannot be",
+        "# stripped to lower the count. No line may be added. Regenerate with",
+        "# `python3 scripts/measure_naming.py --write-budget` after a rename.",
+        "#",
+        f"# {total} candidate(s): " + ", ".join(
+            f"{k} {v['candidates']}" for k, v in sorted(per_tree.items())),
+    ]
+    body = sorted(identity(r) for r in rows)
+    BUDGET.write_text("\n".join(head + body) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# self-test
+# ---------------------------------------------------------------------------
+def _wrap(decl):
+    return f"module f (\n{decl}\n  input wire clk_i //! clock\n);\nendmodule\n"
 
 
 FIXTURES = [
+    # (name, source, expected candidates, expected excluded)
     ("a documented unit missing from the name is a candidate",
-     "  input wire [31:0] pres_ofs_i,  //! presentation offset ns", 1, 0),
+     _wrap("  input wire [31:0] pres_ofs_i,  //! presentation offset ns"), 1, 0),
     ("a name that already carries the unit is not",
-     "  input wire [31:0] pres_ofs_ns_i,  //! presentation offset ns", 0, 0),
+     _wrap("  input wire [31:0] pres_ofs_ns_i,  //! presentation offset ns"), 0, 0),
     ("a one-cycle pulse is a shape, not a unit",
-     "  input wire [3:0] arm_i,  //! 1-cycle pulse: arm the chain", 0, 1),
+     _wrap("  input wire [3:0] arm_i,  //! 1-cycle pulse: arm the chain"), 0, 1),
+    ("shape phrasing does not swallow a real unit",
+     _wrap("  input wire [15:0] len_i,  //! frame length in bytes, sampled every cycle"), 1, 0),
     ("a single-bit port carries no quantity",
-     "  input wire go_i,  //! start, ns aligned", 0, 1),
+     _wrap("  input wire go_i,  //! start, ns aligned"), 0, 1),
     ("a protocol-fixed identifier is left alone",
-     "  input wire [11:0] s_axi_awaddr,  //! Write address (byte offset)", 0, 1),
+     _wrap("  input wire [11:0] s_axi_awaddr,  //! Write address, offset in bytes"), 0, 1),
+    ("a prefix alone is not a protocol name",
+     _wrap("  input wire [31:0] s_axi_probe_timeout,  //! timeout, ns"), 1, 0),
     ("a port with no unit in its comment is not a candidate",
-     "  input wire [31:0] thing_i,  //! some opaque configuration word", 0, 0),
+     _wrap("  input wire [31:0] thing_i,  //! some opaque configuration word"), 0, 0),
     ("an undocumented port is not a candidate",
-     "  input wire [31:0] thing_i,", 0, 0),
+     _wrap("  input wire [31:0] thing_i,"), 0, 0),
     ("ordinary prose using second is not a time unit",
-     "  input wire [31:0] stream_id_i, //! avoids a second copy", 0, 0),
-    ("the comment may sit on the line above",
-     "  //! ring size (bytes)\n  input wire [31:0] ring_len_i,", 1, 0),
+     _wrap("  input wire [31:0] stream_id_i, //! avoids a second copy"), 0, 0),
+    ("a counted second is a time unit",
+     _wrap("  input wire [31:0] window_i, //! window, 1 second"), 1, 0),
+    ("the pronoun us is not microseconds",
+     _wrap("  input wire [31:0] disc_cnt_i, //! ENTITY_DISCOVERs accepted for us"), 0, 0),
+    ("microseconds written as us in a unit context is",
+     _wrap("  input wire [31:0] hold_i, //! hold time, us"), 1, 0),
+    ("ms, kHz, MHz, Mbps and nsec are units",
+     _wrap("  input wire [31:0] a_i, //! timeout, ms\n  input wire [31:0] b_i, //! rate, kHz\n"
+           "  input wire [31:0] c_i, //! clock, MHz\n  input wire [31:0] d_i, //! rate, Mbps\n"
+           "  input wire [31:0] e_i, //! offset, nsec\n  input wire [31:0] f_i, //! rate in bits per second"), 6, 0),
+    ("a capitalised unit is still a unit",
+     _wrap("  input wire [31:0] fl_i, //! Bytes in flight"), 1, 0),
+    ("a name carrying octets satisfies a comment saying octets",
+     _wrap("  input wire [15:0] len_octets_i, //! length, octets"), 0, 0),
+    ("a singular noun for the value is excluded, visibly, not counted",
+     _wrap("  output wire [7:0] dev_wdata_o, //! write byte\n"
+           "  input wire [23:0] pair_l_i, //! subframe A sample"), 0, 2),
+    ("a counted singular is a unit",
+     _wrap("  input wire [7:0] n_i, //! payload, in byte units"), 1, 0),
+    ("a position noun with a number after it is a noun, not a count",
+     _wrap("  input wire [47:0] mac_i, //! MSB-first (byte 0 in [47:40])\n"
+           "  input wire [23:0] ph_i, //! phys channel 0 sample"), 0, 2),
+    ("a unit word joined by a hyphen is an identifier or an adjective, not a unit",
+     _wrap("  input wire [7:0] a_i, //! P-RX-SLOTS / P-RX-SLOT-BYTES (F01.5)\n"
+           "  input wire [7:0] b_i, //! stereo framer, byte-identical\n"
+           "  input wire [7:0] c_i, //! free-running cycle-count width"), 0, 0),
+    ("consecutive standalone comment lines are one group comment",
+     "module f #(\n  //! per-stage re-arm guard, in clk_i cycles; the caller derives it\n"
+     "  //! from the datapath clock rather than restating a count here\n"
+     "  parameter int TIMEOUT_C = 50000\n) (\n  input wire clk_i //! clock\n);\nendmodule\n", 1, 0),
+    ("the comment may sit on the line above, as a group comment",
+     _wrap("  //! ring size (bytes)\n  input wire [31:0] ring_len_i,"), 1, 0),
+    ("a group comment covers the undocumented ports of its bundle",
+     _wrap("  //! window bounds, ns\n  input wire [31:0] lo_i,\n  input wire [31:0] hi_i,"), 2, 0),
+    ("a port's own trailing comment is not inherited by the next port",
+     _wrap("  input wire [31:0] nb1_i, //! delay, ns\n  input wire [31:0] nb2_i,"), 1, 0),
+    ("a port with its own comment ends the bundle",
+     _wrap("  //! window bounds, ns\n  input wire [31:0] lo_i,\n"
+           "  input wire [31:0] hi_i, //! plain\n  input wire [31:0] later_i,"), 1, 0),
+    ("output reg is parsed as a port, not as a name called reg",
+     _wrap("  output reg  [31:0] probe_reg_o,  //! elapsed, ns"), 1, 0),
+    ("an int port has a width even without brackets",
+     _wrap("  output int probe_int_o, //! elapsed, ns"), 1, 0),
+    ("a package-typed port is a boundary",
+     _wrap("  input ethernet_packet_pkg::pkt_len_t probe_typed_i, //! length, bytes"), 1, 0),
+    ("a two-dimensional port is a quantity",
+     _wrap("  input wire [3:0][31:0] probe_2d_i, //! per-lane offsets, ns"), 1, 0),
+    ("a declaration split across lines is one port",
+     _wrap("  input wire [31:0]\n    probe_ml_i, //! delay, ns"), 1, 0),
+    ("names sharing one declaration are each a port",
+     _wrap("  input logic [7:0] probe_sh1_i, probe_sh2_i, //! sizes in bytes"), 2, 0),
+    ("a port-like line inside a block comment is not a port",
+     _wrap("  /* input wire [31:0] probe_blockcmt_i, //! delay, ns */\n  input wire [31:0] real_i, //! delay, ns"), 1, 0),
+    ("a parameter is a boundary too",
+     "module f #(\n  parameter int TIMEOUT_C = 50000 //! re-arm guard, cycles\n) (\n  input wire clk_i //! clock\n);\nendmodule\n", 1, 0),
+    ("a parameter carrying its unit is not",
+     "module f #(\n  parameter int TIMEOUT_CYC_C = 50000 //! re-arm guard, cycles\n) (\n  input wire clk_i //! clock\n);\nendmodule\n", 0, 0),
+    ("a function argument in the body is not a boundary",
+     "module f (\n  input wire clk_i //! clock\n);\n  function automatic int g(input int idle_slope); //! bits/s\n    return idle_slope;\n  endfunction\nendmodule\n", 0, 0),
+    ("an interface modport port parses as one name",
+     _wrap("  axi_stream_if.slave s_axis, //! ingress, bytes per beat"), 1, 0),
 ]
 
 
 def selftest():
     failures = 0
-    for name, src, want_c, want_e in FIXTURES:
-        c, e, _ = scan_text(src)
-        if len(c) == want_c and len(e) == want_e:
+
+    def ck(name, ok, detail=""):
+        nonlocal failures
+        if ok:
             print(f"[PASS] {name}")
         else:
             failures += 1
-            print(f"[FAIL] {name}: got {len(c)} candidate(s) / {len(e)} excluded, "
-                  f"want {want_c} / {want_e}")
+            print(f"[FAIL] {name}{': ' + detail if detail else ''}")
 
-    # the exclusions must be REPORTED, not silently dropped: a filter nobody
-    # can see is how a check quietly stops checking
-    _c, e, _n = scan_text(FIXTURES[2][1])
-    if e and e[0][2].startswith("shape"):
-        print("[PASS] an exclusion names its reason")
-    else:
-        failures += 1
-        print(f"[FAIL] an exclusion names its reason: {e}")
+    for name, src, want_c, want_e in FIXTURES:
+        c, e, _ = scan_text(src)
+        ck(name, len(c) == want_c and len(e) == want_e,
+           f"got {len(c)} candidate(s) {[(x[1], x[2]) for x in c]} / {len(e)} excluded "
+           f"{[(x[1], x[3]) for x in e]}, want {want_c} / {want_e}")
 
-    # and the scan must find something in the real tree - an inert scan would
-    # ratchet to zero and stay green forever
-    rows, drops, total = scan_repo()
-    if total > 500 and rows:
-        print(f"[PASS] the live scan reads the tree ({total} ports)")
-    else:
-        failures += 1
-        print(f"[FAIL] the live scan reads the tree: {total} ports, {len(rows)} candidates")
+    _c, e, _s = scan_text(FIXTURES[2][1])
+    ck("an exclusion names its reason", bool(e) and e[0][3].startswith("shape"), f"{e}")
 
-    n = len(FIXTURES) + 2
+    _c, _e, st = scan_text(_wrap("  input wire [31:0] a_i,\n  input wire [31:0] b_i, //! x"))
+    ck("undocumented ports are counted, not silently skipped",
+       st["undocumented"] == 1 and st["documented"] == 2, f"{st}")
+
+    # the identity ratchet: a stripped comment is refused, a rename or removal is not
+    recorded = {"x.sv:f:pres_ofs_i"}
+    rows_now = [("x.sv", "f", "pres_ofs_i", "ns", "offset ns")]
+    ck("a recorded candidate that is still a candidate is neither new nor gone",
+       ratchet(rows_now, recorded) == ([], [], []))
+    ck("a new identity is refused",
+       ratchet(rows_now + [("x.sv", "f", "zz_i", "ns", "d ns")], recorded)[0] == ["x.sv:f:zz_i"])
+
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        global REPO
+        real = REPO
+        try:
+            REPO = Path(td)
+            (REPO / "x.sv").write_text(_wrap("  input wire [31:0] pres_ofs_i, //! presentation offset"))
+            ck("a recorded port that merely lost the unit from its comment is refused as stripped",
+               ratchet([], recorded) == ([], ["x.sv:f:pres_ofs_i"], []))
+            (REPO / "x.sv").write_text(_wrap("  input wire [31:0] pres_ofs_ns_i, //! presentation offset ns"))
+            ck("a recorded port renamed with its unit has left legitimately",
+               ratchet([], recorded) == ([], [], ["x.sv:f:pres_ofs_i"]))
+            (REPO / "x.sv").write_text(_wrap(""))
+            ck("a recorded port that was removed has left legitimately",
+               ratchet([], recorded) == ([], [], ["x.sv:f:pres_ofs_i"]))
+        finally:
+            REPO = real
+
+    rows, drops, per_tree = scan_repo()
+    total_ports = sum(t["ports"] for t in per_tree.values())
+    ck("the live scan reads the tree", total_ports > 500 and rows,
+       f"{total_ports} ports, {len(rows)} candidates")
+    for sub in ("gptp-processor", "protocol-processor"):
+        t = per_tree.get(sub, {})
+        ck(f"the live scan reaches {sub}", t.get("files", 0) > 0 and t.get("ports", 0) > 0,
+           f"{t}")
+    recorded_live = read_budget()
+    ck("the budget is keyed on identity, not a count",
+       recorded_live is not None and all(":" in i for i in recorded_live),
+       "scripts/naming.budget must list path:module:name lines")
+
+    n = len(FIXTURES) + 10
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
 
+# ---------------------------------------------------------------------------
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--check", action="store_true", help="ratchet: fail if the count rose")
-    ap.add_argument("--excluded", action="store_true", help="show what was filtered, and why")
+    ap.add_argument("--check", action="store_true", help="the identity ratchet")
+    ap.add_argument("--excluded", action="store_true", help="every filtered match, and why")
+    ap.add_argument("--write-budget", action="store_true", help="regenerate scripts/naming.budget")
     ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
     args = ap.parse_args()
 
     if args.selftest:
         return selftest()
 
-    rows, drops, total = scan_repo()
+    rows, drops, per_tree = scan_repo()
 
     if args.excluded:
         print(f"{len(drops)} match(es) filtered, by reason:")
-        for reason in sorted({d[3] for d in drops}):
-            group = [d for d in drops if d[3] == reason]
+        for reason in sorted({d[4] for d in drops}):
+            group = [d for d in drops if d[4] == reason]
             print(f"\n  {reason} ({len(group)}):")
-            for rel, name, unit, _r in group[:12]:
-                print(f"    {name:<28} [{unit}]  {rel}")
-            if len(group) > 12:
-                print(f"    ... and {len(group) - 12} more")
+            for rel, module, name, unit, _r in group:
+                print(f"    {name:<28} [{unit}]  {rel}:{module}")
         return 0
 
-    for rel, name, unit, doc in rows:
-        print(f"{rel}: {name} — documented in {unit}, not named for it: {doc}")
+    if args.write_budget:
+        write_budget(rows, per_tree)
+        print(f"wrote {BUDGET.relative_to(REPO)}: {len(rows)} candidate(s)")
+        return 0
 
-    budget = read_budget()
-    tail = (f"{len(rows)} boundary name(s) hide a documented unit "
-            f"({total} ports scanned, {len(drops)} match(es) excluded with a reason)")
+    for rel, module, name, unit, doc in rows:
+        print(f"{rel}:{module}: {name} — documented in {unit}, not named for it: {doc}")
+
+    print(f"\n{'tree':<20}{'files':>6}{'ports':>7}{'params':>7}{'documented':>11}"
+          f"{'undocumented':>13}{'unit-named':>11}{'matches':>8}{'excluded':>9}{'candidates':>11}")
+    for tree, t in sorted(per_tree.items()):
+        print(f"{tree:<20}{t['files']:>6}{t['ports']:>7}{t['params']:>7}{t['documented']:>11}"
+              f"{t['undocumented']:>13}{t['named']:>11}{t['matches']:>8}{t['excluded']:>9}"
+              f"{t['candidates']:>11}")
+    tot = {k: sum(t[k] for t in per_tree.values()) for k in
+           ("files", "ports", "params", "documented", "undocumented", "named",
+            "matches", "excluded", "candidates")}
+    print(f"{'total':<20}{tot['files']:>6}{tot['ports']:>7}{tot['params']:>7}{tot['documented']:>11}"
+          f"{tot['undocumented']:>13}{tot['named']:>11}{tot['matches']:>8}{tot['excluded']:>9}"
+          f"{tot['candidates']:>11}")
+    print(f"\n{len(rows)} boundary name(s) hide a documented unit "
+          f"({tot['ports']} ports and {tot['params']} parameters scanned, "
+          f"{tot['undocumented']} with no //! and so not judged here, "
+          f"{len(drops)} match(es) excluded with a reason)")
+
     if not args.check:
-        print(f"\n{tail}")
         return 0
 
-    if budget is None:
-        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} is missing or unreadable")
+    recorded = read_budget()
+    if recorded is None:
+        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} is missing")
         return 1
-    if len(rows) > budget:
-        print(f"\nNAMING RATCHET: FAIL ({len(rows)} > ratchet {budget}). A new "
-              f"boundary must state its unit in its name.")
+    new, stripped, left = ratchet(rows, recorded)
+    for ident in new:
+        print(f"\nNEW: {ident} - a new boundary must state its unit in its name")
+    for ident in stripped:
+        print(f"\nSTRIPPED: {ident} is still declared under that name and is no longer a "
+              f"candidate only because its comment no longer names the unit - restore the "
+              f"documentation or rename the boundary")
+    if new or stripped:
+        print(f"\nNAMING RATCHET: FAIL ({len(new)} new, {len(stripped)} stripped)")
         return 1
-    print(f"\nNAMING RATCHET: PASS ({tail}; ratchet {budget})")
-    if len(rows) < budget:
-        print(f"  the ratchet can be lowered to {len(rows)}")
+    print(f"\nNAMING RATCHET: PASS ({len(rows)} candidate(s), all recorded by identity; "
+          f"{len(recorded)} recorded)")
+    if left:
+        print(f"  {len(left)} recorded boundary(ies) were renamed or removed - regenerate the "
+              f"budget with --write-budget: " + ", ".join(left))
     return 0
 
 

--- a/scripts/naming.budget
+++ b/scripts/naming.budget
@@ -11,7 +11,7 @@
 # stripped to lower the count. No line may be added. Regenerate with
 # `python3 scripts/measure_naming.py --write-budget` after a rename.
 #
-# 105 candidate(s): gptp-processor 1, protocol-processor 20, superproject 84
+# 104 candidate(s): gptp-processor 1, protocol-processor 20, superproject 83
 gptp-processor:hdl/top/KL_gptp_engine.sv:KL_gptp_engine:pub_offset_o
 hdl/common/csr/milan_csr.sv:milan_csr:i_lwsrp_slope
 hdl/common/csr/milan_csr.sv:milan_csr:o_lwsrp_latency
@@ -47,7 +47,6 @@ hdl/ieee1722/aaf/aaf_talker_i2s.sv:aaf_talker_i2s:MCLK_DIV_LOG2
 hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:fsh_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:pres_ofs_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:ptp_now_i
-hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:diag_idx_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:dirty_p_o
 hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:fsh_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:mirrored

--- a/scripts/naming.budget
+++ b/scripts/naming.budget
@@ -1,18 +1,27 @@
 # Rule 4 ratchet, keyed on IDENTITY: every boundary port or parameter whose
 # own //! comment names a unit of measure that the identifier does not carry,
-# as path:module:name. A processor entry is spelled <submodule>:<path>:...
-# (colon, not slash, after the submodule name - the scripts/xvlog.budget
-# spelling) so this generated record is not a hand-written source list.
+# or documents a unit of a different family than the one the identifier
+# carries (marked `# named for a different unit than documented`), as path:module:name.
+# A processor entry is spelled <submodule>:<path>:... (colon, not slash,
+# after the submodule name - the scripts/xvlog.budget spelling) so this
+# generated record is not a hand-written source list.
 # See scripts/measure_naming.py.
 #
 # A line may leave this file only because the boundary was renamed with its
-# unit or removed; a port still declared under the same name that has lost
-# the unit word from its comment is refused, so the documentation cannot be
-# stripped to lower the count. No line may be added. Regenerate with
-# `python3 scripts/measure_naming.py --write-budget` after a rename.
+# unit or removed - or, for a name that already carries a unit, because its
+# comment now names that unit's family; a port still declared under the same
+# name that has lost the unit word from its comment is refused, so the
+# documentation cannot be stripped to lower the count. No line may be added.
+# Regenerate with `python3 scripts/measure_naming.py --write-budget`.
 #
-# 104 candidate(s): gptp-processor 1, protocol-processor 20, superproject 83
+# 2026-08-29: the mismatch lines arrived when the measurement began comparing
+# the identifier's unit family to the documented one (PR #278 review,
+# scripts/measure_naming.py classify): a unit token in the name no longer
+# satisfies a comment that documents a different unit.
+#
+# 110 candidate(s): gptp-processor 1, protocol-processor 21, superproject 88; 6 of them named for a different unit than documented
 gptp-processor:hdl/top/KL_gptp_engine.sv:KL_gptp_engine:pub_offset_o
+hdl/common/KL_link_guard.sv:KL_link_guard:SETTLE_CYC_C  # named for a different unit than documented
 hdl/common/csr/milan_csr.sv:milan_csr:i_lwsrp_slope
 hdl/common/csr/milan_csr.sv:milan_csr:o_lwsrp_latency
 hdl/common/csr/milan_csr.sv:milan_csr:o_mac_ifg
@@ -39,14 +48,17 @@ hdl/ieee1722/aaf/KL_lat_history_ring.sv:KL_lat_history_ring:ring_len_i
 hdl/ieee1722/aaf/KL_pcm_ring_bram.sv:KL_pcm_ring_bram:length_i
 hdl/ieee1722/aaf/KL_pcm_ring_bram.sv:KL_pcm_ring_bram:offset_o
 hdl/ieee1722/aaf/KL_pcm_ring_bram.sv:KL_pcm_ring_bram:stride_i
+hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:SAMPLE_DIV_C  # named for a different unit than documented
 hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:rd_ptr_o
 hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:ring_len_i
 hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:ring_stride_i
 hdl/ieee1722/aaf/KL_tdm_capture_master.sv:KL_tdm_capture_master:BCLK_HALF_P
 hdl/ieee1722/aaf/aaf_talker_i2s.sv:aaf_talker_i2s:MCLK_DIV_LOG2
+hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:CLK_FREQ_HZ_P  # named for a different unit than documented
 hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:fsh_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:pres_ofs_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:ptp_now_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:CLK_FREQ_HZ_P  # named for a different unit than documented
 hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:dirty_p_o
 hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:fsh_i
 hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:mirrored
@@ -69,6 +81,7 @@ hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:WIN_LOG2_P
 hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:crf_rate_i
 hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:drp_addr_o
 hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:ptp_now_i
+hdl/ieee1722/maap/KL_maap.sv:KL_maap:CLK_FREQ_HZ_P  # named for a different unit than documented
 hdl/ieee17221/adp/adp_tx_arbiter.sv:adp_tx_arbiter:TO_LOG2_P
 hdl/ieee8021as/ptp_timestamp/ptp_ts_core.sv:ptp_ts_core:lat_corr_i
 hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_adj
@@ -100,6 +113,7 @@ protocol-processor:hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:DEB_TICKS_P
 protocol-processor:hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:LAYOUT_VER_P
 protocol-processor:hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:dbg_drop_o
 protocol-processor:hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:seal_len_i
+protocol-processor:hdl/common/KL_pp_timer_service.sv:KL_pp_timer_service:DIV_US_P  # named for a different unit than documented
 protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:acmp_stall_count_o
 protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:adp_stall_count_o
 protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:aecp_stall_count_o

--- a/scripts/naming.budget
+++ b/scripts/naming.budget
@@ -1,9 +1,9 @@
 # Rule 4 ratchet: boundary ports whose own //! comment names a unit of measure
 # that the identifier does not carry. See scripts/measure_naming.py for the
 # scan, the three exclusion classes and the false-positive measurement behind
-# them (180 raw matches, 100 excluded with a reason, 80 candidates).
+# them (408 raw matches, 255 excluded with a reason, 153 candidates).
 #
 # THIS NUMBER MAY ONLY GO DOWN. A new boundary states its unit in its name;
 # existing debt is paid off deliberately, not all at once. Lower it whenever
 # --check reports it can be lowered.
-80
+153

--- a/scripts/naming.budget
+++ b/scripts/naming.budget
@@ -1,0 +1,9 @@
+# Rule 4 ratchet: boundary ports whose own //! comment names a unit of measure
+# that the identifier does not carry. See scripts/measure_naming.py for the
+# scan, the three exclusion classes and the false-positive measurement behind
+# them (180 raw matches, 100 excluded with a reason, 80 candidates).
+#
+# THIS NUMBER MAY ONLY GO DOWN. A new boundary states its unit in its name;
+# existing debt is paid off deliberately, not all at once. Lower it whenever
+# --check reports it can be lowered.
+80

--- a/scripts/naming.budget
+++ b/scripts/naming.budget
@@ -1,9 +1,116 @@
-# Rule 4 ratchet: boundary ports whose own //! comment names a unit of measure
-# that the identifier does not carry. See scripts/measure_naming.py for the
-# scan, the three exclusion classes and the false-positive measurement behind
-# them (408 raw matches, 255 excluded with a reason, 153 candidates).
+# Rule 4 ratchet, keyed on IDENTITY: every boundary port or parameter whose
+# own //! comment names a unit of measure that the identifier does not carry,
+# as path:module:name. See scripts/measure_naming.py.
 #
-# THIS NUMBER MAY ONLY GO DOWN. A new boundary states its unit in its name;
-# existing debt is paid off deliberately, not all at once. Lower it whenever
-# --check reports it can be lowered.
-153
+# A line may leave this file only because the boundary was renamed with its
+# unit or removed; a port still declared under the same name that has lost
+# the unit word from its comment is refused, so the documentation cannot be
+# stripped to lower the count. No line may be added. Regenerate with
+# `python3 scripts/measure_naming.py --write-budget` after a rename.
+#
+# 105 candidate(s): gptp-processor 1, protocol-processor 20, superproject 84
+gptp-processor/hdl/top/KL_gptp_engine.sv:KL_gptp_engine:pub_offset_o
+hdl/common/csr/milan_csr.sv:milan_csr:i_lwsrp_slope
+hdl/common/csr/milan_csr.sv:milan_csr:o_lwsrp_latency
+hdl/common/csr/milan_csr.sv:milan_csr:o_mac_ifg
+hdl/common/csr/milan_csr.sv:milan_csr:o_ptp_egress_lat
+hdl/common/csr/milan_csr.sv:milan_csr:o_ptp_incr
+hdl/common/csr/milan_csr.sv:milan_csr:o_ptp_ingress_lat
+hdl/common/csr/milan_csr.sv:milan_csr:o_tone_att
+hdl/ieee1722/aaf/KL_aaf_latency_tap_bank.sv:KL_aaf_latency_tap_bank:TIMEOUT_C
+hdl/ieee1722/aaf/KL_aaf_latency_tap_bank.sv:KL_aaf_latency_tap_bank:now_i
+hdl/ieee1722/aaf/KL_aaf_latency_taps.sv:KL_aaf_latency_chain:TIMEOUT_C
+hdl/ieee1722/aaf/KL_aaf_latency_taps.sv:KL_aaf_latency_chain:epoch_o
+hdl/ieee1722/aaf/KL_aaf_latency_taps.sv:KL_aaf_latency_chain:now_i
+hdl/ieee1722/aaf/KL_aaf_latency_taps.sv:KL_aaf_latency_taps:TIMEOUT_C
+hdl/ieee1722/aaf/KL_aaf_latency_taps.sv:KL_aaf_latency_taps:now_i
+hdl/ieee1722/aaf/KL_aaf_packetizer.sv:KL_aaf_packetizer:mr_i
+hdl/ieee1722/aaf/KL_aes3_rx.sv:KL_aes3_rx:RUN_W_P
+hdl/ieee1722/aaf/KL_aes3_tx.sv:KL_aes3_tx:OVERSAMPLE_P
+hdl/ieee1722/aaf/KL_chan_map_capture.sv:KL_chan_map_capture:lb_flush_i
+hdl/ieee1722/aaf/KL_chan_map_capture.sv:KL_chan_map_capture:lb_tdata_i
+hdl/ieee1722/aaf/KL_chan_map_render.sv:KL_chan_map_render:map_flat_o
+hdl/ieee1722/aaf/KL_i2s_feed_mux.sv:KL_i2s_feed_mux:tap_tdata_i
+hdl/ieee1722/aaf/KL_lat_history_ring.sv:KL_lat_history_ring:ring_base_i
+hdl/ieee1722/aaf/KL_lat_history_ring.sv:KL_lat_history_ring:ring_len_i
+hdl/ieee1722/aaf/KL_pcm_ring_bram.sv:KL_pcm_ring_bram:length_i
+hdl/ieee1722/aaf/KL_pcm_ring_bram.sv:KL_pcm_ring_bram:offset_o
+hdl/ieee1722/aaf/KL_pcm_ring_bram.sv:KL_pcm_ring_bram:stride_i
+hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:rd_ptr_o
+hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:ring_len_i
+hdl/ieee1722/aaf/KL_pcm_tx.sv:KL_pcm_tx:ring_stride_i
+hdl/ieee1722/aaf/KL_tdm_capture_master.sv:KL_tdm_capture_master:BCLK_HALF_P
+hdl/ieee1722/aaf/aaf_talker_i2s.sv:aaf_talker_i2s:MCLK_DIV_LOG2
+hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:fsh_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:pres_ofs_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor.sv:KL_avtp_rx_monitor:ptp_now_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:diag_idx_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:dirty_p_o
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:fsh_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:mirrored
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:pres_ofs_i
+hdl/ieee1722/avtp/KL_avtp_rx_monitor_ctx.sv:KL_avtp_rx_monitor_ctx:ptp_now_i
+hdl/ieee1722/avtp/avtp_stream_parser.sv:avtp_stream_parser:fsh2_o
+hdl/ieee1722/crf/KL_crf_rx.sv:KL_crf_rx:a
+hdl/ieee1722/crf/KL_crf_rx.sv:KL_crf_rx:ptp_now_i
+hdl/ieee1722/crf/KL_crf_rx.sv:KL_crf_rx:rate_o
+hdl/ieee1722/crf/KL_media_nco.sv:KL_media_nco:TRIM_MAX_P
+hdl/ieee1722/crf/KL_media_nco.sv:KL_media_nco:a
+hdl/ieee1722/crf/KL_media_nco.sv:KL_media_nco:clamp
+hdl/ieee1722/crf/KL_media_nco.sv:KL_media_nco:servo_trim_i
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:GAIN_NUM_P
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:LOCK_THR_P
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:NORM_SHIFT_P
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:SLEW_MAX_P
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:U_MAX_P
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:WIN_LOG2_P
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:crf_rate_i
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:drp_addr_o
+hdl/ieee1722/crf/KL_mmcm_drp_servo.sv:KL_mmcm_drp_servo:ptp_now_i
+hdl/ieee17221/adp/adp_tx_arbiter.sv:adp_tx_arbiter:TO_LOG2_P
+hdl/ieee8021as/ptp_timestamp/ptp_ts_core.sv:ptp_ts_core:lat_corr_i
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_adj
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_egress_lat
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_incr
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_ingress_lat
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_offset
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:i_ptp_tod_wr
+hdl/ieee8021as/ptp_timestamp/ptp_ts_top.sv:ptp_ts_top:o_ptp_tod_rd
+hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv:timestamp_counter:FRAC_WIDTH
+hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv:timestamp_counter:adj_i
+hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv:timestamp_counter:incr_i
+hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv:timestamp_counter:offset_i
+hdl/ieee8021as/ptp_timestamp/timestamp_counter.sv:timestamp_counter:tod_wr_i
+hdl/milan/KL_pp_shadow.sv:KL_pp_shadow:RESP_BASE_P
+hdl/milan/KL_pp_shadow.sv:KL_pp_shadow:srp_acc_latency_o
+hdl/milan/milan_datapath.sv:milan_datapath:MCSERVO_P
+hdl/milan/milan_datapath.sv:milan_datapath:PP_RESP_BASE_P
+hdl/milan/milan_datapath.sv:milan_datapath:i_resp_mem_rsp_data
+hdl/milan/milan_datapath.sv:milan_datapath:o_resp_mem_req_addr
+hdl/milan/milan_datapath.sv:milan_datapath:o_resp_mem_req_beats
+hdl/milan/milan_datapath.sv:milan_datapath:o_resp_mem_wr_addr
+hdl/milan/milan_datapath.sv:milan_datapath:o_resp_mem_wr_data
+hdl/milan/milan_datapath.sv:milan_datapath:o_resp_mem_wr_strb
+hdl/milan/milan_datapath.sv:milan_datapath:pb_rd_ptr_o
+hdl/milan/milan_datapath.sv:milan_datapath:pb_ring_len_i
+hdl/milan/milan_datapath.sv:milan_datapath:pb_ring_stride_i
+protocol-processor/hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:DEB_TICKS_P
+protocol-processor/hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:LAYOUT_VER_P
+protocol-processor/hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:dbg_drop_o
+protocol-processor/hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:seal_len_i
+protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:acmp_stall_count_o
+protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:adp_stall_count_o
+protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:aecp_stall_count_o
+protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:maap_stall_count_o
+protocol-processor/hdl/packet_engine/KL_pp_nvm_port.sv:KL_pp_nvm_port:MAX_PAYLOAD_P
+protocol-processor/hdl/packet_engine/KL_pp_tx_slots.sv:KL_pp_tx_slots:wr_len_i
+protocol-processor/hdl/srp/KL_srp_decoder.sv:KL_srp_decoder:TP_DEPTH_P
+protocol-processor/hdl/srp/KL_srp_decoder.sv:KL_srp_decoder:dbg_listlen_cnt_o
+protocol-processor/hdl/srp/KL_srp_encoder.sv:KL_srp_encoder:ev_value_i
+protocol-processor/hdl/srp/KL_srp_encoder.sv:KL_srp_encoder:wr_len_o
+protocol-processor/hdl/srp/KL_srp_top.sv:KL_srp_top:TP_DEPTH_P
+protocol-processor/hdl/srp/KL_srp_top.sv:KL_srp_top:draw_kind_o
+protocol-processor/hdl/srp/KL_srp_top.sv:KL_srp_top:wr_len_o
+protocol-processor/hdl/top/protocol_processor_top.sv:protocol_processor_top:RESP_BASE_P
+protocol-processor/hdl/top/protocol_processor_top.sv:protocol_processor_top:srp_acc_latency_o
+protocol-processor/hdl/top/protocol_processor_top.sv:protocol_processor_top:when

--- a/scripts/naming.budget
+++ b/scripts/naming.budget
@@ -1,6 +1,9 @@
 # Rule 4 ratchet, keyed on IDENTITY: every boundary port or parameter whose
 # own //! comment names a unit of measure that the identifier does not carry,
-# as path:module:name. See scripts/measure_naming.py.
+# as path:module:name. A processor entry is spelled <submodule>:<path>:...
+# (colon, not slash, after the submodule name - the scripts/xvlog.budget
+# spelling) so this generated record is not a hand-written source list.
+# See scripts/measure_naming.py.
 #
 # A line may leave this file only because the boundary was renamed with its
 # unit or removed; a port still declared under the same name that has lost
@@ -9,7 +12,7 @@
 # `python3 scripts/measure_naming.py --write-budget` after a rename.
 #
 # 105 candidate(s): gptp-processor 1, protocol-processor 20, superproject 84
-gptp-processor/hdl/top/KL_gptp_engine.sv:KL_gptp_engine:pub_offset_o
+gptp-processor:hdl/top/KL_gptp_engine.sv:KL_gptp_engine:pub_offset_o
 hdl/common/csr/milan_csr.sv:milan_csr:i_lwsrp_slope
 hdl/common/csr/milan_csr.sv:milan_csr:o_lwsrp_latency
 hdl/common/csr/milan_csr.sv:milan_csr:o_mac_ifg
@@ -94,23 +97,23 @@ hdl/milan/milan_datapath.sv:milan_datapath:o_resp_mem_wr_strb
 hdl/milan/milan_datapath.sv:milan_datapath:pb_rd_ptr_o
 hdl/milan/milan_datapath.sv:milan_datapath:pb_ring_len_i
 hdl/milan/milan_datapath.sv:milan_datapath:pb_ring_stride_i
-protocol-processor/hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:DEB_TICKS_P
-protocol-processor/hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:LAYOUT_VER_P
-protocol-processor/hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:dbg_drop_o
-protocol-processor/hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:seal_len_i
-protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:acmp_stall_count_o
-protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:adp_stall_count_o
-protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:aecp_stall_count_o
-protocol-processor/hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:maap_stall_count_o
-protocol-processor/hdl/packet_engine/KL_pp_nvm_port.sv:KL_pp_nvm_port:MAX_PAYLOAD_P
-protocol-processor/hdl/packet_engine/KL_pp_tx_slots.sv:KL_pp_tx_slots:wr_len_i
-protocol-processor/hdl/srp/KL_srp_decoder.sv:KL_srp_decoder:TP_DEPTH_P
-protocol-processor/hdl/srp/KL_srp_decoder.sv:KL_srp_decoder:dbg_listlen_cnt_o
-protocol-processor/hdl/srp/KL_srp_encoder.sv:KL_srp_encoder:ev_value_i
-protocol-processor/hdl/srp/KL_srp_encoder.sv:KL_srp_encoder:wr_len_o
-protocol-processor/hdl/srp/KL_srp_top.sv:KL_srp_top:TP_DEPTH_P
-protocol-processor/hdl/srp/KL_srp_top.sv:KL_srp_top:draw_kind_o
-protocol-processor/hdl/srp/KL_srp_top.sv:KL_srp_top:wr_len_o
-protocol-processor/hdl/top/protocol_processor_top.sv:protocol_processor_top:RESP_BASE_P
-protocol-processor/hdl/top/protocol_processor_top.sv:protocol_processor_top:srp_acc_latency_o
-protocol-processor/hdl/top/protocol_processor_top.sv:protocol_processor_top:when
+protocol-processor:hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:DEB_TICKS_P
+protocol-processor:hdl/acmp/KL_acmp_nvm_shadow.sv:KL_acmp_nvm_shadow:LAYOUT_VER_P
+protocol-processor:hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:dbg_drop_o
+protocol-processor:hdl/aecp/KL_aecp_resp_buf.sv:KL_aecp_resp_buf:seal_len_i
+protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:acmp_stall_count_o
+protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:adp_stall_count_o
+protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:aecp_stall_count_o
+protocol-processor:hdl/packet_engine/KL_pp_dispatch.sv:KL_pp_dispatch:maap_stall_count_o
+protocol-processor:hdl/packet_engine/KL_pp_nvm_port.sv:KL_pp_nvm_port:MAX_PAYLOAD_P
+protocol-processor:hdl/packet_engine/KL_pp_tx_slots.sv:KL_pp_tx_slots:wr_len_i
+protocol-processor:hdl/srp/KL_srp_decoder.sv:KL_srp_decoder:TP_DEPTH_P
+protocol-processor:hdl/srp/KL_srp_decoder.sv:KL_srp_decoder:dbg_listlen_cnt_o
+protocol-processor:hdl/srp/KL_srp_encoder.sv:KL_srp_encoder:ev_value_i
+protocol-processor:hdl/srp/KL_srp_encoder.sv:KL_srp_encoder:wr_len_o
+protocol-processor:hdl/srp/KL_srp_top.sv:KL_srp_top:TP_DEPTH_P
+protocol-processor:hdl/srp/KL_srp_top.sv:KL_srp_top:draw_kind_o
+protocol-processor:hdl/srp/KL_srp_top.sv:KL_srp_top:wr_len_o
+protocol-processor:hdl/top/protocol_processor_top.sv:protocol_processor_top:RESP_BASE_P
+protocol-processor:hdl/top/protocol_processor_top.sv:protocol_processor_top:srp_acc_latency_o
+protocol-processor:hdl/top/protocol_processor_top.sv:protocol_processor_top:when

--- a/scripts/sv_ports.py
+++ b/scripts/sv_ports.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""One parser for SystemVerilog module headers - ports, parameters, comments.
+
+Two code-quality gates read module port lists: the Rule 4 unit-in-the-name
+ratchet (scripts/measure_naming.py) and the Rule 5 port-contract gate
+(scripts/check_port_contracts.py). Their first versions each carried a private
+regex, and review found the same defect in both: a header of the form
+`module X import pkg::*; #(...) (...)` ended at the import's `;`, so every
+port of every module written that way - 23 of them, all three top-level
+integration modules and most of both processors - was invisible. Rule 3 says a
+production fact has one definition; the parse of "what ports does this module
+declare" is that kind of fact, so it lives here and both gates import it.
+
+What is parsed. For every `module` in a source: the header text from the
+keyword to the `;` that closes its port list, with block and ordinary line
+comments blanked and `//!` documentation kept. Inside it, each declaration
+chunk - starting at `input`/`output`/`inout`, `parameter`/`localparam`, or an
+`interface.modport name` port - yields every name it declares, across lines
+and shared declarations, with its documentation and whether it is a quantity
+(any packed or unpacked dimension, an unsized type such as `int`, a package or
+interface type, or a parameter).
+
+Documentation attribution is the bundle rule: a `//!` on a name's own line
+documents every name declared on that line; a run of standalone `//!` lines
+documents the undocumented names that follow until one carries its own
+comment, which ends the bundle. Function and task arguments inside module
+bodies are not boundaries and are never returned.
+
+    from sv_ports import declarations
+    for module, name, doc, multibit, kind in declarations(text): ...
+    kind in {"port", "param", "iface"}; doc == "" when undocumented
+"""
+
+import re
+
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+_LINE_COMMENT = re.compile(r"//(?!!)[^\n]*")      # ordinary comments; `//!` kept
+_MODULE = re.compile(r"^\s*module\s+([A-Za-z_]\w*)", re.M)
+_DIRECTION = re.compile(r"\b(input|output|inout)\b")
+_PARAM_KW = re.compile(r"\b(?:parameter|localparam)\b")
+_TYPE_WORDS = {"wire", "logic", "reg", "var", "bit", "int", "integer", "byte",
+               "shortint", "longint", "signed", "unsigned", "tri", "real",
+               "shortreal", "time", "supply0", "supply1", "type"}
+_UNSIZED_TYPES = {"int", "integer", "byte", "shortint", "longint", "real",
+                  "shortreal", "time"}
+_IDENT = re.compile(r"^[A-Za-z_]\w*$")
+
+
+def _blank_keep_newlines(m):
+    return "".join(c if c == "\n" else " " for c in m.group(0))
+
+
+def module_headers(text):
+    """[(module_name, header_text, first_line_no)] for each module in `text`.
+
+    The header runs from `module` to the `;` that ends the port list, with
+    block and ordinary line comments blanked and `//!` comments kept."""
+    code = _BLOCK_COMMENT.sub(_blank_keep_newlines, text)
+    code = _LINE_COMMENT.sub(_blank_keep_newlines, code)
+    out = []
+    for m in _MODULE.finditer(code):
+        i, depth, seen_paren = m.end(), 0, False
+        while i < len(code):
+            ch = code[i]
+            if ch == "(":
+                depth += 1; seen_paren = True
+            elif ch == ")":
+                depth -= 1
+            elif ch == ";" and depth == 0:
+                # `module X import pkg::*;` - the import's `;` is not the end
+                # of the header; the port list follows it
+                if not seen_paren and re.search(r"\bimport\b[^;]*$", code[m.end():i]):
+                    i += 1
+                    continue
+                break
+            elif ch == "/" and code.startswith("//!", i):
+                j = code.find("\n", i)
+                i = len(code) if j < 0 else j
+                continue
+            i += 1
+        out.append((m.group(1), code[m.start():i], code[:m.start()].count("\n") + 1))
+    return out
+
+
+_IFACE_PORT = re.compile(r"^[ \t]*([A-Za-z_]\w*\.[A-Za-z_]\w*)[ \t]+[A-Za-z_]\w*", re.M)
+
+
+def _split_decls(header):
+    """Split a header into declaration chunks: each starts at a direction or
+    parameter keyword, or at an `interface.modport name` port, and runs to the
+    next such start. Returns (preamble, [(kind, chunk)]) with kind in
+    {'port', 'param', 'iface'}; the preamble is the text before the first
+    declaration, where a group `//!` comment may already be in force."""
+    marks = [(m.start(), "port") for m in _DIRECTION.finditer(header)]
+    marks += [(m.start(), "param") for m in _PARAM_KW.finditer(header)]
+    marks += [(m.start(1), "iface") for m in _IFACE_PORT.finditer(header)]
+    marks.sort()
+    chunks = []
+    for k, (pos, kind) in enumerate(marks):
+        end = marks[k + 1][0] if k + 1 < len(marks) else len(header)
+        chunks.append((kind, header[pos:end]))
+    preamble = header[:marks[0][0]] if marks else header
+    return preamble, chunks
+
+
+def _group_comment_in(text):
+    """The last run of consecutive standalone `//!` lines in `text`, joined,
+    or None."""
+    found, run = None, []
+    for line in text.split("\n"):
+        if "//!" in line and not line.split("//!", 1)[0].strip():
+            run.append(line.split("//!", 1)[1].strip())
+            found = " ".join(run)
+        elif line.strip():
+            run = []
+    return found
+
+
+def _parse_chunk(kind, chunk, carried_doc):
+    """Parse one declaration chunk into [(name, doc, multibit)].
+
+    `carried_doc` is a standalone `//!` group comment still in force; the
+    return also carries the group comment this chunk leaves in force."""
+    lines = chunk.split("\n")
+    # standalone `//!` lines inside the chunk are group comments for what follows
+    docs_by_line, group_after = {}, None
+    code_lines = []
+    run = []
+    for ln, line in enumerate(lines):
+        if "//!" in line:
+            code, doc = line.split("//!", 1)
+            if not code.strip():
+                run.append(doc.strip())            # standalone: applies to what follows
+                group_after = " ".join(run)
+                code_lines.append("")
+                continue
+            run = []
+            docs_by_line[ln] = doc.strip()
+            code_lines.append(code)
+        else:
+            if line.strip():
+                run = []
+            code_lines.append(line)
+    # the declaration's own line is the line of its first name; a same-line
+    # `//!` documents every name declared on that line
+    joined = "\n".join(code_lines)
+    # strip the closing `)` of a port list and any default value
+    joined = joined.replace(")", " ").replace("(", " ")
+    if kind != "iface":
+        kw = _DIRECTION if kind == "port" else _PARAM_KW
+        joined = kw.sub(" ", joined, count=1)
+    # dimensions: packed before the name, unpacked after it; record presence
+    has_dims = bool(re.search(r"\[[^\]]*\]", joined))
+    joined_nodims = re.sub(r"\[[^\]]*\]", " ", joined)
+    # split names by comma, keep track of which line each piece starts on
+    names, line_of = [], {}
+    pos = 0
+    pieces = joined_nodims.split(",")
+    offset = 0
+    first_piece_typed = None
+    for idx, piece in enumerate(pieces):
+        piece_line = joined_nodims[:offset].count("\n")
+        offset += len(piece) + 1
+        piece = piece.split("=")[0]                       # default value
+        toks = [t for t in piece.replace("\n", " ").split() if t]
+        if not toks:
+            continue
+        if idx == 0:
+            ident_toks = [t for t in toks if _IDENT.match(t) or "::" in t or "." in t]
+            if not ident_toks:
+                continue
+            name = ident_toks[-1]
+            typ = [t for t in ident_toks[:-1] if t not in _TYPE_WORDS]
+            first_piece_typed = (bool(typ) or any(t in _UNSIZED_TYPES for t in ident_toks[:-1]))
+        else:
+            ident_toks = [t for t in toks if _IDENT.match(t)]
+            if not ident_toks:
+                continue
+            name = ident_toks[-1]
+        if not _IDENT.match(name):
+            continue
+        # the name's own line: the line on which the name token sits
+        name_line = piece_line + piece[:piece.rfind(name)].count("\n") if name in piece else piece_line
+        names.append(name)
+        line_of[name] = name_line
+    multibit = has_dims or bool(first_piece_typed) or kind in ("param", "iface")
+    rows, any_own = [], False
+    for name in names:
+        ln = line_of[name]
+        doc = docs_by_line.get(ln)
+        if doc is None and docs_by_line and len(names) == 1:
+            # one name, one declaration: its trailing comment may sit on the
+            # last line of a declaration split across lines
+            doc = docs_by_line.get(max(docs_by_line))
+        own = doc is not None
+        any_own |= own
+        rows.append((name, (doc if own else carried_doc) or "", multibit, own))
+    # what stays in force for the next declaration: a standalone `//!` after
+    # this one starts a new bundle; a declaration with its own comment ends
+    # the bundle; otherwise the group comment carries on
+    if group_after is not None:
+        nxt = group_after
+    elif any_own:
+        nxt = None
+    else:
+        nxt = carried_doc
+    return rows, nxt
+
+
+def declarations(text):
+    """[(module, name, doc, multibit, kind)] for every port/parameter in `text`."""
+    out = []
+    for module, header, _ in module_headers(text):
+        preamble, chunks = _split_decls(header)
+        carried = _group_comment_in(preamble)
+        for kind, chunk in chunks:
+            rows, carried = _parse_chunk(kind, chunk, carried)
+            for name, doc, multibit, _own in rows:
+                out.append((module, name, doc, multibit, kind))
+    return out
+
+

--- a/tb/utests/802_1q_traffic_shaper/README.md
+++ b/tb/utests/802_1q_traffic_shaper/README.md
@@ -6,7 +6,7 @@ self-checking Verilator harnesses under `tb/verilator/` for CI and regression:
 
 | Legacy TB | Status | Superseded by |
 |-----------|--------|---------------|
-| `tb_credit_based_shaper.sv` | **removed** — CBS is now runtime-configured (`shaped_i`/`idle_slope_i`/`hi_credit_i`/`lo_credit_i` ports) | [`tb/verilator/cbs`](../../verilator/cbs) |
+| `tb_credit_based_shaper.sv` | **removed** — CBS is now runtime-configured (`shaped_i`/`idle_slope_bps_i`/`hi_credit_bytes_i`/`lo_credit_bytes_i` ports) | [`tb/verilator/cbs`](../../verilator/cbs) |
 | `tb_traffic_shaping_core.sv` | stale ports (per-queue CBS config is now packed `cbs_*_i`) | [`tb/verilator/shaper_core`](../../verilator/shaper_core) |
 | `tb_traffic_classifier.sv` | stale (classification is now CSR-driven; decode moved to `traffic_class_map`) | [`tb/verilator/cls`](../../verilator/cls) |
 | `tb_traffic_queues.sv` | still valid (`traffic_queues` interface unchanged) | — |

--- a/tb/verilator/cbs/cbs_ref_model.h
+++ b/tb/verilator/cbs/cbs_ref_model.h
@@ -75,9 +75,9 @@ struct CbsInputs {
     bool     tlast      = false;           // bytes_sent carries the frame's last beat
     // runtime configuration ports
     bool     shaped     = true;
-    int32_t  idle_slope = 500000000;       // bits/s for current link rate
-    int32_t  hi_credit  = 761;             // signed bytes
-    int32_t  lo_credit  = -761;            // signed bytes
+    int32_t  idle_slope_bps = 500000000;       // bits/s for current link rate
+    int32_t  hi_credit_bytes  = 761;             // signed bytes
+    int32_t  lo_credit_bytes  = -761;            // signed bytes
 };
 
 // ---------------------------------------------------------------------------
@@ -96,7 +96,7 @@ static const int CBS_MIN_FRAME_BYTES     = 60;   // 64 wire octets less FCS
 // State-for-state mirror of the RTL sequential slope engine (slope_engine in
 // credit_based_shaper.sv). Fixed 100-cycle cadence:
 //   cnt 0      sample idle_slope_bps_i / is_1g_i
-//   cnt 1      load |idle_slope <<< 16| (48-bit wrap), divisor clk_freq_hz*8
+//   cnt 1      load |idle_slope_bps <<< 16| (48-bit wrap), divisor clk_freq_hz*8
 //   cnt 2..49  48 restoring-divider iterations (idle_slope_per_cycle)
 //   cnt 50     stash signed quotient 1; load |send_slope <<< 16|, divisor link
 //   cnt 51..98 48 iterations (send_slope_per_byte)
@@ -185,14 +185,14 @@ public:
         if ((m % d) * 2 >= d) q++;
         return neg ? -(int64_t)q : (int64_t)q;
     }
-    int64_t idle_slope_per_cycle(bool is_1g, int32_t idle_slope) const {
+    int64_t idle_slope_per_cycle(bool is_1g, int32_t idle_slope_bps) const {
         (void)is_1g;
-        int64_t idle = (int64_t)idle_slope;
+        int64_t idle = (int64_t)idle_slope_bps;
         return div_round(idle << CbsConfig::FP, cfg.clk_freq_hz * CbsConfig::BYTE_TO_BIT);
     }
-    int64_t send_slope_per_byte(bool is_1g, int32_t idle_slope) const {
+    int64_t send_slope_per_byte(bool is_1g, int32_t idle_slope_bps) const {
         int64_t link = is_1g ? 1000000000LL : 100000000LL;
-        int64_t send = (int64_t)idle_slope - link;   // negative
+        int64_t send = (int64_t)idle_slope_bps - link;   // negative
         return div_round(send << CbsConfig::FP, link);
     }
 
@@ -202,8 +202,8 @@ public:
 
     // Advance one posedge. `in` are the input values stable before the edge.
     void step(const CbsInputs& in) {
-        const int64_t HIc = (int64_t)in.hi_credit << CbsConfig::FP;
-        const int64_t LOc = (int64_t)in.lo_credit << CbsConfig::FP;
+        const int64_t HIc = (int64_t)in.hi_credit_bytes << CbsConfig::FP;
+        const int64_t LOc = (int64_t)in.lo_credit_bytes << CbsConfig::FP;
 
         // ---- next-state values (nonblocking: all computed from current) ----
 
@@ -276,7 +276,7 @@ public:
             wire_debt = 0; debt_add = 0; frame_cnt = 0; is1g_r = false;
         } else {
             credit = n_credit;
-            eng.step(in.idle_slope, in.is_1g, cfg.clk_freq_hz);
+            eng.step(in.idle_slope_bps, in.is_1g, cfg.clk_freq_hz);
             send_delta = n_send_delta; credit_add_idle = n_credit_add_idle;
             istx = n_istx; qhd = n_qhd; isg = n_isg; shaped = n_shaped;
             wire_debt = n_wire_debt; debt_add = n_debt_add;
@@ -318,18 +318,18 @@ public:
         wire_debt = 0.0; debt_add = 0.0; frame_cnt = 0; is1g_r = false;
     }
 
-    double idle_rate_per_cycle(bool is_1g, int32_t idle_slope) const {
+    double idle_rate_per_cycle(bool is_1g, int32_t idle_slope_bps) const {
         (void)is_1g;
-        return (double)idle_slope / (double)cfg.clk_freq_hz / (double)CbsConfig::BYTE_TO_BIT;
+        return (double)idle_slope_bps / (double)cfg.clk_freq_hz / (double)CbsConfig::BYTE_TO_BIT;
     }
-    double send_rate_per_byte(bool is_1g, int32_t idle_slope) const {
+    double send_rate_per_byte(bool is_1g, int32_t idle_slope_bps) const {
         double link = is_1g ? 1e9 : 1e8;
-        return ((double)idle_slope - link) / link;
+        return ((double)idle_slope_bps - link) / link;
     }
 
     void step(const CbsInputs& in) {
-        const double HIc = (double)in.hi_credit;
-        const double LOc = (double)in.lo_credit;
+        const double HIc = (double)in.hi_credit_bytes;
+        const double LOc = (double)in.lo_credit_bytes;
 
         // slope-engine cadence mirror (float): sample the exact rates at cnt 0,
         // commit at cnt 99, exactly aligned with SlopeEngineRef so the DUT-vs-
@@ -337,8 +337,8 @@ public:
         double n_isc_r = isc_r, n_ssb_r = ssb_r;
         double n_pend_isc = pend_isc, n_pend_ssb = pend_ssb;
         if (cnt == 0) {
-            n_pend_isc = idle_rate_per_cycle(in.is_1g, in.idle_slope);
-            n_pend_ssb = send_rate_per_byte(in.is_1g, in.idle_slope);
+            n_pend_isc = idle_rate_per_cycle(in.is_1g, in.idle_slope_bps);
+            n_pend_ssb = send_rate_per_byte(in.is_1g, in.idle_slope_bps);
         } else if (cnt == 99) {
             n_isc_r = pend_isc; n_ssb_r = pend_ssb;
         }

--- a/tb/verilator/cbs/cbs_ref_model.h
+++ b/tb/verilator/cbs/cbs_ref_model.h
@@ -95,7 +95,7 @@ static const int CBS_MIN_FRAME_BYTES     = 60;   // 64 wire octets less FCS
 // ---------------------------------------------------------------------------
 // State-for-state mirror of the RTL sequential slope engine (slope_engine in
 // credit_based_shaper.sv). Fixed 100-cycle cadence:
-//   cnt 0      sample idle_slope_i / is_1g_i
+//   cnt 0      sample idle_slope_bps_i / is_1g_i
 //   cnt 1      load |idle_slope <<< 16| (48-bit wrap), divisor clk_freq_hz*8
 //   cnt 2..49  48 restoring-divider iterations (idle_slope_per_cycle)
 //   cnt 50     stash signed quotient 1; load |send_slope <<< 16|, divisor link
@@ -123,7 +123,7 @@ struct SlopeEngineRef {
         return (u & ((uint64_t)1 << 47)) ? (int64_t)(u | ~M48) : (int64_t)u;
     }
 
-    void step(int32_t idle_slope_i, bool is_1g_i, int64_t clk_freq_hz) {
+    void step(int32_t idle_slope_bps_i, bool is_1g_i, int64_t clk_freq_hz) {
         // combinational helpers from PRE-step state
         int64_t  link   = is1g_s ? 1000000000LL : 100000000LL;
         int64_t  ldval  = (cnt == 1) ? wrap48(idle_s << CbsConfig::FP)
@@ -138,7 +138,7 @@ struct SlopeEngineRef {
         int64_t  quo_s  = sign ? -(int64_t)quo_r : (int64_t)quo_r;
 
         if (cnt == 0) {
-            idle_s = (int64_t)idle_slope_i;
+            idle_s = (int64_t)idle_slope_bps_i;
             is1g_s = is_1g_i;
         } else if (cnt == 1 || cnt == 50) {
             if (cnt == 50) q1 = quo_s;

--- a/tb/verilator/cbs/cbs_ver_wrap.sv
+++ b/tb/verilator/cbs/cbs_ver_wrap.sv
@@ -24,9 +24,9 @@ module cbs_ver_wrap #(
   input  wire        resetn,            //! Active-low synchronous reset
 
   input  wire        shaped_i,          //! 1 = apply CBS; 0 = strict priority
-  input  wire [31:0] idle_slope_i,      //! idleSlope for current link rate, bits/s
-  input  wire signed [31:0] hi_credit_i,//! hiCredit clamp, signed bytes
-  input  wire signed [31:0] lo_credit_i,//! loCredit clamp, signed bytes
+  input  wire [31:0] idle_slope_bps_i,      //! idleSlope for current link rate, bits/s
+  input  wire signed [31:0] hi_credit_bytes_i,//! hiCredit clamp, signed bytes
+  input  wire signed [31:0] lo_credit_bytes_i,//! loCredit clamp, signed bytes
 
   input  wire        queue_has_data_i,  //! Queue has frames waiting to send
   input  wire        is_transmitting_i, //! This queue is actively transmitting
@@ -52,9 +52,9 @@ module cbs_ver_wrap #(
     .clk               (clk),
     .resetn            (resetn),
     .shaped_i          (shaped_i),
-    .idle_slope_i      (idle_slope_i),
-    .hi_credit_i       (hi_credit_i),
-    .lo_credit_i       (lo_credit_i),
+    .idle_slope_bps_i      (idle_slope_bps_i),
+    .hi_credit_bytes_i       (hi_credit_bytes_i),
+    .lo_credit_bytes_i       (lo_credit_bytes_i),
     .queue_has_data_i  (queue_has_data_i),
     .is_transmitting_i (is_transmitting_i),
     .is_1g_i           (is_1g_i),

--- a/tb/verilator/cbs/sim_main.cpp
+++ b/tb/verilator/cbs/sim_main.cpp
@@ -42,7 +42,7 @@ static CbsInputs mk(bool resetn, bool qhd, bool istx, bool is1g, bool isg,
     CbsInputs in;
     in.resetn = resetn; in.queue_has_data = qhd; in.is_transmitting = istx;
     in.is_1g = is1g; in.is_granted = isg; in.bytes_sent = bytes;
-    in.shaped = shaped; in.idle_slope = idle; in.hi_credit = hi; in.lo_credit = lo;
+    in.shaped = shaped; in.idle_slope_bps = idle; in.hi_credit_bytes = hi; in.lo_credit_bytes = lo;
     in.tlast = tlast;
     return in;
 }
@@ -74,9 +74,9 @@ struct Harness {
         dut->bytes_sent_i      = in.bytes_sent;
         dut->tlast_i           = in.tlast;
         dut->shaped_i          = in.shaped;
-        dut->idle_slope_bps_i      = (uint32_t)in.idle_slope;
-        dut->hi_credit_bytes_i       = (uint32_t)in.hi_credit;
-        dut->lo_credit_bytes_i       = (uint32_t)in.lo_credit;
+        dut->idle_slope_bps_i      = (uint32_t)in.idle_slope_bps;
+        dut->hi_credit_bytes_i       = (uint32_t)in.hi_credit_bytes;
+        dut->lo_credit_bytes_i       = (uint32_t)in.lo_credit_bytes;
         posedge();
 
         fref.step(in);

--- a/tb/verilator/cbs/sim_main.cpp
+++ b/tb/verilator/cbs/sim_main.cpp
@@ -74,9 +74,9 @@ struct Harness {
         dut->bytes_sent_i      = in.bytes_sent;
         dut->tlast_i           = in.tlast;
         dut->shaped_i          = in.shaped;
-        dut->idle_slope_i      = (uint32_t)in.idle_slope;
-        dut->hi_credit_i       = (uint32_t)in.hi_credit;
-        dut->lo_credit_i       = (uint32_t)in.lo_credit;
+        dut->idle_slope_bps_i      = (uint32_t)in.idle_slope;
+        dut->hi_credit_bytes_i       = (uint32_t)in.hi_credit;
+        dut->lo_credit_bytes_i       = (uint32_t)in.lo_credit;
         posedge();
 
         fref.step(in);

--- a/tb/verilator/controller_rate/controller_rate_wrap.sv
+++ b/tb/verilator/controller_rate/controller_rate_wrap.sv
@@ -23,9 +23,9 @@ module controller_rate_wrap #(
   input  wire [23:0] cls_pcp_tc_map_i,
   input  wire [23:0] cls_prio_regen_i,
   input  wire [31:0] cls_tc_queue_map_i,
-  input  wire [32*NQ-1:0] cbs_idle_slope_i,
-  input  wire [32*NQ-1:0] cbs_hi_credit_i,
-  input  wire [32*NQ-1:0] cbs_lo_credit_i,
+  input  wire [32*NQ-1:0] cbs_idle_slope_bps_i,
+  input  wire [32*NQ-1:0] cbs_hi_credit_bytes_i,
+  input  wire [32*NQ-1:0] cbs_lo_credit_bytes_i,
   input  wire [NQ-1:0]    cbs_shaped_i,
   input  wire [TDATA_WIDTH-1:0]     s_tdata,
   input  wire [(TDATA_WIDTH/8)-1:0] s_tkeep,
@@ -83,8 +83,8 @@ module controller_rate_wrap #(
     .cls_use_pcp_i(cls_use_pcp_i), .cls_dmac_check_i(1'b0), .cls_ctrl_class_i(1'b1),
     .cls_default_pcp_i(cls_default_pcp_i), .cls_pcp_tc_map_i(cls_pcp_tc_map_i),
     .cls_prio_regen_i(cls_prio_regen_i), .cls_tc_queue_map_i(cls_tc_queue_map_i),
-    .cbs_idle_slope_i(cbs_idle_slope_i), .cbs_hi_credit_i(cbs_hi_credit_i),
-    .cbs_lo_credit_i(cbs_lo_credit_i), .cbs_shaped_i(cbs_shaped_i),
+    .cbs_idle_slope_bps_i(cbs_idle_slope_bps_i), .cbs_hi_credit_bytes_i(cbs_hi_credit_bytes_i),
+    .cbs_lo_credit_bytes_i(cbs_lo_credit_bytes_i), .cbs_shaped_i(cbs_shaped_i),
     .s_axis(s_if), .m_axis(m_if)
   );
 endmodule

--- a/tb/verilator/controller_rate/sim_main.cpp
+++ b/tb/verilator/controller_rate/sim_main.cpp
@@ -22,8 +22,8 @@ int main(int argc, char** argv) {
     dut->cls_pcp_tc_map_i = 0xFAC688; dut->cls_prio_regen_i = 0xFAC688;
     dut->cls_tc_queue_map_i = 0xE1;                  // TC0->q1, TC1->q0
     for (int q = 0; q < 4; q++) {
-        dut->cbs_idle_slope_i[q] = (q == 0) ? 10000000u : 0u;
-        dut->cbs_hi_credit_i[q] = 200; dut->cbs_lo_credit_i[q] = (uint32_t)-1522;
+        dut->cbs_idle_slope_bps_i[q] = (q == 0) ? 10000000u : 0u;
+        dut->cbs_hi_credit_bytes_i[q] = 200; dut->cbs_lo_credit_bytes_i[q] = (uint32_t)-1522;
     }
     dut->cbs_shaped_i = 0x1; dut->m_tready = 1;
 

--- a/tb/verilator/csr/README.md
+++ b/tb/verilator/csr/README.md
@@ -49,7 +49,7 @@ An AXI4-Lite master BFM (`sim_main.cpp`) exercises the register map
 * **RO enforcement** — writes to `ID`/`MAC_STATUS` are ignored.
 * **RW + output wiring** — SCRATCH, MAC control bits drive `o_mac_*`, station MAC
   reconstructs on `o_mac_addr`, per-queue CBS idleSlope drives
-  `o_cbs_idle_slope[q]`, CBS enable drives `o_cbs_enable`.
+  `o_cbs_idle_slope_bps[q]`, CBS enable drives `o_cbs_enable`.
 * **IRQ** — hardware event latch → `IRQ_STATUS`, masking → `o_irq`, and
   write-1-to-clear.
 * **PTP command strobes** — `PTP_CMD` snapshot latches the live TOD into

--- a/tb/verilator/csr/sim_main.cpp
+++ b/tb/verilator/csr/sim_main.cpp
@@ -257,9 +257,9 @@ int main(int argc, char** argv) {
   dut->eval();
   ck("o_cls_tc_queue_map == CLS_TCQ readback", dut->o_cls_tc_queue_map,
      axi_read(A_CLS_TCQ));
-  ck("o_cbs_idle_slope[0] == CBS0_IDLE readback", dut->o_cbs_idle_slope[0],
+  ck("o_cbs_idle_slope_bps[0] == CBS0_IDLE readback", dut->o_cbs_idle_slope_bps[0],
      axi_read(A_CBS0_IDLE));
-  ck("o_cbs_idle_slope[4] == CBS4_IDLE readback", dut->o_cbs_idle_slope[4],
+  ck("o_cbs_idle_slope_bps[4] == CBS4_IDLE readback", dut->o_cbs_idle_slope_bps[4],
      axi_read(A_CBS4_IDLE));
   ck("o_cbs_enable == 0 at reset (all five unshaped)", dut->o_cbs_enable, 0);
 
@@ -321,7 +321,7 @@ int main(int argc, char** argv) {
   axi_write(A_CBS1_IDLE, 0x0AABBCCD);
   ck("CBS1_IDLE rw", axi_read(A_CBS1_IDLE), 0x0AABBCCD);
   dut->eval();
-  ck("o_cbs_idle_slope[1]", dut->o_cbs_idle_slope[1], 0x0AABBCCD);
+  ck("o_cbs_idle_slope_bps[1]", dut->o_cbs_idle_slope_bps[1], 0x0AABBCCD);
 
   axi_write(A_CBS3_CTRL, 0x1);           // enable queue 3 shaping
   dut->eval();
@@ -332,7 +332,7 @@ int main(int argc, char** argv) {
   axi_write(A_CBS4_IDLE, 0x0C0FFEE0);
   ck("CBS4_IDLE rw", axi_read(A_CBS4_IDLE), 0x0C0FFEE0);
   dut->eval();
-  ck("o_cbs_idle_slope[4]", dut->o_cbs_idle_slope[4], 0x0C0FFEE0);
+  ck("o_cbs_idle_slope_bps[4]", dut->o_cbs_idle_slope_bps[4], 0x0C0FFEE0);
   axi_write(A_CBS4_CTRL, 0x1);           // shape the class-A queue
   dut->eval();
   ck("o_cbs_enable bit4", (dut->o_cbs_enable >> 4) & 1, 1);

--- a/tb/verilator/datapath/datapath_wrap.sv
+++ b/tb/verilator/datapath/datapath_wrap.sv
@@ -26,9 +26,9 @@ module datapath_wrap #(
   input  wire [23:0]                   cls_prio_regen_i,
   input  wire [31:0]                   cls_tc_queue_map_i,
   // CBS config (packed per queue)
-  input  wire [32*NUMBER_OF_QUEUES-1:0] cbs_idle_slope_i,
-  input  wire [32*NUMBER_OF_QUEUES-1:0] cbs_hi_credit_i,
-  input  wire [32*NUMBER_OF_QUEUES-1:0] cbs_lo_credit_i,
+  input  wire [32*NUMBER_OF_QUEUES-1:0] cbs_idle_slope_bps_i,
+  input  wire [32*NUMBER_OF_QUEUES-1:0] cbs_hi_credit_bytes_i,
+  input  wire [32*NUMBER_OF_QUEUES-1:0] cbs_lo_credit_bytes_i,
   input  wire [NUMBER_OF_QUEUES-1:0]    cbs_shaped_i,
   // AXIS in
   input  wire [TDATA_WIDTH-1:0]        s_tdata,
@@ -64,8 +64,8 @@ module datapath_wrap #(
     .cls_ctrl_class_i(cls_ctrl_class_i),
     .cls_default_pcp_i(cls_default_pcp_i), .cls_pcp_tc_map_i(cls_pcp_tc_map_i),
     .cls_prio_regen_i(cls_prio_regen_i), .cls_tc_queue_map_i(cls_tc_queue_map_i),
-    .cbs_idle_slope_i(cbs_idle_slope_i), .cbs_hi_credit_i(cbs_hi_credit_i),
-    .cbs_lo_credit_i(cbs_lo_credit_i), .cbs_shaped_i(cbs_shaped_i),
+    .cbs_idle_slope_bps_i(cbs_idle_slope_bps_i), .cbs_hi_credit_bytes_i(cbs_hi_credit_bytes_i),
+    .cbs_lo_credit_bytes_i(cbs_lo_credit_bytes_i), .cbs_shaped_i(cbs_shaped_i),
     .s_axis(s_axis), .m_axis(m_axis)
   );
 

--- a/tb/verilator/datapath/sim_main.cpp
+++ b/tb/verilator/datapath/sim_main.cpp
@@ -41,9 +41,9 @@ static const int NQ = 5;    // ethernet_packet_pkg::NUMBER_OF_QUEUES (802.1Q ord
 static void set_cbs(bool shaped, uint32_t slope, int32_t hicr, int32_t locr) {
     dut->cbs_shaped_i = shaped ? ((1u << NQ) - 1) : 0x0;
     for (int q = 0; q < NQ; q++) {
-        dut->cbs_idle_slope_i[q] = slope;
-        dut->cbs_hi_credit_i[q]  = (uint32_t)hicr;
-        dut->cbs_lo_credit_i[q]  = (uint32_t)locr;
+        dut->cbs_idle_slope_bps_i[q] = slope;
+        dut->cbs_hi_credit_bytes_i[q]  = (uint32_t)hicr;
+        dut->cbs_lo_credit_bytes_i[q]  = (uint32_t)locr;
     }
 }
 

--- a/tb/verilator/shaper_core/shaper_core_wrap.sv
+++ b/tb/verilator/shaper_core/shaper_core_wrap.sv
@@ -23,9 +23,9 @@ module shaper_core_wrap #(
   input  wire [NQ-1:0]   queue_has_data_i, //! Per-queue data-available
   input  wire            is_1g_i,      //! Link rate select
 
-  input  wire [32*NQ-1:0] cbs_idle_slope_i, //! Per-queue idleSlope (bits/s)
-  input  wire [32*NQ-1:0] cbs_hi_credit_i,  //! Per-queue hiCredit (signed bytes)
-  input  wire [32*NQ-1:0] cbs_lo_credit_i,  //! Per-queue loCredit (signed bytes)
+  input  wire [32*NQ-1:0] cbs_idle_slope_bps_i, //! Per-queue idleSlope (bits/s)
+  input  wire [32*NQ-1:0] cbs_hi_credit_bytes_i,  //! Per-queue hiCredit (signed bytes)
+  input  wire [32*NQ-1:0] cbs_lo_credit_bytes_i,  //! Per-queue loCredit (signed bytes)
   input  wire [NQ-1:0]    cbs_shaped_i,     //! Per-queue shaped-enable
 
   // flattened s_axis (stimulus) / m_axis (drain) handshake
@@ -105,9 +105,9 @@ module shaper_core_wrap #(
     .resetn            (resetn),
     .queue_has_data_i  (queue_has_data_i),
     .is_1g_i           (is_1g_i),
-    .cbs_idle_slope_i  (cbs_idle_slope_i),
-    .cbs_hi_credit_i   (cbs_hi_credit_i),
-    .cbs_lo_credit_i   (cbs_lo_credit_i),
+    .cbs_idle_slope_bps_i  (cbs_idle_slope_bps_i),
+    .cbs_hi_credit_bytes_i   (cbs_hi_credit_bytes_i),
+    .cbs_lo_credit_bytes_i   (cbs_lo_credit_bytes_i),
     .cbs_shaped_i      (cbs_shaped_i),
     .grant_queue_o     (grant_o),
     .s_axis            (s_if),
@@ -148,9 +148,9 @@ module shaper_core_wrap #(
     .resetn            (resetn),
     .queue_has_data_i  (queue_has_data_i),
     .is_1g_i           (is_1g_i),
-    .cbs_idle_slope_i  (cbs_idle_slope_i),
-    .cbs_hi_credit_i   (cbs_hi_credit_i),
-    .cbs_lo_credit_i   (cbs_lo_credit_i),
+    .cbs_idle_slope_bps_i  (cbs_idle_slope_bps_i),
+    .cbs_hi_credit_bytes_i   (cbs_hi_credit_bytes_i),
+    .cbs_lo_credit_bytes_i   (cbs_lo_credit_bytes_i),
     .cbs_shaped_i      (cbs_shaped_i),
     .grant_queue_o     (),
     .s_axis            (sm_if),

--- a/tb/verilator/shaper_core/sim_main.cpp
+++ b/tb/verilator/shaper_core/sim_main.cpp
@@ -142,10 +142,10 @@ struct Harness {
 //  bursty the drain is. If bytes_sent/is_transmitting counted anything other
 //  than accepted beats, the two regimes would disagree.
 // ---------------------------------------------------------------------------
-static long run_rate(Harness& h, uint32_t idle_slope, int ready_period,
+static long run_rate(Harness& h, uint32_t idle_slope_bps, int ready_period,
                      int cycles, int frame_beats, const char* tag) {
     Cfg c;
-    c.idle[0] = idle_slope;
+    c.idle[0] = idle_slope_bps;
     c.hi[0]   = 456; c.lo[0] = -1065;
     c.shaped  = 0x3F;
     h.apply_cfg(c);

--- a/tb/verilator/shaper_core/sim_main.cpp
+++ b/tb/verilator/shaper_core/sim_main.cpp
@@ -60,9 +60,9 @@ struct Harness {
         // Verilator packs <=64-bit wide ports as scalars, wider as arrays; the
         // 128-bit CBS vectors are VlWide — assign per 32-bit lane.
         for (int i = 0; i < NQ; i++) {
-            dut->cbs_idle_slope_i.at(i) = c.idle[i];
-            dut->cbs_hi_credit_i.at(i)  = (uint32_t)c.hi[i];
-            dut->cbs_lo_credit_i.at(i)  = (uint32_t)c.lo[i];
+            dut->cbs_idle_slope_bps_i.at(i) = c.idle[i];
+            dut->cbs_hi_credit_bytes_i.at(i)  = (uint32_t)c.hi[i];
+            dut->cbs_lo_credit_bytes_i.at(i)  = (uint32_t)c.lo[i];
         }
         dut->cbs_shaped_i = c.shaped;
     }


### PR DESCRIPTION
> [!IMPORTANT]
> **Post-review correction (2026-08-28, head `ece93aad`).** The naming ratchet now covers both processor submodules and no longer treats ordinary prose such as “a second copy” as a seconds unit. Result: 3,491 ports, 408 raw matches, 255 reasoned exclusions, 153 candidates at the ratchet; self-test 11/11. Earlier figures below are superseded.

Closes #252

Rule 4 of the #248 contract. **Stacked on #277 (Rule 3) → #276 → #275. Review in that order; this PR's diff is incremental.**

## What changed

| Area | Change |
|---|---|
| Guide | Rule 4 section: the qualifier table (time, cycles, size, rate, clock domain, predicate, event), what a qualifier is **not** for, cross-language equivalence, review checklist. |
| Rename | The credit-based shaper configuration interface, end to end through 19 files. |
| Measurement | `scripts/measure_naming.py` + `scripts/naming.budget` — a ratchet, with the false positives measured first. |
| CI | The ratchet and its self-test run in `docs.yml`. |

## The interface, renamed end to end

Three quantities, three different units, none of them stated in a name:

| Was | Now | Unit, from its own `//!` comment |
|---|---|---|
| `o_cbs_hi_credit`, `cbs_hi_credit_i`, `hi_credit_i` | `…_hi_credit_bytes…` | signed bytes |
| `o_cbs_lo_credit`, `cbs_lo_credit_i`, `lo_credit_i` | `…_lo_credit_bytes…` | signed bytes |
| `o_cbs_idle_slope`, `cbs_idle_slope_i`, `idle_slope_i` | `…_idle_slope_bps…` | bits per second |

Every hop it crosses: `milan_csr` → `milan_datapath` / `milan_top` → `traffic_controller_802_1q` → `traffic_shaping_core` → `credit_based_shaper`, plus four testbench wrappers, their harnesses, the CBS reference model, and the register documentation. `hiCredit`/`loCredit` are 802.1Q terms and keep their spelling; only the unit is added.

The rename is pure — no logic moved. LiteX binds none of these names (they are internal to `milan_top`/`milan_datapath`, all past the port list), so the change is contained in RTL, testbenches and docs.

## The false positives were measured before anything was gated

This is the acceptance criterion the issue puts hardest, and the naive check fails it: **180** of 1,757 ports match a unit word in their comment, and most are not findings.

| Excluded | Count | Reason |
|---|---:|---|
| Single-bit ports | 94 | A one-bit port carries no quantity |
| Protocol-fixed identifiers | 4 | `s_axi_awaddr` is AXI's name; renaming it breaks what the name is for |
| Shape, not unit | 2 | "1-cycle pulse" is shape — `_p` already encodes it, and `_cyc` would fight the house convention |

`bit`, `bits` and `word` are excluded from the unit vocabulary itself: bit width is already explicit in the SystemVerilog type, and "word" is used here both as a count and as a noun for the value.

That leaves **80 candidates, down from 91** before this rename. The residual set still holds judgement calls, so it ships as a **ratchet**, not a verdict — the count may only fall. `--excluded` prints every filtered match with its reason, because a filter nobody can see is how a check quietly stops checking.

The rule extends the `CONTRIBUTING.md` suffixes rather than competing with them: `_r`/`_w`/`_p`/`_S`/`_C`/`_P` say what a signal *is*, a unit qualifier says what its value *means*, and a port can carry both.

## Evidence

- `scripts/measure_naming.py --selftest` — **10/10**, including arms for each exclusion class and one proving an exclusion names its reason. Three arms failed on first run and exposed a real defect: the unit vocabulary was too narrow to *see* the false positives it claimed to filter.
- `scripts/measure_naming.py --check` — PASS at the ratchet.
- `scripts/lint_rtl.py --check` — PASS, 99 ≤ ratchet 99.
- Suites touching the renamed interface, all re-run: **cbs** (130,256 cycle checks, 0 mismatches, max |DUT−ideal| 0.1526 bytes), **shaper_core** (1,521,627 cycle checks, 0 mismatches), **controller_rate**, **datapath** (23/23), **csr** (31/31).
- `ci_events.py --check` OK (222 items); traceability matrix up to date.
- `docs_check` 0 findings / `gen_toc --check` OK / `check_doc_paths` OK.

## Not covered

- `tsn_fuzz` declared SKIP (tsn-gen absent); builder gate 23h pre-existing on this host and on a pristine `dev` checkout.
- No Vivado run. A pure rename has no expected area effect, and none was measured.
