### PR TITLE
[Code quality] Rule 6: refuse the build the shield cannot filter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,9 +119,11 @@ jobs:
           python3 scripts/check_port_contracts.py
           python3 scripts/check_port_contracts.py --selftest
 
-      # Rule 6: a parameterised module that refuses nothing, and a pipeline
-      # that throws away its producer's verdict. The second ratchet is 0 and
-      # must stay 0; the first is paid down as modules gain contracts.
+      # Rule 6: a parameterised module that refuses nothing, a pipeline that
+      # throws away its producer's verdict, and a captured verdict whose exit
+      # status is never read. Three ratchets that may only go down: the first
+      # is paid down as modules gain contracts, the other two hold pinned
+      # processor debt and two coverage recipes until their fixes land.
       - name: Fail-fast ratchet
         run: |
           python3 scripts/measure_fail_fast.py --check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,6 +119,14 @@ jobs:
           python3 scripts/check_port_contracts.py
           python3 scripts/check_port_contracts.py --selftest
 
+      # Rule 6: a parameterised module that refuses nothing, and a pipeline
+      # that throws away its producer's verdict. The second ratchet is 0 and
+      # must stay 0; the first is paid down as modules gain contracts.
+      - name: Fail-fast ratchet
+        run: |
+          python3 scripts/measure_fail_fast.py --check
+          python3 scripts/measure_fail_fast.py --selftest
+
       # CI event and SHA contract gate (#174, #181): the four workflow files
       # and docs/testing/CI_WORKFLOWS.md must agree on the triggers, the cron
       # time, the public check names, cancel-in-progress and the one-SHA rule

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -29,6 +29,7 @@ shape rather than guess at it.
 - **[Rule 4: use intention-revealing names and explicit units](#rule-4-use-intention-revealing-names-and-explicit-units)** -- What a name must reveal, the unit and clock-domain qualifiers that extend the existing HDL suffixes rather than competing with them, cross-language equivalents, and the interface renamed end to end to prove it.
 - **[Measuring hidden units](#measuring-hidden-units)** -- The port's own documentation as the evidence, the three exclusion classes and the false positives that forced them, and why this ships as a ratchet instead of a verdict.
 - **[Rule 5: make ports, contracts and ownership explicit](#rule-5-make-ports-contracts-and-ownership-explicit)** -- What a port contract must state, why wildcard, positional and hierarchical bindings are refused outright while missing documentation and unjustified open or tied connections are only ratcheted, the exact scope of the inventory, the boundary documented end to end as proof, and the review checklist.
+- **[Rule 6: fail fast and encode invariants](#rule-6-fail-fast-and-encode-invariants)** -- Where a verdict must be refused rather than logged, the elaboration contract added to the receive shield and mutation-proven against four illegal parameter sets, the two masked-failure populations that are now ratcheted, and the review checklist.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -1194,14 +1195,98 @@ guarded by the build, not by a check that cannot see it.
   backdoor?
 - Is a tied-off or ignored port justified locally, or is it decorative?
 
+## Rule 6: fail fast and encode invariants
+
+> Invalid parameters, configurations, states, inputs and tool failures MUST be
+> rejected at the nearest responsible boundary and MUST propagate a non-success
+> verdict. Important invariants and reset or overflow laws are executable
+> assertions or self-checking tests, not comments alone.
+
+The failure mode this rule exists for is not a crash. It is a build, a
+generator or a gate that reports something wrong and then exits 0, because
+everything downstream then treats a wrong answer as a checked one.
+
+### Repository interpretation
+
+- A shell, Tcl or Python step checks the status of what it ran, and never
+  prints a failure and returns success.
+- SystemVerilog rejects impossible parameter combinations **at elaboration**,
+  where the message can still name the parameter and the law it broke.
+- Counter wrap, saturation, reset and update priority are stated and tested.
+- An assertion carries a message naming the contract it violated, not just the
+  expression that failed.
+
+### A comment is not a guard
+
+`hdl/ieee8021q/filtering/rx_mac_filter.sv` is the receive shield. Its banner
+said the destination-address compare works "for TDATA_WIDTH>=48", and nothing
+enforced it. At 32 bits the concatenation that builds the destination address
+indexes past the end of the beat, the compare runs against whatever those bits
+are, and the shield silently admits or drops the wrong frames — a failure no
+downstream check can see, because a filter that is wrong looks exactly like a
+filter that is right until the traffic is inspected on the wire.
+
+It now carries an elaboration contract in the house form — a module-scope
+`if (…) $error("one format string", …)`, the same shape `milan_datapath` and
+`KL_media_nco` already use. Four laws: the datapath must be wide enough to hold
+the 48-bit destination address in one beat, it must be a whole number of bytes
+so `tkeep` can describe it, the TCAM must have at least one entry, and an
+action must be wide enough to distinguish two matches.
+
+**The contract is graded by mutation, permanently.** `make negative` in
+`tb/verilator/rx_filter` elaborates four illegal parameter sets and requires
+each to be refused, then elaborates the legal default and requires it to be
+accepted. That last arm is what stops the contract from becoming a ban, and it
+is why the arm reads the exit status directly rather than through a pipe — a
+pipeline returns its *last* command's status, which is how a refused build
+reads as a pass.
+
+### The two populations, measured
+
+[`scripts/measure_fail_fast.py`](../../scripts/measure_fail_fast.py) counts
+both ways a failure can pass for success here.
+
+| Population | Count | Disposition |
+|---|---:|---|
+| Parameterised modules with no elaboration contract | 37 of 42 | Ratchet. Paid down as modules gain contracts. |
+| Pipelines that discard their producer's exit status | **0** | Ratchet at zero. It must stay zero. |
+| Pipelines waived because the consumer *is* the assertion | 27 | Named, with the reason recorded |
+
+The waiver matters: `verilator --version | grep -F "$WANT"` wants grep's status,
+because grep is the assertion. Those are excluded by name rather than by
+pattern, so a new one has to be added deliberately.
+
+Both false positives that this check produced on its first run were in the
+checker, not the tree: a tool name inside a `printf` **format string** read as
+a command, and a pipe inside a `$(…)` substitution — whose status is never the
+line's verdict — read as a masked one. Quoted spans and substitutions are
+blanked before the producer search, and both cases have arms.
+
+### Already satisfied, and verified rather than rebuilt
+
+The rule also asks that suite tally parsing treat missing or malformed evidence
+as failure rather than zero checks.
+[`scripts/suite_tally.py`](../../scripts/suite_tally.py) already does: a suite
+whose log carries no readable tally is `NOCOUNT`, an unknown is never allowed to
+look like agreement, and a skip marker cannot suppress it. That was confirmed by
+running its self-test, not by writing a second one.
+
+### Review checklist
+
+- If this step fails, does the caller find out — or does it print and continue?
+- Is the invariant executable, or only written in a comment?
+- Does the assertion message name the contract, or only the expression?
+- Is there an arm proving the refusal fires, **and** one proving the legal case
+  still passes?
+- Does any verdict travel through a pipe?
+
 ## Rules not yet landed
 
-The contract is ten rules. Rules 1 to 5 are above; the rest keep these
+The contract is ten rules. Rules 1 to 6 are above; the rest keep these
 numbers so citations stay stable as they land:
 
 | Rule | Subject |
 |---|---|
-| 6 | Fail fast and encode invariants |
 | 7 | Comments explain why; no dead or speculative code |
 | 8 | Deterministic, specification-derived tests |
 | 9 | Automated mechanical hygiene with measured ratchets |

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1299,7 +1299,24 @@ check: Verilator builds the binary, Vivado and Yosys synthesise the module,
 and only a simulation run refuses, so both are inventoried as unguarded. A
 `$error` inside `always` is a runtime assertion; before this distinction
 `KL_gptp_engine` would have counted as guarded on three PathTrace assertions
-that never look at a parameter. The self-test has an arm for each shape.
+that never look at a parameter. A concurrent assertion at module scope —
+`assert property (@(posedge clk) …) else $error`, its `assume`/`cover`
+forms, a `property … endproperty` it names — or a deferred immediate
+`assert #0 (…) else $error` is not a contract either: the action block fires
+during simulation, at a clock edge or in the Observed region, and cannot
+refuse an illegal parameter when the parameters are bound. Review reproduced
+the concurrent form counting as a guard, so the recognition is now
+**positive** rather than a list of exclusions: the scan starts after the
+module header and descends only into what elaboration evaluates —
+`generate`, `if`/`else`, `for`, `case` and `begin : name … end` — and steps
+over every other item whole (a procedural block, any assertion with its
+action block, a `property`/`sequence`/`function`/`task` declaration, a
+preprocessor line, a plain item to its `;`); a `$error` the walk never
+reaches is not the contract. Re-measured under that rule no module moved —
+the first-party HDL writes no concurrent assertion today — and the count in
+the table below is what the tool printed. The self-test has an arm for each
+shape, including the `` `endif `` that sits right before a named `always_ff`
+in `KL_gptp_engine`, which the first positive walk read as a block label.
 
 ### The three populations, measured
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1249,15 +1249,59 @@ both ways a failure can pass for success here.
 | Population | Count | Disposition |
 |---|---:|---|
 | Parameterised modules with no elaboration contract | 43 of 53 | Ratchet across the superproject and both project-owned processor submodules. Paid down as modules gain contracts. |
-| Pipelines that discard their producer's exit status | **0** | Ratchet at zero. It must stay zero. |
+| Pipelines that discard their producer's exit status | **2** | Ratchet. Both are `gptp-processor/syn/ooc/run.sh` reading a Vivado report through `grep … | head` (see below); fixed upstream, and the pin bump takes this to zero, where it must then stay. |
+| Captured verdicts whose exit status is discarded | **1** | Ratchet. `protocol-processor/scripts/lint_hdl.sh:14` (see below); fixed upstream, and the pin bump takes this to zero. |
 | Pipelines waived because the consumer *is* the assertion | 2 | Named, with the reason recorded |
 
 The waiver matters: `verilator --version | grep -F "$WANT"` wants grep's status,
 because grep is the assertion. Those two sites are excluded by name rather than
-by pattern, so a new one has to be added deliberately. GitHub workflow `run`
-blocks use the runner's default bash `-o pipefail`; ordinary shell scripts are
-protected only after their own `set ... pipefail` executes. A later setting no
-longer retroactively masks an earlier unsafe pipeline in the measurement.
+by pattern, so a new one has to be added deliberately.
+
+The shell model is per unit, in line order. An ordinary script starts with
+neither `errexit` nor `pipefail` and is protected only after its own `set`
+executes; a later setting cannot retroactively protect an earlier line. A
+GitHub workflow step is its own shell, and the default one is `bash -e {0}`:
+**errexit, no pipefail**. Only a step that declares `shell: bash` runs
+`bash --noprofile --norc -eo pipefail {0}`. The first version of this scan
+assumed every step had pipefail and let a `set -o pipefail` in one step protect
+the next; both were wrong, both have arms now, and the correction found no
+victim only because every piped step in this tree sets `set -euo pipefail`
+itself.
+
+### Two shapes the first scan could not see, both in the processors
+
+Review reproduced two false-green paths at the pinned processor commits, and
+the scan reported zero for both because it had not modelled either shape.
+
+1. **A captured verdict decided from text.** `protocol-processor/scripts/lint_hdl.sh`
+   runs `out=$(verilator --lint-only …)` under `set -u` only, then greps the
+   text for `%Error`. The assignment's exit status goes nowhere. A `verilator`
+   stub that exits 7 and prints nothing makes it print `LINT OK` for every top
+   and exit 0 — reproduced here, not inferred. The scan now reads `$(tool …)`
+   captures on the raw logical line (continuations joined): a bare assignment
+   with no `errexit` in force and no `||`/`&&` consulting the status is a
+   discarded verdict, and `local`/`export` in front discards it even under
+   `errexit`, because the shell sees the builtin's status. `if`/`!`/`[`
+   forms consult the status and are not findings. An argument form such as
+   `echo "rtl=$(python3 scripts/ci_scope.py)"` is the *consumer's* verdict and
+   is deliberately not modelled: the one site of that shape here is the CI
+   scope publication in `elaborate.yml`, which the CI contract fails closed —
+   an empty publication is treated as RTL-relevant.
+2. **A file-reading `grep` piped under `set -e` without `pipefail`.**
+   `gptp-processor/syn/ooc/run.sh` is `#!/bin/sh` with `set -e` and reads each
+   utilisation report through `grep -A2 "…" ucpu_util.rpt | head -20`. When
+   Vivado produced no report, `grep` fails, `head` succeeds, and the flow exits
+   0 having measured nothing. `grep` reading stdin is a consumer and stays
+   out of the producer set; a leftmost `grep`/`cat` naming a file operand is a
+   producer, because the file is the flow's product and its absence is the
+   failure.
+
+Neither wrapper can be fixed from this repository, so both are counted and
+ratcheted at the pin with the reason written beside the number in
+`scripts/fail_fast.budget`, exactly as the Rule 9 hygiene ratchet carries its
+one pinned processor finding. The upstream fixes are one line each — consult
+`$?` after the capture; `test -r` the report before reading it — and the pin
+bump that brings them in lowers both ratchets to zero.
 
 Both false positives that this check produced on its first run were in the
 checker, not the tree: a tool name inside a `printf` **format string** read as

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -29,7 +29,7 @@ shape rather than guess at it.
 - **[Rule 4: use intention-revealing names and explicit units](#rule-4-use-intention-revealing-names-and-explicit-units)** -- What a name must reveal, the unit and clock-domain qualifiers that extend the existing HDL suffixes rather than competing with them, cross-language equivalents, and the interface renamed end to end to prove it.
 - **[Measuring hidden units](#measuring-hidden-units)** -- The port's own documentation as the evidence, the three exclusion classes and the false positives that forced them, and why this ships as a ratchet instead of a verdict.
 - **[Rule 5: make ports, contracts and ownership explicit](#rule-5-make-ports-contracts-and-ownership-explicit)** -- What a port contract must state, why wildcard, positional and hierarchical bindings are refused outright while missing documentation and unjustified open or tied connections are only ratcheted, the exact scope of the inventory, the boundary documented end to end as proof, and the review checklist.
-- **[Rule 6: fail fast and encode invariants](#rule-6-fail-fast-and-encode-invariants)** -- Where a verdict must be refused rather than logged, the elaboration contract added to the receive shield and mutation-proven against four illegal parameter sets, the two masked-failure populations that are now ratcheted, and the review checklist.
+- **[Rule 6: fail fast and encode invariants](#rule-6-fail-fast-and-encode-invariants)** -- Where a verdict must be refused rather than logged, one in-tree example per boundary (elaboration, FSM default, generator, pipeline, Tcl flow), the elaboration contract added to the receive shield and mutation-proven by its own diagnostic, where that contract is and is not enforced, the three masked-failure populations ratcheted over a stated population, the sweep's refusal of a suite that logs a failure and exits 0, and the review checklist.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -1216,6 +1216,19 @@ everything downstream then treats a wrong answer as a checked one.
 - An assertion carries a message naming the contract it violated, not just the
   expression that failed.
 
+### Five boundaries, one in-tree example each
+
+None of these was written for this page; each is where the tree already
+refuses, or — for the pipeline — where it used to let a failure through.
+
+| Boundary | Example | What is refused, and how |
+|---|---|---|
+| RTL elaboration | `hdl/ieee8021q/filtering/rx_mac_filter.sv`, the `gen_guard_*` blocks | A datapath narrower than the 48-bit destination address, a beat that is not whole bytes, a TCAM with no entry, an action that cannot tell two matches apart. Each `$error` names the parameter, its value and the law. Detailed below. |
+| FSM default arm | `hdl/ieee1722/aaf/KL_aes3_rx.sv`, `default: st_r <= HUNT_S;` | The decoder's 2-bit state has four legal values and one arm no transition produces. Rather than leave that arm to hold whatever the `case` did not cover, it sends the receiver back to `HUNT_S` — re-acquiring the unit interval from nothing, the one state that assumes nothing about what came before. |
+| Python generator | `scripts/pp_srcs.py` | An empty source list. The script raises instead of printing nothing, because an empty list builds cleanly and proves nothing, and every consumer — `syn/yosys/run.sh`, `syn/yosys/ooc.sh`, `tb/verilator/milan_dp/Makefile`, `syn/ooc/dp_srcs.py` — takes that status rather than discarding it. |
+| Shell pipeline | `gate \| tee log` in a shell without `pipefail` | Nothing — that is the defect. The pipeline exits with `tee`'s status, so a failing gate is a pass. Measured and ratcheted below. |
+| Tcl synthesis flow | `bd/build.tcl` after each `wait_on_run`; `syn/ooc/milan_datapath_ooc.tcl` around its ROM generators | A run whose `PROGRESS` is not `100%` is `error "SYNTHESIS FAILED …"`, so the bitstream step can never run on a synthesis that quietly did not finish. The OOC flow's `exec` raises on a non-zero generator status, and a generator that exited 0 leaving no file, or a malformed image, is refused before Yosys reads it. |
+
 ### A comment is not a guard
 
 `hdl/ieee8021q/filtering/rx_mac_filter.sv` is the receive shield. Its banner
@@ -1227,46 +1240,116 @@ downstream check can see, because a filter that is wrong looks exactly like a
 filter that is right until the traffic is inspected on the wire.
 
 It now carries an elaboration contract in the house form — a module-scope
-`if (…) $error("one format string", …)`, the same shape `milan_datapath` and
-`KL_media_nco` already use. Four laws: the datapath must be wide enough to hold
+`if (…) begin : gen_guard_… $error("one format string", …) end`, the named
+generate block `KL_media_nco` writes. `milan_datapath` leaves its guard blocks
+unnamed, which is a `GENUNNAMED` warning in every `-Wall` build; the named
+form is the house form. Four laws: the datapath must be wide enough to hold
 the 48-bit destination address in one beat, it must be a whole number of bytes
 so `tkeep` can describe it, the TCAM must have at least one entry, and an
 action must be wide enough to distinguish two matches.
 
-**The contract is graded by mutation, permanently.** `make negative` in
-`tb/verilator/rx_filter` elaborates four illegal parameter sets and requires
-each to be refused, then elaborates the legal default and requires it to be
-accepted. That last arm is what stops the contract from becoming a ban, and it
-is why the arm reads the exit status directly rather than through a pipe — a
-pipeline returns its *last* command's status, which is how a refused build
-reads as a pass.
+**Where the contract is enforced, and where it is not.** Verilator refuses
+the build whenever `USERERROR` is fatal: its default with no `-Wno-fatal`, or
+`-Werror-USERERROR`. Every suite that builds the shield carries the latter —
+`tb/verilator/rx_filter`, `milan_dp`, `hostplane` and `tcam_csr` — because
+`-Wno-fatal` on its own demotes a `$error` to a warning, and review built
+`-GTDATA_WIDTH=52` in the rx_filter suite with rc 0 before the flag was added
+there. Vivado refuses it at elaboration. It is **not** enforced on the
+sv2v → Yosys path that `syn/yosys/run.sh` and `syn/yosys/ooc.sh` use: sv2v
+lowers a module-scope `$error` to an `initial $display`, which Yosys ignores,
+so `OOC_CHPARAM="TDATA_WIDTH=52" syn/yosys/ooc.sh rx_mac_filter` synthesises
+the illegal shape and reports PASS. Yosys's own `read_verilog -sv` does honour
+the `$error`, so a Yosys-side check would take the shape
+`protocol-processor/tb/timer_map/shape_elab.sh` already has for the
+processor top: elaborate each illegal shape and require the guard's own
+message, fed the original SystemVerilog rather than sv2v's output. That check
+is not in this change; this paragraph is here so nobody reads the Yosys gate's
+PASS as the contract having run.
 
-### The two populations, measured
+**The contract is graded by mutation, permanently, and by its own
+diagnostic.** `make negative` in `tb/verilator/rx_filter` elaborates four
+illegal parameter sets and requires each to be refused *with a `USERERROR`
+line carrying `rx_mac_filter: <PARAM>=<value>`*, then elaborates the legal
+default and requires it to be accepted — that last arm is what stops the
+contract from becoming a ban. The exit status alone was not proof: review
+deleted the whole `$error` chain and three of the four arms still printed
+`[PASS]`, refused by an accidental `SELRANGE`, `ASCRANGE` or `ZEROREPL`
+warning in `tcam.sv` rather than by the contract. Each arm now captures
+stderr to a file and lets `grep -q` on that file be the assertion — the shape
+`shape_elab.sh` uses — and nothing goes through a pipe, because a pipeline
+returns its *last* command's status. With the chain deleted all four arms
+print `[FAIL]`; restored, five of five.
+
+### What the module ratchet counts
+
+Which modules have parameters is read with `scripts/sv_ports.py`, the header
+parser the Rule 4 and Rule 5 gates share, so every parameter form the tree
+writes counts: `int unsigned`, `string`, `type`, `real`, `longint`, a packed
+range, a parameter with no default. The first version carried a private regex
+that knew only `parameter int X =`; it saw 53 of the 102 parameterised modules
+and none of gptp-processor's, and the ratchet it published (43) was satisfied
+vacuously by exactly the `_P` / `int unsigned` idiom Rule 4 asks for.
+
+What counts as a contract is a `$error` or `$fatal` at **module or generate
+scope** — outside every `always`, `initial` and `final` block and every
+function or task. That is the one form every flow evaluates when the
+parameters are bound. An `initial begin … $fatal` (`KL_pp_acmp_listener`) or
+an `initial … assert … else $error` (`KL_avtp_common_parser`) is a simulation
+check: Verilator builds the binary, Vivado and Yosys synthesise the module,
+and only a simulation run refuses, so both are inventoried as unguarded. A
+`$error` inside `always` is a runtime assertion; before this distinction
+`KL_gptp_engine` would have counted as guarded on three PathTrace assertions
+that never look at a parameter. The self-test has an arm for each shape.
+
+### The three populations, measured
 
 [`scripts/measure_fail_fast.py`](../../scripts/measure_fail_fast.py) counts
-both ways a failure can pass for success here.
+the ways a failure can pass for success here, over a stated population: every
+first-party `.sh` (34), every GitHub workflow `run:` block (5 files), and
+every recipe line of every first-party Makefile (93). Python and Tcl are
+**not** measured: review surveyed both at this head — no `os.system`, no
+`shell=True`, every `check=False` keeps the return code, Tcl `exec` raises on
+a non-zero status and the only `catch` sites are Vivado-generated — and this
+table says what it covers rather than reading as tree-wide.
 
 | Population | Count | Disposition |
 |---|---:|---|
-| Parameterised modules with no elaboration contract | 43 of 53 | Ratchet across the superproject and both project-owned processor submodules. Paid down as modules gain contracts. |
-| Pipelines that discard their producer's exit status | **2** | Ratchet. Both are `gptp-processor/syn/ooc/run.sh` reading a Vivado report through `grep … | head` (see below); fixed upstream, and the pin bump takes this to zero, where it must then stay. |
-| Captured verdicts whose exit status is discarded | **1** | Ratchet. `protocol-processor/scripts/lint_hdl.sh:14` (see below); fixed upstream, and the pin bump takes this to zero. |
-| Pipelines waived because the consumer *is* the assertion | 2 | Named, with the reason recorded |
+| Parameterised modules with no elaboration contract | 85 of 102 | Ratchet across the superproject and both project-owned processor submodules. Paid down as modules gain contracts. |
+| Pipelines that discard their producer's exit status | **4** | Ratchet. Two are `gptp-processor/syn/ooc/run.sh` reading a Vivado report through `grep … \| head` (below); fixed upstream, the pin bump removes them. Two are coverage recipes, `tb/verilator/avtp_rxmon/Makefile` and `tb/verilator/maap/Makefile`, piping `verilator_coverage --annotate` into `tail` under make's own `/bin/sh -c`; `cov_gate.py` refuses a missing annotate directory behind them, and the fix is to drop the pipe. |
+| Captured verdicts whose exit status is discarded | **2** | Ratchet. `protocol-processor/scripts/lint_hdl.sh:14` (below), and `protocol-processor/tb/timer_map/shape_elab.sh:48`, whose over-large arm decides from the guard's text — a silent Verilator there reads as GUARD FAIL, so it fails closed, but the status is never read; line 35 of the same script reads `$?` on the next line and is the model. Both fixed upstream. |
+| Pipelines waived because the consumer *is* the assertion | 2 | Waived by **site** — path and exact line — with the reason recorded. |
 
-The waiver matters: `verilator --version | grep -F "$WANT"` wants grep's status,
-because grep is the assertion. Those two sites are excluded by name rather than
-by pattern, so a new one has to be added deliberately.
+The waiver is by site, not by pattern. `verilator --version | grep -F "$WANT"`
+wants grep's status, because grep is the assertion. The first version waived
+any line containing `--version | grep`, before it had even tested for a
+producer, and review bypassed the ratchet by appending `--version` to a lint
+gate's arguments. Now the producer test runs first, the table names the path
+and the exact line, a new `--version | grep` anywhere else is reported as
+masked, and a waiver whose line no longer exists fails the self-test.
 
-The shell model is per unit, in line order. An ordinary script starts with
-neither `errexit` nor `pipefail` and is protected only after its own `set`
-executes; a later setting cannot retroactively protect an earlier line. A
-GitHub workflow step is its own shell, and the default one is `bash -e {0}`:
+The shell model is per unit, in line order. A script starts with whatever its
+shebang says (`#!/bin/bash -eo pipefail` counts) and is protected only after
+its own `set` runs; a later setting cannot retroactively protect an earlier
+line. Comments are blanked before that search, so `# set -o pipefail is not
+used here` protects nothing; a here-document body is text, not commands, and
+an unterminated one makes the file unreadable, which the tool refuses with
+exit 2 rather than scan a partial population; a `set` inside `( … )` lasts
+until the subshell closes; backslash-continued lines are one line. A GitHub
+workflow step is its own shell, and the default one is `bash -e {0}`:
 **errexit, no pipefail**. Only a step that declares `shell: bash` runs
-`bash --noprofile --norc -eo pipefail {0}`. The first version of this scan
-assumed every step had pipefail and let a `set -o pipefail` in one step protect
-the next; both were wrong, both have arms now, and the correction found no
-victim only because every piped step in this tree sets `set -euo pipefail`
-itself.
+`bash --noprofile --norc -eo pipefail {0}`, and options set inside one step
+never reach the next. The first version of this scan assumed every step had
+pipefail and let a `set -o pipefail` in one step protect the next; both were
+wrong, both have arms now, and the correction found no victim only because
+every piped step in this tree sets `set -euo pipefail` itself. Producers are
+the tools (`verilator`, `verilator_coverage`, `yosys`, `sv2v`, `vivado`,
+`xvlog`, `xelab`, `iverilog`, `python3`), `make` bare or as `$MAKE`, any
+`.sh` invocation, and a simulator binary (`./obj_dir/V…`). A Makefile recipe
+line is its own `/bin/sh -c` with neither option unless `.SHELLFLAGS` says so
+(no Makefile here sets it), and `$(VERILATOR)`, `$(PY)` and `$(MAKE)` are
+expanded from the file's own definitions before the line is read; a group
+that saves its producer's status before the pipe, `{ tool; echo $? > f; } \|
+tee out`, keeps its verdict and is not a finding.
 
 ### Two shapes the first scan could not see, both in the processors
 
@@ -1277,16 +1360,17 @@ the scan reported zero for both because it had not modelled either shape.
    runs `out=$(verilator --lint-only …)` under `set -u` only, then greps the
    text for `%Error`. The assignment's exit status goes nowhere. A `verilator`
    stub that exits 7 and prints nothing makes it print `LINT OK` for every top
-   and exit 0 — reproduced here, not inferred. The scan now reads `$(tool …)`
+   and exit 0 — reproduced here, not inferred. The scan reads `$(tool …)`
    captures on the raw logical line (continuations joined): a bare assignment
-   with no `errexit` in force and no `||`/`&&` consulting the status is a
-   discarded verdict, and `local`/`export` in front discards it even under
-   `errexit`, because the shell sees the builtin's status. `if`/`!`/`[`
-   forms consult the status and are not findings. An argument form such as
-   `echo "rtl=$(python3 scripts/ci_scope.py)"` is the *consumer's* verdict and
-   is deliberately not modelled: the one site of that shape here is the CI
-   scope publication in `elaborate.yml`, which the CI contract fails closed —
-   an empty publication is treated as RTL-relevant.
+   with no `errexit` in force and nothing consulting the status is a discarded
+   verdict, and `local`/`export` in front discards it even under `errexit`,
+   because the shell sees the builtin's status. `||`, `&&`, an `if`/`!`/`[`
+   in front, or `$?` read on the same or the next line, consult it and are not
+   findings. An argument form such as `echo "rtl=$(python3 scripts/ci_scope.py)"`
+   is the *consumer's* verdict and is deliberately not modelled: the one site
+   of that shape here is the CI scope publication in `elaborate.yml`, which
+   the CI contract fails closed — an empty publication is treated as
+   RTL-relevant.
 2. **A file-reading `grep` piped under `set -e` without `pipefail`.**
    `gptp-processor/syn/ooc/run.sh` is `#!/bin/sh` with `set -e` and reads each
    utilisation report through `grep -A2 "…" ucpu_util.rpt | head -20`. When
@@ -1301,7 +1385,7 @@ ratcheted at the pin with the reason written beside the number in
 `scripts/fail_fast.budget`, exactly as the Rule 9 hygiene ratchet carries its
 one pinned processor finding. The upstream fixes are one line each — consult
 `$?` after the capture; `test -r` the report before reading it — and the pin
-bump that brings them in lowers both ratchets to zero.
+bump that brings them in lowers both ratchets.
 
 Both false positives that this check produced on its first run were in the
 checker, not the tree: a tool name inside a `printf` **format string** read as
@@ -1309,30 +1393,40 @@ a command, and a pipe inside a `$(…)` substitution — whose status is never t
 line's verdict — read as a masked one. Quoted spans and substitutions are
 blanked before the producer search, and both cases have arms.
 
-Review found the opposite false negative too: the first implementation treated
-the word `pipefail` anywhere in a file as protection for every pipeline in that
-file. The mutation `python3 gate.py | tee log` followed by `set -o pipefail`
-therefore passed even though the producer status had already been lost. The
-scan now models activation in line order, and a permanent arm requires that
-mutation to fail.
+### Assertions that only log: inventoried and gated
 
-### Already satisfied, and verified rather than rebuilt
+The issue's other inventory is the harness whose `check()` prints `[FAIL]`,
+counts it, and whose `main()` returns 0 anyway — or the target that prints
+`5 checks: 4 PASS, 1 FAIL` above an `exit 0`. `make` cannot read, so such a
+suite was a PASS of the sweep; review crafted exactly that log and
+[`scripts/run_all_suites.sh`](../../scripts/run_all_suites.sh) accepted it.
+Now every suite that exits 0 has its log read back by
+[`scripts/suite_tally.py`](../../scripts/suite_tally.py) `--verdict`, with the
+same recognisers the tally uses: a tally in any shape with a non-zero failure
+count, or a line that starts with `[FAIL]`, turns that green into
+`FAIL … (exited 0, but its log reports a failure - a masked verdict)`, counted
+among the failed suites. This is the representative masked failure fixed
+here. `suite_tally.py --selftest` refuses the contradictory log through the
+CLI and its exit code, and accepts a clean one; every `[FAIL]` printer in the
+tree sits on a counted failure branch, and the two suites that run deliberate
+failures keep that output out of their logs, so a green sweep stays green.
 
-The rule also asks that suite tally parsing treat missing or malformed evidence
-as failure rather than zero checks.
-[`scripts/suite_tally.py`](../../scripts/suite_tally.py) already does: a suite
-whose log carries no readable tally is `NOCOUNT`, an unknown is never allowed to
-look like agreement, and a skip marker cannot suppress it. That was confirmed by
-running its self-test, not by writing a second one.
+The rule also asks that suite tally parsing treat missing or malformed
+evidence as failure rather than zero checks. `suite_tally.py` already did: a
+suite whose log carries no readable tally is `NOCOUNT`, an unknown is never
+allowed to look like agreement, and a skip marker cannot suppress it. That
+was confirmed by running its self-test, not by writing a second one.
 
 ### Review checklist
 
 - If this step fails, does the caller find out — or does it print and continue?
 - Is the invariant executable, or only written in a comment?
 - Does the assertion message name the contract, or only the expression?
-- Is there an arm proving the refusal fires, **and** one proving the legal case
-  still passes?
-- Does any verdict travel through a pipe?
+- Is there an arm proving the refusal fires **by its own diagnostic**, and one
+  proving the legal case still passes?
+- Does any verdict travel through a pipe, or sit in a `$(…)` nobody consults?
+- Does the flow you are relying on evaluate the contract at all — Verilator
+  with `USERERROR` fatal, Vivado — or is it the sv2v path?
 
 ## Rules not yet landed
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1248,19 +1248,29 @@ both ways a failure can pass for success here.
 
 | Population | Count | Disposition |
 |---|---:|---|
-| Parameterised modules with no elaboration contract | 37 of 42 | Ratchet. Paid down as modules gain contracts. |
+| Parameterised modules with no elaboration contract | 43 of 53 | Ratchet across the superproject and both project-owned processor submodules. Paid down as modules gain contracts. |
 | Pipelines that discard their producer's exit status | **0** | Ratchet at zero. It must stay zero. |
-| Pipelines waived because the consumer *is* the assertion | 27 | Named, with the reason recorded |
+| Pipelines waived because the consumer *is* the assertion | 2 | Named, with the reason recorded |
 
 The waiver matters: `verilator --version | grep -F "$WANT"` wants grep's status,
-because grep is the assertion. Those are excluded by name rather than by
-pattern, so a new one has to be added deliberately.
+because grep is the assertion. Those two sites are excluded by name rather than
+by pattern, so a new one has to be added deliberately. GitHub workflow `run`
+blocks use the runner's default bash `-o pipefail`; ordinary shell scripts are
+protected only after their own `set ... pipefail` executes. A later setting no
+longer retroactively masks an earlier unsafe pipeline in the measurement.
 
 Both false positives that this check produced on its first run were in the
 checker, not the tree: a tool name inside a `printf` **format string** read as
 a command, and a pipe inside a `$(…)` substitution — whose status is never the
 line's verdict — read as a masked one. Quoted spans and substitutions are
 blanked before the producer search, and both cases have arms.
+
+Review found the opposite false negative too: the first implementation treated
+the word `pipefail` anywhere in a file as protection for every pipeline in that
+file. The mutation `python3 gate.py | tee log` followed by `set -o pipefail`
+therefore passed even though the producer status had already been lost. The
+scan now models activation in line order, and a permanent arm requires that
+mutation to fail.
 
 ### Already satisfied, and verified rather than rebuilt
 

--- a/hdl/ieee8021q/filtering/rx_mac_filter.sv
+++ b/hdl/ieee8021q/filtering/rx_mac_filter.sv
@@ -122,6 +122,33 @@ module rx_mac_filter #(
     output wire                     frame_dropped_o //! current frame is being dropped
 );
 
+  // =======================================================================
+  //  ELABORATION CONTRACT. The banner above states that the destination
+  //  address is read out of the FIRST BEAT, and that this holds "for
+  //  TDATA_WIDTH>=48". That was a comment, and a comment does not stop a
+  //  build: at TDATA_WIDTH=32 the dmac concatenation below indexes past the
+  //  end of s_tdata, the compare runs against whatever those bits are, and
+  //  the shield silently admits or drops the wrong frames. Nothing downstream
+  //  can detect that - a filter that is wrong is indistinguishable from a
+  //  filter that is right until the traffic is inspected on the wire.
+  //
+  //  ONE format string per check: $error takes later arguments as VALUES, so
+  //  a message split across string literals prints its continuations as
+  //  integers.
+  // =======================================================================
+  if (TDATA_WIDTH < 48)
+    $error("rx_mac_filter: TDATA_WIDTH=%0d cannot carry the 48-bit destination address in one beat, and the first-beat compare this module is built on would read past the end of s_tdata and filter on undefined bits. The 802.3 destination address is 6 bytes (IEEE 802.3 3.2.3), so the RX datapath must be at least 48 bits wide.",
+           TDATA_WIDTH);
+  else if ((TDATA_WIDTH % 8) != 0)
+    $error("rx_mac_filter: TDATA_WIDTH=%0d is not a whole number of bytes, so s_tkeep (TDATA_WIDTH/8) cannot describe the beat it qualifies and the final beat's byte count would be unrepresentable.",
+           TDATA_WIDTH);
+  else if (NUM_ENTRIES < 1)
+    $error("rx_mac_filter: NUM_ENTRIES=%0d leaves the TCAM with no entry to program, so every frame takes the default_pass_i path and the stream-drop shield cannot exist. Prune the filter at its instantiation instead of sizing it to zero.",
+           NUM_ENTRIES);
+  else if (ACTION_WIDTH < 1)
+    $error("rx_mac_filter: ACTION_WIDTH=%0d cannot carry a match action, so frame_action_o would be empty and every hit would be indistinguishable from every other hit.",
+           ACTION_WIDTH);
+
   // -----------------------------------------------------------------------
   //  Destination MAC = first 6 bytes on the wire (byte 0 = MAC MSB).
   //  AXIS byte lane 0 (tdata[7:0]) carries byte 0, so swap into MAC order.

--- a/hdl/ieee8021q/filtering/rx_mac_filter.sv
+++ b/hdl/ieee8021q/filtering/rx_mac_filter.sv
@@ -36,11 +36,12 @@
 //                addr_filter_en_i is TCAM_CTRL[1], reset 0, so a build that
 //                never sets it behaves exactly as before.
 //
-//                Assumes the 6-byte destination MAC lies entirely in beat 0
-//                (true for TDATA_WIDTH>=48, e.g. the 64-bit datapath), so the
-//                accept/drop decision is available before beat 0 is forwarded —
-//                no store-and-forward buffering. The TCAM write port is exported
-//                so milan_csr can add/remove entries (0x700 group).
+//                Requires the 6-byte destination MAC to lie entirely in beat 0
+//                (TDATA_WIDTH >= 48, e.g. the 64-bit datapath) — refused at
+//                elaboration below, not assumed — so the accept/drop decision is
+//                available before beat 0 is forwarded: no store-and-forward
+//                buffering. The TCAM write port is exported so milan_csr can
+//                add/remove entries (0x700 group).
 //---------------------------------------------------------------------------//
 
 `default_nettype none
@@ -134,20 +135,39 @@ module rx_mac_filter #(
   //
   //  ONE format string per check: $error takes later arguments as VALUES, so
   //  a message split across string literals prints its continuations as
-  //  integers.
+  //  integers. The blocks are NAMED (gen_guard_*), the form KL_media_nco
+  //  uses: an unnamed generate block is a GENUNNAMED warning in every -Wall
+  //  build of this module.
+  //
+  //  WHERE THIS IS ENFORCED. Verilator refuses the build whenever USERERROR
+  //  is fatal: its default (no -Wno-fatal), or -Werror-USERERROR, which every
+  //  suite that builds this module carries (tb/verilator/rx_filter, milan_dp,
+  //  hostplane, tcam_csr) because -Wno-fatal on its own demotes a $error to a
+  //  warning and the illegal shape BUILDS. Vivado refuses it at elaboration.
+  //  It is NOT enforced on the sv2v -> Yosys path (syn/yosys/run.sh, ooc.sh):
+  //  sv2v lowers a module-scope $error to an `initial $display`, which Yosys
+  //  ignores, so that flow synthesises an illegal shape without a word. A
+  //  Yosys-side check would take the shape of
+  //  protocol-processor/tb/timer_map/shape_elab.sh - elaborate each illegal
+  //  shape and require the guard's own message - fed the original
+  //  SystemVerilog, since Yosys's own `read_verilog -sv` does honour it.
   // =======================================================================
-  if (TDATA_WIDTH < 48)
+  if (TDATA_WIDTH < 48) begin : gen_guard_dmac_in_beat0
     $error("rx_mac_filter: TDATA_WIDTH=%0d cannot carry the 48-bit destination address in one beat, and the first-beat compare this module is built on would read past the end of s_tdata and filter on undefined bits. The 802.3 destination address is 6 bytes (IEEE 802.3 3.2.3), so the RX datapath must be at least 48 bits wide.",
            TDATA_WIDTH);
-  else if ((TDATA_WIDTH % 8) != 0)
+  end
+  else if ((TDATA_WIDTH % 8) != 0) begin : gen_guard_byte_lanes
     $error("rx_mac_filter: TDATA_WIDTH=%0d is not a whole number of bytes, so s_tkeep (TDATA_WIDTH/8) cannot describe the beat it qualifies and the final beat's byte count would be unrepresentable.",
            TDATA_WIDTH);
-  else if (NUM_ENTRIES < 1)
+  end
+  else if (NUM_ENTRIES < 1) begin : gen_guard_tcam_entries
     $error("rx_mac_filter: NUM_ENTRIES=%0d leaves the TCAM with no entry to program, so every frame takes the default_pass_i path and the stream-drop shield cannot exist. Prune the filter at its instantiation instead of sizing it to zero.",
            NUM_ENTRIES);
-  else if (ACTION_WIDTH < 1)
+  end
+  else if (ACTION_WIDTH < 1) begin : gen_guard_action_width
     $error("rx_mac_filter: ACTION_WIDTH=%0d cannot carry a match action, so frame_action_o would be empty and every hit would be indistinguishable from every other hit.",
            ACTION_WIDTH);
+  end
 
   // -----------------------------------------------------------------------
   //  Destination MAC = first 6 bytes on the wire (byte 0 = MAC MSB).

--- a/scripts/fail_fast.budget
+++ b/scripts/fail_fast.budget
@@ -1,11 +1,21 @@
 # Rule 6 ratchets, in order. See scripts/measure_fail_fast.py.
-# BOTH NUMBERS MAY ONLY GO DOWN.
+# ALL THREE NUMBERS MAY ONLY GO DOWN.
 #
 # 1. Parameterised first-party modules with NO elaboration contract. A module
 #    that accepts any parameter its caller passes cannot refuse an impossible
 #    build, and a banner comment does not stop one.
 43
 # 2. Pipelines whose producer is a verdict and whose exit status is therefore
-#    the CONSUMER's. Currently zero: it must stay zero. Pipelines where the
+#    the CONSUMER's. Two at the pin, both gptp-processor/syn/ooc/run.sh
+#    (lines 15 and 17): `grep ... util.rpt | head` under `set -e` in a POSIX
+#    sh that has no pipefail, so a flow whose Vivado produced no report exits
+#    0. The fix is upstream (test for the report before reading it); the pin
+#    bump lowers this to 0, where it must then stay. Pipelines where the
 #    consumer IS the assertion are waived by name in the script, with a reason.
-0
+2
+# 3. Captured verdicts whose exit status is discarded: `out=$(tool ...)` with
+#    no errexit and no guard, or behind local/export. One at the pin,
+#    protocol-processor/scripts/lint_hdl.sh:14, where a Verilator that exits
+#    non-zero without printing %Error reads as LINT OK. Fixed upstream by
+#    consulting the status; the pin bump lowers this to 0.
+1

--- a/scripts/fail_fast.budget
+++ b/scripts/fail_fast.budget
@@ -12,6 +12,12 @@
 #    MODULE-SCOPE $error/$fatal counts as a contract - an initial-block $fatal
 #    is a simulation check that every synthesis flow drops, so
 #    KL_pp_acmp_listener and KL_avtp_common_parser moved into this count.
+#    Re-measured 2026-08-29 when review showed a module-scope CONCURRENT
+#    assertion (`assert property ... else $error`) counted as a contract:
+#    the recognition is now positive (generate scope only; every assertion,
+#    procedural block and preprocessor line stepped over) and the tool
+#    printed the same 85 of 102 - the tree writes no concurrent assertion -
+#    so this number did not move.
 85
 # 2. Pipelines whose producer is a verdict and whose exit status is therefore
 #    the CONSUMER's. Four: two in gptp-processor/syn/ooc/run.sh (lines 15 and

--- a/scripts/fail_fast.budget
+++ b/scripts/fail_fast.budget
@@ -1,21 +1,36 @@
 # Rule 6 ratchets, in order. See scripts/measure_fail_fast.py.
-# ALL THREE NUMBERS MAY ONLY GO DOWN.
+# ALL THREE NUMBERS MAY ONLY GO DOWN. Each was re-based ONCE, on 2026-08-28,
+# when review showed the population it had been measured over was incomplete;
+# the reason sits beside the number and the value is what the tool printed.
 #
 # 1. Parameterised first-party modules with NO elaboration contract. A module
 #    that accepts any parameter its caller passes cannot refuse an impossible
-#    build, and a banner comment does not stop one.
-43
+#    build, and a banner comment does not stop one. 85 of 102: the first
+#    reading said 43 of 53 because the parameter regex knew only
+#    `parameter int X =` and saw none of gptp-processor's modules; the shared
+#    header parser (scripts/sv_ports.py) now reads every form, and only a
+#    MODULE-SCOPE $error/$fatal counts as a contract - an initial-block $fatal
+#    is a simulation check that every synthesis flow drops, so
+#    KL_pp_acmp_listener and KL_avtp_common_parser moved into this count.
+85
 # 2. Pipelines whose producer is a verdict and whose exit status is therefore
-#    the CONSUMER's. Two at the pin, both gptp-processor/syn/ooc/run.sh
-#    (lines 15 and 17): `grep ... util.rpt | head` under `set -e` in a POSIX
-#    sh that has no pipefail, so a flow whose Vivado produced no report exits
-#    0. The fix is upstream (test for the report before reading it); the pin
-#    bump lowers this to 0, where it must then stay. Pipelines where the
-#    consumer IS the assertion are waived by name in the script, with a reason.
-2
+#    the CONSUMER's. Four: two in gptp-processor/syn/ooc/run.sh (lines 15 and
+#    17, `grep ... util.rpt | head` under `set -e` in a POSIX sh that has no
+#    pipefail, so a flow whose Vivado produced no report exits 0 - fixed
+#    upstream, the pin bump removes them), and two Makefile coverage recipes
+#    the scan did not read before this re-base (tb/verilator/avtp_rxmon:56 and
+#    tb/verilator/maap:27, `verilator_coverage --annotate ... | tail -2` under
+#    make's own /bin/sh -c; cov_gate.py refuses a missing annotate directory
+#    behind them, and the fix is to drop the pipe). Pipelines where the
+#    consumer IS the assertion are waived by SITE in the script, with a reason.
+4
 # 3. Captured verdicts whose exit status is discarded: `out=$(tool ...)` with
-#    no errexit and no guard, or behind local/export. One at the pin,
-#    protocol-processor/scripts/lint_hdl.sh:14, where a Verilator that exits
-#    non-zero without printing %Error reads as LINT OK. Fixed upstream by
-#    consulting the status; the pin bump lowers this to 0.
-1
+#    no errexit and nothing consulting the status, or behind local/export.
+#    Two, both in the pinned protocol-processor: scripts/lint_hdl.sh:14, where
+#    a Verilator that exits non-zero without printing %Error reads as LINT OK;
+#    and tb/timer_map/shape_elab.sh:48, whose OVER arm decides from the guard's
+#    text - a silent Verilator there reads as GUARD FAIL, so it fails closed
+#    today, but the status is still never read (line 35 of the same script
+#    reads `$?` on the next line and is the model). Both are fixed upstream;
+#    the pin bump lowers this to 0.
+2

--- a/scripts/fail_fast.budget
+++ b/scripts/fail_fast.budget
@@ -4,7 +4,7 @@
 # 1. Parameterised first-party modules with NO elaboration contract. A module
 #    that accepts any parameter its caller passes cannot refuse an impossible
 #    build, and a banner comment does not stop one.
-37
+43
 # 2. Pipelines whose producer is a verdict and whose exit status is therefore
 #    the CONSUMER's. Currently zero: it must stay zero. Pipelines where the
 #    consumer IS the assertion are waived by name in the script, with a reason.

--- a/scripts/fail_fast.budget
+++ b/scripts/fail_fast.budget
@@ -1,0 +1,11 @@
+# Rule 6 ratchets, in order. See scripts/measure_fail_fast.py.
+# BOTH NUMBERS MAY ONLY GO DOWN.
+#
+# 1. Parameterised first-party modules with NO elaboration contract. A module
+#    that accepts any parameter its caller passes cannot refuse an impossible
+#    build, and a banner comment does not stop one.
+37
+# 2. Pipelines whose producer is a verdict and whose exit status is therefore
+#    the CONSUMER's. Currently zero: it must stay zero. Pipelines where the
+#    consumer IS the assertion are waived by name in the script, with a reason.
+0

--- a/scripts/measure_fail_fast.py
+++ b/scripts/measure_fail_fast.py
@@ -9,8 +9,9 @@ result must be rejected at the nearest responsible boundary and must propagate
 a non-success verdict. Two populations in this tree can break that, and they
 break it silently:
 
-  1. A PARAMETERISED MODULE WITH NO ELABORATION CONTRACT. Forty-three
-     first-party modules declare parameters; four reject an impossible
+  1. A PARAMETERISED MODULE WITH NO ELABORATION CONTRACT. Fifty-three
+     first-party modules across the superproject and its project-owned
+     processor submodules declare parameters; ten reject an impossible
      combination at elaboration. The rest accept any value the caller passes.
      `rx_mac_filter` documented "true for TDATA_WIDTH>=48" in a banner for
      months - a comment does not stop a build, and at 32 bits the destination
@@ -38,7 +39,6 @@ Exit 0 = at or under the ratchet in scripts/fail_fast.budget.
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -47,6 +47,7 @@ BUDGET = Path(__file__).resolve().parent / "fail_fast.budget"
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lint_rtl import LINT_EXCLUDE
+from code_quality_scope import tracked
 
 COMMENT = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
 PARAM = re.compile(r"\bparameter\s+(?:int|logic|bit|integer|byte)?\s*"
@@ -72,18 +73,27 @@ def blank_comments(text):
                        text)
 
 
-def tracked(*pats):
-    out = subprocess.run(["git", "ls-files", *pats], cwd=REPO,
-                         capture_output=True, text=True, check=True).stdout.split()
-    return [p for p in out
-            if not p.startswith(("third_party/", "external/", "protocol-processor/",
-                                 "gptp-processor/", "gen/", "build/"))]
-
-
 def scan_module(text):
     """(declares_parameters, has_elaboration_check) for one SystemVerilog source."""
     code = blank_comments(text)
     return bool(PARAM.search(code)), bool(ELAB_CHECK.search(code))
+
+
+MODULE = re.compile(r"^\s*module\s+([A-Za-z_]\w*)\b", re.M)
+ENDMODULE = re.compile(r"\bendmodule\b")
+
+
+def scan_modules(text):
+    """Return `(name, has_parameters, has_check)` per module, never per file."""
+    code = blank_comments(text)
+    rows = []
+    for match in MODULE.finditer(code):
+        end = ENDMODULE.search(code, match.end())
+        if end is None:
+            continue
+        has_params, has_check = scan_module(code[match.start():end.end()])
+        rows.append((match.group(1), has_params, has_check))
+    return rows
 
 
 #: quoted spans and command substitutions, blanked before the producer search
@@ -107,31 +117,52 @@ def scan_pipeline(line):
     for needle, why in INTENTIONAL:
         if needle in line:
             return False, why
-    if "pipefail" in line:
-        return False, "the line sets pipefail"
     if line.lstrip().startswith("#"):
         return False, ""
     return bool(PIPE.match(shell_code(line))), ""
 
 
+def scan_pipelines(text, workflow=False):
+    """Return masked and waived pipeline rows, respecting activation order.
+
+    GitHub's default Linux bash shell starts every `run` script with
+    `-o pipefail`; ordinary `.sh` files must enable it before the pipeline.
+    A later mention of pipefail cannot retroactively protect an earlier line.
+    """
+    active = workflow
+    masked, waived = [], []
+    for n, line in enumerate(text.splitlines(), 1):
+        code = shell_code(line)
+        if re.search(r"\bset\s+\+o\s+pipefail\b", code):
+            active = False
+        elif re.search(r"\bset\b[^#\n]*\bpipefail\b", code):
+            active = True
+        is_masked, why = scan_pipeline(line)
+        if why:
+            waived.append((n, why))
+        elif is_masked and not active:
+            masked.append((n, line.strip()[:96]))
+    return masked, waived
+
+
 def audit():
     unguarded, guarded = [], []
     for rel in [p for p in tracked("hdl") if p.endswith(".sv") and p not in LINT_EXCLUDE]:
-        has_params, has_check = scan_module((REPO / rel).read_text(errors="replace"))
-        if not has_params:
-            continue
-        (guarded if has_check else unguarded).append(rel)
+        for name, has_params, has_check in scan_modules(
+                (REPO / rel).read_text(errors="replace")):
+            if not has_params:
+                continue
+            unit = f"{rel}:{name}"
+            (guarded if has_check else unguarded).append(unit)
 
     masked, waived = [], []
     for rel in tracked("*.sh", ".github/workflows/*.yml", "syn/**/*.sh", "harness/**/*.sh"):
         text = (REPO / rel).read_text(errors="replace")
-        pipefail_file = "pipefail" in text
-        for n, line in enumerate(text.splitlines(), 1):
-            is_masked, why = scan_pipeline(line)
-            if why:
-                waived.append((rel, n, why))
-            elif is_masked and not pipefail_file:
-                masked.append((rel, n, line.strip()[:96]))
+        found, exceptions = scan_pipelines(
+            text, workflow=rel.startswith(".github/workflows/") or
+            "/.github/workflows/" in rel)
+        masked.extend((rel, n, line) for n, line in found)
+        waived.extend((rel, n, why) for n, why in exceptions)
     return unguarded, guarded, masked, waived
 
 
@@ -164,6 +195,11 @@ def selftest():
        scan_module("module m #(parameter int W = 8)();\n // $error(\"no\");\n"
                    "endmodule") == (True, False),
        "comments are blanked before the search")
+    rows = scan_modules(
+        "module guarded #(parameter int A=1)(); if (!A) $error(\"A\"); endmodule\n"
+        "module bare #(parameter int B=1)(); endmodule")
+    ck("two modules in one file are measured independently",
+       rows == [("guarded", True, True), ("bare", True, False)], f"{rows}")
 
     ck("a piped gate is masked", scan_pipeline("  python3 scripts/x.py | tee log")[0])
     ck("a piped make is masked", scan_pipeline("  make run | tail -5")[0])
@@ -175,7 +211,12 @@ def selftest():
     ck("a pipe inside a command substitution is not the line's verdict",
        not scan_pipeline('  msg=$(grep ERROR log | head -1); python3 x.py')[0])
     ck("a line that sets pipefail is not masked",
-       not scan_pipeline("  set -o pipefail; python3 x.py | tee log")[0])
+       not scan_pipelines("set -o pipefail\npython3 x.py | tee log")[0])
+    ck("a later pipefail cannot protect an earlier pipeline",
+       scan_pipelines("python3 x.py | tee log\nset -o pipefail")[0] ==
+       [(1, "python3 x.py | tee log")])
+    ck("GitHub's default bash shell carries pipefail",
+       not scan_pipelines("python3 x.py | tee log", workflow=True)[0])
     ck("the version assertion is waived by name, with a reason",
        scan_pipeline('  verilator --version | grep -F "$WANT"') == (False,
        "the grep IS the version assertion; its status is the verdict"))
@@ -190,7 +231,7 @@ def selftest():
     ck("the waiver actually fires on the live tree", bool(waived),
        "no intentional pipeline was seen - the waiver is untested here")
 
-    n = 16
+    n = 19
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 

--- a/scripts/measure_fail_fast.py
+++ b/scripts/measure_fail_fast.py
@@ -125,7 +125,7 @@ def scan_pipeline(line):
 def scan_pipelines(text, workflow=False):
     """Return masked and waived pipeline rows, respecting activation order.
 
-    GitHub's default Linux bash shell starts every `run` script with
+    GitHub Actions starts its default bash shell for every `run` script with
     `-o pipefail`; ordinary `.sh` files must enable it before the pipeline.
     A later mention of pipefail cannot retroactively protect an earlier line.
     """
@@ -215,7 +215,7 @@ def selftest():
     ck("a later pipefail cannot protect an earlier pipeline",
        scan_pipelines("python3 x.py | tee log\nset -o pipefail")[0] ==
        [(1, "python3 x.py | tee log")])
-    ck("GitHub's default bash shell carries pipefail",
+    ck("the GitHub Actions default bash shell carries pipefail",
        not scan_pipelines("python3 x.py | tee log", workflow=True)[0])
     ck("the version assertion is waived by name, with a reason",
        scan_pipeline('  verilator --version | grep -F "$WANT"') == (False,

--- a/scripts/measure_fail_fast.py
+++ b/scripts/measure_fail_fast.py
@@ -21,20 +21,43 @@ break it silently:
   2. A PIPELINE THAT DISCARDS ITS PRODUCER'S EXIT CODE. In a shell without
      `pipefail`, `gate | tee log` exits with tee's status, so a failing gate
      reads as a pass. This is scored per-line and only for producers that ARE
-     a verdict - a tool run, a make, a gate script.
+     a verdict - a tool run, a make, a gate script - and, since review, a
+     leftmost `grep`/`cat` that READS A FILE: `grep -A2 "LUTs" util.rpt |
+     head` under `set -e` without pipefail exits 0 when the report does not
+     exist, which is how a synthesis flow whose tools produced nothing was
+     published as measured (gptp-processor/syn/ooc/run.sh, at the pin).
 
-Both are RATCHETS. Neither population can be emptied in one change without
-exactly the churn the governing rule forbids, and the second has legitimate
+  3. A CAPTURED VERDICT WHOSE STATUS IS DISCARDED. `out=$(verilator ...)`
+     followed by a grep of the TEXT decides the verdict from what the tool
+     printed, never from what it returned. Without errexit the assignment's
+     status goes nowhere; with `local`/`export` in front it is the builtin's
+     status even under errexit. A verilator that crashes silently, or is not
+     installed and shadowed by a stub, prints nothing, matches no `%Error`,
+     and reads as LINT OK for every top (protocol-processor/scripts/
+     lint_hdl.sh, at the pin). Only the assignment forms are modelled: an
+     argument-form `echo "k=$(tool)"` is a verdict the CONSUMER decides, and
+     the one such site here (elaborate.yml's scope publication) is fail-closed
+     by the CI contract, which treats an empty publication as RTL-relevant.
+
+All three are RATCHETS. None can be emptied in one change without exactly the
+churn the governing rule forbids, and the pipeline population has legitimate
 members: `verilator --version | grep -F "$WANT"` deliberately wants grep's
 status, because grep IS the assertion. Those are excluded by name, with the
-reason recorded.
+reason recorded. Debt that lives in a pinned processor submodule is counted
+here and fixed upstream; the pin bump lowers the ratchet.
+
+GITHUB'S DEFAULT `run` SHELL IS `bash -e {0}`: errexit, NO pipefail. Only a
+step that declares `shell: bash` gets `-eo pipefail`. The first version of
+this scan assumed every workflow step had pipefail and let one step's
+`set -o pipefail` protect the next; both are modelled per step now, and every
+piped step in this tree sets `set -euo pipefail` itself.
 
 Usage:
     python3 scripts/measure_fail_fast.py            # both inventories
     python3 scripts/measure_fail_fast.py --check    # the ratchet
     python3 scripts/measure_fail_fast.py --selftest # fixture arms
 
-Exit 0 = at or under the ratchet in scripts/fail_fast.budget.
+Exit 0 = at or under all three ratchets in scripts/fail_fast.budget.
 """
 
 import argparse
@@ -60,6 +83,18 @@ ELAB_CHECK = re.compile(r"\$fatal|\$error")
 PIPE = re.compile(
     r"^\s*(?P<lhs>.*?\b(?:python3?|make|verilator|yosys|sv2v|behave|pytest"
     r"|\./run\.sh|\./ooc\.sh|scripts/\S+\.(?:py|sh))\b[^|]*?)\|(?!\|)")
+
+#: A leftmost grep/cat that reads a FILE and feeds a consumer. The file is the
+#: flow's product, so its absence is the failure; grep reading stdin is a
+#: consumer (an assertion) and is not matched here. Matched against
+#: shell_code(), where quoted patterns are already blanked.
+FILE_PIPE = re.compile(r"^\s*(?:grep|egrep|fgrep|cat)\b(?P<args>[^|]*)\|(?!\|)")
+
+#: A captured verdict: `$(tool ...)` for the same producers as PIPE. Matched
+#: on the RAW logical line (shell_code() blanks substitutions on purpose).
+SUBST = re.compile(
+    r"\$\(\s*(?:python3?|make|verilator|yosys|sv2v|vivado|iverilog|behave|pytest"
+    r"|\./run\.sh|\./ooc\.sh|scripts/\S+\.(?:py|sh))\b")
 
 #: Pipelines where the CONSUMER is the assertion and its status is the point.
 #: Each is matched on the whole line, so a new one has to be added deliberately.
@@ -112,6 +147,16 @@ def shell_code(line):
     return _QUOTED.sub(lambda m: " " * len(m.group(0)), line)
 
 
+def _reads_a_file(args):
+    """True when a grep/cat argument list names at least one file operand.
+
+    Options are skipped; for grep the first bare token is the pattern (blank
+    when it was quoted), so a file is the second bare token; for cat any bare
+    token is a file."""
+    bare = [t for t in args.split() if not t.startswith("-")]
+    return len(bare) >= 1
+
+
 def scan_pipeline(line):
     """(is_masked, reason) for one shell/workflow line."""
     for needle, why in INTENTIONAL:
@@ -119,30 +164,140 @@ def scan_pipeline(line):
             return False, why
     if line.lstrip().startswith("#"):
         return False, ""
-    return bool(PIPE.match(shell_code(line))), ""
+    code = shell_code(line)
+    if PIPE.match(code):
+        return True, ""
+    m = FILE_PIPE.match(code)
+    if m:
+        args = m.group("args")
+        bare = [t for t in args.split() if not t.startswith("-")]
+        # grep: pattern then file(s) - a quoted pattern was blanked, so a bare
+        # file token alone means the pattern was quoted; cat: any bare token
+        is_cat = code.lstrip().startswith("cat")
+        quoted_pattern = bool(re.match(r"^\s*(?:grep|egrep|fgrep)\b[^|]*?[\"']", line))
+        needs = 1 if (is_cat or quoted_pattern) else 2
+        return len(bare) >= needs, ""
+    return False, ""
+
+
+_STEP_START = re.compile(r"^\s*-\s+\w+:")
+_SHELL_BASH = re.compile(r"^\s*shell:\s*bash\b")
+
+
+def workflow_steps(text):
+    """[(first_line_no, lines, bash_shell)] - one entry per workflow step.
+
+    Text before the first `- key:` is the preamble (one entry, no shell). A
+    step declares `shell: bash` before or after its `run:` block, so the whole
+    step is read before its lines are scanned."""
+    steps, cur, start = [], [], 1
+    for n, line in enumerate(text.splitlines(), 1):
+        if _STEP_START.match(line) and cur:
+            steps.append((start, cur))
+            cur, start = [], n
+        cur.append(line)
+    if cur:
+        steps.append((start, cur))
+    return [(start, lines, any(_SHELL_BASH.match(l) for l in lines))
+            for start, lines in steps]
+
+
+def _units(text, workflow):
+    """[(first_line_no, lines, pipefail0, errexit0)] - the scan units.
+
+    A `.sh` file is one unit that starts with neither option. A workflow is one
+    unit per step: GitHub's default shell is `bash -e {0}` (errexit, no
+    pipefail), and `shell: bash` is `bash --noprofile --norc -eo pipefail {0}`.
+    Options set inside one step never reach the next - each step is a fresh
+    shell."""
+    if not workflow:
+        return [(1, text.splitlines(), False, False)]
+    return [(start, lines, bash, True) for start, lines, bash in workflow_steps(text)]
 
 
 def scan_pipelines(text, workflow=False):
     """Return masked and waived pipeline rows, respecting activation order.
 
-    GitHub Actions starts its default bash shell for every `run` script with
-    `-o pipefail`; ordinary `.sh` files must enable it before the pipeline.
-    A later mention of pipefail cannot retroactively protect an earlier line.
+    Ordinary `.sh` files must enable pipefail before the pipeline; a later
+    mention cannot retroactively protect an earlier line. A workflow step
+    starts without pipefail unless it declares `shell: bash`.
     """
-    active = workflow
     masked, waived = [], []
-    for n, line in enumerate(text.splitlines(), 1):
-        code = shell_code(line)
-        if re.search(r"\bset\s+\+o\s+pipefail\b", code):
-            active = False
-        elif re.search(r"\bset\b[^#\n]*\bpipefail\b", code):
-            active = True
-        is_masked, why = scan_pipeline(line)
-        if why:
-            waived.append((n, why))
-        elif is_masked and not active:
-            masked.append((n, line.strip()[:96]))
+    for start, lines, active, _ in _units(text, workflow):
+        for n, line in enumerate(lines, start):
+            code = shell_code(line)
+            if re.search(r"\bset\s+\+o\s+pipefail\b", code):
+                active = False
+            elif re.search(r"\bset\b[^#\n]*\bpipefail\b", code):
+                active = True
+            is_masked, why = scan_pipeline(line)
+            if why:
+                waived.append((n, why))
+            elif is_masked and not active:
+                masked.append((n, line.strip()[:96]))
     return masked, waived
+
+
+_ERREXIT_ON = re.compile(r"\bset\s+(?:-[a-df-zA-Z]*e[a-zA-Z]*\b|-o\s+errexit\b|-[a-zA-Z]*\s+-o\s+errexit\b)")
+_ERREXIT_OFF = re.compile(r"\bset\s+(?:\+[a-zA-Z]*e[a-zA-Z]*\b|\+o\s+errexit\b)")
+_GUARD_PREFIX = re.compile(r"^\s*(?:if|elif|while|until)\b|^\s*!\s|^\s*\[|^\s*test\b")
+_BUILTIN_PREFIX = re.compile(r"^\s*(?:local|export|declare|readonly|typeset)\b")
+_ASSIGN_PREFIX = re.compile(r"^\s*[A-Za-z_]\w*\+?=")
+
+
+def logical_lines(lines, start):
+    """Join backslash-continued lines; yields (first_line_no, joined)."""
+    buf, first = [], None
+    for n, line in enumerate(lines, start):
+        if first is None:
+            first = n
+        if line.rstrip().endswith("\\"):
+            buf.append(line.rstrip()[:-1])
+            continue
+        buf.append(line)
+        yield first, " ".join(buf)
+        buf, first = [], None
+    if buf:
+        yield first, " ".join(buf)
+
+
+def scan_substitution(line, errexit):
+    """(is_masked, form) for one logical line holding `$(producer ...)`.
+
+    Forms: `local/export x=$(...)` is masked whatever errexit says - the status
+    is the builtin's. A bare assignment is masked when errexit is off and no
+    `||`/`&&` consults the status. A test (`if`, `!`, `[`) consults it. Any
+    other form is the consumer's verdict and is not modelled here."""
+    if line.lstrip().startswith("#"):
+        return False, "comment"
+    m = SUBST.search(line)
+    if not m:
+        return False, ""
+    if _BUILTIN_PREFIX.match(line):
+        return True, "builtin"
+    if _GUARD_PREFIX.match(line):
+        return False, "test"
+    if _ASSIGN_PREFIX.match(line):
+        tail = line[m.end():]
+        consulted = ("||" in tail) or ("&&" in tail)
+        return (not errexit) and not consulted, "assignment"
+    return False, "argument"
+
+
+def scan_substitutions(text, workflow=False):
+    """Masked captured-verdict rows [(line_no, text)], errexit in line order."""
+    masked = []
+    for start, lines, _, errexit in _units(text, workflow):
+        for n, line in logical_lines(lines, start):
+            code = shell_code(line.replace("$(", "  "))   # keep the $( visible below
+            if _ERREXIT_OFF.search(code):
+                errexit = False
+            elif _ERREXIT_ON.search(code):
+                errexit = True
+            is_masked, _form = scan_substitution(line, errexit)
+            if is_masked:
+                masked.append((n, line.strip()[:96]))
+    return masked
 
 
 def audit():
@@ -155,22 +310,22 @@ def audit():
             unit = f"{rel}:{name}"
             (guarded if has_check else unguarded).append(unit)
 
-    masked, waived = [], []
+    masked, waived, captured = [], [], []
     for rel in tracked("*.sh", ".github/workflows/*.yml", "syn/**/*.sh", "harness/**/*.sh"):
         text = (REPO / rel).read_text(errors="replace")
-        found, exceptions = scan_pipelines(
-            text, workflow=rel.startswith(".github/workflows/") or
-            "/.github/workflows/" in rel)
+        workflow = rel.startswith(".github/workflows/") or "/.github/workflows/" in rel
+        found, exceptions = scan_pipelines(text, workflow=workflow)
         masked.extend((rel, n, line) for n, line in found)
         waived.extend((rel, n, why) for n, why in exceptions)
-    return unguarded, guarded, masked, waived
+        captured.extend((rel, n, line) for n, line in scan_substitutions(text, workflow=workflow))
+    return unguarded, guarded, masked, waived, captured
 
 
 def read_budget():
     if not BUDGET.is_file():
         return None, None
     vals = [int(x) for x in re.findall(r"^\s*(\d+)\s*$", BUDGET.read_text(), re.M)]
-    return (vals + [None, None])[:2]
+    return (vals + [None, None, None])[:3]
 
 
 def selftest():
@@ -215,23 +370,71 @@ def selftest():
     ck("a later pipefail cannot protect an earlier pipeline",
        scan_pipelines("python3 x.py | tee log\nset -o pipefail")[0] ==
        [(1, "python3 x.py | tee log")])
-    ck("the GitHub Actions default bash shell carries pipefail",
-       not scan_pipelines("python3 x.py | tee log", workflow=True)[0])
+    ck("the GitHub Actions default run shell has NO pipefail",
+       scan_pipelines("    - name: s\n      run: |\n        python3 x.py | tee log\n",
+                      workflow=True)[0] == [(3, "python3 x.py | tee log")],
+       "GitHub's default is `bash -e {0}`; only `shell: bash` adds pipefail")
+    ck("a step that declares shell: bash is protected, before or after its run block",
+       not scan_pipelines("    - name: s\n      run: |\n        python3 x.py | tee log\n"
+                          "      shell: bash\n", workflow=True)[0])
+    ck("pipefail set in one step does not protect the next step",
+       scan_pipelines("    - run: |\n        set -euo pipefail\n        python3 a.py | tee a\n"
+                      "    - run: |\n        python3 b.py | tee b\n", workflow=True)[0]
+       == [(5, "python3 b.py | tee b")])
+    ck("a file-reading grep piped to head is a producer whose status is lost",
+       scan_pipelines('set -e\ngrep -A2 "Slice LUTs\\|DSPs" ucpu_util.rpt | head -20\n')[0]
+       == [(2, 'grep -A2 "Slice LUTs\\|DSPs" ucpu_util.rpt | head -20')],
+       "a missing report makes grep fail and head succeed: the flow exits 0")
+    ck("a file-reading cat piped to a consumer is the same shape",
+       scan_pipeline("cat engine_util.rpt | tail -3")[0])
+    ck("grep reading stdin is a consumer, not a producer",
+       not scan_pipeline('echo "$out" | grep -q FAIL')[0])
+    ck("a bare grep pattern with no file reads stdin and is not a producer",
+       not scan_pipeline("grep foo | head -1")[0])
+    ck("the file-reading grep is protected once pipefail is on",
+       not scan_pipelines("set -eo pipefail\ngrep x rpt | head\n")[0])
+    ck("a captured verdict with no errexit and no guard is discarded",
+       scan_substitutions("set -u\nout=$(verilator --lint-only -Wall \\\n  $pkgs $all 2>&1)\n"
+                          "if echo \"$out\" | grep -q Error; then rc=1; fi\n")
+       == [(2, "out=$(verilator --lint-only -Wall    $pkgs $all 2>&1)")],
+       "a silent non-zero verilator prints nothing, matches nothing, reads as OK")
+    ck("the same capture under errexit is not discarded",
+       not scan_substitutions("set -eu\nout=$(verilator --lint-only x.sv 2>&1)\n"))
+    ck("errexit switched off later un-protects a later capture",
+       scan_substitutions("set -e\nset +e\nout=$(make lint)\n") == [(3, "out=$(make lint)")])
+    ck("a local/export assignment discards the status even under errexit",
+       scan_substitutions("set -e\nf() {\n  local out=$(make lint)\n}\n") == [(3, "local out=$(make lint)")]
+       and scan_substitutions("set -e\nexport OUT=$(python3 x.py)\n") == [(2, "export OUT=$(python3 x.py)")],
+       "the builtin's status is what the shell sees")
+    ck("a capture whose status is consulted is not discarded",
+       not scan_substitutions("x=$(python3 y.py) || exit 2\n")
+       and not scan_substitutions("if ! x=$(python3 y.py); then exit 2; fi\n"))
+    ck("an argument-form substitution is the consumer's verdict and is not modelled",
+       not scan_substitutions('echo "rtl=$(python3 scripts/ci_scope.py)" >> "$OUT"\n'))
+    ck("a workflow step starts with errexit, so a bare capture there is not discarded",
+       not scan_substitutions("    - run: |\n        rtl=\"$(python3 scripts/ci_scope.py)\"\n",
+                              workflow=True))
+    ck("a capture inside a comment is not a finding",
+       not scan_substitutions("set -u\n# out=$(verilator x)\n"))
     ck("the version assertion is waived by name, with a reason",
        scan_pipeline('  verilator --version | grep -F "$WANT"') == (False,
        "the grep IS the version assertion; its status is the verdict"))
     ck("an ordinary command is not a pipeline",
        not scan_pipeline("  python3 scripts/x.py")[0])
 
-    unguarded, guarded, masked, waived = audit()
+    unguarded, guarded, masked, waived, captured = audit()
     ck("the live scan reads the tree", len(unguarded) + len(guarded) > 20,
        f"{len(unguarded)} + {len(guarded)} modules with parameters")
     ck("the guarded set is not empty", len(guarded) >= 4,
        "an inert scan would report every module unguarded")
     ck("the waiver actually fires on the live tree", bool(waived),
        "no intentional pipeline was seen - the waiver is untested here")
+    ck("the live scan reaches both processor submodules' shell wrappers",
+       any(rel.startswith("gptp-processor/") for rel, _, _ in masked + captured) and
+       any(rel.startswith("protocol-processor/") for rel, _, _ in masked + captured),
+       f"masked {[r for r, _, _ in masked]}, captured {[r for r, _, _ in captured]}")
 
-    n = 19
+    n = 36
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -245,7 +448,7 @@ def main():
     if args.selftest:
         return selftest()
 
-    unguarded, guarded, masked, waived = audit()
+    unguarded, guarded, masked, waived, captured = audit()
 
     print(f"parameterised modules with no elaboration contract "
           f"({len(unguarded)} of {len(unguarded) + len(guarded)}):")
@@ -254,6 +457,9 @@ def main():
     print(f"\npipelines that discard their producer's exit code ({len(masked)}):")
     for rel, n, line in masked:
         print(f"   {rel}:{n}  {line}")
+    print(f"\ncaptured verdicts whose exit status is discarded ({len(captured)}):")
+    for rel, n, line in captured:
+        print(f"   {rel}:{n}  {line}")
     print(f"\nwaived, with a reason ({len(waived)}):")
     for rel, n, why in waived:
         print(f"   {rel}:{n}  {why}")
@@ -261,9 +467,9 @@ def main():
     if not args.check:
         return 0
 
-    b_unguarded, b_masked = read_budget()
-    if b_unguarded is None or b_masked is None:
-        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} must hold two counts")
+    b_unguarded, b_masked, b_captured = read_budget()
+    if b_unguarded is None or b_masked is None or b_captured is None:
+        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} must hold three counts")
         return 1
     bad = False
     if len(unguarded) > b_unguarded:
@@ -274,13 +480,19 @@ def main():
         print(f"\nFAIL: {len(masked)} masked pipeline(s) > ratchet {b_masked}. "
               f"A verdict must not be piped away.")
         bad = True
+    if len(captured) > b_captured:
+        print(f"\nFAIL: {len(captured)} captured verdict(s) discarded > ratchet "
+              f"{b_captured}. A tool's exit status is the verdict; its text is not.")
+        bad = True
     if bad:
         return 1
     print(f"\nFAIL-FAST RATCHET: PASS ({len(unguarded)} <= {b_unguarded} modules "
           f"without an elaboration contract, {len(masked)} <= {b_masked} masked "
-          f"pipeline(s), {len(waived)} waived with a reason)")
-    if len(unguarded) < b_unguarded or len(masked) < b_masked:
-        print(f"  the ratchets can be lowered to {len(unguarded)} and {len(masked)}")
+          f"pipeline(s), {len(captured)} <= {b_captured} discarded captured "
+          f"verdict(s), {len(waived)} waived with a reason)")
+    if len(unguarded) < b_unguarded or len(masked) < b_masked or len(captured) < b_captured:
+        print(f"  the ratchets can be lowered to {len(unguarded)}, {len(masked)} "
+              f"and {len(captured)}")
     return 0
 
 

--- a/scripts/measure_fail_fast.py
+++ b/scripts/measure_fail_fast.py
@@ -6,26 +6,48 @@
 Why this exists. Rule 6 of the maintainability guide
 (docs/development/CODE_QUALITY.md) says an invalid parameter, state or tool
 result must be rejected at the nearest responsible boundary and must propagate
-a non-success verdict. Two populations in this tree can break that, and they
+a non-success verdict. Three populations in this tree can break that, and they
 break it silently:
 
-  1. A PARAMETERISED MODULE WITH NO ELABORATION CONTRACT. Fifty-three
-     first-party modules across the superproject and its project-owned
-     processor submodules declare parameters; ten reject an impossible
-     combination at elaboration. The rest accept any value the caller passes.
+  1. A PARAMETERISED MODULE WITH NO ELABORATION CONTRACT. 102 first-party
+     modules across the superproject and its project-owned processor
+     submodules declare parameters; 18 reject an impossible combination at
+     elaboration. The rest accept any value the caller passes.
      `rx_mac_filter` documented "true for TDATA_WIDTH>=48" in a banner for
      months - a comment does not stop a build, and at 32 bits the destination
      compare would have read past the end of the beat and filtered on
      undefined bits, which nothing downstream can detect.
 
+     WHAT COUNTS AS A CONTRACT: `$error` or `$fatal` at MODULE OR GENERATE
+     SCOPE - outside every always/initial/final block and outside every
+     function and task. That is the one form every flow evaluates when the
+     parameters are bound. An `initial begin ... $fatal` or an `assert (...)
+     else $error` inside `initial` is a simulation check: Verilator builds the
+     binary, Vivado and Yosys synthesise the module, and only a simulation run
+     refuses - so it is NOT counted (KL_pp_acmp_listener, KL_avtp_common_parser
+     are inventoried as unguarded for that reason). A `$error` inside `always`
+     is a runtime assertion and is not counted either, so adding one cannot
+     empty this ratchet (review found KL_gptp_engine would otherwise have
+     counted as guarded on three runtime PathTrace assertions).
+
+     WHICH MODULES HAVE PARAMETERS is read with scripts/sv_ports.py, the one
+     header parser the Rule 4 and Rule 5 gates already use, so every parameter
+     form this tree writes counts: `int unsigned`, `string`, `type`, `real`,
+     `longint`, a packed range, and a parameter with no default. The first
+     regex here accepted only `parameter int X =` and saw 53 of the 102 -
+     none of gptp-processor's - which is why the first budget said 43.
+
   2. A PIPELINE THAT DISCARDS ITS PRODUCER'S EXIT CODE. In a shell without
      `pipefail`, `gate | tee log` exits with tee's status, so a failing gate
-     reads as a pass. This is scored per-line and only for producers that ARE
-     a verdict - a tool run, a make, a gate script - and, since review, a
-     leftmost `grep`/`cat` that READS A FILE: `grep -A2 "LUTs" util.rpt |
-     head` under `set -e` without pipefail exits 0 when the report does not
-     exist, which is how a synthesis flow whose tools produced nothing was
-     published as measured (gptp-processor/syn/ooc/run.sh, at the pin).
+     reads as a pass. This is scored per logical line and only for producers
+     that ARE a verdict - a tool run, a make, a gate script, a simulator
+     binary, a `.sh` invocation - and for a leftmost `grep`/`cat` that READS A
+     FILE: `grep -A2 "LUTs" util.rpt | head` under `set -e` without pipefail
+     exits 0 when the report does not exist, which is how a synthesis flow
+     whose tools produced nothing was published as measured
+     (gptp-processor/syn/ooc/run.sh, at the pin). A pipeline that writes its
+     producer's status to a file inside its own group - `{ tool; echo $? > f; }
+     | tee out` - keeps the verdict and is not a finding.
 
   3. A CAPTURED VERDICT WHOSE STATUS IS DISCARDED. `out=$(verilator ...)`
      followed by a grep of the TEXT decides the verdict from what the tool
@@ -34,30 +56,49 @@ break it silently:
      status even under errexit. A verilator that crashes silently, or is not
      installed and shadowed by a stub, prints nothing, matches no `%Error`,
      and reads as LINT OK for every top (protocol-processor/scripts/
-     lint_hdl.sh, at the pin). Only the assignment forms are modelled: an
-     argument-form `echo "k=$(tool)"` is a verdict the CONSUMER decides, and
-     the one such site here (elaborate.yml's scope publication) is fail-closed
-     by the CI contract, which treats an empty publication as RTL-relevant.
+     lint_hdl.sh, at the pin). A capture whose status is consulted - `||`,
+     `&&`, an `if`/`!`/`[` in front, or `$?` read on the same or the next
+     logical line - is not a finding. Only the assignment forms are modelled:
+     an argument-form `echo "k=$(tool)"` is a verdict the CONSUMER decides,
+     and the one such site here (elaborate.yml's scope publication) is
+     fail-closed by the CI contract, which treats an empty publication as
+     RTL-relevant.
 
-All three are RATCHETS. None can be emptied in one change without exactly the
-churn the governing rule forbids, and the pipeline population has legitimate
-members: `verilator --version | grep -F "$WANT"` deliberately wants grep's
-status, because grep IS the assertion. Those are excluded by name, with the
-reason recorded. Debt that lives in a pinned processor submodule is counted
-here and fixed upstream; the pin bump lowers the ratchet.
+THE MEASURED POPULATION for 2 and 3 is every first-party `.sh`, every GitHub
+workflow `run:` block, and every RECIPE line of every first-party Makefile.
+Each logical recipe line is its own `/bin/sh -c`, so a recipe never has
+pipefail or errexit unless `.SHELLFLAGS` says so (no Makefile here sets it),
+and make variables that name a tool (`$(VERILATOR)`, `$(PY)`, `$(MAKE)`) are
+expanded from the file's own definitions before the line is read. Python and
+Tcl are NOT measured: review surveyed both at this head - no `os.system`, no
+`shell=True`, every `check=False` keeps the return code, Tcl `exec` raises on
+a non-zero status and the only `catch` sites are Vivado-generated - and the
+guide says so rather than letting the table read as tree-wide.
 
-GITHUB'S DEFAULT `run` SHELL IS `bash -e {0}`: errexit, NO pipefail. Only a
-step that declares `shell: bash` gets `-eo pipefail`. The first version of
-this scan assumed every workflow step had pipefail and let one step's
-`set -o pipefail` protect the next; both are modelled per step now, and every
-piped step in this tree sets `set -euo pipefail` itself.
+THE SHELL MODEL is per unit, in order. A `.sh` starts with whatever its
+shebang says (`#!/bin/bash -eo pipefail` counts) and is protected only after
+its own `set` runs; a later `set` cannot protect an earlier line. Comments are
+blanked before that search, so `# set -o pipefail is not used` protects
+nothing; a here-document body is text, not commands; a `set` inside `( ... )`
+lasts until the subshell closes. GITHUB'S DEFAULT `run` SHELL IS `bash -e {0}`:
+errexit, NO pipefail. Only a step that declares `shell: bash` gets
+`-eo pipefail`, and options set inside one step never reach the next.
+
+WAIVERS are by SITE - path plus the exact line - and are consulted only after
+a line has been found masked: `verilator --version | grep -F "$WANT"` wants
+grep's status, because grep IS the assertion. A new site has to be added here
+deliberately, and a waiver whose line no longer exists fails the self-test.
+Debt that lives in a pinned processor submodule is counted here and fixed
+upstream; the pin bump lowers the ratchet.
 
 Usage:
-    python3 scripts/measure_fail_fast.py            # both inventories
+    python3 scripts/measure_fail_fast.py            # the inventories
     python3 scripts/measure_fail_fast.py --check    # the ratchet
     python3 scripts/measure_fail_fast.py --selftest # fixture arms
 
-Exit 0 = at or under all three ratchets in scripts/fail_fast.budget.
+Exit 0 = at or under all three ratchets in scripts/fail_fast.budget; 1 = over
+a ratchet or the budget is unusable; 2 = the population could not be read
+(an unterminated here-document makes the rest of a script unreadable).
 """
 
 import argparse
@@ -71,18 +112,194 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lint_rtl import LINT_EXCLUDE
 from code_quality_scope import tracked
+from sv_ports import declarations
+
+#: vendor and archive scope: tracked() recurses into every submodule, and the
+#: Makefile pathspec below would otherwise pull in verilog-axis's test benches
+NOT_FIRST_PARTY = ("third_party/", "external/", "historical_now_obsolete/")
+
+
+class Unreadable(Exception):
+    """The population cannot be read to the end - a partial scan is not a pass."""
+
+
+# --- 1. modules ----------------------------------------------------------------
 
 COMMENT = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
-PARAM = re.compile(r"\bparameter\s+(?:int|logic|bit|integer|byte)?\s*"
-                   r"(?:signed\s+)?(?:\[[^\]]*\]\s*)?(\w+)\s*=")
-ELAB_CHECK = re.compile(r"\$fatal|\$error")
+STRING = re.compile(r'"(?:[^"\\\n]|\\.)*"')
+IMPORT = re.compile(r"\bimport\b[^;]*;")
+ELAB_CHECK = re.compile(r"\$(?:fatal|error)\b")
+MODULE = re.compile(r"^\s*module\s+([A-Za-z_]\w*)\b", re.M)
+ENDMODULE = re.compile(r"\bendmodule\b")
+
+#: what follows one of these runs at simulation time, not at elaboration
+_PROCEDURAL = re.compile(r"\b(?:always(?:_ff|_comb|_latch)?|initial|final)\b")
+_FUNC_TASK = re.compile(r"\bfunction\b.*?\bendfunction\b|\btask\b.*?\bendtask\b", re.S)
+_WORD = re.compile(r"[A-Za-z_]\w*")
+_BLOCKS = {
+    "begin": re.compile(r"\b(?P<open>begin)\b|\b(?P<close>end)\b"),
+    "fork": re.compile(r"\b(?P<open>fork)\b|\b(?P<close>join(?:_any|_none)?)\b"),
+    "case": re.compile(r"\b(?P<open>case[xz]?)\b|\b(?P<close>endcase)\b"),
+}
+
+
+def _blank(m):
+    return "".join(c if c == "\n" else " " for c in m.group(0))
+
+
+def blank_comments(text):
+    return COMMENT.sub(_blank, text)
+
+
+def _skip_ws(code, i):
+    while i < len(code) and code[i].isspace():
+        i += 1
+    return i
+
+
+def _skip_parens(code, i):
+    """`i` at `(`; the index just past its matching `)`."""
+    depth = 0
+    while i < len(code):
+        if code[i] == "(":
+            depth += 1
+        elif code[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return len(code)
+
+
+def _word_at(code, i):
+    m = _WORD.match(code, i)
+    return m.group(0) if m else ""
+
+
+def _block_end(code, i, kind):
+    depth = 1
+    for m in _BLOCKS[kind].finditer(code, i):
+        depth += 1 if m.group("open") else -1
+        if depth == 0:
+            return m.end()
+    return len(code)
+
+
+def _statement_end(code, i):
+    """The index just past the procedural statement that starts at code[i:].
+
+    `begin`/`fork`/`case` blocks run to their closer; `if` (and an immediate
+    `assert`) takes a parenthesised condition, a statement and an optional
+    `else` statement; loops take a head and a statement; anything else is a
+    simple statement that runs to its `;`."""
+    i = _skip_ws(code, i)
+    if i >= len(code):
+        return i
+    w = _word_at(code, i)
+    if w in ("begin", "fork"):
+        return _block_end(code, i + len(w), w)
+    if w in ("case", "casez", "casex"):
+        return _block_end(code, i + len(w), "case")
+    if w in ("if", "assert", "assume", "cover"):
+        j = _skip_ws(code, i + len(w))
+        while _word_at(code, j) in ("property", "final"):
+            j = _skip_ws(code, j + len(_word_at(code, j)))
+        if j < len(code) and code[j] == "(":
+            j = _skip_parens(code, j)
+        j = _skip_ws(code, j)
+        if _word_at(code, j) != "else":
+            j = _skip_ws(code, _statement_end(code, j))
+        if _word_at(code, j) == "else":
+            j = _statement_end(code, j + 4)
+        return j
+    if w in ("for", "while", "foreach", "repeat"):
+        j = _skip_ws(code, i + len(w))
+        if j < len(code) and code[j] == "(":
+            j = _skip_parens(code, j)
+        return _statement_end(code, j)
+    if w == "forever":
+        return _statement_end(code, i + len(w))
+    depth = 0
+    while i < len(code):
+        if code[i] == "(":
+            depth += 1
+        elif code[i] == ")":
+            depth -= 1
+        elif code[i] == ";" and depth <= 0:
+            return i + 1
+        i += 1
+    return len(code)
+
+
+def procedural_spans(code):
+    """[(start, end)] of every always/initial/final block, sensitivity list
+    and all, in comment- and string-blanked module text."""
+    spans = []
+    for m in _PROCEDURAL.finditer(code):
+        j = _skip_ws(code, m.end())
+        if j < len(code) and code[j] == "@":
+            j = _skip_ws(code, j + 1)
+            if j < len(code) and code[j] == "(":
+                j = _skip_parens(code, j)
+            elif j < len(code) and code[j] == "*":
+                j += 1
+        spans.append((m.start(), _statement_end(code, j)))
+    return spans
+
+
+def has_elaboration_check(code):
+    """True when `$error`/`$fatal` sits at module or generate scope.
+
+    `code` is one module with comments blanked. Strings go too (a message may
+    say "always"), then imports (a DPI `import ... function` has no
+    `endfunction`), then function and task bodies; what is left inside a
+    procedural span is a simulation check, and everything else is the
+    contract."""
+    code = STRING.sub(_blank, code)
+    code = IMPORT.sub(_blank, code)
+    code = _FUNC_TASK.sub(_blank, code)
+    spans = procedural_spans(code)
+    return any(not any(a <= m.start() < b for a, b in spans)
+               for m in ELAB_CHECK.finditer(code))
+
+
+def scan_modules(text):
+    """Return `(name, has_parameters, has_check)` per module, never per file."""
+    code = blank_comments(text)
+    with_params = {mod for mod, _n, _d, _mb, kind in declarations(text) if kind == "param"}
+    rows = []
+    for match in MODULE.finditer(code):
+        end = ENDMODULE.search(code, match.end())
+        if end is None:
+            continue
+        name = match.group(1)
+        rows.append((name, name in with_params,
+                     has_elaboration_check(code[match.start():end.end()])))
+    return rows
+
+
+def scan_module(text):
+    """(declares_parameters, has_elaboration_check) for a one-module source."""
+    rows = scan_modules(text)
+    return (rows[0][1], rows[0][2]) if rows else (False, False)
+
+
+# --- 2 and 3. shell ------------------------------------------------------------
+
+#: Commands whose exit status IS a verdict: tools, make (bare or as `$MAKE`),
+#: gate scripts, any `.sh`, a Verilator simulator binary (`.../V<top>`), and
+#: the same names spelled as a shell variable (`$VERILATOR`, `$PY`).
+PRODUCER = (
+    r"(?:python3?|make|verilator(?:_coverage)?|yosys|sv2v|vivado|xvlog|xelab|xsim"
+    r"|iverilog|vvp|behave|pytest|\S*\.sh|\S*/V\w+|scripts/\S+\.py"
+    r"|\$\{?(?:MAKE|PY|PYTHON3?|VERILATOR(?:_COVERAGE)?|YOSYS|SV2V|VIVADO|XVLOG"
+    r"|XELAB|IVERILOG)\}?)(?=\s|$|;|\))"
+)
 
 #: A pipeline whose producer is a verdict-bearing command. `\|\|` is excluded:
 #: `a || b` is a fallback, not a pipe. Matched against shell_code(), never the
 #: raw line.
-PIPE = re.compile(
-    r"^\s*(?P<lhs>.*?\b(?:python3?|make|verilator|yosys|sv2v|behave|pytest"
-    r"|\./run\.sh|\./ooc\.sh|scripts/\S+\.(?:py|sh))\b[^|]*?)\|(?!\|)")
+PIPE = re.compile(r"^\s*(?P<lhs>.*?(?<![\w.-])(?:\S*/)?" + PRODUCER + r"[^|]*?)\|(?!\|)")
 
 #: A leftmost grep/cat that reads a FILE and feeds a consumer. The file is the
 #: flow's product, so its absence is the failure; grep reading stdin is a
@@ -90,94 +307,176 @@ PIPE = re.compile(
 #: shell_code(), where quoted patterns are already blanked.
 FILE_PIPE = re.compile(r"^\s*(?:grep|egrep|fgrep|cat)\b(?P<args>[^|]*)\|(?!\|)")
 
+#: `{ tool; echo $? > file; } | tee out` - the status is written before the
+#: pipe can lose it (tb/verilator/tsn_fuzz reads it back on the next line)
+STATUS_SAVED = re.compile(r"echo\s+\$\?\s*>")
+
 #: A captured verdict: `$(tool ...)` for the same producers as PIPE. Matched
 #: on the RAW logical line (shell_code() blanks substitutions on purpose).
-SUBST = re.compile(
-    r"\$\(\s*(?:python3?|make|verilator|yosys|sv2v|vivado|iverilog|behave|pytest"
-    r"|\./run\.sh|\./ooc\.sh|scripts/\S+\.(?:py|sh))\b")
+SUBST = re.compile(r"\$\(\s*" + PRODUCER)
 
 #: Pipelines where the CONSUMER is the assertion and its status is the point.
-#: Each is matched on the whole line, so a new one has to be added deliberately.
+#: Waived by SITE: the path and the exact line, consulted only once the line
+#: has been found masked. A new one is added here, deliberately; one whose
+#: line is gone fails the self-test.
 INTENTIONAL = (
-    ("--version | grep", "the grep IS the version assertion; its status is the verdict"),
+    (".github/workflows/rtl-fast.yml",
+     '/opt/verilator/bin/verilator --version | grep -F "${VERILATOR_VERSION#v}"',
+     "the grep IS the version assertion; its status is the verdict"),
+    (".github/workflows/rtl.yml",
+     '/opt/verilator/bin/verilator --version | grep -F "${VERILATOR_VERSION#v}"',
+     "the grep IS the version assertion; its status is the verdict"),
 )
 
-
-def blank_comments(text):
-    return COMMENT.sub(lambda m: "".join(c if c == "\n" else " " for c in m.group(0)),
-                       text)
-
-
-def scan_module(text):
-    """(declares_parameters, has_elaboration_check) for one SystemVerilog source."""
-    code = blank_comments(text)
-    return bool(PARAM.search(code)), bool(ELAB_CHECK.search(code))
-
-
-MODULE = re.compile(r"^\s*module\s+([A-Za-z_]\w*)\b", re.M)
-ENDMODULE = re.compile(r"\bendmodule\b")
-
-
-def scan_modules(text):
-    """Return `(name, has_parameters, has_check)` per module, never per file."""
-    code = blank_comments(text)
-    rows = []
-    for match in MODULE.finditer(code):
-        end = ENDMODULE.search(code, match.end())
-        if end is None:
-            continue
-        has_params, has_check = scan_module(code[match.start():end.end()])
-        rows.append((match.group(1), has_params, has_check))
-    return rows
+#: quoted spans, arithmetic, command substitutions and parameter expansions,
+#: blanked before the producer search
+_QUOTED = re.compile(r"\$\(\([^)]*\)\)|\$\([^()]*\)|\$\{[^}]*\}|'[^']*'|\"[^\"]*\"")
+_ARITH_SUBST = re.compile(r"\$\(\([^)]*\)\)|\$\([^()]*\)")
+_COMMENT = re.compile(r"(?:^|(?<=\s))#.*$")
+_HEREDOC = re.compile(r"(?<!<)<<(?!<)-?\s*(?:'([A-Za-z_]\w*)'|\"([A-Za-z_]\w*)\"|([A-Za-z_]\w*))")
+#: `(`, `)` and every `set` invocation, in line order
+_SET_TOKENS = re.compile(r"\(|\)|\bset\s+(?:[-+][\w-]*\s+)*[-+][\w-]*(?:\s+[a-z]+)*")
+_PIPEFAIL_OFF = re.compile(r"\+o\s+pipefail\b")
+_ERREXIT_ON = re.compile(r"(?:^|\s)-[a-df-zA-Z]*e[a-zA-Z]*\b|-o\s+errexit\b")
+_ERREXIT_OFF = re.compile(r"(?:^|\s)\+[a-zA-Z]*e[a-zA-Z]*\b|\+o\s+errexit\b")
+_GUARD_PREFIX = re.compile(r"^\s*(?:if|elif|while|until)\b|^\s*!\s|^\s*\[|^\s*test\b")
+_BUILTIN_PREFIX = re.compile(r"^\s*(?:local|export|declare|readonly|typeset)\b")
+_ASSIGN_PREFIX = re.compile(r"^\s*[A-Za-z_]\w*\+?=")
+_SEGMENT = re.compile(r";|&&|\|\||\bthen\b|\bdo\b|\belse\b|\{")
+_SHEBANG = re.compile(r"^#!.*\b(?:ba)?sh\b(.*)$")
 
 
-#: quoted spans and command substitutions, blanked before the producer search
-_QUOTED = re.compile(r"\$\([^()]*\)|'[^']*'|\"[^\"]*\"")
+def _blank_len(m):
+    return " " * len(m.group(0))
 
 
 def shell_code(line):
-    """The part of a shell line that is COMMAND, with quotes and `$(...)`
-    blanked out.
+    """The part of a shell line that is COMMAND, with quotes, arithmetic,
+    `$(...)`, `${...}` and the trailing comment blanked out, length kept.
 
-    Two false positives forced this. `printf "yosys FAIL: %s" ... | head`
-    matched because the tool name was inside a FORMAT STRING, and a pipe inside
-    `$(...)` is a substitution feeding an argument - its status is never the
-    line's verdict, which is set by the command that consumes it.
+    Two false positives forced the first two. `printf "yosys FAIL: %s" ... |
+    head` matched because the tool name was inside a FORMAT STRING, and a pipe
+    inside `$(...)` is a substitution feeding an argument - its status is
+    never the line's verdict, which is set by the command that consumes it.
+    The comment came from review: `# set -o pipefail is not used here` used
+    to protect every pipeline after it.
     """
-    return _QUOTED.sub(lambda m: " " * len(m.group(0)), line)
+    return _COMMENT.sub(_blank_len, _QUOTED.sub(_blank_len, line))
 
 
-def _reads_a_file(args):
-    """True when a grep/cat argument list names at least one file operand.
+def logical_lines(lines, start):
+    """Join backslash-continued lines; yields (first_line_no, joined)."""
+    buf, first = [], None
+    for n, line in enumerate(lines, start):
+        if first is None:
+            first = n
+        if line.rstrip().endswith("\\"):
+            buf.append(line.rstrip()[:-1])
+            continue
+        buf.append(line)
+        yield first, " ".join(buf)
+        buf, first = [], None
+    if buf:
+        yield first, " ".join(buf)
 
-    Options are skipped; for grep the first bare token is the pattern (blank
-    when it was quoted), so a file is the second bare token; for cat any bare
-    token is a file."""
-    bare = [t for t in args.split() if not t.startswith("-")]
-    return len(bare) >= 1
+
+def shebang_options(text):
+    """(pipefail, errexit) a `.sh` starts with: `#!/bin/bash -eo pipefail`."""
+    m = _SHEBANG.match(text.split("\n", 1)[0])
+    if not m:
+        return False, False
+    opts = m.group(1)
+    return bool(re.search(r"\bpipefail\b", opts)), bool(_ERREXIT_ON.search(opts))
+
+
+def _apply_set(tok, state):
+    """Fold one `set ...` invocation into state = {pipefail, errexit}."""
+    if "pipefail" in tok:
+        state["pipefail"] = not _PIPEFAIL_OFF.search(tok)
+    if _ERREXIT_OFF.search(tok):
+        state["errexit"] = False
+    elif _ERREXIT_ON.search(tok):
+        state["errexit"] = True
+
+
+def _state_walk(code, state, stack):
+    """Yield (position, state-snapshot) for every token that can change the
+    shell's options on this line, folding `(`/`)` scoping and `set` into
+    `state` in place. The caller reads the snapshot at the position it cares
+    about (the pipe, the `$(`)."""
+    for m in _SET_TOKENS.finditer(code):
+        tok = m.group(0)
+        if tok == "(":
+            stack.append(dict(state))
+        elif tok == ")":
+            if stack:
+                state.update(stack.pop())
+        else:
+            _apply_set(tok, state)
+        yield m.end(), dict(state)
+
+
+def _state_at(pos, walk, state0):
+    """The option state in force at character `pos`, given the walk."""
+    cur = state0
+    for end, snap in walk:
+        if end > pos:
+            break
+        cur = snap
+    return cur
 
 
 def scan_pipeline(line):
-    """(is_masked, reason) for one shell/workflow line."""
-    for needle, why in INTENTIONAL:
-        if needle in line:
-            return False, why
+    """(is_masked, pipe_position) for one shell logical line, ignoring
+    options: is there a verdict-bearing producer on the left of a pipe?"""
     if line.lstrip().startswith("#"):
-        return False, ""
+        return False, -1
     code = shell_code(line)
-    if PIPE.match(code):
-        return True, ""
+    m = PIPE.match(code)
+    if m:
+        if STATUS_SAVED.search(m.group("lhs")):
+            return False, -1
+        return True, m.end() - 1
     m = FILE_PIPE.match(code)
     if m:
-        args = m.group("args")
-        bare = [t for t in args.split() if not t.startswith("-")]
+        bare = [t for t in m.group("args").split() if not t.startswith("-")]
         # grep: pattern then file(s) - a quoted pattern was blanked, so a bare
         # file token alone means the pattern was quoted; cat: any bare token
         is_cat = code.lstrip().startswith("cat")
         quoted_pattern = bool(re.match(r"^\s*(?:grep|egrep|fgrep)\b[^|]*?[\"']", line))
         needs = 1 if (is_cat or quoted_pattern) else 2
-        return len(bare) >= needs, ""
-    return False, ""
+        return len(bare) >= needs, m.end() - 1
+    return False, -1
+
+
+def scan_substitution(line, errexit, next_line=""):
+    """(is_masked, form) for one logical line holding `$(producer ...)`.
+
+    Forms: `local/export x=$(...)` is masked whatever errexit says - the status
+    is the builtin's. A bare assignment is masked when errexit is off and
+    nothing consults the status: no `||`/`&&` after it, no `$?` in the rest of
+    the command or at the start of the next line. A test (`if`, `!`, `[`)
+    consults it. Any other form is the consumer's verdict and is not modelled
+    here."""
+    if line.lstrip().startswith("#"):
+        return False, "comment"
+    m = SUBST.search(line)
+    if not m:
+        return False, ""
+    seg_start = 0
+    for s in _SEGMENT.finditer(shell_code(line), 0, m.start()):
+        seg_start = s.end()
+    head = line[seg_start:m.start()]
+    if _BUILTIN_PREFIX.match(head):
+        return True, "builtin"
+    if _GUARD_PREFIX.match(head):
+        return False, "test"
+    if _ASSIGN_PREFIX.match(head):
+        tail = line[m.end():]
+        consulted = ("||" in tail) or ("&&" in tail) or ("$?" in tail) \
+            or bool(re.match(r"\s*(?:if\s+|\[\s*|test\s+)?[^;]*\$\?", next_line))
+        return (not errexit) and not consulted, "assignment"
+    return False, "argument"
 
 
 _STEP_START = re.compile(r"^\s*-\s+\w+:")
@@ -202,103 +501,106 @@ def workflow_steps(text):
             for start, lines in steps]
 
 
-def _units(text, workflow):
+_MAKE_VAR = re.compile(r"^[ \t]*([A-Za-z_]\w*)[ \t]*[?:+!]*=[ \t]*(.*?)[ \t]*$", re.M)
+_MAKE_REF = re.compile(r"\$[({]([A-Za-z_]\w*)[)}]")
+_SHELLFLAGS = re.compile(r"^[ \t]*\.SHELLFLAGS[ \t]*[?:+!]*=[ \t]*(.*?)[ \t]*$", re.M)
+
+
+def make_recipes(text):
+    """[(first_line_no, shell_line)] - every logical recipe line of a Makefile
+    as the shell will see it: `$$` lowered to `$`, `$(VAR)` expanded from the
+    file's own definitions (so `$(VERILATOR)`, `$(PY)` and `$(MAKE)` name
+    their tools), leading `@`/`-`/`+` dropped."""
+    defs = {"MAKE": "make"}
+    for m in _MAKE_VAR.finditer(text):
+        defs.setdefault(m.group(1), m.group(2))
+
+    def expand(s):
+        for _ in range(4):
+            s2 = _MAKE_REF.sub(lambda m: defs.get(m.group(1), m.group(0)), s)
+            if s2 == s:
+                break
+            s = s2
+        return s
+
+    out = []
+    for n, line in logical_lines(text.splitlines(), 1):
+        if not line.startswith("\t"):
+            continue
+        shell = expand(line.replace("$$", "\0")).replace("\0", "$")
+        shell = re.sub(r"^[\t ]*[@+-]*", "", shell)
+        out.append((n, shell))
+    return out
+
+
+def _units(text, kind):
     """[(first_line_no, lines, pipefail0, errexit0)] - the scan units.
 
-    A `.sh` file is one unit that starts with neither option. A workflow is one
-    unit per step: GitHub's default shell is `bash -e {0}` (errexit, no
-    pipefail), and `shell: bash` is `bash --noprofile --norc -eo pipefail {0}`.
-    Options set inside one step never reach the next - each step is a fresh
-    shell."""
-    if not workflow:
-        return [(1, text.splitlines(), False, False)]
-    return [(start, lines, bash, True) for start, lines, bash in workflow_steps(text)]
+    A `.sh` file is one unit that starts with its shebang's options. A
+    workflow is one unit per step: GitHub's default shell is `bash -e {0}`
+    (errexit, no pipefail), and `shell: bash` is `bash --noprofile --norc -eo
+    pipefail {0}`; options set inside one step never reach the next. A
+    Makefile is one unit per logical recipe line, each its own `/bin/sh -c`
+    with only what `.SHELLFLAGS` gives it."""
+    if kind == "workflow":
+        return [(start, lines, bash, True) for start, lines, bash in workflow_steps(text)]
+    if kind == "makefile":
+        m = _SHELLFLAGS.search(text)
+        flags = m.group(1) if m else ""
+        pf, ee = bool(re.search(r"\bpipefail\b", flags)), bool(_ERREXIT_ON.search(flags))
+        return [(n, [line], pf, ee) for n, line in make_recipes(text)]
+    pf, ee = shebang_options(text)
+    return [(1, text.splitlines(), pf, ee)]
 
 
-def scan_pipelines(text, workflow=False):
-    """Return masked and waived pipeline rows, respecting activation order.
-
-    Ordinary `.sh` files must enable pipefail before the pipeline; a later
-    mention cannot retroactively protect an earlier line. A workflow step
-    starts without pipefail unless it declares `shell: bash`.
-    """
-    masked, waived = [], []
-    for start, lines, active, _ in _units(text, workflow):
-        for n, line in enumerate(lines, start):
+def scan_shell(text, kind="sh", rel=""):
+    """(masked_pipelines, waived, masked_captures) for one file, each a list
+    of (line_no, text-or-reason), respecting activation order per unit."""
+    masked, waived, captured = [], [], []
+    for start, lines, pipefail0, errexit0 in _units(text, kind):
+        state, stack, heredoc = {"pipefail": pipefail0, "errexit": errexit0}, [], None
+        logical = list(logical_lines(lines, start))
+        for k, (n, line) in enumerate(logical):
+            if heredoc is not None:
+                if line.strip() == heredoc:
+                    heredoc = None
+                continue
             code = shell_code(line)
-            if re.search(r"\bset\s+\+o\s+pipefail\b", code):
-                active = False
-            elif re.search(r"\bset\b[^#\n]*\bpipefail\b", code):
-                active = True
-            is_masked, why = scan_pipeline(line)
-            if why:
-                waived.append((n, why))
-            elif is_masked and not active:
-                masked.append((n, line.strip()[:96]))
+            hd = _HEREDOC.search(_COMMENT.sub(_blank_len, _ARITH_SUBST.sub(_blank_len, line)))
+            if hd:
+                heredoc = hd.group(1) or hd.group(2) or hd.group(3)
+            state0 = dict(state)
+            walk = list(_state_walk(code, state, stack))
+            is_masked, pos = scan_pipeline(line)
+            text = " ".join(line.split())
+            if is_masked and not _state_at(pos, walk, state0)["pipefail"]:
+                site = next((why for path, txt, why in INTENTIONAL
+                             if path == rel and text == txt), None)
+                (waived if site else masked).append((n, site or text[:96]))
+            m = SUBST.search(line)
+            if m:
+                nxt = logical[k + 1][1] if k + 1 < len(logical) else ""
+                errexit = _state_at(m.start(), walk, state0)["errexit"]
+                if scan_substitution(line, errexit, nxt)[0]:
+                    captured.append((n, text[:96]))
+        if heredoc is not None:
+            raise Unreadable(f"{rel or '<text>'}:{start}: here-document `{heredoc}` "
+                             f"is never terminated, so the rest of the unit cannot be read")
+    return masked, waived, captured
+
+
+def scan_pipelines(text, workflow=False, rel="", kind=None):
+    """Masked and waived pipeline rows - the pipeline half of scan_shell()."""
+    masked, waived, _ = scan_shell(text, kind or ("workflow" if workflow else "sh"), rel)
     return masked, waived
 
 
-_ERREXIT_ON = re.compile(r"\bset\s+(?:-[a-df-zA-Z]*e[a-zA-Z]*\b|-o\s+errexit\b|-[a-zA-Z]*\s+-o\s+errexit\b)")
-_ERREXIT_OFF = re.compile(r"\bset\s+(?:\+[a-zA-Z]*e[a-zA-Z]*\b|\+o\s+errexit\b)")
-_GUARD_PREFIX = re.compile(r"^\s*(?:if|elif|while|until)\b|^\s*!\s|^\s*\[|^\s*test\b")
-_BUILTIN_PREFIX = re.compile(r"^\s*(?:local|export|declare|readonly|typeset)\b")
-_ASSIGN_PREFIX = re.compile(r"^\s*[A-Za-z_]\w*\+?=")
+def scan_substitutions(text, workflow=False, kind=None):
+    """Masked captured-verdict rows - the capture half of scan_shell()."""
+    return scan_shell(text, kind or ("workflow" if workflow else "sh"))[2]
 
 
-def logical_lines(lines, start):
-    """Join backslash-continued lines; yields (first_line_no, joined)."""
-    buf, first = [], None
-    for n, line in enumerate(lines, start):
-        if first is None:
-            first = n
-        if line.rstrip().endswith("\\"):
-            buf.append(line.rstrip()[:-1])
-            continue
-        buf.append(line)
-        yield first, " ".join(buf)
-        buf, first = [], None
-    if buf:
-        yield first, " ".join(buf)
-
-
-def scan_substitution(line, errexit):
-    """(is_masked, form) for one logical line holding `$(producer ...)`.
-
-    Forms: `local/export x=$(...)` is masked whatever errexit says - the status
-    is the builtin's. A bare assignment is masked when errexit is off and no
-    `||`/`&&` consults the status. A test (`if`, `!`, `[`) consults it. Any
-    other form is the consumer's verdict and is not modelled here."""
-    if line.lstrip().startswith("#"):
-        return False, "comment"
-    m = SUBST.search(line)
-    if not m:
-        return False, ""
-    if _BUILTIN_PREFIX.match(line):
-        return True, "builtin"
-    if _GUARD_PREFIX.match(line):
-        return False, "test"
-    if _ASSIGN_PREFIX.match(line):
-        tail = line[m.end():]
-        consulted = ("||" in tail) or ("&&" in tail)
-        return (not errexit) and not consulted, "assignment"
-    return False, "argument"
-
-
-def scan_substitutions(text, workflow=False):
-    """Masked captured-verdict rows [(line_no, text)], errexit in line order."""
-    masked = []
-    for start, lines, _, errexit in _units(text, workflow):
-        for n, line in logical_lines(lines, start):
-            code = shell_code(line.replace("$(", "  "))   # keep the $( visible below
-            if _ERREXIT_OFF.search(code):
-                errexit = False
-            elif _ERREXIT_ON.search(code):
-                errexit = True
-            is_masked, _form = scan_substitution(line, errexit)
-            if is_masked:
-                masked.append((n, line.strip()[:96]))
-    return masked
-
+# --- the audit -------------------------------------------------------------------
 
 def audit():
     unguarded, guarded = [], []
@@ -310,15 +612,27 @@ def audit():
             unit = f"{rel}:{name}"
             (guarded if has_check else unguarded).append(unit)
 
+    shell = tracked("*.sh", ".github/workflows/*.yml", "syn/**/*.sh", "harness/**/*.sh")
+    all_makefiles = tracked("Makefile", "*/Makefile", "*.mk")
+    makefiles = [p for p in all_makefiles if not p.startswith(NOT_FIRST_PARTY)]
+    population = {"sh": sum(1 for p in shell if p.endswith(".sh")),
+                  "workflow": sum(1 for p in shell if p.endswith(".yml")),
+                  "makefile": len(makefiles),
+                  "vendor_makefiles_excluded": len(all_makefiles) - len(makefiles)}
     masked, waived, captured = [], [], []
-    for rel in tracked("*.sh", ".github/workflows/*.yml", "syn/**/*.sh", "harness/**/*.sh"):
+    for rel in shell + makefiles:
         text = (REPO / rel).read_text(errors="replace")
-        workflow = rel.startswith(".github/workflows/") or "/.github/workflows/" in rel
-        found, exceptions = scan_pipelines(text, workflow=workflow)
+        if rel in makefiles:
+            kind = "makefile"
+        elif rel.startswith(".github/workflows/") or "/.github/workflows/" in rel:
+            kind = "workflow"
+        else:
+            kind = "sh"
+        found, exceptions, caught = scan_shell(text, kind, rel)
         masked.extend((rel, n, line) for n, line in found)
         waived.extend((rel, n, why) for n, why in exceptions)
-        captured.extend((rel, n, line) for n, line in scan_substitutions(text, workflow=workflow))
-    return unguarded, guarded, masked, waived, captured
+        captured.extend((rel, n, line) for n, line in caught)
+    return unguarded, guarded, masked, waived, captured, population
 
 
 def read_budget():
@@ -330,15 +644,18 @@ def read_budget():
 
 def selftest():
     failures = 0
+    arms = 0
 
     def ck(name, ok, detail=""):
-        nonlocal failures
+        nonlocal failures, arms
+        arms += 1
         if ok:
             print(f"[PASS] {name}")
         else:
             failures += 1
             print(f"[FAIL] {name}{': ' + detail if detail else ''}")
 
+    # --- modules: which parameter forms count ------------------------------
     ck("a module with parameters and no check is unguarded",
        scan_module("module m #(parameter int W = 8)(); endmodule") == (True, False))
     ck("a module with an elaboration $error is guarded",
@@ -346,6 +663,12 @@ def selftest():
                    "endmodule") == (True, True))
     ck("a module with no parameters is not counted",
        scan_module("module m (); endmodule") == (False, False))
+    for form in ("int unsigned W = 8", "string HEX_P = \"\"", "type T = logic [7:0]",
+                 "real R = 1.5", "longint L = 64'd0", "int W", "[3:0] X = 4'd2",
+                 "X = 3", "int A = 1, B = 2"):
+        ck(f"`parameter {form}` is a parameter",
+           scan_module(f"module m #(parameter {form})(); endmodule") == (True, False),
+           "the header parser is scripts/sv_ports.py; a private regex saw 53 of 102")
     ck("an $error inside a COMMENT does not count as a guard",
        scan_module("module m #(parameter int W = 8)();\n // $error(\"no\");\n"
                    "endmodule") == (True, False),
@@ -356,20 +679,116 @@ def selftest():
     ck("two modules in one file are measured independently",
        rows == [("guarded", True, True), ("bare", True, False)], f"{rows}")
 
+    # --- modules: which $error sites count ---------------------------------
+    ck("a runtime $error inside always is NOT an elaboration contract",
+       scan_module("module m #(parameter int W=8)(input logic clk);\n"
+                   " always @(posedge clk) if (W) $error(\"runtime\");\nendmodule")
+       == (True, False), "review: any $error counted, so a runtime assertion emptied the ratchet")
+    ck("a $error inside an always_ff begin/end block is not a contract",
+       scan_module("module m #(parameter int W=8)(input logic clk);\n"
+                   " always_ff @(posedge clk) begin : p\n  if (W) $error(\"r\");\n end : p\n"
+                   "endmodule") == (True, False))
+    ck("an initial-block $fatal is a simulation check, not an elaboration contract",
+       scan_module("module m #(parameter int T_P=0)();\n initial begin : parameter_checks\n"
+                   "  if (T_P == 0) $fatal(1, \"T_P must be > 0\");\n end\nendmodule")
+       == (True, False), "Verilator builds it, Vivado and Yosys synthesise it; only a run refuses")
+    ck("an initial assert ... else $error is not a contract either",
+       scan_module("module m #(parameter int D=1)();\n initial begin\n"
+                   "  assert (D >= 1) else $error(\"D\");\n end\nendmodule") == (True, False))
+    ck("a $error inside a function body is not a contract",
+       scan_module("module m #(parameter int W=8)();\n function int f(input int x);\n"
+                   "  if (x < 0) $error(\"f\"); return x;\n endfunction\nendmodule")
+       == (True, False))
+    ck("a module-scope $error in a NAMED generate block is a contract",
+       scan_module("module m #(parameter int W=8)();\n if (W < 2) begin : gen_guard\n"
+                   "  $error(\"W\");\n end\nendmodule") == (True, True))
+    ck("a generate/endgenerate guard is a contract",
+       scan_module("module m #(parameter int W=8)();\n generate if (W < 2) begin : g\n"
+                   "  $error(\"W\");\n end endgenerate\nendmodule") == (True, True))
+    ck("a module-scope $error AFTER an always block is still seen",
+       scan_module("module m #(parameter int W=8)(input logic clk, output logic q);\n"
+                   " always_ff @(posedge clk) begin q <= ~q; end\n"
+                   " if (W < 2) $error(\"W\");\nendmodule") == (True, True),
+       "the procedural span must end at its `end`, not at endmodule")
+    ck("a single-statement always ends at its `;`",
+       scan_module("module m #(parameter int W=8)(input logic clk, output logic q);\n"
+                   " always @(posedge clk) q <= ~q;\n if (W < 2) $error(\"W\");\nendmodule")
+       == (True, True))
+    ck("a single-statement always with an else ends after the else",
+       scan_module("module m #(parameter int W=8)(input logic clk, a, output logic q);\n"
+                   " always @(posedge clk) if (a) q <= 1; else q <= 0;\n"
+                   " if (W < 2) $error(\"W\");\nendmodule") == (True, True))
+    ck("a bare initial $readmemh does not swallow the guard after it",
+       scan_module("module m #(parameter string F=\"\")();\n logic [7:0] rom [0:3];\n"
+                   " initial $readmemh(F, rom);\n if (F == \"\") $error(\"F\");\nendmodule")
+       == (True, True))
+    ck("the word `always` inside a $error message does not open a span",
+       scan_module("module m #(parameter int W=8)();\n"
+                   " if (W < 2) $error(\"W is always at least 2\");\nendmodule") == (True, True))
+
+    # --- pipelines: producers ---------------------------------------------
     ck("a piped gate is masked", scan_pipeline("  python3 scripts/x.py | tee log")[0])
     ck("a piped make is masked", scan_pipeline("  make run | tail -5")[0])
+    for cmd in ("$MAKE -C x", "./obj_dir/Vsim +arg", "./lint_hdl.sh", "bash scripts/x.sh",
+                "xvlog -sv a.sv", "xelab top", "vivado -mode batch", "iverilog -o a b.v",
+                "verilator_coverage --annotate d coverage.dat", "$VERILATOR --lint-only x.sv"):
+        ck(f"`{cmd} | tee` is a masked producer", scan_pipeline(f"  {cmd} | tee log")[0],
+           "review listed these shapes as unmodelled")
     ck("a fallback is not a pipe", not scan_pipeline("  python3 scripts/x.py || exit 2")[0])
     ck("a comment is not a pipeline", not scan_pipeline("  # python3 x.py | tee log")[0])
     ck("a tool name inside a string is not a producer",
        not scan_pipeline('  printf "yosys FAIL: %s" "$x" | head -1')[0],
        "the match came from a format string, not a command")
+    ck("a tool name glued to a suffix is not a producer",
+       not scan_pipeline("  ls make.log | head -1")[0])
+    ck("a path-qualified tool is a producer",
+       scan_pipeline("  /opt/verilator/bin/verilator --version | grep -F 5.050")[0])
     ck("a pipe inside a command substitution is not the line's verdict",
        not scan_pipeline('  msg=$(grep ERROR log | head -1); python3 x.py')[0])
+    ck("a pipe inside a parameter expansion is not a pipe",
+       not scan_pipeline("  d=${g%%|*}; verilator --lint-only x.sv")[0])
+    ck("a group that saves the producer's status before the pipe keeps the verdict",
+       not scan_pipeline("  { python3 fuzz.py 2>&1; echo $? > obj/aaf.rc; } | tee obj/aaf.out")[0],
+       "tb/verilator/tsn_fuzz reads the .rc back on the next line")
+    ck("a file-reading grep piped to head is a producer whose status is lost",
+       scan_pipelines('set -e\ngrep -A2 "Slice LUTs\\|DSPs" ucpu_util.rpt | head -20\n')[0]
+       == [(2, 'grep -A2 "Slice LUTs\\|DSPs" ucpu_util.rpt | head -20')],
+       "a missing report makes grep fail and head succeed: the flow exits 0")
+    ck("a file-reading cat piped to a consumer is the same shape",
+       scan_pipeline("cat engine_util.rpt | tail -3")[0])
+    ck("grep reading stdin is a consumer, not a producer",
+       not scan_pipeline('echo "$out" | grep -q FAIL')[0])
+    ck("a bare grep pattern with no file reads stdin and is not a producer",
+       not scan_pipeline("grep foo | head -1")[0])
+    ck("an ordinary command is not a pipeline",
+       not scan_pipeline("  python3 scripts/x.py")[0])
+
+    # --- pipelines: the shell model ----------------------------------------
     ck("a line that sets pipefail is not masked",
        not scan_pipelines("set -o pipefail\npython3 x.py | tee log")[0])
+    ck("the file-reading grep is protected once pipefail is on",
+       not scan_pipelines("set -eo pipefail\ngrep x rpt | head\n")[0])
     ck("a later pipefail cannot protect an earlier pipeline",
        scan_pipelines("python3 x.py | tee log\nset -o pipefail")[0] ==
        [(1, "python3 x.py | tee log")])
+    ck("a pipefail mentioned in a COMMENT protects nothing",
+       scan_pipelines("# note: set -o pipefail is not used here\npython3 gate.py | tee log")[0]
+       == [(2, "python3 gate.py | tee log")], "comments are blanked before the search")
+    ck("a pipefail inside a here-document body protects nothing",
+       scan_pipelines("cat <<EOF\nset -o pipefail\nEOF\npython3 gate.py | tee log")[0]
+       == [(4, "python3 gate.py | tee log")])
+    ck("a pipefail set inside a subshell ends with the subshell",
+       scan_pipelines("(set -o pipefail; make | tee a)\nmake | tee b")[0]
+       == [(2, "make | tee b")], "the pipeline inside the subshell is protected; the next is not")
+    ck("a multi-line subshell scopes its pipefail the same way",
+       scan_pipelines("(\n  set -o pipefail\n  make | tee a\n)\nmake | tee b")[0]
+       == [(5, "make | tee b")])
+    ck("a backslash-continued pipeline is one line, found at its first line",
+       scan_pipelines("make -C x \\\n  | tee log")[0] == [(1, "make -C x | tee log")])
+    ck("a shebang carrying -eo pipefail protects the script",
+       not scan_pipelines("#!/bin/bash -eo pipefail\nmake | tee log")[0])
+    ck("a plain shebang protects nothing",
+       scan_pipelines("#!/usr/bin/env bash\nmake | tee log")[0] == [(2, "make | tee log")])
     ck("the GitHub Actions default run shell has NO pipefail",
        scan_pipelines("    - name: s\n      run: |\n        python3 x.py | tee log\n",
                       workflow=True)[0] == [(3, "python3 x.py | tee log")],
@@ -381,22 +800,33 @@ def selftest():
        scan_pipelines("    - run: |\n        set -euo pipefail\n        python3 a.py | tee a\n"
                       "    - run: |\n        python3 b.py | tee b\n", workflow=True)[0]
        == [(5, "python3 b.py | tee b")])
-    ck("a file-reading grep piped to head is a producer whose status is lost",
-       scan_pipelines('set -e\ngrep -A2 "Slice LUTs\\|DSPs" ucpu_util.rpt | head -20\n')[0]
-       == [(2, 'grep -A2 "Slice LUTs\\|DSPs" ucpu_util.rpt | head -20')],
-       "a missing report makes grep fail and head succeed: the flow exits 0")
-    ck("a file-reading cat piped to a consumer is the same shape",
-       scan_pipeline("cat engine_util.rpt | tail -3")[0])
-    ck("grep reading stdin is a consumer, not a producer",
-       not scan_pipeline('echo "$out" | grep -q FAIL')[0])
-    ck("a bare grep pattern with no file reads stdin and is not a producer",
-       not scan_pipeline("grep foo | head -1")[0])
-    ck("the file-reading grep is protected once pipefail is on",
-       not scan_pipelines("set -eo pipefail\ngrep x rpt | head\n")[0])
+
+    # --- pipelines: Makefile recipes --------------------------------------
+    mk = ("VERILATOR ?= verilator\nPY = python3\n\ncov:\n"
+          "\tverilator_coverage --annotate d --annotate-min 1 coverage.dat \\\n"
+          "\t    | tail -2\n"
+          "\t$(VERILATOR) --lint-only x.sv | tee lint.log\n"
+          "\t$(MAKE) -C sub | tee sub.log\n"
+          "\t$(PY) gate.py || exit 1\n"
+          "X = a | b\n")
+    ck("a Makefile recipe pipe runs under /bin/sh -c with no pipefail and is masked",
+       scan_pipelines(mk, kind="makefile")[0] == [
+           (5, "verilator_coverage --annotate d --annotate-min 1 coverage.dat | tail -2"),
+           (7, "verilator --lint-only x.sv | tee lint.log"),
+           (8, "make -C sub | tee sub.log")],
+       f"make variables must expand to their tools; got {scan_pipelines(mk, kind='makefile')[0]}")
+    ck("a Makefile whose .SHELLFLAGS carries pipefail protects its recipes",
+       not scan_pipelines(".SHELLFLAGS = -eo pipefail -c\nt:\n\tmake -C sub | tee log\n",
+                          kind="makefile")[0])
+    ck("a `$$(...)` in a recipe is the shell's substitution, not a make variable",
+       scan_substitutions("t:\n\tout=$$(python3 gen.py); grep ok <<<$$out\n", kind="makefile")
+       == [(2, "out=$(python3 gen.py); grep ok <<<$out")])
+
+    # --- captured verdicts -------------------------------------------------
     ck("a captured verdict with no errexit and no guard is discarded",
        scan_substitutions("set -u\nout=$(verilator --lint-only -Wall \\\n  $pkgs $all 2>&1)\n"
                           "if echo \"$out\" | grep -q Error; then rc=1; fi\n")
-       == [(2, "out=$(verilator --lint-only -Wall    $pkgs $all 2>&1)")],
+       == [(2, "out=$(verilator --lint-only -Wall $pkgs $all 2>&1)")],
        "a silent non-zero verilator prints nothing, matches nothing, reads as OK")
     ck("the same capture under errexit is not discarded",
        not scan_substitutions("set -eu\nout=$(verilator --lint-only x.sv 2>&1)\n"))
@@ -409,6 +839,14 @@ def selftest():
     ck("a capture whose status is consulted is not discarded",
        not scan_substitutions("x=$(python3 y.py) || exit 2\n")
        and not scan_substitutions("if ! x=$(python3 y.py); then exit 2; fi\n"))
+    ck("a capture whose $? is read on the next line is not discarded",
+       not scan_substitutions("out=$($VERILATOR --lint-only x.sv 2>&1)\n"
+                              "if [ $? -ne 0 ] || echo \"$out\" | grep -q Error; then rc=1; fi\n"),
+       "protocol-processor/tb/timer_map/shape_elab.sh reads it immediately")
+    ck("a capture through a tool VARIABLE is a capture",
+       scan_substitutions("set -u\nout=$($VERILATOR --lint-only x.sv 2>&1)\n"
+                          "if echo \"$out\" | grep -q OVERLAP; then ok=1; fi\n")
+       == [(2, "out=$($VERILATOR --lint-only x.sv 2>&1)")])
     ck("an argument-form substitution is the consumer's verdict and is not modelled",
        not scan_substitutions('echo "rtl=$(python3 scripts/ci_scope.py)" >> "$OUT"\n'))
     ck("a workflow step starts with errexit, so a bare capture there is not discarded",
@@ -416,51 +854,95 @@ def selftest():
                               workflow=True))
     ck("a capture inside a comment is not a finding",
        not scan_substitutions("set -u\n# out=$(verilator x)\n"))
-    ck("the version assertion is waived by name, with a reason",
-       scan_pipeline('  verilator --version | grep -F "$WANT"') == (False,
-       "the grep IS the version assertion; its status is the verdict"))
-    ck("an ordinary command is not a pipeline",
-       not scan_pipeline("  python3 scripts/x.py")[0])
+    ck("a capture inside a subshell that set errexit is protected only there",
+       scan_substitutions("(set -e; a=$(make x))\nb=$(make y)\n") == [(2, "b=$(make y)")])
 
-    unguarded, guarded, masked, waived, captured = audit()
-    ck("the live scan reads the tree", len(unguarded) + len(guarded) > 20,
+    # --- waivers -------------------------------------------------------------
+    site_path, site_text, site_why = INTENTIONAL[0]
+    ck("the version assertion is waived by SITE, with a reason",
+       scan_pipelines(f"    - run: |\n        {site_text}\n", workflow=True, rel=site_path)
+       == ([], [(2, site_why)]))
+    ck("the same line at another path is masked, not waived",
+       scan_pipelines(f"    - run: |\n        {site_text}\n", workflow=True, rel="scripts/x.yml")
+       == ([(2, site_text)], []))
+    ck("a NEW `--version | grep` is masked: the waiver is not a substring",
+       scan_pipelines('yosys --version | grep -q "0.0"\n', rel="scripts/run_all_suites.sh")[0]
+       == [(1, 'yosys --version | grep -q "0.0"')],
+       "review bypassed the ratchet by adding --version to a gate's arguments")
+    ck("a gate verdict carrying --version is masked, not waived",
+       scan_pipelines("python3 scripts/lint_rtl.py --check --version | grep -c FAIL\n",
+                      rel="scripts/run_all_suites.sh")[0]
+       == [(1, "python3 scripts/lint_rtl.py --check --version | grep -c FAIL")])
+    ck("an unterminated here-document makes the unit unreadable, never a pass",
+       _raises(Unreadable, scan_pipelines, "cat <<EOF\nset -o pipefail\nmake | tee log\n"),
+       "a partial population is not a pass; the CLI exits 2")
+
+    # --- the live tree --------------------------------------------------------
+    unguarded, guarded, masked, waived, captured, population = audit()
+    ck("the live scan reads the tree", len(unguarded) + len(guarded) > 80,
        f"{len(unguarded)} + {len(guarded)} modules with parameters")
     ck("the guarded set is not empty", len(guarded) >= 4,
        "an inert scan would report every module unguarded")
-    ck("the waiver actually fires on the live tree", bool(waived),
-       "no intentional pipeline was seen - the waiver is untested here")
+    ck("the gptp-processor modules in the `int unsigned`/`string` idiom are in the population",
+       all(any(u.endswith(":" + m) for u in unguarded)
+           for m in ("KL_gptp_timer", "KL_gptp_ucpu", "KL_gptp_tx_slot")),
+       "review: the first regex saw none of gptp-processor")
+    ck("KL_media_nco, the house form the guide cites, is counted guarded",
+       any(u.endswith(":KL_media_nco") for u in guarded))
+    ck("every site waiver names a line that exists and is masked without it",
+       sorted((rel, why) for rel, _n, why in waived) == sorted((p, w) for p, _t, w in INTENTIONAL),
+       f"waived {[(r, n) for r, n, _ in waived]} vs {len(INTENTIONAL)} sites - a stale waiver "
+       "must be removed")
     ck("the live scan reaches both processor submodules' shell wrappers",
        any(rel.startswith("gptp-processor/") for rel, _, _ in masked + captured) and
        any(rel.startswith("protocol-processor/") for rel, _, _ in masked + captured),
        f"masked {[r for r, _, _ in masked]}, captured {[r for r, _, _ in captured]}")
+    ck("the Makefile population is first-party only and not empty",
+       population["makefile"] > 50 and population["vendor_makefiles_excluded"] > 0
+       and not any(rel.startswith(NOT_FIRST_PARTY) for rel, _, _ in masked + captured),
+       f"{population} - tracked() recurses into verilog-axis, whose benches are vendor scope")
 
-    n = 36
-    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    print(f"\n{arms} checks: {arms - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
+
+
+def _raises(exc, fn, *args):
+    try:
+        fn(*args)
+    except exc:
+        return True
+    return False
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--check", action="store_true", help="ratchet both counts")
+    ap.add_argument("--check", action="store_true", help="ratchet all three counts")
     ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
     args = ap.parse_args()
 
     if args.selftest:
         return selftest()
 
-    unguarded, guarded, masked, waived, captured = audit()
+    try:
+        unguarded, guarded, masked, waived, captured, population = audit()
+    except Unreadable as exc:
+        print(f"UNREADABLE POPULATION: {exc}")
+        return 2
 
     print(f"parameterised modules with no elaboration contract "
           f"({len(unguarded)} of {len(unguarded) + len(guarded)}):")
     for rel in unguarded:
         print(f"   {rel}")
+    print(f"\nmeasured shell population: {population['sh']} shell scripts, "
+          f"{population['workflow']} workflow files, {population['makefile']} Makefiles "
+          f"(recipe lines); Python and Tcl are not measured")
     print(f"\npipelines that discard their producer's exit code ({len(masked)}):")
     for rel, n, line in masked:
         print(f"   {rel}:{n}  {line}")
     print(f"\ncaptured verdicts whose exit status is discarded ({len(captured)}):")
     for rel, n, line in captured:
         print(f"   {rel}:{n}  {line}")
-    print(f"\nwaived, with a reason ({len(waived)}):")
+    print(f"\nwaived by site, with a reason ({len(waived)}):")
     for rel, n, why in waived:
         print(f"   {rel}:{n}  {why}")
 
@@ -489,7 +971,7 @@ def main():
     print(f"\nFAIL-FAST RATCHET: PASS ({len(unguarded)} <= {b_unguarded} modules "
           f"without an elaboration contract, {len(masked)} <= {b_masked} masked "
           f"pipeline(s), {len(captured)} <= {b_captured} discarded captured "
-          f"verdict(s), {len(waived)} waived with a reason)")
+          f"verdict(s), {len(waived)} waived by site)")
     if len(unguarded) < b_unguarded or len(masked) < b_masked or len(captured) < b_captured:
         print(f"  the ratchets can be lowered to {len(unguarded)}, {len(masked)} "
               f"and {len(captured)}")

--- a/scripts/measure_fail_fast.py
+++ b/scripts/measure_fail_fast.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Measure where a failure could pass for success, and hold the count down.
+
+Why this exists. Rule 6 of the maintainability guide
+(docs/development/CODE_QUALITY.md) says an invalid parameter, state or tool
+result must be rejected at the nearest responsible boundary and must propagate
+a non-success verdict. Two populations in this tree can break that, and they
+break it silently:
+
+  1. A PARAMETERISED MODULE WITH NO ELABORATION CONTRACT. Forty-three
+     first-party modules declare parameters; four reject an impossible
+     combination at elaboration. The rest accept any value the caller passes.
+     `rx_mac_filter` documented "true for TDATA_WIDTH>=48" in a banner for
+     months - a comment does not stop a build, and at 32 bits the destination
+     compare would have read past the end of the beat and filtered on
+     undefined bits, which nothing downstream can detect.
+
+  2. A PIPELINE THAT DISCARDS ITS PRODUCER'S EXIT CODE. In a shell without
+     `pipefail`, `gate | tee log` exits with tee's status, so a failing gate
+     reads as a pass. This is scored per-line and only for producers that ARE
+     a verdict - a tool run, a make, a gate script.
+
+Both are RATCHETS. Neither population can be emptied in one change without
+exactly the churn the governing rule forbids, and the second has legitimate
+members: `verilator --version | grep -F "$WANT"` deliberately wants grep's
+status, because grep IS the assertion. Those are excluded by name, with the
+reason recorded.
+
+Usage:
+    python3 scripts/measure_fail_fast.py            # both inventories
+    python3 scripts/measure_fail_fast.py --check    # the ratchet
+    python3 scripts/measure_fail_fast.py --selftest # fixture arms
+
+Exit 0 = at or under the ratchet in scripts/fail_fast.budget.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BUDGET = Path(__file__).resolve().parent / "fail_fast.budget"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lint_rtl import LINT_EXCLUDE
+
+COMMENT = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
+PARAM = re.compile(r"\bparameter\s+(?:int|logic|bit|integer|byte)?\s*"
+                   r"(?:signed\s+)?(?:\[[^\]]*\]\s*)?(\w+)\s*=")
+ELAB_CHECK = re.compile(r"\$fatal|\$error")
+
+#: A pipeline whose producer is a verdict-bearing command. `\|\|` is excluded:
+#: `a || b` is a fallback, not a pipe. Matched against shell_code(), never the
+#: raw line.
+PIPE = re.compile(
+    r"^\s*(?P<lhs>.*?\b(?:python3?|make|verilator|yosys|sv2v|behave|pytest"
+    r"|\./run\.sh|\./ooc\.sh|scripts/\S+\.(?:py|sh))\b[^|]*?)\|(?!\|)")
+
+#: Pipelines where the CONSUMER is the assertion and its status is the point.
+#: Each is matched on the whole line, so a new one has to be added deliberately.
+INTENTIONAL = (
+    ("--version | grep", "the grep IS the version assertion; its status is the verdict"),
+)
+
+
+def blank_comments(text):
+    return COMMENT.sub(lambda m: "".join(c if c == "\n" else " " for c in m.group(0)),
+                       text)
+
+
+def tracked(*pats):
+    out = subprocess.run(["git", "ls-files", *pats], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout.split()
+    return [p for p in out
+            if not p.startswith(("third_party/", "external/", "protocol-processor/",
+                                 "gptp-processor/", "gen/", "build/"))]
+
+
+def scan_module(text):
+    """(declares_parameters, has_elaboration_check) for one SystemVerilog source."""
+    code = blank_comments(text)
+    return bool(PARAM.search(code)), bool(ELAB_CHECK.search(code))
+
+
+#: quoted spans and command substitutions, blanked before the producer search
+_QUOTED = re.compile(r"\$\([^()]*\)|'[^']*'|\"[^\"]*\"")
+
+
+def shell_code(line):
+    """The part of a shell line that is COMMAND, with quotes and `$(...)`
+    blanked out.
+
+    Two false positives forced this. `printf "yosys FAIL: %s" ... | head`
+    matched because the tool name was inside a FORMAT STRING, and a pipe inside
+    `$(...)` is a substitution feeding an argument - its status is never the
+    line's verdict, which is set by the command that consumes it.
+    """
+    return _QUOTED.sub(lambda m: " " * len(m.group(0)), line)
+
+
+def scan_pipeline(line):
+    """(is_masked, reason) for one shell/workflow line."""
+    for needle, why in INTENTIONAL:
+        if needle in line:
+            return False, why
+    if "pipefail" in line:
+        return False, "the line sets pipefail"
+    if line.lstrip().startswith("#"):
+        return False, ""
+    return bool(PIPE.match(shell_code(line))), ""
+
+
+def audit():
+    unguarded, guarded = [], []
+    for rel in [p for p in tracked("hdl") if p.endswith(".sv") and p not in LINT_EXCLUDE]:
+        has_params, has_check = scan_module((REPO / rel).read_text(errors="replace"))
+        if not has_params:
+            continue
+        (guarded if has_check else unguarded).append(rel)
+
+    masked, waived = [], []
+    for rel in tracked("*.sh", ".github/workflows/*.yml", "syn/**/*.sh", "harness/**/*.sh"):
+        text = (REPO / rel).read_text(errors="replace")
+        pipefail_file = "pipefail" in text
+        for n, line in enumerate(text.splitlines(), 1):
+            is_masked, why = scan_pipeline(line)
+            if why:
+                waived.append((rel, n, why))
+            elif is_masked and not pipefail_file:
+                masked.append((rel, n, line.strip()[:96]))
+    return unguarded, guarded, masked, waived
+
+
+def read_budget():
+    if not BUDGET.is_file():
+        return None, None
+    vals = [int(x) for x in re.findall(r"^\s*(\d+)\s*$", BUDGET.read_text(), re.M)]
+    return (vals + [None, None])[:2]
+
+
+def selftest():
+    failures = 0
+
+    def ck(name, ok, detail=""):
+        nonlocal failures
+        if ok:
+            print(f"[PASS] {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] {name}{': ' + detail if detail else ''}")
+
+    ck("a module with parameters and no check is unguarded",
+       scan_module("module m #(parameter int W = 8)(); endmodule") == (True, False))
+    ck("a module with an elaboration $error is guarded",
+       scan_module("module m #(parameter int W = 8)();\n if (W < 2) $error(\"no\");\n"
+                   "endmodule") == (True, True))
+    ck("a module with no parameters is not counted",
+       scan_module("module m (); endmodule") == (False, False))
+    ck("an $error inside a COMMENT does not count as a guard",
+       scan_module("module m #(parameter int W = 8)();\n // $error(\"no\");\n"
+                   "endmodule") == (True, False),
+       "comments are blanked before the search")
+
+    ck("a piped gate is masked", scan_pipeline("  python3 scripts/x.py | tee log")[0])
+    ck("a piped make is masked", scan_pipeline("  make run | tail -5")[0])
+    ck("a fallback is not a pipe", not scan_pipeline("  python3 scripts/x.py || exit 2")[0])
+    ck("a comment is not a pipeline", not scan_pipeline("  # python3 x.py | tee log")[0])
+    ck("a tool name inside a string is not a producer",
+       not scan_pipeline('  printf "yosys FAIL: %s" "$x" | head -1')[0],
+       "the match came from a format string, not a command")
+    ck("a pipe inside a command substitution is not the line's verdict",
+       not scan_pipeline('  msg=$(grep ERROR log | head -1); python3 x.py')[0])
+    ck("a line that sets pipefail is not masked",
+       not scan_pipeline("  set -o pipefail; python3 x.py | tee log")[0])
+    ck("the version assertion is waived by name, with a reason",
+       scan_pipeline('  verilator --version | grep -F "$WANT"') == (False,
+       "the grep IS the version assertion; its status is the verdict"))
+    ck("an ordinary command is not a pipeline",
+       not scan_pipeline("  python3 scripts/x.py")[0])
+
+    unguarded, guarded, masked, waived = audit()
+    ck("the live scan reads the tree", len(unguarded) + len(guarded) > 20,
+       f"{len(unguarded)} + {len(guarded)} modules with parameters")
+    ck("the guarded set is not empty", len(guarded) >= 4,
+       "an inert scan would report every module unguarded")
+    ck("the waiver actually fires on the live tree", bool(waived),
+       "no intentional pipeline was seen - the waiver is untested here")
+
+    n = 16
+    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--check", action="store_true", help="ratchet both counts")
+    ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    unguarded, guarded, masked, waived = audit()
+
+    print(f"parameterised modules with no elaboration contract "
+          f"({len(unguarded)} of {len(unguarded) + len(guarded)}):")
+    for rel in unguarded:
+        print(f"   {rel}")
+    print(f"\npipelines that discard their producer's exit code ({len(masked)}):")
+    for rel, n, line in masked:
+        print(f"   {rel}:{n}  {line}")
+    print(f"\nwaived, with a reason ({len(waived)}):")
+    for rel, n, why in waived:
+        print(f"   {rel}:{n}  {why}")
+
+    if not args.check:
+        return 0
+
+    b_unguarded, b_masked = read_budget()
+    if b_unguarded is None or b_masked is None:
+        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} must hold two counts")
+        return 1
+    bad = False
+    if len(unguarded) > b_unguarded:
+        print(f"\nFAIL: {len(unguarded)} module(s) without an elaboration contract "
+              f"> ratchet {b_unguarded}. A new parameter states what it refuses.")
+        bad = True
+    if len(masked) > b_masked:
+        print(f"\nFAIL: {len(masked)} masked pipeline(s) > ratchet {b_masked}. "
+              f"A verdict must not be piped away.")
+        bad = True
+    if bad:
+        return 1
+    print(f"\nFAIL-FAST RATCHET: PASS ({len(unguarded)} <= {b_unguarded} modules "
+          f"without an elaboration contract, {len(masked)} <= {b_masked} masked "
+          f"pipeline(s), {len(waived)} waived with a reason)")
+    if len(unguarded) < b_unguarded or len(masked) < b_masked:
+        print(f"  the ratchets can be lowered to {len(unguarded)} and {len(masked)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_fail_fast.py
+++ b/scripts/measure_fail_fast.py
@@ -11,7 +11,7 @@ break it silently:
 
   1. A PARAMETERISED MODULE WITH NO ELABORATION CONTRACT. 102 first-party
      modules across the superproject and its project-owned processor
-     submodules declare parameters; 18 reject an impossible combination at
+     submodules declare parameters; 17 reject an impossible combination at
      elaboration. The rest accept any value the caller passes.
      `rx_mac_filter` documented "true for TDATA_WIDTH>=48" in a banner for
      months - a comment does not stop a build, and at 32 bits the destination
@@ -28,7 +28,19 @@ break it silently:
      are inventoried as unguarded for that reason). A `$error` inside `always`
      is a runtime assertion and is not counted either, so adding one cannot
      empty this ratchet (review found KL_gptp_engine would otherwise have
-     counted as guarded on three runtime PathTrace assertions).
+     counted as guarded on three runtime PathTrace assertions). Nor is a
+     CONCURRENT or DEFERRED assertion at module scope: `assert property
+     (@(posedge clk) P) else $error` fires its action block at a clock edge
+     during simulation, `assert #0 (...) else $error` in the Observed region,
+     and neither can refuse an illegal parameter when the parameters are
+     bound - review reproduced the concurrent form counting as a contract.
+     So the recognition is POSITIVE: the scan starts after the module header
+     and descends only into what elaboration evaluates - `generate`,
+     `if`/`else`, `for`, `case` and `begin : name ... end` - and steps over
+     every other item whole (a procedural block, any assert/assume/cover/
+     restrict with its action block, a property/sequence/function/task
+     declaration, a preprocessor line, a plain item to its `;`). A `$error`
+     the walk never reaches is not the contract.
 
      WHICH MODULES HAVE PARAMETERS is read with scripts/sv_ports.py, the one
      header parser the Rule 4 and Rule 5 gates already use, so every parameter
@@ -133,7 +145,20 @@ MODULE = re.compile(r"^\s*module\s+([A-Za-z_]\w*)\b", re.M)
 ENDMODULE = re.compile(r"\bendmodule\b")
 
 #: what follows one of these runs at simulation time, not at elaboration
-_PROCEDURAL = re.compile(r"\b(?:always(?:_ff|_comb|_latch)?|initial|final)\b")
+_PROCEDURAL = ("always", "always_ff", "always_comb", "always_latch", "initial", "final")
+#: an assertion of any kind - immediate, deferred (`#0`, `final`) or
+#: concurrent (`property`, `sequence`) - whose action block is simulation-time
+_ASSERTION = ("assert", "assume", "cover", "restrict")
+#: declarations that close with their own keyword and hold no generate scope
+_OPAQUE = {
+    "property": "endproperty", "sequence": "endsequence",
+    "function": "endfunction", "task": "endtask", "checker": "endchecker",
+    "class": "endclass", "clocking": "endclocking", "covergroup": "endgroup",
+    "module": "endmodule", "macromodule": "endmodule",
+    "interface": "endinterface", "program": "endprogram", "package": "endpackage",
+}
+#: a closer met where no opener was walked: stepped over, never descended
+_STRAY = ("end", "endcase", "endgenerate", "endmodule", "join", "join_any", "join_none")
 _FUNC_TASK = re.compile(r"\bfunction\b.*?\bendfunction\b|\btask\b.*?\bendtask\b", re.S)
 _WORD = re.compile(r"[A-Za-z_]\w*")
 _BLOCKS = {
@@ -200,9 +225,14 @@ def _statement_end(code, i):
         return _block_end(code, i + len(w), w)
     if w in ("case", "casez", "casex"):
         return _block_end(code, i + len(w), "case")
-    if w in ("if", "assert", "assume", "cover"):
+    if w == "if" or w in _ASSERTION:
         j = _skip_ws(code, i + len(w))
-        while _word_at(code, j) in ("property", "final"):
+        if j < len(code) and code[j] == "#":  # deferred immediate: `assert #0 (...)`
+            j = _skip_ws(code, j + 1)
+            while j < len(code) and code[j].isdigit():
+                j += 1
+            j = _skip_ws(code, j)
+        while _word_at(code, j) in ("property", "sequence", "final"):
             j = _skip_ws(code, j + len(_word_at(code, j)))
         if j < len(code) and code[j] == "(":
             j = _skip_parens(code, j)
@@ -231,36 +261,154 @@ def _statement_end(code, i):
     return len(code)
 
 
-def procedural_spans(code):
-    """[(start, end)] of every always/initial/final block, sensitivity list
-    and all, in comment- and string-blanked module text."""
-    spans = []
-    for m in _PROCEDURAL.finditer(code):
-        j = _skip_ws(code, m.end())
-        if j < len(code) and code[j] == "@":
-            j = _skip_ws(code, j + 1)
-            if j < len(code) and code[j] == "(":
-                j = _skip_parens(code, j)
-            elif j < len(code) and code[j] == "*":
-                j += 1
-        spans.append((m.start(), _statement_end(code, j)))
-    return spans
+def _procedural_end(code, i, w):
+    """`i` at always*/initial/final: the index just past the whole procedural
+    statement, sensitivity list and all."""
+    j = _skip_ws(code, i + len(w))
+    if j < len(code) and code[j] == "@":
+        j = _skip_ws(code, j + 1)
+        if j < len(code) and code[j] == "(":
+            j = _skip_parens(code, j)
+        elif j < len(code) and code[j] == "*":
+            j += 1
+    return _statement_end(code, j)
 
 
-def has_elaboration_check(code):
-    """True when `$error`/`$fatal` sits at module or generate scope.
+def _skip_block_label(code, j):
+    """`j` just past `begin`/`end`: past an optional `: name`."""
+    k = _skip_ws(code, j)
+    if k < len(code) and code[k] == ":" and code[k:k + 2] != "::":
+        k = _skip_ws(code, k + 1)
+        return k + len(_word_at(code, k))
+    return j
 
-    `code` is one module with comments blanked. Strings go too (a message may
-    say "always"), then imports (a DPI `import ... function` has no
-    `endfunction`), then function and task bodies; what is left inside a
-    procedural span is a simulation check, and everything else is the
-    contract."""
+
+_LABEL_TOK = re.compile(r"::|[;?:`()\[\]{}]|\b(?:begin|end)\b")
+
+
+def _label_end(code, i):
+    """`i` at an item that may start with a label - `a1: assert ...`,
+    `8, 16: begin`, `default:` - the index just past its `:`, or -1 when no
+    label opens the item. A `;`, a ternary `?`, a directive, a `begin` or an
+    `end` met first means there is none: the `begin : name` of a block is
+    not a label, and reading it as one would walk INTO the block
+    (KL_gptp_engine, whose `endif sits right before a named always_ff)."""
+    depth = 0
+    for m in _LABEL_TOK.finditer(code, i):
+        t = m.group(0)
+        if t in ("(", "[", "{"):
+            depth += 1
+        elif t in (")", "]", "}"):
+            depth -= 1
+        elif t == "::" or depth:
+            continue
+        elif t == ":":
+            return m.end()
+        else:
+            return -1
+    return -1
+
+
+def _directive_end(code, i):
+    """`i` at a backtick: past the preprocessor line and any backslash-
+    continued line after it. `ifdef/`else/`endif/`define/`include are
+    lines, not items; nothing on such a line opens a scope."""
+    while True:
+        j = code.find("\n", i)
+        if j < 0:
+            return len(code)
+        if code[i:j].rstrip().endswith("\\"):
+            i = j + 1
+            continue
+        return j + 1
+
+
+def _walk_one(code, i, found):
+    """One generate item at `i`; the index just past it."""
+    i = _skip_ws(code, i)
+    if i >= len(code):
+        return i
+    j = _walk_item(code, i, _word_at(code, i), found)
+    return j if j > i else i + 1
+
+
+def _walk_items(code, i, closer, found):
+    """Generate items from `i` up to and including `closer` (or the end)."""
+    while True:
+        i = _skip_ws(code, i)
+        if i >= len(code):
+            return i
+        w = _word_at(code, i)
+        if closer is not None and w == closer:
+            return _skip_block_label(code, i + len(w))
+        j = _walk_item(code, i, w, found)
+        i = j if j > i else i + 1
+
+
+def _walk_item(code, i, w, found):
+    """Classify the item at `i` and descend only into what elaboration
+    evaluates; record a `$error`/`$fatal` met at that scope in `found`."""
+    n = len(code)
+    if code[i] == ";":
+        return i + 1
+    if code[i] == "`":
+        return _directive_end(code, i)
+    if ELAB_CHECK.match(code, i):
+        found.append(i)
+        return _statement_end(code, i)
+    if w in _PROCEDURAL:
+        return _procedural_end(code, i, w)
+    if w in _ASSERTION:
+        return _statement_end(code, i)
+    if w in _OPAQUE:
+        m = re.compile(r"\b" + _OPAQUE[w] + r"\b").search(code, i + len(w))
+        return m.end() if m else n
+    if w == "generate":
+        return i + len(w)
+    if w == "begin":
+        return _walk_items(code, _skip_block_label(code, i + len(w)), "end", found)
+    if w in ("if", "for", "case", "casex", "casez"):
+        j = _skip_ws(code, i + len(w))
+        if j < n and code[j] == "(":
+            j = _skip_parens(code, j)
+        if w.startswith("case"):
+            return _walk_items(code, j, "endcase", found)
+        j = _walk_one(code, j, found)
+        if w == "if":
+            k = _skip_ws(code, j)
+            if _word_at(code, k) == "else":
+                j = _walk_one(code, k + 4, found)
+        return j
+    if w in _STRAY:
+        return _skip_block_label(code, i + len(w))
+    k = _label_end(code, i)
+    if k > 0:
+        return k
+    return _statement_end(code, i)
+
+
+def elaboration_checks(code):
+    """Indexes of every `$error`/`$fatal` reached from module scope through
+    generate constructs only. `code` is one module, comments blanked. Strings
+    go too (a message may say "always"), then imports (a DPI `import ...
+    function` has no `endfunction`), then function and task bodies. The walk
+    starts after the module header and descends only into `generate`,
+    `if`/`else`, `for`, `case` and `begin : name ... end`; a procedural
+    block, an assertion of any kind with its action block (immediate,
+    deferred `#0`/`final`, concurrent `property`/`sequence`), a
+    property/sequence declaration and every plain item are stepped over
+    whole. A `$error` the walk never reaches is not the contract."""
     code = STRING.sub(_blank, code)
     code = IMPORT.sub(_blank, code)
     code = _FUNC_TASK.sub(_blank, code)
-    spans = procedural_spans(code)
-    return any(not any(a <= m.start() < b for a, b in spans)
-               for m in ELAB_CHECK.finditer(code))
+    found = []
+    _walk_items(code, _statement_end(code, 0), None, found)
+    return found
+
+
+def has_elaboration_check(code):
+    """True when `$error`/`$fatal` sits at module or generate scope."""
+    return bool(elaboration_checks(code))
 
 
 def scan_modules(text):
@@ -722,9 +870,80 @@ def selftest():
        scan_module("module m #(parameter string F=\"\")();\n logic [7:0] rom [0:3];\n"
                    " initial $readmemh(F, rom);\n if (F == \"\") $error(\"F\");\nendmodule")
        == (True, True))
-    ck("the word `always` inside a $error message does not open a span",
+    ck("the word `always` inside a $error message does not open a procedural block",
        scan_module("module m #(parameter int W=8)();\n"
                    " if (W < 2) $error(\"W is always at least 2\");\nendmodule") == (True, True))
+
+    # --- modules: assertions are simulation-time, whatever scope they sit at --
+    ck("a module-scope concurrent `assert property ... else $error` is NOT a contract",
+       scan_module("module m #(parameter int W=8)(input logic clk, P);\n"
+                   " assert property (@(posedge clk) P) else $error;\nendmodule") == (True, False),
+       "review: its action block fires at a clock edge in simulation and cannot refuse a parameter")
+    ck("a labelled concurrent assertion with a begin/end action block is not a contract",
+       scan_module("module m #(parameter int W=8)(input logic clk, P);\n"
+                   " a_p: assert property (@(posedge clk) disable iff (!P) P |-> W > 1)\n"
+                   "  else begin $error(\"p\"); end\nendmodule") == (True, False))
+    ck("assume property and cover property are not contracts either",
+       scan_module("module m #(parameter int W=8)(input logic clk, P);\n"
+                   " assume property (@(posedge clk) P) else $error(\"a\");\n"
+                   " cover property (@(posedge clk) P) $error(\"c\");\nendmodule") == (True, False))
+    ck("a deferred immediate `assert #0 (...) else $error` at module scope is not a contract",
+       scan_module("module m #(parameter int W=8)(input logic P);\n"
+                   " assert #0 (P) else $error(\"P\");\nendmodule") == (True, False),
+       "a deferred assertion is evaluated in the simulator's Observed region; synthesis drops it")
+    ck("an `assert final` at module scope is not a contract",
+       scan_module("module m #(parameter int W=8)(input logic P);\n"
+                   " assert final (P) else $error(\"P\");\nendmodule") == (True, False))
+    ck("a $error inside property ... endproperty is not a contract",
+       scan_module("module m #(parameter int W=8)(input logic clk, P);\n"
+                   " property p; @(posedge clk) P; endproperty\n"
+                   " a1: assert property (p) else $error(\"p\");\nendmodule") == (True, False))
+    ck("a $error inside sequence ... endsequence is not a contract",
+       scan_module("module m #(parameter int W=8)(input logic clk, P);\n"
+                   " sequence s; @(posedge clk) P ##1 P; endsequence\n"
+                   " cover sequence (s) $error(\"s\");\nendmodule") == (True, False))
+    ck("a concurrent assertion NEXT TO a module-scope $error does not hide the guard",
+       scan_module("module m #(parameter int W=8)(input logic clk, P);\n"
+                   " a1: assert property (@(posedge clk) P) else $error;\n"
+                   " if (W < 2) $error(\"W\");\n"
+                   " assert property (@(posedge clk) !P) else $error;\nendmodule") == (True, True),
+       "the assertion is stepped over whole; the guard beside it is still reached")
+    ck("a $error inside an always inside a generate block is still a runtime assertion",
+       scan_module("module m #(parameter int W=8)(input logic clk);\n if (W > 1) begin : g\n"
+                   "  always @(posedge clk) if (W) $error(\"r\");\n end\nendmodule") == (True, False))
+
+    # --- modules: the generate shapes the positive walk must reach ---------
+    ck("a generate-if guard with an else arm is a contract",
+       scan_module("module m #(parameter int W=8)();\n generate\n"
+                   "  if (W < 2) begin : gen_guard\n   $error(\"W\");\n  end else begin : gen_ok\n"
+                   "   wire ok = 1'b1;\n  end\n endgenerate\nendmodule") == (True, True))
+    ck("a guard at the end of an else-if chain is a contract",
+       scan_module("module m #(parameter int W=8)();\n"
+                   " if (W == 8) begin : g8 end else if (W == 16) begin : g16 end\n"
+                   " else $error(\"W\");\nendmodule") == (True, True))
+    ck("a case-generate default $error is a contract",
+       scan_module("module m #(parameter int W=8)();\n case (W)\n  8, 16: begin : ok end\n"
+                   "  default: $error(\"W\");\n endcase\nendmodule") == (True, True))
+    ck("a guard inside a for-generate body is a contract",
+       scan_module("module m #(parameter int N=2)();\n for (genvar i = 0; i < N; i++) begin : g\n"
+                   "  if (i > 3) $error(\"N\");\n end\nendmodule") == (True, True))
+    ck("a preprocessor directive before a named always block is a line, not a label",
+       scan_module("module m #(parameter int W=8)(input logic clk, output logic q);\n"
+                   "`ifndef SYNTHESIS\n logic dbg_r;\n`endif\n"
+                   " always_ff @(posedge clk) begin : st\n  q <= ~q;\n"
+                   "`ifndef SYNTHESIS\n  if (W) $error(\"r\");\n`endif\n end : st\nendmodule")
+       == (True, False),
+       "KL_gptp_engine: `endif then `begin : st_port` read as a label and the walk entered the block")
+    ck("a guard wrapped in `ifdef/`else/`endif is still reached",
+       scan_module("module m #(parameter int W=8)();\n`ifdef FOO\n if (W < 2) $error(\"W\");\n"
+                   "`else\n if (W < 4) $error(\"W\");\n`endif\nendmodule") == (True, True))
+    ck("a guard after a typedef, an instantiation and a DPI import is still reached",
+       scan_module("module m #(parameter int W=8)(input logic clk);\n"
+                   " import \"DPI-C\" function int f(input int x);\n"
+                   " typedef struct packed { logic a; logic b; } t_s;\n"
+                   " sub #(.A(1)) u_sub (.clk(clk), .q());\n"
+                   " if (W < 2) $error(\"W\");\nendmodule") == (True, True),
+       "a plain item runs to its `;`; none of them may swallow what follows")
 
     # --- pipelines: producers ---------------------------------------------
     ck("a piped gate is masked", scan_pipeline("  python3 scripts/x.py | tee log")[0])

--- a/scripts/run_all_suites.sh
+++ b/scripts/run_all_suites.sh
@@ -16,7 +16,11 @@
 #
 # Exit status:
 #   0        every suite passed AND every check count was readable
-#   1..89    that many suites FAILED (unchanged - CI can still gate on it)
+#   1..89    that many suites FAILED (unchanged - CI can still gate on it). A
+#            suite whose make exited 0 while its log reports a failure - a
+#            [FAIL] line or a tally counting one - is a FAILED suite here too
+#            (scripts/suite_tally.py --verdict), because an assertion that
+#            only logs is exactly the false green Rule 6 exists to stop.
 #   90       every suite passed, but the CHECK ACCOUNTING is incomplete: some
 #            suite's count could not be read, so the printed total is a partial
 #            sum and must not be quoted. See scripts/suite_tally.py.
@@ -265,8 +269,21 @@ for suite in "${suites[@]}"; do
   d="$ROOT/tb/verilator/$suite"
   timeout "$TMO" make -C "$d" > "$OUT/$suite.log" 2>&1
   rc=$?
+  # Rule 6: a suite that PRINTS a failure and exits 0 is a masked verdict, and
+  # make cannot read. The log is asked, with the same recognisers the tally
+  # uses, whether it reports a failure - a [FAIL] line, or a tally counting
+  # one - and a green that its own log contradicts is a FAIL here.
+  masked_verdict=""
+  if [ "$rc" -eq 0 ] && \
+     ! masked_verdict=$(python3 "$ROOT/scripts/suite_tally.py" --verdict "$OUT/$suite.log" 2>&1); then
+    rc=93
+  fi
   case $rc in
     0)   pass=$((pass + 1)); printf 'PASS     %s\n' "$suite" ;;
+    93)  fail=$((fail + 1)); failed="$failed $suite"
+         printf 'FAIL     %s   (exited 0, but its log reports a failure - a masked verdict)\n' \
+                "$suite"
+         printf '%s\n' "$masked_verdict" | sed 's/^/         /' ;;
     # 124: timeout(1) killed it. 137: SIGKILL, i.e. timeout's -k follow-up or
     # the OOM killer - either way the suite did not get to render a verdict.
     124|137)

--- a/scripts/suite_tally.py
+++ b/scripts/suite_tally.py
@@ -3,6 +3,7 @@
 
     python3 scripts/suite_tally.py <logdir>... [--quiet]
         [--expect-suite-root <tb/verilator>]
+    python3 scripts/suite_tally.py --verdict <suite.log>
 
 ``<logdir>`` is the directory ``scripts/run_all_suites.sh`` writes
 ``<suite>.log`` into (default ``.suite-logs/``).  This script is the *only*
@@ -41,7 +42,11 @@ Two detectors implement that:
   which is the case a per-log "did anything match?" test would miss.
 
 Both are accounting verdicts.  Neither changes whether a suite passed --
-``run_all_suites.sh`` still gates that on the suite's exit status alone.
+``run_all_suites.sh`` gates that on the suite's exit status, plus one more
+reading of the same log: ``--verdict`` (``log_reports_failure()``) refuses a
+suite that exited 0 while its log carries a ``[FAIL]`` line or a tally with a
+non-zero failure count.  An assertion that only logs is Rule 6's masked
+verdict, and make cannot see it.
 
 DECLARED SKIPS ARE REPORTING, NOT A VERDICT
 -------------------------------------------
@@ -256,6 +261,33 @@ def campaign_accounted_for(text):
         return (f"tallied {checks} checks and {failures} failures -- it ran, "
                 f"and measured nothing", False)
     return (f"tallied {checks} checks, {failures} failures", True)
+
+
+# A line a harness prints for a check that FAILED. Anchored at the start of the
+# line: the shape every sim_main.cpp here prints from its check() helper, and
+# the shape the negative arms print. Prose mentioning FAIL mid-line is not it.
+FAIL_MARKER = re.compile(r"^\s*\[FAIL\]")
+
+
+def log_reports_failure(text):
+    """(reason, failed) - does one suite log say that something FAILED?
+
+    Rule 6's other inventory: an assertion that only logs. A harness whose
+    check() prints `[FAIL]` and counts it, but whose main() returns 0 anyway,
+    hands make a green it did not earn; so does a tally reading `4 PASS, 1
+    FAIL` above an `exit 0`. ``run_all_suites.sh`` calls this for every suite
+    that exited 0 and refuses the pass when its log contradicts it. Two
+    detectors: a tally in any shape above with a non-zero failure count, and a
+    line that starts with ``[FAIL]``. Silence is not this function's business
+    (that is ``NOCOUNT``), and a suite that exited non-zero has already failed.
+    """
+    checks, failures, _matched, _unparsed, _skipped = scan(text)
+    markers = [line.strip() for line in text.splitlines() if FAIL_MARKER.match(line)]
+    if failures:
+        return (f"its tallies report {failures} failure(s) across {checks} checks", True)
+    if markers:
+        return (f"it carries {len(markers)} [FAIL] line(s), first: {markers[0][:80]}", True)
+    return ("no failure reported", False)
 
 
 # --- self-test ---------------------------------------------------------------
@@ -596,6 +628,67 @@ def selftest():
         bad += 1
         print("       expected rc=1")
 
+    # --- the LOG VERDICT: an assertion that only logs --------------------------
+    # Rule 6. A suite that prints [FAIL] and exits 0 used to be a PASS of the
+    # sweep, because make cannot read; review crafted exactly that log and the
+    # sweep accepted it. These pin the detector, then its CLI and exit code.
+    for name, text, want_failed, why in (
+        ("verdict-clean", "5 checks: 5 PASS, 0 FAIL\n", False,
+         "a clean tally reports no failure"),
+        ("verdict-tally-failure", "5 checks: 4 PASS, 1 FAIL\n", True,
+         "a tally with a non-zero failure count is a failure, whatever make said"),
+        ("verdict-marker-beside-clean-tally",
+         "[FAIL] elaboration ACCEPTED illegal TDATA_WIDTH=52\n5 checks: 5 PASS, 0 FAIL\n",
+         True, "a [FAIL] line is a failure even when the tally beside it says 0"),
+        ("verdict-canonical-failures", "checks: 100   failures: 3\n", True,
+         "...in every shape the sweep reads, not just one"),
+        ("verdict-prose-is-not-a-marker",
+         "note: a [FAIL] here would mean the guard fired\n0 FAIL lines seen\n", False,
+         "FAIL mid-line is prose; the marker is anchored"),
+        ("verdict-silence-is-not-this-detector", "building...\n", False,
+         "a silent log is NOCOUNT's finding, not a reported failure"),
+    ):
+        reason, got = log_reports_failure(text)
+        ok = got == want_failed
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} failed={got}  -- {why}")
+        if not ok:
+            bad += 1
+            print(f"       expected failed={want_failed}, got reason: {reason}")
+
+    for name, text, want_rc, want_out, why in (
+        ("cli-verdict-accepts", "62 checks: 62 PASS, 0 FAIL\n", 0, None,
+         "the verdict CLI passes a log that reports no failure"),
+        ("cli-verdict-refuses-marker",
+         "62 checks: 62 PASS, 0 FAIL\n[FAIL] elaboration ACCEPTED illegal TDATA_WIDTH=52\n",
+         1, "VERDICT CONTRADICTED", "...and refuses one that printed [FAIL], with a non-zero exit"),
+        ("cli-verdict-refuses-tally", "5 checks: 4 PASS, 1 FAIL\n", 1,
+         "1 failure(s)", "...and one whose tally counts a failure"),
+    ):
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td, "suite.log")
+            log.write_text(text)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                rc = main([sys.argv[0], "--verdict", str(log)])
+        out = buf.getvalue()
+        ok = rc == want_rc and (want_out is None or want_out in out)
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:<32} rc={rc}  -- {why}")
+        if not ok:
+            bad += 1
+            print(f"       expected rc={want_rc}"
+                  + (f" and {want_out!r} in the output" if want_out else ""))
+    with tempfile.TemporaryDirectory() as td:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+            rc = main([sys.argv[0], "--verdict", str(Path(td, "absent.log"))])
+    ok = rc == 2
+    print(f"  {'ok  ' if ok else 'FAIL'} {'cli-verdict-unreadable-log':<32} rc={rc}  "
+          f"-- a log that cannot be read is an unknown, never a pass")
+    if not ok:
+        bad += 1
+        print("       expected rc=2")
+
     print("selftest:", "PASS" if bad == 0 else f"{bad} FAILURE(S)")
     return 1 if bad else 0
 
@@ -617,6 +710,23 @@ def main(argv):
         print("  NOT show up as a NOCOUNT. Print a tally in one of the shapes")
         print("  in scripts/suite_tally.py, or a SUITE-SKIP: line saying why")
         print("  the campaign ran nothing.")
+        return 1
+    if "--verdict" in argv[1:]:
+        #! One suite log, asked whether it REPORTS a failure. run_all_suites.sh
+        #! consults it for every suite that exited 0. See log_reports_failure().
+        path = argv[argv.index("--verdict") + 1]
+        try:
+            text = Path(path).read_text(errors="replace")
+        except OSError as exc:
+            sys.stderr.write(f"suite_tally: cannot read {path}: {exc}\n")
+            return 2
+        reason, failed = log_reports_failure(text)
+        if not failed:
+            return 0
+        print(f"VERDICT CONTRADICTED -- {reason}.")
+        print("  The suite exited 0 while its own log reports a failure: an")
+        print("  assertion that only logs is a masked verdict (Rule 6). Make the")
+        print("  harness return non-zero when a check fails.")
         return 1
     quiet = False
     expected_root = None

--- a/tb/verilator/rx_filter/Makefile
+++ b/tb/verilator/rx_filter/Makefile
@@ -25,8 +25,18 @@ VFLAGS = --cc --exe --build -j 0 \
 SRCS = $(RTL_DIR)/ieee8021q/filtering/tcam.sv $(RTL_DIR)/ieee8021q/filtering/rx_mac_filter.sv
 CPP  = sim_main.cpp
 
-.PHONY: all run binding-negative print-vflags clean
-all: binding-negative
+# Rule 6: the module's elaboration contract, graded by MUTATION. Each case is
+# a parameter set the module declares impossible; elaboration must REFUSE it.
+# The pair matters as much as the list: a legal default that still elaborates
+# proves the contract is a guard and not a ban. Verilator's default (no
+# -Wno-fatal) makes an elaboration $error exit nonzero, which is the verdict
+# these arms read - they must not go through a pipe, which would return the
+# exit status of the pipe's last command instead.
+NEG_LINT = $(VERILATOR) --lint-only --top-module $(TOP) $(SRCS)
+NEG_CASES = TDATA_WIDTH=32 TDATA_WIDTH=52 NUM_ENTRIES=0 ACTION_WIDTH=0
+
+.PHONY: all run binding-negative negative print-vflags clean
+all: binding-negative negative
 
 run:
 	$(VERILATOR) $(VFLAGS) $(SRCS) $(CPP) -o Vrx_filter_sim
@@ -47,6 +57,26 @@ binding-negative: run
 # a copy of it. One word per line so the shell's quoting of -CFLAGS survives.
 print-vflags:
 	@printf '%s\n' $(VERILATOR) $(VFLAGS)
+
+negative:
+	@echo "======================================================================"
+	@pass=0; fail=0; \
+	for c in $(NEG_CASES); do \
+	  if $(NEG_LINT) -G$$c >/dev/null 2>&1; then \
+	    echo "[FAIL] elaboration ACCEPTED illegal $$c"; fail=$$((fail+1)); \
+	  else \
+	    echo "[PASS] elaboration refused $$c"; pass=$$((pass+1)); \
+	  fi; \
+	done; \
+	if $(NEG_LINT) -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-UNUSEDPARAM \
+	     >/dev/null 2>&1; then \
+	  echo "[PASS] elaboration accepted the legal default shape"; pass=$$((pass+1)); \
+	else \
+	  echo "[FAIL] elaboration REFUSED the legal default shape"; fail=$$((fail+1)); \
+	fi; \
+	echo ""; \
+	echo "$$((pass+fail)) checks: $$pass PASS, $$fail FAIL"; \
+	test $$fail -eq 0
 
 clean:
 	rm -rf obj_dir

--- a/tb/verilator/rx_filter/Makefile
+++ b/tb/verilator/rx_filter/Makefile
@@ -11,14 +11,19 @@ VERILATOR ?= verilator
 RTL_DIR    = ../../../hdl
 TOP        = rx_mac_filter
 
+# -Wno-fatal keeps the waived lint categories non-fatal - and on its own it
+# also demotes an elaboration $error to a warning, so an illegal shield shape
+# BUILDS and simulates (review built -GTDATA_WIDTH=52 here, rc 0).
+# -Werror-USERERROR restores the contract: a $error is a failed verilate, the
+# same discipline tb/verilator/milan_dp and tb/verilator/hostplane carry.
 # -Werror-PINMISSING / -Werror-UNDRIVEN: a missing binding or a port with the
 # wrong direction is refused BY NAME even under -Wno-fatal. Verilator inlines
 # the child, so no harness check can see a direction error; these two are what
 # let binding_mutant.py tell "direction-wrong" from "did not compile".
 VFLAGS = --cc --exe --build -j 0 \
          --top-module $(TOP) \
-         -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-WIDTHEXPAND \
-         -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-PINCONNECTEMPTY \
+         -Wall -Wno-fatal -Werror-USERERROR -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL \
+         -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNUSEDPARAM -Wno-PINCONNECTEMPTY \
          -Werror-PINMISSING -Werror-UNDRIVEN \
          -CFLAGS "-std=c++17 -O2"
 
@@ -26,13 +31,17 @@ SRCS = $(RTL_DIR)/ieee8021q/filtering/tcam.sv $(RTL_DIR)/ieee8021q/filtering/rx_
 CPP  = sim_main.cpp
 
 # Rule 6: the module's elaboration contract, graded by MUTATION. Each case is
-# a parameter set the module declares impossible; elaboration must REFUSE it.
-# The pair matters as much as the list: a legal default that still elaborates
-# proves the contract is a guard and not a ban. Verilator's default (no
-# -Wno-fatal) makes an elaboration $error exit nonzero, which is the verdict
-# these arms read - they must not go through a pipe, which would return the
-# exit status of the pipe's last command instead.
-NEG_LINT = $(VERILATOR) --lint-only --top-module $(TOP) $(SRCS)
+# a parameter set the module declares impossible; elaboration must REFUSE it
+# WITH THE MODULE'S OWN DIAGNOSTIC. The exit status alone proves nothing:
+# review deleted the whole $error chain and three of the four refusals still
+# printed [PASS], refused by an accidental SELRANGE/ASCRANGE/ZEROREPL warning
+# in tcam.sv rather than by the contract. So each arm captures stderr to a
+# file and requires a USERERROR line carrying `rx_mac_filter: <PARAM>=<value> `
+# - grep's status on that FILE is the assertion, and nothing goes through a
+# pipe (a pipeline returns its LAST command's status, which is how a refused
+# build reads as a pass). The legal default must still elaborate: that last
+# arm is what makes the contract a guard and not a ban.
+NEG_LINT  = $(VERILATOR) --lint-only -Werror-USERERROR --top-module $(TOP) $(SRCS)
 NEG_CASES = TDATA_WIDTH=32 TDATA_WIDTH=52 NUM_ENTRIES=0 ACTION_WIDTH=0
 
 .PHONY: all run binding-negative negative print-vflags clean
@@ -60,12 +69,17 @@ print-vflags:
 
 negative:
 	@echo "======================================================================"
-	@pass=0; fail=0; \
+	@mkdir -p obj_dir; pass=0; fail=0; \
 	for c in $(NEG_CASES); do \
-	  if $(NEG_LINT) -G$$c >/dev/null 2>&1; then \
+	  log=obj_dir/neg_$${c%%=*}_$${c##*=}.log; \
+	  if $(NEG_LINT) -G$$c >/dev/null 2>$$log; then \
 	    echo "[FAIL] elaboration ACCEPTED illegal $$c"; fail=$$((fail+1)); \
+	  elif grep -q "USERERROR.*rx_mac_filter: $$c " $$log; then \
+	    echo "[PASS] elaboration refused $$c with the contract's own diagnostic"; \
+	    pass=$$((pass+1)); \
 	  else \
-	    echo "[PASS] elaboration refused $$c"; pass=$$((pass+1)); \
+	    echo "[FAIL] elaboration refused $$c, but NOT by the contract (see $$log)"; \
+	    fail=$$((fail+1)); \
 	  fi; \
 	done; \
 	if $(NEG_LINT) -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-UNUSEDPARAM \

--- a/tb/verilator/tcam_csr/Makefile
+++ b/tb/verilator/tcam_csr/Makefile
@@ -1,5 +1,7 @@
+# -Werror-USERERROR: rx_mac_filter's elaboration contract must fail this
+# build too; -Wno-fatal alone demotes a $error to a warning (Rule 6).
 run:
-	verilator --cc --exe --build -j 8 --top-module tcam_csr_wrap -Wno-fatal \
+	verilator --cc --exe --build -j 8 --top-module tcam_csr_wrap -Wno-fatal -Werror-USERERROR \
 	  -CFLAGS "-std=c++17 -O2" \
 	  ../../../hdl/ieee8021q/filtering/tcam.sv ../../../hdl/ieee8021q/filtering/rx_mac_filter.sv wrap.sv \
 	  sim_main.cpp -o Vtcw


### PR DESCRIPTION
> [!IMPORTANT]
> **Post-review correction (2026-08-29, head `e7e6995b`).** The "Evidence" figures below were measured at the round-1 head; after review round 2 the tool, the budget and the suite changed, and these are the figures at the current head:
> - `scripts/measure_fail_fast.py --selftest` — 90/90; `--check` — PASS (85 ≤ 85 modules without a module-scope elaboration contract, 4 ≤ 4 masked pipelines, 2 ≤ 2 discarded captured verdicts, 2 waived by site).
> - Population: 102 parameterised modules, 85 without a module-scope contract, 17 with; 34 `.sh`, 5 workflow files, 93 Makefiles (recipe lines); Python and Tcl are not measured, and the guide says so.
> - `tb/verilator/rx_filter` — 62 checks 0 failures, binding-negative 5/5, negative 5/5, each refusal graded by the contract's own `USERERROR` line (with the `$error` chain deleted all four arms print `[FAIL]`); `-GTDATA_WIDTH=52` in the build flags → `%Error-USERERROR`, rc 2; `tb/verilator/tcam_csr` 2 checks 0 failures with `-Werror-USERERROR`.
> - `scripts/suite_tally.py --selftest` PASS (a suite whose log tallies a failure while `make` exits 0 is refused by `scripts/run_all_suites.sh`); `ci_events.py --check` OK (230); `lint_rtl.py --check` PASS (99 ≤ 99); `docs_check` 0 / `gen_toc --check` OK / `check_doc_paths` OK.
> - Not enforced, and stated: the sv2v → Yosys path lowers a module-scope `$error` to a `$display` Yosys ignores (`OOC_CHPARAM="TDATA_WIDTH=52" syn/yosys/ooc.sh rx_mac_filter` still passes).

> [!IMPORTANT]
> **Post-review correction (2026-08-28, head `04d0fa5d`).** Fail-fast measurement remains per module across both processor submodules, pipe protection is order-sensitive, and the GitHub Actions default bash contract is modeled without violating bare-metal terminology. Result: 53 parameterised modules, 43 unguarded, zero masked pipelines, two named waivers; self-test 19/19. Earlier figures below are superseded.

Closes #254

Rule 6 of the #248 contract. **Stacked on #279 (Rule 5) → #278 → #277 → #276 → #275.**

## What changed

| Area | Change |
|---|---|
| Guide | Rule 6 section: repository interpretation, the comment-is-not-a-guard example, the two measured populations, review checklist. |
| Invariant | `hdl/ieee8021q/filtering/rx_mac_filter.sv` gains an elaboration contract in the house form. |
| Mutation proof | `make negative` in `tb/verilator/rx_filter` — permanent, four refusals plus one acceptance. |
| Measurement | `scripts/measure_fail_fast.py` + `scripts/fail_fast.budget` (two ratchets). |
| CI | The ratchet and its self-test run in `docs.yml`. |

## A comment is not a guard

`rx_mac_filter` is the receive shield — it decides which frames reach the host. Its banner said the destination compare holds "for TDATA_WIDTH>=48" and **nothing enforced it**. At 32 bits the concatenation building the destination address indexes past the end of the beat, the compare runs on undefined bits, and the shield silently admits or drops the wrong frames. No downstream check can see that: a filter that is wrong looks exactly like a filter that is right until the traffic is inspected on the wire.

Four laws are now executable, in the same module-scope `if (…) $error("one format string", …)` form `milan_datapath` and `KL_media_nco` already use: the datapath must hold the 48-bit destination address in one beat, it must be a whole number of bytes so `tkeep` can describe it, the TCAM needs at least one entry, and an action must distinguish two matches.

## Graded by mutation, permanently

```
[PASS] elaboration refused TDATA_WIDTH=32
[PASS] elaboration refused TDATA_WIDTH=52
[PASS] elaboration refused NUM_ENTRIES=0
[PASS] elaboration refused ACTION_WIDTH=0
[PASS] elaboration accepted the legal default shape

5 checks: 5 PASS, 0 FAIL
```

The last arm is what stops the contract being a ban rather than a guard. The arms read the exit status **directly, never through a pipe** — a pipeline returns its last command's status, which is exactly how a refused build reads as a pass.

## The two populations

| Population | Count | Disposition |
|---|---:|---|
| Parameterised modules with no elaboration contract | **37 of 42** | Ratchet, paid down as modules gain contracts |
| Pipelines that discard their producer's exit status | **0** | Ratchet at zero — it must stay zero |
| Pipelines waived because the consumer *is* the assertion | 27 | Named, with the reason recorded |

`verilator --version \| grep -F "$WANT"` wants grep's status, because grep is the assertion. Those are waived **by name**, not by pattern, so a new one must be added deliberately.

## Both false positives were in the checker, not the tree

On its first run the pipeline scan reported one masked pipeline. It was wrong twice over: a tool name inside a `printf` **format string** read as a command, and a pipe inside a `$(…)` substitution — whose status is never the line's verdict — read as masked. Quoted spans and substitutions are now blanked before the producer search, and both cases have arms. The true count is 0.

## Already satisfied — verified, not rebuilt

The issue also asks that suite tally parsing treat missing or malformed evidence as failure rather than zero checks. `scripts/suite_tally.py` already does this by design (`NOCOUNT`; a skip marker cannot suppress it). Confirmed by running its self-test — `selftest: PASS` — rather than writing a second one.

## Evidence

- `scripts/measure_fail_fast.py --selftest` — **16/16**.
- `scripts/measure_fail_fast.py --check` — PASS (37 ≤ 37, 0 ≤ 0, 27 waived).
- `tb/verilator/rx_filter` — 62 checks 0 failures, plus 5/5 negative arms.
- Direct exit codes: illegal `TDATA_WIDTH=32` → rc 1; illegal `NUM_ENTRIES=0` → rc 1; legal default → rc 0.
- `suite_tally.py --selftest` — PASS.
- `ci_events.py --check` OK (222 items); traceability matrix up to date.
- `docs_check` 0 findings / `gen_toc --check` OK / `check_doc_paths` OK.

## Not covered

- The other 37 modules' contracts; that is the ratchet's job.
- `tsn_fuzz` declared SKIP; builder gate 23h pre-existing on this host and on a pristine `dev` checkout.

