### PR TITLE
[Code quality] Rule 8: prove the TCAM harness can fail

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -143,6 +143,13 @@ jobs:
           python3 scripts/check_todo_ownership.py
           python3 scripts/check_todo_ownership.py --selftest
 
+      # Rule 8: how much a passing suite proves. Suites without a mutation arm
+      # are ratcheted down; unseeded random draws are held at zero.
+      - name: Test-evidence ratchet
+        run: |
+          python3 scripts/measure_test_evidence.py --check
+          python3 scripts/measure_test_evidence.py --selftest
+
       # CI event and SHA contract gate (#174, #181): the four workflow files
       # and docs/testing/CI_WORKFLOWS.md must agree on the triggers, the cron
       # time, the public check names, cancel-in-progress and the one-SHA rule

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -31,6 +31,7 @@ shape rather than guess at it.
 - **[Rule 5: make ports, contracts and ownership explicit](#rule-5-make-ports-contracts-and-ownership-explicit)** -- What a port contract must state, why wildcard, positional and hierarchical bindings are refused outright while missing documentation and unjustified open or tied connections are only ratcheted, the exact scope of the inventory, the boundary documented end to end as proof, and the review checklist.
 - **[Rule 6: fail fast and encode invariants](#rule-6-fail-fast-and-encode-invariants)** -- Where a verdict must be refused rather than logged, one in-tree example per boundary (elaboration, FSM default, generator, pipeline, Tcl flow), the elaboration contract added to the receive shield and mutation-proven by its own diagnostic, where that contract is and is not enforced, the three masked-failure populations ratcheted over a stated population, the sweep's refusal of a suite that logs a failure and exits 0, and the review checklist.
 - **[Rule 7: comments explain why, and dead code goes](#rule-7-comments-explain-why-and-dead-code-goes)** -- What a comment is for, why a marker names its issue or is resolved, the near-misses that forced a narrow definition of "marker" and what the gate reads to find one, the two stale markers removed, and the dead code the inventory found.
+- **[Rule 8: tests prove something, and prove they can fail](#rule-8-tests-prove-something-and-prove-they-can-fail)** -- Why a green suite can prove nothing, the three defects injected into the TCAM to show its harness is load-bearing, the two evidence ratchets, and what was found already clean.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -1656,13 +1657,85 @@ behavior.
 - Is any helper, branch or parameter here for a requirement that does not exist
   yet?
 
+## Rule 8: tests prove something, and prove they can fail
+
+> Every behavioral change has a deterministic, self-checking test whose oracle
+> comes from the governing specification or an independent contract. New
+> assertions are mutation-proven, failures return non-zero, and the test names
+> the law it proves.
+
+This consolidates the verification bar in
+[CONTRIBUTING.md](../../CONTRIBUTING.md) rather than competing with it: that
+page says a change owes a self-checking Verilator harness and a runnable matrix
+row. This rule says what makes such a harness *evidence*.
+
+### The failure mode is a green suite that proves nothing
+
+An assertion that has never been observed to fail is indistinguishable from an
+assertion that cannot fail. The two are the same colour in CI, and the second
+one is worse than no test, because it occupies the place where a test would go.
+
+### Three defects, to show the harness is load-bearing
+
+`tb/verilator/tcam` checked exact match, ternary match, priority, the multi-hit
+vector, add/remove/update and a clean miss — and nothing proved any of those
+checks could fail. The TCAM is the match engine behind the receive shield, so a
+silently vacuous test there is a silently unguarded filter.
+
+`make mutants` now injects one defect at a time into the real RTL and runs the
+**same** harness against each:
+
+| Mutant | The assertion it must break |
+|---|---|
+| Priority inverted (`p` counts up, so the highest index wins) | lowest matching index wins |
+| Care mask ignored (the ternary compare becomes exact) | a wildcard entry matches a range |
+| Entry validity ignored (`ent_valid[m] &&` dropped) | a removed entry stops matching |
+
+All three are caught, and the **unmutated build still passes** — without that
+control the arm would be satisfied by a harness that fails on everything.
+
+Two details make it stay honest. Each mutation's pattern must appear in the RTL
+**exactly once**, so a refactor that moves the priority encoder fails here
+loudly instead of silently mutating nothing. And the mutants are built in a
+temporary directory, so a mutated source is never written into the tree.
+
+### The two evidence ratchets
+
+[`scripts/measure_test_evidence.py`](../../scripts/measure_test_evidence.py):
+
+| Population | Count | Disposition |
+|---|---:|---|
+| Verilator suites with no mutation or negative arm | 33 of 54 (was 34) | Ratchet. A new suite proves its own assertions can fail. |
+| First-party files drawing random values with no recorded seed | **0** | Ratchet at zero. |
+
+### Two things found already clean, and verified rather than rebuilt
+
+- **Replayable randomness.** Every first-party file that draws random values
+  already records a seed — `test_tx_bd.py` seeds immediately before each block
+  of draws, `test_ring_bd.py` uses `random.Random(13)`. The first pass of this
+  audit reported five unseeded draws; that was a defect in the audit, which
+  flagged the draws without checking whether the file seeded. The true count is
+  zero, and the ratchet holds it there.
+- **Tally integrity.** A missing or malformed tally is `NOCOUNT` in
+  [`scripts/suite_tally.py`](../../scripts/suite_tally.py), which refuses to let
+  an unknown look like agreement and cannot be suppressed by a skip marker. That
+  is confirmed by running its self-test, not by writing a second one.
+
+### Review checklist
+
+- Where does the expected value come from — the specification, or the thing
+  being tested?
+- Has any assertion here ever been seen to fail?
+- If this test draws randomly, can a failure be replayed from its own output?
+- Does the suite publish a non-zero tally, and does a failure return non-zero?
+- Does the test name the law it proves, or only the function it calls?
+
 ## Rules not yet landed
 
-The contract is ten rules. Rules 1 to 7 are above; the rest keep these
+The contract is ten rules. Rules 1 to 8 are above; the rest keep these
 numbers so citations stay stable as they land:
 
 | Rule | Subject |
 |---|---|
-| 8 | Deterministic, specification-derived tests |
 | 9 | Automated mechanical hygiene with measured ratchets |
 | 10 | Idiomatic SystemVerilog and explicit HDL boundaries |

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1705,7 +1705,7 @@ temporary directory, so a mutated source is never written into the tree.
 
 | Population | Count | Disposition |
 |---|---:|---|
-| Verilator suites with no mutation or negative arm | 33 of 54 (was 34) | Ratchet. A new suite proves its own assertions can fail. |
+| RTL suites with no executable mutation or negative arm | 82 of 87 (was 83) | Ratchet across the superproject and both project-owned processor submodules. A comment or manual mutation record is not evidence; a new suite exposes a runnable arm that proves its assertions can fail. |
 | First-party files drawing random values with no recorded seed | **0** | Ratchet at zero. |
 
 ### Two things found already clean, and verified rather than rebuilt

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1675,6 +1675,34 @@ An assertion that has never been observed to fail is indistinguishable from an
 assertion that cannot fail. The two are the same colour in CI, and the second
 one is worse than no test, because it occupies the place where a test would go.
 
+Three small shapes make the rule concrete. A wire-format oracle writes the
+governing bytes independently instead of asking the encoder under test to
+produce its own expected value:
+
+```python
+expected_dmac = bytes.fromhex("0180c200000e")  # IEEE reserved gPTP address
+check("destination bytes", encoded_frame[:6], expected_dmac)
+```
+
+A randomized test prints the exact seed before drawing, so the failing case is
+one command away from replay:
+
+```python
+seed = int(os.environ.get("TEST_SEED", "23"))
+print(f"TEST_SEED={seed}")
+rng = random.Random(seed)
+frame = bytes(rng.randrange(256) for _ in range(64))
+```
+
+And a mutation-proven assertion has both signs: the clean implementation
+passes, while a named defect must make the same assertion fail. A comment that
+someone once tried a mutation is not an executable arm.
+
+```text
+[PASS] the unmutated RTL still passes the harness
+[PASS] mutant caught: priority inverted -- lowest matching index wins
+```
+
 ### Three defects, to show the harness is load-bearing
 
 `tb/verilator/tcam` checked exact match, ternary match, priority, the multi-hit
@@ -1699,7 +1727,7 @@ Two details make it stay honest. Each mutation's pattern must appear in the RTL
 loudly instead of silently mutating nothing. And the mutants are built in a
 temporary directory, so a mutated source is never written into the tree.
 
-### The two evidence ratchets
+### The four evidence populations
 
 [`scripts/measure_test_evidence.py`](../../scripts/measure_test_evidence.py):
 
@@ -1707,6 +1735,24 @@ temporary directory, so a mutated source is never written into the tree.
 |---|---:|---|
 | RTL suites with no executable mutation or negative arm | 82 of 87 (was 83) | Ratchet across the superproject and both project-owned processor submodules. A comment or manual mutation record is not evidence; a new suite exposes a runnable arm that proves its assertions can fail. |
 | First-party files drawing random values with no recorded seed | **0** | Ratchet at zero. |
+| Unexplained tests reading production HDL text | **0** | Four readers are explicitly classified: three mutation campaigns and one structural boundary check. A new reader is refused until review proves it is not importing expected behavior from the DUT. |
+| Suite files using host wall-clock/process deadlines | **2** | Ratcheted. Both are in the external `tsn_fuzz` cosimulation boundary; behavioral RTL timeouts elsewhere advance explicit DUT cycles. |
+
+### Audit of weak-evidence failure modes
+
+The audit separates a count from its interpretation:
+
+| Failure mode | Audit result | Evidence contract |
+|---|---|---|
+| Zero-evidence pass | 82 of 87 suites lack an executable negative/mutation arm. | Ratchet; the TCAM repair moves one suite to the armed side. |
+| Implementation-derived oracle | Four test programs read HDL text; all are structural or mutation-only, with zero unexplained readers. | A disposition allowlist must match the live readers exactly. The TCAM behavioral oracle remains literal/specification-derived. |
+| Nondeterministic timeout | Two suite files use host deadlines, both in `tsn_fuzz`; other protocol deadlines are cycle-counted. | The common sweep maps host kills (124/137) to UNKNOWN/exit 92, never pass or fail. New wall-clock files exceed the ratchet. |
+| Missing or malformed tally | The candidate sweep reported every root suite; no `NOCOUNT` or unparsed tally. | `suite_tally.py --selftest` runs before the first suite. A silent/zero/unparsed log exits 90, and a skip marker cannot hide it. |
+
+`measure_test_evidence.py` mutation-arms both the static classifications and
+the runner wiring: changing the UNKNOWN exit to an ordinary failure makes its
+self-test fail. This keeps a future runner edit from turning infrastructure
+contention into test evidence.
 
 ### Two things found already clean, and verified rather than rebuilt
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1764,6 +1764,26 @@ arm; the self-test carries a fixture for every one of those shapes and for the
 five live arms. The tool prints, for each armed suite, the executed target and
 the shape that arms it.
 
+**And the recipe's error control must let the arm turn the suite red.** A
+second review showed the classifier erasing Make's leading `-` and splitting
+`||` into independent commands, so `-python3 mutants.py` and
+`python3 mutants.py || true` both armed a suite whose mutation campaign could
+fail without the suite noticing. The classifier now reads a recipe the way
+Make and `sh -c` do. A line whose prefix carries `-` (in any order with `@`
+and `+`, read after expansion), or a target `.IGNORE` names, has its errors
+ignored and arms nothing, whatever shape sits on it. Per command, a driver
+followed by `||` reports the fallback's status — `|| true`, `|| :` and
+`|| echo …` mask it, a fallback ending in `exit`, `exit N` or `false`
+re-raises it and still counts; a driver followed by `;` and another command
+reports that command's status unless `set -e` (or `.POSIX`/`.SHELLFLAGS -e`)
+is in force and the driver is the last element of its own list; a driver
+feeding a pipe reports the consumer's; an `if`/`while` condition is consumed.
+A plain driver and an `&&` chain carry the failure and count, and a `-` on
+another line of the same target (`-rm -rf obj_mut`) does not touch the
+driver's line. The self-test carries a fixture for each of these shapes; the
+five live arms are all plain or `@`-silenced, so the count in the table below
+did not move.
+
 ### The four evidence populations
 
 [`scripts/measure_test_evidence.py`](../../scripts/measure_test_evidence.py):
@@ -1801,7 +1821,14 @@ a structural import from an oracle import needs a reading of each wrapper, not
 a pattern. `secrets.token_*` is a nonce, not a test draw (the draw-shaped
 `secrets.randbelow/randbits/choice` are counted and can never be seeded). A
 deadline passed positionally (`asyncio.wait_for(coro, 5)`) is not seen; the
-keyword form is. A Makefile conditional is read with every branch live. Eight
+keyword form is. A Makefile conditional is read with every branch live.
+Recipe error control is read as Make and `sh -c` read it and no further: a
+status captured and re-raised later (`x || rc=1; …; exit $$rc`, the shape the
+multi-binary suites use for their own harnesses), a driver used as an
+`if`/`while` condition, a driver inside `$(…)`, backticks or `$(shell …)`,
+`set -o pipefail` (Make's shell is `/bin/sh`) and `make -i`/`MAKEFLAGS` at the
+entry are not followed, so a driver in those shapes is not credited — write
+the arm plain or `&&`-chained. Eight
 harnesses include the Verilator-internal `V*___024root.h` to reach state
 through a backdoor (`crf_rx`, five `milan_dp` programs, `pp_shadow`, `tkdiag`);
 this rule says a backdoor may seed a state but must not be the only proof of

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -31,7 +31,7 @@ shape rather than guess at it.
 - **[Rule 5: make ports, contracts and ownership explicit](#rule-5-make-ports-contracts-and-ownership-explicit)** -- What a port contract must state, why wildcard, positional and hierarchical bindings are refused outright while missing documentation and unjustified open or tied connections are only ratcheted, the exact scope of the inventory, the boundary documented end to end as proof, and the review checklist.
 - **[Rule 6: fail fast and encode invariants](#rule-6-fail-fast-and-encode-invariants)** -- Where a verdict must be refused rather than logged, one in-tree example per boundary (elaboration, FSM default, generator, pipeline, Tcl flow), the elaboration contract added to the receive shield and mutation-proven by its own diagnostic, where that contract is and is not enforced, the three masked-failure populations ratcheted over a stated population, the sweep's refusal of a suite that logs a failure and exits 0, and the review checklist.
 - **[Rule 7: comments explain why, and dead code goes](#rule-7-comments-explain-why-and-dead-code-goes)** -- What a comment is for, why a marker names its issue or is resolved, the near-misses that forced a narrow definition of "marker" and what the gate reads to find one, the two stale markers removed, and the dead code the inventory found.
-- **[Rule 8: tests prove something, and prove they can fail](#rule-8-tests-prove-something-and-prove-they-can-fail)** -- Why a green suite can prove nothing, the three defects injected into the TCAM to show its harness is load-bearing, the two evidence ratchets, and what was found already clean.
+- **[Rule 8: tests prove something, and prove they can fail](#rule-8-tests-prove-something-and-prove-they-can-fail)** -- Why a green suite can prove nothing, the three defects injected into the TCAM to show its harness is load-bearing, what counts as an executed arm, the four evidence ratchets, and what was found already clean.
 - **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
 
 ## The governing rule
@@ -1722,10 +1722,47 @@ silently vacuous test there is a silently unguarded filter.
 All three are caught, and the **unmutated build still passes** — without that
 control the arm would be satisfied by a harness that fails on everything.
 
-Two details make it stay honest. Each mutation's pattern must appear in the RTL
-**exactly once**, so a refactor that moves the priority encoder fails here
-loudly instead of silently mutating nothing. And the mutants are built in a
-temporary directory, so a mutated source is never written into the tree.
+Three details make it stay honest. Each mutation's pattern must appear in the
+RTL **exactly once**, so a refactor that moves the priority encoder fails here
+loudly instead of silently mutating nothing. The mutants are built in a
+temporary directory, so a mutated source is never written into the tree. And
+"caught" is the harness's **own verdict** — a `[FAIL]` line or a failing tally
+in its stdout, read by the same [`scripts/suite_tally.py`](../../scripts/suite_tally.py)
+the sweep uses — never a bare non-zero exit: a mutant that makes the DUT abort,
+dies by a signal, or hangs past the driver's per-mutant guard is reported as
+exactly that and is **not** a catch. The guard is why the driver is one of the
+three wall-clock files below.
+
+```
+make -C tb/verilator/tcam                           # the suite: run, then mutants (~25 s)
+make -C tb/verilator/tcam mutants                   # the mutation arm alone
+python3 scripts/measure_test_evidence.py            # the four inventories, and what arms each armed suite
+python3 scripts/measure_test_evidence.py --check    # the ratchets
+python3 scripts/measure_test_evidence.py --selftest # the fixture arms
+```
+
+### What counts as an arm: something the entry executes
+
+The first version of the audit matched text — any file in the suite directory
+naming `mutants.py`, a `mutants:` target, a `-D…MUT…` define — and a review
+showed that a README sentence, a comment, an empty `mutants:` target and
+`-DUSE_MUTEX` each satisfied it. Text is not an arm. The classifier now reads
+the suite's **Makefile** (targets, prerequisites, recipes, with its variables
+expanded) and the suite's **entry** — the sweep's bare `make`, the protocol
+processor's runner and CI, the gPTP processor's top-level Makefile — and an arm
+is one of three shapes sitting in the recipe of a target that entry reaches:
+
+- a **driver script** the recipe invokes that carries a mutation or negative
+  table (`MUTATIONS =`, `NEG_CASES =`, `mutation_checks(`), or that reads the
+  DUT text, rewrites it and runs the harness on the result;
+- a **compile-time mutation define** the recipe passes (`+define+NVM_MUT_…`,
+  `-D…_MUTANT`; `MUT` as a whole `_`-delimited word, so `USE_MUTEX` is not);
+- a **negative-case table** the recipe consumes (`$(NEG_CASES)`).
+
+A driver named in a comment, in `echo`, or on a target nothing runs is not an
+arm; the self-test carries a fixture for every one of those shapes and for the
+five live arms. The tool prints, for each armed suite, the executed target and
+the shape that arms it.
 
 ### The four evidence populations
 
@@ -1733,10 +1770,10 @@ temporary directory, so a mutated source is never written into the tree.
 
 | Population | Count | Disposition |
 |---|---:|---|
-| RTL suites with no executable mutation or negative arm | 82 of 87 (was 83) | Ratchet across the superproject and both project-owned processor submodules. A comment or manual mutation record is not evidence; a new suite exposes a runnable arm that proves its assertions can fail. |
-| First-party files drawing random values with no recorded seed | **0** | Ratchet at zero. |
-| Unexplained tests reading production HDL text | **0** | Four readers are explicitly classified: three mutation campaigns and one structural boundary check. A new reader is refused until review proves it is not importing expected behavior from the DUT. |
-| Suite files using host wall-clock/process deadlines | **2** | Ratcheted. Both are in the external `tsn_fuzz` cosimulation boundary; behavioral RTL timeouts elsewhere advance explicit DUT cycles. |
+| RTL suites with no executable mutation or negative arm | 82 of 87 (was 83) | Ratchet across the superproject (54 suites, entry `scripts/run_all_suites.sh`) and both project-owned processor submodules (30 under `protocol-processor/tb`, entry `protocol-processor/scripts/run_suites.sh` and its CI; 3 under `gptp-processor/tb/verilator`, entry `gptp-processor/Makefile`). Only an executed recipe arms a suite, as defined above. |
+| First-party files drawing random values with no recorded seed | **10** | Ratchet. The scan reads code, not comments or strings, in every language the test trees carry: Python module draws, `random.Random()`/`SystemRandom()` instance draws, `from random import …`, `choices`/`gauss` and friends, numpy, `secrets`; C `rand()`, `std::rand()`, `random()`, `*rand48`, `random_device`; SystemVerilog `$urandom`, `$urandom_range`, `$random`, `randomize()`. A seed is `random.seed(x)`, `random.Random(x)` with any non-empty `x` (the documented `TEST_SEED` pattern), `np.random.seed`/`default_rng(x)`, `srand(x)` (not `srand(time(NULL))`), a printed seed beside `random_device`, `srandom(x)`, `$urandom(x)` or a `+seed` plusarg. **All ten are legacy xsim benches** under `tb/utests`, `tb/itests` and `tb/avtp_packet_gen_sv` drawing `$urandom` with no seed ([TESTING.md section 5](../testing/TESTING.md#5-legacy--auxiliary-testbenches): superseded, not exit-code gating). Every gating harness is seeded. |
+| Unexplained tests reading production HDL text | **0** | Four readers are explicitly classified: three mutation campaigns and one structural boundary check. Idioms: `read_text`/`read_bytes`, `open(…).read()`/`readlines()`, C++ `ifstream`/`fopen`, SystemVerilog `` `include `` of `hdl/` or `$fopen`/`$readmemh`, shell `cat`/`grep`/`sed`/`awk` over `hdl/`, each paired with an `hdl/` path. A new reader is refused until review proves it is not importing expected behavior from the DUT. |
+| Suite files using host wall-clock/process deadlines | **3** | Ratcheted. Two are in the external `tsn_fuzz` cosimulation boundary; the third is the tcam mutation driver's per-mutant guard, a bound on a hang, not an oracle. Idioms: Python `time.*`/`datetime.now`/`settimeout`/`select.select`/`signal.alarm`/`SO_RCVTIMEO` and a `timeout=` keyword on `run`/`check_output`/`communicate`/`wait`/`wait_for` and friends (nested parentheses included); C++ `chrono`, `clock()`, `time(NULL)`, `gettimeofday`, `usleep`/`sleep`; shell and Makefile `sleep N`, `timeout N …`, `date`. Behavioral RTL timeouts elsewhere advance explicit DUT cycles. |
 
 ### Audit of weak-evidence failure modes
 
@@ -1746,26 +1783,50 @@ The audit separates a count from its interpretation:
 |---|---|---|
 | Zero-evidence pass | 82 of 87 suites lack an executable negative/mutation arm. | Ratchet; the TCAM repair moves one suite to the armed side. |
 | Implementation-derived oracle | Four test programs read HDL text; all are structural or mutation-only, with zero unexplained readers. | A disposition allowlist must match the live readers exactly. The TCAM behavioral oracle remains literal/specification-derived. |
-| Nondeterministic timeout | Two suite files use host deadlines, both in `tsn_fuzz`; other protocol deadlines are cycle-counted. | The common sweep maps host kills (124/137) to UNKNOWN/exit 92, never pass or fail. New wall-clock files exceed the ratchet. |
-| Missing or malformed tally | The candidate sweep reported every root suite; no `NOCOUNT` or unparsed tally. | `suite_tally.py --selftest` runs before the first suite. A silent/zero/unparsed log exits 90, and a skip marker cannot hide it. |
+| Nondeterministic timeout | Three suite files use host deadlines: two in `tsn_fuzz`, one the tcam mutation driver's hang guard; other protocol deadlines are cycle-counted. | The common sweep maps host kills (124/137) to UNKNOWN/exit 92, never pass or fail. New wall-clock files exceed the ratchet. |
+| Missing or malformed tally | **Population: the 54 superproject suites** that [`scripts/run_all_suites.sh`](../../scripts/run_all_suites.sh) sweeps. Every one reported; no `NOCOUNT` or unparsed tally. The 33 processor suites are **outside** that sweep: the 30 `protocol-processor/tb` suites run under `protocol-processor/scripts/run_suites.sh` in the processor's own CI, and the 3 `gptp-processor/tb/verilator` suites run only from `gptp-processor/Makefile` — gptp-processor has **no CI of its own** and its Makefile reads no tally. | `suite_tally.py --selftest` runs before the first suite. A silent/zero/unparsed log exits 90, and a skip marker cannot hide it. **Processor debt, recorded in the budget:** the protocol processor's reader (`run_suites.sh`) takes a zero tally as PASS, keeps only the last tally line of a multi-executable suite, and knows one shape; the superproject reader refuses all three, and `measure_test_evidence.py --selftest` proves that on those exact logs. The upstream fix is to sum every tally line in every shape and treat zero as `NOCOUNT`, or to call `suite_tally.py`'s `scan`. |
 
 `measure_test_evidence.py` mutation-arms both the static classifications and
 the runner wiring: changing the UNKNOWN exit to an ordinary failure makes its
 self-test fail. This keeps a future runner edit from turning infrastructure
-contention into test evidence.
+contention into test evidence. The gate refuses (exit 2) an empty suite
+population or a missing entry file, so a checkout that finds nothing is never
+a pass, and the self-test's printed total is counted from its arms rather than
+typed.
+
+**Known limits, by name.** A package import in a testbench wrapper
+(`import x_pkg::*`) binds the DUT's types and constants and is not read as a
+DUT-source reader: the seven live wrappers carry no compare lines, and telling
+a structural import from an oracle import needs a reading of each wrapper, not
+a pattern. `secrets.token_*` is a nonce, not a test draw (the draw-shaped
+`secrets.randbelow/randbits/choice` are counted and can never be seeded). A
+deadline passed positionally (`asyncio.wait_for(coro, 5)`) is not seen; the
+keyword form is. A Makefile conditional is read with every branch live. Eight
+harnesses include the Verilator-internal `V*___024root.h` to reach state
+through a backdoor (`crf_rx`, five `milan_dp` programs, `pp_shadow`, `tkdiag`);
+this rule says a backdoor may seed a state but must not be the only proof of
+behavior, and that inventory is noted here for a later round, not measured.
 
 ### Two things found already clean, and verified rather than rebuilt
 
-- **Replayable randomness.** Every first-party file that draws random values
-  already records a seed — `test_tx_bd.py` seeds immediately before each block
-  of draws, `test_ring_bd.py` uses `random.Random(13)`. The first pass of this
-  audit reported five unseeded draws; that was a defect in the audit, which
-  flagged the draws without checking whether the file seeded. The true count is
-  zero, and the ratchet holds it there.
+- **Replayable randomness.** Every **gating** first-party file that draws
+  random values records a seed — `test_tx_bd.py` seeds immediately before each
+  block of draws, `test_ring_bd.py` uses `random.Random(13)`, the `tsn_fuzz`
+  campaigns and the Verilator harnesses seed their `random.Random`/`mt19937`
+  instances. The first pass of this audit reported five unseeded draws; that
+  was a defect in the audit, which flagged the draws without checking whether
+  the file seeded. The second pass reported zero, and a review showed that was
+  a defect too: it recognised only module-level `random.<fn>(` and bare
+  `rand()`, so the guide's own recommended idiom and every SystemVerilog
+  `$urandom` were invisible. The scan now reads the shapes listed in the table
+  above, and what it measures is **ten** — all legacy xsim benches that no
+  exit code gates. That is the ratchet, and seeding one of them lowers it.
 - **Tally integrity.** A missing or malformed tally is `NOCOUNT` in
   [`scripts/suite_tally.py`](../../scripts/suite_tally.py), which refuses to let
   an unknown look like agreement and cannot be suppressed by a skip marker. That
-  is confirmed by running its self-test, not by writing a second one.
+  is confirmed by running its self-test, not by writing a second one — and
+  by the evidence gate's own arms, which feed that reader the three log shapes
+  the protocol processor's runner gets wrong.
 
 ### Review checklist
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -364,7 +364,7 @@ verdicts and for check counts.
 | [`tb/verilator/queues`](../../tb/verilator/queues) | — |
 | [`tb/verilator/rx_filter`](../../tb/verilator/rx_filter) | — |
 | [`tb/verilator/shaper_core`](../../tb/verilator/shaper_core) | FQTSS/arbitration, incl. the gPTP-not-starved measurement |
-| [`tb/verilator/tcam`](../../tb/verilator/tcam) | — |
+| [`tb/verilator/tcam`](../../tb/verilator/tcam) | the ternary CAM behind the receive shield: exact and ternary match, priority, the multi-hit vector, add/remove/update, a clean miss — **and its mutation arm**: `make` runs `run` then `mutants` (~25 s, four extra Verilator builds), three injected RTL defects must each make the same harness fail by its own verdict, the clean build must pass, and a DUT abort or a hang is not a catch |
 | [`tb/verilator/tcam_csr`](../../tb/verilator/tcam_csr) | — |
 | [`tb/verilator/tdm`](../../tb/verilator/tdm) | — |
 | [`tb/verilator/tdm_render`](../../tb/verilator/tdm_render) | — |

--- a/scripts/code_quality_scope.py
+++ b/scripts/code_quality_scope.py
@@ -75,8 +75,15 @@ def tracked(*patterns):
 
     With no pattern, every tracked first-party path.
     """
+    return tracked_exact(*scoped_pathspecs(*patterns))
+
+
+def tracked_exact(*pathspecs):
+    """Tracked first-party paths for already-rooted pathspecs, without scope
+    expansion; the vendor gitlinks are filtered here too, so no caller can
+    reach a third-party tree by spelling its path."""
     _assert_pinned_submodules()
     run = subprocess.run(
-        ["git", "ls-files", "--recurse-submodules", "--", *scoped_pathspecs(*patterns)],
+        ["git", "ls-files", "--recurse-submodules", "--", *pathspecs],
         cwd=REPO, capture_output=True, text=True, check=True)
     return first_party(run.stdout.splitlines(), gitlinks())

--- a/scripts/measure_test_evidence.py
+++ b/scripts/measure_test_evidence.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Measure how much a passing suite actually proves.
+
+Why this exists. Rule 8 of the maintainability guide
+(docs/development/CODE_QUALITY.md) says a test's oracle comes from the
+specification, its assertions are mutation-proven, and a pass publishes a
+non-zero tally. A suite can be green and prove nothing: assertions that have
+never been observed to fail are indistinguishable from assertions that cannot.
+
+Two things are counted, and one is already clean.
+
+  1. MUTATION COVERAGE. A suite carries an arm that deliberately breaks
+     something and requires the suite to notice - a mutated DUT, an illegal
+     parameter, a broken fixture. Thirty of fifty-four Verilator suites do.
+     This is a RATCHET: the number without one may only fall.
+
+  2. REPLAYABLE RANDOMNESS. A test that draws random values without recording
+     a seed cannot be replayed from its own failure. Every first-party file
+     that draws already seeds - this is measured and reported as ZERO, and it
+     must stay zero, because the cost of finding out otherwise is a flaky
+     failure nobody can reproduce.
+
+Not counted here, because another gate already owns it: a missing or malformed
+tally is `NOCOUNT` in `scripts/suite_tally.py`, which refuses to let an unknown
+look like agreement. This script does not re-implement that judgement.
+
+Usage:
+    python3 scripts/measure_test_evidence.py            # both inventories
+    python3 scripts/measure_test_evidence.py --check    # the ratchets
+    python3 scripts/measure_test_evidence.py --selftest # fixture arms
+
+Exit 0 = at or under the ratchets in scripts/test_evidence.budget.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BUDGET = Path(__file__).resolve().parent / "test_evidence.budget"
+SUITE_ROOT = REPO / "tb/verilator"
+
+#: A suite has a mutation arm when it deliberately breaks something and
+#: requires the break to be noticed. The vocabulary is the one this tree
+#: already uses in the suites that have one.
+ARM = re.compile(r"mutant|mutation|negative (?:arm|control|self-?test)"
+                 r"|deliberately broken|anti-vacuity|must fail|gate bites"
+                 r"|self-?test", re.I)
+
+#: a random draw, and the seed that makes it replayable
+DRAW = re.compile(r"(?<![\w.])random\.(?:random|randint|choice|shuffle|randrange"
+                  r"|uniform|sample|getrandbits)\s*\(|(?<![\w:])rand\s*\(\s*\)")
+SEED = re.compile(r"random\.Random\s*\(\s*\d|random\.seed\s*\(\s*\d|srand\s*\(\s*\d")
+
+EXCLUDED_PREFIXES = ("third_party/", "external/", "protocol-processor/",
+                     "gptp-processor/", "gen/", "build/")
+
+
+def tracked(*pats):
+    out = subprocess.run(["git", "ls-files", *pats], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout.split()
+    return [p for p in out if not p.startswith(EXCLUDED_PREFIXES)]
+
+
+def suite_text(name):
+    """Everything a suite is made of: its makefile, harnesses and wrappers."""
+    parts = []
+    for rel in tracked(f"tb/verilator/{name}/*"):
+        try:
+            parts.append((REPO / rel).read_text(errors="replace"))
+        except OSError:
+            pass
+    return "\n".join(parts)
+
+
+def suites():
+    names = set()
+    for rel in tracked("tb/verilator/*/*"):
+        bits = rel.split("/")
+        if len(bits) >= 4:
+            names.add(bits[2])
+    return sorted(names)
+
+
+def has_arm(text):
+    return bool(ARM.search(text))
+
+
+def draws_without_seed(text):
+    return bool(DRAW.search(text)) and not SEED.search(text)
+
+
+def audit():
+    armed, unarmed = [], []
+    for name in suites():
+        (armed if has_arm(suite_text(name)) else unarmed).append(name)
+
+    unseeded = []
+    for rel in tracked("tb/**/*.py", "sw/**/*.py", "scripts/*.py", "tests/**/*.py",
+                       "tb/**/*.cpp"):
+        if draws_without_seed((REPO / rel).read_text(errors="replace")):
+            unseeded.append(rel)
+    return armed, unarmed, unseeded
+
+
+def read_budget():
+    if not BUDGET.is_file():
+        return None, None
+    vals = [int(x) for x in re.findall(r"^\s*(\d+)\s*$", BUDGET.read_text(), re.M)]
+    return (vals + [None, None])[:2]
+
+
+def selftest():
+    failures = 0
+
+    def ck(name, ok, detail=""):
+        nonlocal failures
+        if ok:
+            print(f"[PASS] {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] {name}{': ' + detail if detail else ''}")
+
+    ck("a suite naming a mutant is armed", has_arm("run mutants.py # mutant caught"))
+    ck("a suite naming a negative control is armed", has_arm("negative control: must fail"))
+    ck("a suite with a self-test is armed", has_arm("python3 x.py --selftest"))
+    ck("an ordinary suite is not armed", not has_arm("build and run the harness"))
+
+    ck("an unseeded draw is caught", draws_without_seed("x = random.choice([1,2])"))
+    ck("a seeded draw is not", not draws_without_seed("random.seed(11)\nx = random.choice([1,2])"))
+    ck("a Random(seed) instance counts as seeded",
+       not draws_without_seed("rng = random.Random(13)\nx = random.choice([1,2])"))
+    ck("a file that never draws is not counted", not draws_without_seed("x = 1"))
+    ck("a C rand() with no srand is caught", draws_without_seed("int x = rand();"))
+    ck("a C rand() with srand is not", not draws_without_seed("srand(7); int x = rand();"))
+
+    armed, unarmed, unseeded = audit()
+    ck("the live scan sees the suites", len(armed) + len(unarmed) > 40,
+       f"{len(armed) + len(unarmed)} suites")
+    ck("both sides of the mutation split are non-empty",
+       bool(armed) and bool(unarmed),
+       "an inert classifier would put every suite on one side")
+
+    n = 12
+    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--check", action="store_true", help="ratchet both counts")
+    ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    armed, unarmed, unseeded = audit()
+    print(f"Verilator suites with a mutation or negative arm: "
+          f"{len(armed)} of {len(armed) + len(unarmed)}")
+    print(f"\nsuites with none ({len(unarmed)}):")
+    for name in unarmed:
+        print(f"   {name}")
+    print(f"\nfiles that draw random values without recording a seed ({len(unseeded)}):")
+    for rel in unseeded:
+        print(f"   {rel}")
+
+    if not args.check:
+        return 0
+
+    b_unarmed, b_unseeded = read_budget()
+    if b_unarmed is None or b_unseeded is None:
+        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} must hold two counts")
+        return 1
+    bad = False
+    if len(unarmed) > b_unarmed:
+        print(f"\nFAIL: {len(unarmed)} suite(s) with no mutation arm > ratchet "
+              f"{b_unarmed}. A new suite proves its own assertions can fail.")
+        bad = True
+    if len(unseeded) > b_unseeded:
+        print(f"\nFAIL: {len(unseeded)} unseeded random draw site(s) > ratchet "
+              f"{b_unseeded}. A random test records the seed it can be replayed from.")
+        bad = True
+    if bad:
+        return 1
+    print(f"\nTEST-EVIDENCE RATCHET: PASS ({len(unarmed)} <= {b_unarmed} suite(s) "
+          f"without a mutation arm, {len(unseeded)} <= {b_unseeded} unseeded draw site(s))")
+    if len(unarmed) < b_unarmed:
+        print(f"  the mutation ratchet can be lowered to {len(unarmed)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_test_evidence.py
+++ b/scripts/measure_test_evidence.py
@@ -11,9 +11,10 @@ never been observed to fail are indistinguishable from assertions that cannot.
 
 Two things are counted, and one is already clean.
 
-  1. MUTATION COVERAGE. A suite carries an arm that deliberately breaks
+  1. MUTATION COVERAGE. A suite carries an executable arm that deliberately breaks
      something and requires the suite to notice - a mutated DUT, an illegal
-     parameter, a broken fixture. Thirty of fifty-four Verilator suites do.
+     parameter, a broken fixture. The inventory includes the superproject's
+     Verilator suites and the processor submodules' own RTL suites.
      This is a RATCHET: the number without one may only fall.
 
   2. REPLAYABLE RANDOMNESS. A test that draws random values without recording
@@ -36,7 +37,6 @@ Exit 0 = at or under the ratchets in scripts/test_evidence.budget.
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -44,32 +44,29 @@ REPO = Path(__file__).resolve().parent.parent
 BUDGET = Path(__file__).resolve().parent / "test_evidence.budget"
 SUITE_ROOT = REPO / "tb/verilator"
 
-#: A suite has a mutation arm when it deliberately breaks something and
-#: requires the break to be noticed. The vocabulary is the one this tree
-#: already uses in the suites that have one.
-ARM = re.compile(r"mutant|mutation|negative (?:arm|control|self-?test)"
-                 r"|deliberately broken|anti-vacuity|must fail|gate bites"
-                 r"|self-?test", re.I)
+#: Executable evidence, not prose claiming that a mutation once ran. A suite
+#: must expose a runnable target/command, a mutation table, an illegal-case
+#: table, or compile-time mutation defines that the driver actually exercises.
+ARM = re.compile(
+    r"(?m)^\s*(?:mutants?|negative|self-?test)\s*:"
+    r"|\bmutants?\.py\b|--self-?test\b|\bMUTATIONS?\s*="
+    r"|\bNEG_CASES\s*=|\bmutation_checks\s*\("
+    r"|-D[A-Za-z0-9_]*MUT[A-Za-z0-9_]*"
+    r"|\+define\+[A-Za-z0-9_]*MUT[A-Za-z0-9_]*", re.I)
 
 #: a random draw, and the seed that makes it replayable
 DRAW = re.compile(r"(?<![\w.])random\.(?:random|randint|choice|shuffle|randrange"
                   r"|uniform|sample|getrandbits)\s*\(|(?<![\w:])rand\s*\(\s*\)")
 SEED = re.compile(r"random\.Random\s*\(\s*\d|random\.seed\s*\(\s*\d|srand\s*\(\s*\d")
 
-EXCLUDED_PREFIXES = ("third_party/", "external/", "protocol-processor/",
-                     "gptp-processor/", "gen/", "build/")
-
-
-def tracked(*pats):
-    out = subprocess.run(["git", "ls-files", *pats], cwd=REPO,
-                         capture_output=True, text=True, check=True).stdout.split()
-    return [p for p in out if not p.startswith(EXCLUDED_PREFIXES)]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from code_quality_scope import tracked, tracked_exact
 
 
 def suite_text(name):
     """Everything a suite is made of: its makefile, harnesses and wrappers."""
     parts = []
-    for rel in tracked(f"tb/verilator/{name}/*"):
+    for rel in tracked_exact(f"{name}/*"):
         try:
             parts.append((REPO / rel).read_text(errors="replace"))
         except OSError:
@@ -78,12 +75,9 @@ def suite_text(name):
 
 
 def suites():
-    names = set()
-    for rel in tracked("tb/verilator/*/*"):
-        bits = rel.split("/")
-        if len(bits) >= 4:
-            names.add(bits[2])
-    return sorted(names)
+    makefiles = tracked("tb/verilator/*/Makefile", "tb/*/Makefile")
+    return sorted({str(Path(rel).parent) for rel in makefiles
+                   if "/tb/" in rel or rel.startswith("tb/")})
 
 
 def has_arm(text):
@@ -125,10 +119,12 @@ def selftest():
             failures += 1
             print(f"[FAIL] {name}{': ' + detail if detail else ''}")
 
-    ck("a suite naming a mutant is armed", has_arm("run mutants.py # mutant caught"))
-    ck("a suite naming a negative control is armed", has_arm("negative control: must fail"))
+    ck("a runnable mutant command is armed", has_arm("python3 mutants.py"))
+    ck("an executable negative target is armed", has_arm("negative:\n\t./broken-case"))
     ck("a suite with a self-test is armed", has_arm("python3 x.py --selftest"))
     ck("an ordinary suite is not armed", not has_arm("build and run the harness"))
+    ck("mutation prose alone is not an executable arm",
+       not has_arm("the mutation was run by hand and failed"))
 
     ck("an unseeded draw is caught", draws_without_seed("x = random.choice([1,2])"))
     ck("a seeded draw is not", not draws_without_seed("random.seed(11)\nx = random.choice([1,2])"))
@@ -145,7 +141,7 @@ def selftest():
        bool(armed) and bool(unarmed),
        "an inert classifier would put every suite on one side")
 
-    n = 12
+    n = 13
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -160,7 +156,7 @@ def main():
         return selftest()
 
     armed, unarmed, unseeded = audit()
-    print(f"Verilator suites with a mutation or negative arm: "
+    print(f"RTL suites with an executable mutation or negative arm: "
           f"{len(armed)} of {len(armed) + len(unarmed)}")
     print(f"\nsuites with none ({len(unarmed)}):")
     for name in unarmed:

--- a/scripts/measure_test_evidence.py
+++ b/scripts/measure_test_evidence.py
@@ -9,19 +9,28 @@ specification, its assertions are mutation-proven, and a pass publishes a
 non-zero tally. A suite can be green and prove nothing: assertions that have
 never been observed to fail are indistinguishable from assertions that cannot.
 
-Four things are counted or refused, and one is already clean.
+Four things are counted or refused.
 
-  1. MUTATION COVERAGE. A suite carries an executable arm that deliberately breaks
-     something and requires the suite to notice - a mutated DUT, an illegal
-     parameter, a broken fixture. The inventory includes the superproject's
-     Verilator suites and the processor submodules' own RTL suites.
-     This is a RATCHET: the number without one may only fall.
+  1. MUTATION COVERAGE. A suite carries an executable arm that deliberately
+     breaks something and requires the suite to notice. "Executable" is read
+     from the suite's Makefile, not from its prose: the arm must sit in the
+     recipe of a target that the suite's ENTRY runs (the sweep's bare `make`,
+     the processor's own suite runner or CI), and must be one of three shapes -
+     a mutation/negative driver script the recipe invokes, a compile-time
+     mutation define the recipe passes, or a negative-case table the recipe
+     consumes. A README sentence, a comment naming `mutants.py`, an empty
+     `mutants:` target and an unrelated `-DUSE_MUTEX` all count for nothing.
+     The inventory includes the superproject's Verilator suites and the
+     processor submodules' own RTL suites. This is a RATCHET: the number
+     without an arm may only fall.
 
   2. REPLAYABLE RANDOMNESS. A test that draws random values without recording
-     a seed cannot be replayed from its own failure. Every first-party file
-     that draws already seeds - this is measured and reported as ZERO, and it
-     must stay zero, because the cost of finding out otherwise is a flaky
-     failure nobody can reproduce.
+     a seed cannot be replayed from its own failure. The scan knows the idioms
+     of each language it reads (Python module and instance draws, `from random
+     import`, numpy, `secrets`; C `rand()`, `std::rand`, `random_device`;
+     SystemVerilog `$urandom`/`$random`/`randomize`) and the seed shapes that
+     make each replayable, and it reads code, not comments or strings. This is
+     a RATCHET; the guide records what it measures.
 
   3. DUT-SOURCE ORACLES. A high-signal inventory finds test programs that read
      production HDL text. The current readers are structural contract or
@@ -37,14 +46,36 @@ Four things are counted or refused, and one is already clean.
 
 Not counted here, because another gate already owns it: a missing or malformed
 tally is `NOCOUNT` in `scripts/suite_tally.py`, which refuses to let an unknown
-look like agreement. This script does not re-implement that judgement.
+look like agreement. This script imports that reader for its own arms instead
+of re-implementing the judgement. The superproject sweep is the population of
+that gate; the processor suites run under their own entries (see
+SUITE_TREES), and the protocol processor's reader is recorded as upstream debt
+in scripts/test_evidence.budget.
+
+KNOWN LIMITS, by name, so nobody rediscovers them:
+  - a package import in a testbench wrapper (`import x_pkg::*`) binds the
+    DUT's types and constants and is not read as a DUT-source reader; the live
+    wrappers carry no compare lines, and telling a structural import from an
+    oracle import needs a reading of each wrapper, not a pattern;
+  - `secrets.token_*` is a nonce (a container or file name), not a test draw;
+    the draw-shaped `secrets.randbelow/randbits/choice` are counted, and can
+    never be seeded;
+  - a deadline passed positionally (`asyncio.wait_for(coro, 5)`) is not seen;
+    the keyword form is;
+  - a Makefile conditional is read with every branch live, so an arm inside an
+    `ifeq` counts even when that branch would not be taken on the sweep host;
+  - a default-constructed C++ engine (`std::mt19937 g;`) is deterministic by
+    the standard and is not flagged; `srand(time(NULL))` is not a recorded
+    seed and is.
 
 Usage:
-    python3 scripts/measure_test_evidence.py            # both inventories
+    python3 scripts/measure_test_evidence.py            # the inventories
     python3 scripts/measure_test_evidence.py --check    # the ratchets
     python3 scripts/measure_test_evidence.py --selftest # fixture arms
 
-Exit 0 = at or under the ratchets in scripts/test_evidence.budget.
+Exit 0 = at or under the ratchets in scripts/test_evidence.budget; 1 = a
+ratchet is exceeded; 2 = the population could not be established (a missing
+entry file, no suites found), which no caller may read as a count of zero.
 """
 
 import argparse
@@ -54,29 +85,376 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 BUDGET = Path(__file__).resolve().parent / "test_evidence.budget"
-SUITE_ROOT = REPO / "tb/verilator"
 
-#: Executable evidence, not prose claiming that a mutation once ran. A suite
-#: must expose a runnable target/command, a mutation table, an illegal-case
-#: table, or compile-time mutation defines that the driver actually exercises.
-ARM = re.compile(
-    r"(?m)^\s*(?:mutants?|negative|self-?test)\s*:"
-    r"|\bmutants?\.py\b|--self-?test\b|\bMUTATIONS?\s*="
-    r"|\bNEG_CASES\s*=|\bmutation_checks\s*\("
-    r"|-D[A-Za-z0-9_]*MUT[A-Za-z0-9_]*"
-    r"|\+define\+[A-Za-z0-9_]*MUT[A-Za-z0-9_]*", re.I)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from code_quality_scope import tracked  # noqa: E402
+import suite_tally  # noqa: E402
 
-#: a random draw, and the seed that makes it replayable
-DRAW = re.compile(r"(?<![\w.])random\.(?:random|randint|choice|shuffle|randrange"
-                  r"|uniform|sample|getrandbits)\s*\(|(?<![\w:])rand\s*\(\s*\)")
-SEED = re.compile(r"random\.Random\s*\(\s*\d|random\.seed\s*\(\s*\d|srand\s*\(\s*\d")
+#: Every suite tree, and the files whose `make` invocations are its entry. A
+#: target is executed only if one of these runs it: the superproject sweep and
+#: the protocol processor's runner run bare `make` in every suite directory,
+#: the protocol processor's CI names one extra target by hand, and the gPTP
+#: processor's top-level Makefile is its only runner (it has no CI of its own).
+SUITE_TREES = (
+    ("tb/verilator", "", ("scripts/run_all_suites.sh",)),
+    ("protocol-processor/tb", "protocol-processor",
+     ("protocol-processor/scripts/run_suites.sh",
+      "protocol-processor/.github/workflows/hdl.yml")),
+    ("gptp-processor/tb/verilator", "gptp-processor", ("gptp-processor/Makefile",)),
+)
+
+# --- source hygiene ----------------------------------------------------------
+
+SLASH_FAMILY = {".c", ".cc", ".cpp", ".h", ".hpp", ".sv", ".svh", ".v"}
+HASH_FAMILY = {".py", ".sh", ""}  # "" is a Makefile
+
+
+def strip_source(text, suffix, strings=False):
+    """Drop comments and, if asked, string contents, so prose cannot arm or seed.
+
+    A `#` preceded by `$`, `{` or `\\` is shell parameter syntax, not a comment.
+    In the slash family only double quotes delimit strings; SystemVerilog's
+    `1'b0` and C's char literals make the apostrophe useless as a delimiter.
+    """
+    slash = suffix in SLASH_FAMILY
+    out, i, n = [], 0, len(text)
+    while i < n:
+        c = text[i]
+        if slash and text.startswith("//", i):
+            j = text.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if slash and text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            i = n if j < 0 else j + 2
+            continue
+        if not slash and c == "#" and (i == 0 or text[i - 1] not in "${\\"):
+            j = text.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if c == '"' or (c == "'" and not slash):
+            q = text[i:i + 3] if not slash and text[i:i + 3] in ('"""', "'''") else c
+            j = i + len(q)
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text.startswith(q, j):
+                    j += len(q)
+                    break
+                if len(q) == 1 and text[j] == "\n":
+                    break
+                j += 1
+            out.append(q + q if strings else text[i:j])
+            i = j
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+# --- 1. mutation coverage: what the entry actually executes -----------------
+
+MAKE_VAR = re.compile(r"^(?:override\s+|export\s+)?([.\w]+)\s*(::=|:=|\?=|\+=|=)\s*(.*)$")
+MAKE_RULE = re.compile(r"^([^\s=][^=]*?)\s*::?(?!=)\s*(.*)$")
+MAKE_REF = re.compile(r"\$\((\w[\w.]*)\)|\$\{(\w[\w.]*)\}")
+MAKE_SKIP = re.compile(r"^(?:ifeq|ifneq|ifdef|ifndef|else|endif|include|-include|sinclude|"
+                       r"vpath|unexport|\$\(eval)\b")
+#: `make ... -C <dir> [targets]` inside an entry file, and the runner form
+#: `cd "$d" && make [targets]`. The argument list stops at a shell operator.
+MAKE_CALL = re.compile(r"(?:\$\(MAKE\)|(?<![\w/.-])make)\s+([^;&|)>\n]*)")
+CD_MAKE_CALL = re.compile(r"cd\s+\"?(\$\{?\w+\}?)\"?/?\s*&&\s*make\b([^;&|)>\n]*)")
+SHELL_WORDS = {"if", "then", "else", "elif", "fi", "do", "done", "for", "while",
+               "until", "!", "{", "}", "in", "case", "esac", "exec", "time"}
+INTERPRETERS = re.compile(r"^(?:python[\d.]*|sh|bash|dash|env)$")
+#: A define that means "mutate", as a whole `_`-delimited word: NVM_MUT_MAP_ALIAS
+#: and X_MUTANT are; USE_MUTEX and COMMUTE are not.
+MUT_DEFINE = re.compile(r"(?:\+define\+|-D)([A-Za-z_]\w*)")
+MUT_NAME = re.compile(r"(?:^|_)MUT(?:ANTS?|ATIONS?|ATED?)?(?:_|$)")
+#: A negative/mutation table a recipe consumes, or a driver script carries.
+TABLE_VAR = re.compile(r"\$[({](MUTATIONS|MUTANTS|NEG_CASES|NEGATIVE_CASES)[)}]")
+DRIVER_TABLE = re.compile(r"(?m)^\s*(?:MUTATIONS|MUTANTS|NEG_CASES|NEGATIVE_CASES)\s*=|"
+                          r"\bmutation_checks\s*\(")
+REWRITE = re.compile(r"\.replace\s*\(")
+WRITES_BACK = re.compile(r"\.write_text\s*\(|\.write\s*\(|\bopen\s*\([^)]*[\"'][wa]")
+
+
+def parse_makefile(text):
+    """(variables, rules, first_target). rules: target -> (prereqs, recipe lines)."""
+    text = re.sub(r"\\\n[ \t]*", " ", strip_source(text, ""))
+    variables, rules, first, current, in_define = {}, {}, None, [], False
+    for line in text.splitlines():
+        if in_define:
+            in_define = not line.strip().startswith("endef")
+            continue
+        if line.startswith("\t"):
+            for target in current:
+                rules[target][1].append(line[1:].strip())
+            continue
+        s = line.strip()
+        if not s or MAKE_SKIP.match(s):
+            continue
+        if s.startswith("define "):
+            in_define = True
+            continue
+        m = MAKE_VAR.match(s)
+        if m:
+            name, op, value = m.groups()
+            if op == "+=":
+                variables[name] = (variables.get(name, "") + " " + value).strip()
+            elif op != "?=" or name not in variables:
+                variables[name] = value
+            current = []
+            continue
+        m = MAKE_RULE.match(s)
+        if m:
+            targets = m.group(1).split()
+            body = m.group(2)
+            prereqs, _, inline = body.partition(";")
+            current = targets
+            for target in targets:
+                rules.setdefault(target, [[], []])
+                rules[target][0].extend(prereqs.split())
+                if inline.strip():
+                    rules[target][1].append(inline.strip())
+                if first is None and not target.startswith("."):
+                    first = target
+            continue
+        current = []
+    return variables, rules, first
+
+
+def expand(value, variables, depth=0):
+    """Expand `$(NAME)` references; functions and automatic variables stay."""
+    if depth > 8:
+        return value
+
+    def rep(m):
+        name = m.group(1) or m.group(2)
+        if name in variables:
+            return expand(variables[name], variables, depth + 1)
+        return m.group(0)
+    return MAKE_REF.sub(rep, value)
+
+
+def make_invocations(text):
+    """[(dir, [targets])] for every `make` an entry file runs; dir None = cwd."""
+    calls = []
+    for m in CD_MAKE_CALL.finditer(text):
+        calls.append((m.group(1), [t for t in m.group(2).split() if not t.startswith("-")]))
+    for m in MAKE_CALL.finditer(text):
+        args, directory, targets, i = m.group(1).split(), None, [], 0
+        while i < len(args):
+            a = args[i]
+            if a == "-C" and i + 1 < len(args):
+                directory = args[i + 1].strip("\"'")
+                i += 2
+                continue
+            if a.startswith("-C"):
+                directory = a[2:].strip("\"'")
+            elif a in ("-j", "-l", "-f", "-o") and i + 1 < len(args):
+                i += 1
+            elif not a.startswith("-") and "=" not in a:
+                targets.append(a)
+            i += 1
+        if directory is not None:
+            calls.append((directory, targets))
+    return calls
+
+
+def entry_targets():
+    """suite -> set of targets its entries run ("" = the default goal)."""
+    out = {}
+    for tree, root, entries in SUITE_TREES:
+        for entry in entries:
+            path = REPO / entry
+            if not path.is_file():
+                print(f"REFUSED: suite entry {entry} is missing, so which targets "
+                      f"the {tree} suites execute cannot be established", file=sys.stderr)
+                sys.exit(2)
+            for directory, targets in make_invocations(path.read_text(errors="replace")):
+                goals = set(targets) or {""}
+                if "$" in directory:
+                    key = ("*", tree)
+                else:
+                    key = "/".join(p for p in (root, directory.strip("/")) if p)
+                out.setdefault(key, set()).update(goals)
+    return out
+
+
+def suite_entries(suite, table):
+    goals = set(table.get(suite, ()))
+    for tree, _root, _entries in SUITE_TREES:
+        if suite.startswith(tree + "/"):
+            goals |= table.get(("*", tree), set())
+    return goals
+
+
+def reachable_targets(variables, rules, first, goals):
+    stack = [variables.get(".DEFAULT_GOAL", first) if g == "" else g for g in goals]
+    seen = set()
+    while stack:
+        target = stack.pop()
+        if target is None or target in seen or target not in rules:
+            continue
+        seen.add(target)
+        prereqs, recipe = rules[target]
+        stack.extend(expand(" ".join(prereqs), variables).split())
+        for line in recipe:
+            for m in MAKE_CALL.finditer(expand(line, variables)):
+                stack.extend(t for t in m.group(1).split()
+                             if not t.startswith("-") and "=" not in t)
+    return seen
+
+
+def commands(line):
+    """The (command, argument) pairs a recipe line runs, per shell segment."""
+    pairs = []
+    for segment in re.split(r"\s*(?:;|&&|\|\||\|)\s*", line):
+        words = [w for w in segment.split() if w]
+        while words and (words[0].lstrip("@-+") in SHELL_WORDS
+                         or re.match(r"^\w+=", words[0]) or not words[0].lstrip("@-+")):
+            words.pop(0)
+        if not words:
+            continue
+        cmd = words[0].lstrip("@-+")
+        rest = [w for w in words[1:] if not w.startswith("-")]
+        pairs.append((cmd, rest[0] if rest else None))
+    return pairs
+
+
+def is_driver(text, suffix):
+    """A script that carries a mutation/negative table, or rewrites the DUT
+    text it reads and runs the harness on the result."""
+    code = strip_source(text, suffix, strings=True)
+    if DRIVER_TABLE.search(code):
+        return True
+    return bool(reads_dut_source(text, suffix) and REWRITE.search(code)
+                and WRITES_BACK.search(strip_source(text, suffix)))
+
+
+def arms(makefile, goals, scripts):
+    """Every executable arm: (target, kind, detail). `scripts` maps a script's
+    basename to its text; only .py/.sh files are consulted, never prose."""
+    variables, rules, first = parse_makefile(makefile)
+    found = []
+    for target in sorted(reachable_targets(variables, rules, first, goals)):
+        for raw in rules[target][1]:
+            line = expand(raw, variables)
+            for m in MUT_DEFINE.finditer(line):
+                if MUT_NAME.search(m.group(1)):
+                    found.append((target, "define", m.group(0)))
+            for m in TABLE_VAR.finditer(raw):
+                if expand(m.group(0), variables).strip() not in ("", m.group(0)):
+                    found.append((target, "table", m.group(0)))
+            for cmd, arg in commands(line):
+                candidate = arg if INTERPRETERS.match(cmd) and arg else cmd
+                name = candidate.rsplit("/", 1)[-1].strip("\"'")
+                suffix = Path(name).suffix
+                if suffix in (".py", ".sh") and name in scripts \
+                        and is_driver(scripts[name], suffix):
+                    found.append((target, "driver", name))
+    return found
+
+
+def suites():
+    makefiles = tracked("tb/verilator/*/Makefile", "tb/*/Makefile")
+    return sorted({str(Path(rel).parent) for rel in makefiles
+                   if "/tb/" in rel or rel.startswith("tb/")})
+
+
+def suite_files():
+    """suite -> every tracked file under it, from one listing of the trees."""
+    files = tracked("tb/*")
+    return {name: [rel for rel in files if rel.startswith(name + "/")] for name in suites()}
+
+
+def suite_arms(name, files, table):
+    scripts = {Path(rel).name: (REPO / rel).read_text(errors="replace")
+               for rel in files if Path(rel).suffix in (".py", ".sh")}
+    makefile = (REPO / name / "Makefile").read_text(errors="replace")
+    return arms(makefile, suite_entries(name, table), scripts)
+
+
+# --- 2. replayable randomness ---------------------------------------------
+
+PY_DRAWS = ("random|randint|randrange|choice|choices|shuffle|sample|uniform|gauss|"
+            "normalvariate|lognormvariate|expovariate|betavariate|gammavariate|"
+            "triangular|vonmisesvariate|paretovariate|weibullvariate|getrandbits|randbytes")
+PY_MODULE_DRAW = re.compile(rf"(?<![\w.])random\.(?:{PY_DRAWS})\s*\(")
+PY_MODULE_SEED = re.compile(r"(?<![\w.])random\.seed\s*\(\s*[^\s)]")
+PY_INSTANCE = re.compile(r"([\w.]+)\s*=\s*random\.(Random|SystemRandom)\s*\(\s*([^)]*)\)")
+PY_FROM_IMPORT = re.compile(r"^\s*from\s+random\s+import\s+\(?([^)\n]+)", re.M)
+PY_BARE_SEED = re.compile(r"(?<![\w.])seed\s*\(\s*[^\s)]")
+NP_DRAW = re.compile(r"\b(?:np|numpy)\.random\.(?!seed\b|default_rng\b|RandomState\b)\w+\s*\("
+                     r"|\b(?:np|numpy)\.random\.(?:default_rng|RandomState)\s*\(\s*\)")
+NP_SEED = re.compile(r"\b(?:np|numpy)\.random\.(?:seed|default_rng|RandomState)\s*\(\s*[^\s)]")
+SECRETS_DRAW = re.compile(r"\bsecrets\.(?:randbelow|randbits|choice)\s*\(")
+C_DRAW = re.compile(r"(?<![\w:.>])(?:std::)?rand\s*\(\s*\)|(?<![\w:.>])(?:std::)?random\s*\(\s*\)"
+                    r"|\b[ld]?rand48\s*\(|\brandom_device\b")
+C_SEED = re.compile(r"\bsrand(?:om|48)?\s*\(\s*(?!(?:std::)?time\s*\(|(?:std::)?random_device)[^\s)]")
+SEED_RECORDED = re.compile(r"\"[^\"\n]*\bseed\b[^\"\n]*\"", re.I)
+SV_DRAW = re.compile(r"\$urandom(?:_range)?\b|\$random\b|\.randomize\s*\(")
+SV_SEED = re.compile(r"\bsrandom\s*\(|\$urandom\s*\(\s*[^\s)]|\$random\s*\(\s*[^\s)]"
+                     r"|\$value\$plusargs\s*\(\s*\"[^\"]*(?i:seed)")
+
+
+def unseeded_draws(text, suffix):
+    """The random-draw shapes in `text` that no recorded seed makes replayable."""
+    code = strip_source(text, suffix, strings=True)
+    seedable = strip_source(text, suffix)
+    found = []
+    if suffix == ".py":
+        if PY_MODULE_DRAW.search(code) and not PY_MODULE_SEED.search(code):
+            found.append("random.<draw>() without random.seed(...)")
+        for name, cls, arg in PY_INSTANCE.findall(code):
+            if re.search(rf"(?<![\w.]){re.escape(name)}\.(?:{PY_DRAWS})\s*\(", code):
+                if cls == "SystemRandom":
+                    found.append(f"{name} = random.SystemRandom() cannot be seeded")
+                elif not arg.strip():
+                    found.append(f"{name} = random.Random() carries no seed")
+        for m in PY_FROM_IMPORT.finditer(code):
+            names = [n.strip().split(" as ")[-1].strip() for n in m.group(1).split(",")]
+            for n in names:
+                if n in PY_DRAWS.split("|") and re.search(rf"(?<![\w.]){n}\s*\(", code) \
+                        and not (PY_MODULE_SEED.search(code) or PY_BARE_SEED.search(code)):
+                    found.append(f"from random import {n} without seed(...)")
+        if NP_DRAW.search(code) and not NP_SEED.search(code):
+            found.append("numpy draw without np.random.seed/default_rng(seed)")
+        if SECRETS_DRAW.search(code):
+            found.append("secrets draw (never seedable)")
+    elif suffix in SLASH_FAMILY and suffix not in (".sv", ".svh", ".v"):
+        if C_DRAW.search(code) and not C_SEED.search(code):
+            if not ("random_device" in code and SEED_RECORDED.search(seedable)):
+                found.append("C draw without a recorded srand/seed")
+    elif suffix in (".sv", ".svh", ".v"):
+        if SV_DRAW.search(code) and not SV_SEED.search(seedable):
+            found.append("$urandom/$random/randomize without srandom or a seed")
+    return found
+
+
+def draws_without_seed(text, suffix=".py"):
+    return bool(unseeded_draws(text, suffix))
+
+
+def seed_population():
+    return sorted(tracked("tb/*.py", "tb/*.cpp", "tb/*.cc", "tb/*.c", "tb/*.h",
+                          "tb/*.sv", "tb/*.svh", "tb/*.v", "tb/*.sh",
+                          "sw/*.py", "scripts/*.py", "tests/*.py"))
+
+
+# --- 3. DUT-source oracles --------------------------------------------------
 
 # Reading the DUT is not automatically wrong: mutation arms must rewrite the
 # DUT and structural contract checks must inspect it. It is, however, the
 # smallest useful static population for an implementation-derived-oracle
 # review. Every present reader has a narrow recorded reason; a new one is debt
 # until it is classified.
-DUT_READ = re.compile(r"\bread_text\s*\(")
+DUT_READ_PY = re.compile(r"\bread_text\s*\(|\bread_bytes\s*\(|\bopen\s*\(|\.read\s*\(|\.readlines\s*\(")
+DUT_READ_C = re.compile(r"\bifstream\b|\bfopen\s*\(|\bstd::filesystem\b")
+DUT_READ_SV = re.compile(r"`include\s+\"[^\"\n]*hdl/|\$fopen\s*\(|\$readmem[hb]\s*\(")
+DUT_READ_SH = re.compile(r"(?m)^[^\n]*\b(?:cat|grep|sed|awk|head|tail|diff)\b[^\n]*"
+                         r"(?:hdl/|\$[({](?:RTL|HDL)\w*[)}])")
 DUT_PATH = re.compile(r"\b(?:RTL|FILTER)\s*=|[\"'][^\"'\n]*hdl/")
 DUT_READER_DISPOSITIONS = {
     "gptp-processor/tb/check_phc_contract.py":
@@ -89,63 +467,60 @@ DUT_READER_DISPOSITIONS = {
         "mutation campaign; it injects three RTL defects and requires failure",
 }
 
+
+def reads_dut_source(text, suffix=".py"):
+    code = strip_source(text, suffix)
+    if suffix in (".sh", ""):
+        return bool(DUT_READ_SH.search(code))
+    if suffix in (".sv", ".svh", ".v"):
+        return bool(DUT_READ_SV.search(code) and DUT_PATH.search(code))
+    reader = DUT_READ_C if suffix in SLASH_FAMILY else DUT_READ_PY
+    return bool(reader.search(code) and DUT_PATH.search(code))
+
+
+# --- 4. wall-clock dependence ----------------------------------------------
+
 # Host time can vary with machine load. This deliberately ignores identifiers
-# such as `timeout_cycles`: protocol time advanced by explicit DUT ticks is a
-# deterministic oracle. It catches actual host clocks, sleeps, socket deadlines
-# and subprocess deadlines.
-WALL_CLOCK = re.compile(
-    r"\btime\.(?:time|monotonic|sleep)\s*\(|\.settimeout\s*\("
-    r"|\b(?:subprocess\.)?(?:run|wait)\s*\([^)]*\btimeout\s*=", re.S)
-
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from code_quality_scope import tracked, tracked_exact
-
-
-def suite_text(name):
-    """Everything a suite is made of: its makefile, harnesses and wrappers."""
-    parts = []
-    for rel in tracked_exact(f"{name}/*"):
-        try:
-            parts.append((REPO / rel).read_text(errors="replace"))
-        except OSError:
-            pass
-    return "\n".join(parts)
+# such as `timeout_cycles` and `int timeout = 100`: protocol time advanced by
+# explicit DUT ticks is a deterministic oracle. It catches actual host clocks,
+# sleeps, socket deadlines and subprocess deadlines, in each language's idiom.
+PY_CLOCK = re.compile(r"\btime\.(?:time|monotonic|perf_counter|sleep|time_ns|monotonic_ns|"
+                      r"perf_counter_ns)\s*\(|\bdatetime\.(?:now|utcnow|today)\s*\("
+                      r"|\.settimeout\s*\(|\bselect\.select\s*\(|\bsignal\.alarm\s*\("
+                      r"|\bSO_(?:RCV|SND)TIMEO\b")
+PY_DEADLINE_CALL = re.compile(r"(?:\b(?:subprocess\.)?(?:run|call|check_call|check_output|Popen)"
+                              r"|\.communicate|\.wait|\bwait_for|\.join|\.get|\.acquire"
+                              r"|\.connect|\.recv)\s*\(")
+C_CLOCK = re.compile(r"\bstd::chrono\b|\bchrono::|\bsteady_clock\b|\bsystem_clock\b"
+                     r"|\bhigh_resolution_clock\b|(?<![\w:.>])clock\s*\(\s*\)"
+                     r"|(?<![\w:.>])time\s*\(\s*(?:NULL|0|nullptr)?\s*\)|\bgettimeofday\s*\("
+                     r"|\bclock_gettime\s*\(|(?<![\w:.>])(?:u|nano)?sleep\s*\(|\balarm\s*\("
+                     r"|\bSO_(?:RCV|SND)TIMEO\b")
+SH_CLOCK = re.compile(r"^\s*[-@+]*\s*timeout\s+\S|(?<![\w.$])sleep\s+[0-9.]|\$\(shell\s+date\b"
+                      r"|^\s*[-@+]*\s*date\b|(?<![\w.$])date\s+\+", re.M)
 
 
-def suites():
-    makefiles = tracked("tb/verilator/*/Makefile", "tb/*/Makefile")
-    return sorted({str(Path(rel).parent) for rel in makefiles
-                   if "/tb/" in rel or rel.startswith("tb/")})
+def call_with_keyword(code, call, keyword):
+    """Does any `call(` carry `keyword=` inside its own (balanced) parentheses?"""
+    for m in call.finditer(code):
+        depth, i = 1, m.end()
+        while i < len(code) and depth:
+            depth += {"(": 1, ")": -1}.get(code[i], 0)
+            i += 1
+        if re.search(rf"\b{keyword}\s*=", code[m.end():i]):
+            return True
+    return False
 
 
-def has_arm(text):
-    return bool(ARM.search(text))
-
-
-def draws_without_seed(text):
-    return bool(DRAW.search(text)) and not SEED.search(text)
-
-
-def test_sources():
-    suffixes = {".py", ".cpp", ".cc", ".c", ".sv", ".v", ".sh"}
-    return sorted(rel for rel in tracked("tb/*", "tb/**/*")
-                  if Path(rel).suffix in suffixes or Path(rel).name == "Makefile")
-
-
-def suite_sources():
-    """Executable files owned by a directory that the suite inventory names."""
-    suffixes = {".py", ".cpp", ".cc", ".c", ".sv", ".v", ".sh"}
-    paths = {rel for name in suites() for rel in tracked_exact(f"{name}/*")}
-    return sorted(rel for rel in paths
-                  if Path(rel).suffix in suffixes or Path(rel).name == "Makefile")
-
-
-def reads_dut_source(text):
-    return bool(DUT_READ.search(text) and DUT_PATH.search(text))
-
-
-def uses_wall_clock(text):
-    return bool(WALL_CLOCK.search(text))
+def uses_wall_clock(text, suffix=".py"):
+    code = strip_source(text, suffix)
+    if suffix == ".py":
+        return bool(PY_CLOCK.search(code) or call_with_keyword(code, PY_DEADLINE_CALL, "timeout"))
+    if suffix in (".sh", ""):
+        return bool(SH_CLOCK.search(code))
+    if suffix in SLASH_FAMILY and suffix not in (".sv", ".svh", ".v"):
+        return bool(C_CLOCK.search(code))
+    return False
 
 
 def runner_contract(text):
@@ -169,27 +544,47 @@ def runner_contract(text):
     return problems
 
 
+# --- the audit ---------------------------------------------------------------
+
+def test_sources():
+    suffixes = {".py", ".cpp", ".cc", ".c", ".h", ".sv", ".svh", ".v", ".sh"}
+    return sorted(rel for rel in tracked("tb/*")
+                  if Path(rel).suffix in suffixes or Path(rel).name == "Makefile")
+
+
+def suite_sources(by_suite):
+    """Executable files owned by a directory that the suite inventory names."""
+    suffixes = {".py", ".cpp", ".cc", ".c", ".h", ".sv", ".svh", ".v", ".sh"}
+    paths = {rel for files in by_suite.values() for rel in files}
+    return sorted(rel for rel in paths
+                  if Path(rel).suffix in suffixes or Path(rel).name == "Makefile")
+
+
+def file_suffix(rel):
+    return "" if Path(rel).name == "Makefile" else Path(rel).suffix
+
+
 def audit():
-    armed, unarmed = [], []
-    for name in suites():
-        (armed if has_arm(suite_text(name)) else unarmed).append(name)
+    table = entry_targets()
+    by_suite = suite_files()
+    armed, unarmed = {}, []
+    for name, files in by_suite.items():
+        found = suite_arms(name, files, table)
+        if found:
+            armed[name] = found
+        else:
+            unarmed.append(name)
 
-    unseeded = []
-    for rel in tracked("tb/**/*.py", "sw/**/*.py", "scripts/*.py", "tests/**/*.py",
-                       "tb/**/*.cpp"):
-        if draws_without_seed((REPO / rel).read_text(errors="replace")):
-            unseeded.append(rel)
+    unseeded = {}
+    for rel in seed_population():
+        shapes = unseeded_draws((REPO / rel).read_text(errors="replace"), file_suffix(rel))
+        if shapes:
+            unseeded[rel] = shapes
 
-    readers = []
-    for rel in test_sources():
-        text = (REPO / rel).read_text(errors="replace")
-        if reads_dut_source(text):
-            readers.append(rel)
-    wallclock = []
-    for rel in suite_sources():
-        text = (REPO / rel).read_text(errors="replace")
-        if uses_wall_clock(text):
-            wallclock.append(rel)
+    readers = [rel for rel in test_sources()
+               if reads_dut_source((REPO / rel).read_text(errors="replace"), file_suffix(rel))]
+    wallclock = [rel for rel in suite_sources(by_suite)
+                 if uses_wall_clock((REPO / rel).read_text(errors="replace"), file_suffix(rel))]
     unexplained = sorted(set(readers) - set(DUT_READER_DISPOSITIONS))
     stale = sorted(set(DUT_READER_DISPOSITIONS) - set(readers))
     return armed, unarmed, unseeded, readers, unexplained, stale, wallclock
@@ -202,39 +597,196 @@ def read_budget():
     return (vals + [None, None, None, None])[:4]
 
 
+# --- self-test ---------------------------------------------------------------
+
 def selftest():
-    failures = 0
+    failures = total = 0
 
     def ck(name, ok, detail=""):
-        nonlocal failures
+        nonlocal failures, total
+        total += 1
         if ok:
             print(f"[PASS] {name}")
         else:
             failures += 1
             print(f"[FAIL] {name}{': ' + detail if detail else ''}")
 
-    ck("a runnable mutant command is armed", has_arm("python3 mutants.py"))
-    ck("an executable negative target is armed", has_arm("negative:\n\t./broken-case"))
-    ck("a suite with a self-test is armed", has_arm("python3 x.py --selftest"))
-    ck("an ordinary suite is not armed", not has_arm("build and run the harness"))
+    # -- 1. an arm is what the entry executes --------------------------------
+    driver = ("MUTATIONS = [\n  ('x', 'a', 'b'),\n]\n"
+              "def main():\n    return 0\n")
+    default = {""}
+    ck("a reachable target running a mutation driver is armed",
+       bool(arms("all: run mutants\nrun:\n\t./sim\nmutants:\n\tpython3 mutants.py\n",
+                 default, {"mutants.py": driver})))
+    ck("the driver may be reached through a make variable ($(PY) x.py)",
+       bool(arms("PY ?= python3\nall: graderself\ngraderself:\n\t@$(PY) test_grade_tx.py\n",
+                 default, {"test_grade_tx.py": "def mutation_checks(t):\n    pass\n"})))
+    ck("a driver on a target the entry never runs is not an arm",
+       not arms("run:\n\t./sim\nfigures:\n\tpython3 $(CURDIR)/measure_figures.py --check\n",
+                default, {"measure_figures.py": driver}))
+    ck("...until the processor's CI names that target",
+       bool(arms("run:\n\t./sim\nfigures:\n\tpython3 $(CURDIR)/measure_figures.py --check\n",
+                 {"", "figures"}, {"measure_figures.py": driver})))
+    ck("a compile-time mutation define a recipe passes is armed",
+       bool(arms("all: obj_mut/V\nobj_mut/V:\n\tverilator +define+NVM_MUT_MAP_ALIAS x.sv\n",
+                 default, {})))
+    ck("a mutation define reaches the recipe through variable expansion",
+       bool(arms("MUTFLAGS = -DCORE_MUTANT_1\nall:\n\tg++ $(MUTFLAGS) x.cpp\n", default, {})))
+    ck("a negative-case table the recipe consumes is armed",
+       bool(arms("NEG_CASES = W=32 N=0\nall: negative\nnegative:\n\tfor c in $(NEG_CASES); do "
+                 "$(V) -G$$c; done\n", default, {})))
+    ck("a DUT-rewriting driver with no table is still a driver",
+       bool(arms("all: run neg\nrun:\n\t./sim\nneg: run\n\tpython3 binding_mutant.py\n", default,
+                 {"binding_mutant.py": 'FILTER = HERE / "../../../hdl/f.sv"\n'
+                  'src = FILTER.read_text()\nout.write_text(src.replace(A, B))\n'})))
+    ck("a DUT reader that rewrites nothing is not a driver",
+       not arms("all:\n\tpython3 check.py\n", default,
+                {"check.py": 'src = open("../hdl/x.sv").read()\nassert "port" in src\n'}))
+    ck("(A) a suite whose entry runs nothing is not armed",
+       not arms("all:\n\t@true\n# no mutant or negative arm here\n", default, {}))
+    ck("(B) a comment naming mutants.py is not an arm",
+       not arms("# TODO: write a mutants.py like tcam\nall:\n\t./sim\n", default,
+                {"mutants.py": driver}))
+    ck("(C) an unrelated -DUSE_MUTEX define is not an arm, even when passed",
+       not arms("CFLAGS += -DUSE_MUTEX\nall:\n\tg++ $(CFLAGS) x.cpp\n", default, {}))
+    ck("(D) an empty mutants: target is not an arm",
+       not arms("all: mutants\nmutants:\n\t@true\n", default, {"mutants.py": driver}))
+    ck("(E) README prose about a negative arm is not an arm",
+       not arms("all:\n\t./sim\n", default,
+                {"README.md": "Negative: none of the checks has a negative arm yet.\n"
+                              "MUTATIONS = see above\n"}))
+    ck("(F) a comment mentioning --selftest is not an arm",
+       not arms("# run with --selftest to see the fixtures\nall:\n\t./sim\n", default, {}))
+    ck("a driver named as an echo argument is not run, so not an arm",
+       not arms("all:\n\t@echo mutants.py\n", default, {"mutants.py": driver}))
+    ck("a table variable nobody's recipe consumes is not an arm",
+       not arms("NEG_CASES = W=32\nall:\n\t./sim\n", default, {}))
     ck("mutation prose alone is not an executable arm",
-       not has_arm("the mutation was run by hand and failed"))
+       not arms("all:\n\t./sim\n# the mutation was run by hand and failed\n", default, {}))
+    ck("a comment marker inside the driver does not make it one",
+       not arms("all:\n\tpython3 x.py\n", default, {"x.py": "# MUTATIONS = none yet\nrun()\n"}))
+    calls = make_invocations('for d in tb/*/; do\n  if (cd "$d" && make) >"$log" 2>&1; then\n'
+                             'make -C tb/nvm_port figures\n$(MAKE) -C tb/verilator/ucpu\n')
+    ck("the entry reader sees the loop, the named target and the sub-make",
+       calls == [("$d", []), ("tb/nvm_port", ["figures"]), ("tb/verilator/ucpu", [])], str(calls))
 
+    # -- 2. replayable randomness, one arm per idiom ----------------------
     ck("an unseeded draw is caught", draws_without_seed("x = random.choice([1,2])"))
     ck("a seeded draw is not", not draws_without_seed("random.seed(11)\nx = random.choice([1,2])"))
     ck("a Random(seed) instance counts as seeded",
-       not draws_without_seed("rng = random.Random(13)\nx = random.choice([1,2])"))
+       not draws_without_seed("rng = random.Random(13)\nx = rng.choice([1,2])"))
+    ck("the guide's TEST_SEED pattern is clean",
+       not draws_without_seed('seed = int(os.environ.get("TEST_SEED", "23"))\n'
+                              'print(f"TEST_SEED={seed}")\nrng = random.Random(seed)\n'
+                              'frame = bytes(rng.randrange(256) for _ in range(64))\n'))
+    ck("an unseeded random.Random() instance draw is caught",
+       draws_without_seed("_rng = random.Random()\n_probe = _rng.randint(0, 9)\n"))
+    ck("a SystemRandom draw is caught (it cannot be seeded)",
+       draws_without_seed("g = random.SystemRandom()\nx = g.random()\n"))
+    ck("from random import randint is caught",
+       draws_without_seed("from random import randint\nx = randint(0, 9)\n"))
+    ck("...and seeded through seed() is not",
+       not draws_without_seed("from random import randint, seed\nseed(7)\nx = randint(0, 9)\n"))
+    ck("random.choices and random.gauss are draws",
+       draws_without_seed("a = random.choices(p, k=2)\n") and draws_without_seed("b = random.gauss(0, 1)\n"))
+    ck("np.random draws are caught",
+       draws_without_seed("import numpy as np\n_probe = np.random.randint(0, 9)\n"))
+    ck("...and np.random.seed / default_rng(seed) make them replayable",
+       not draws_without_seed("np.random.seed(3)\nx = np.random.randint(0, 9)\n")
+       and not draws_without_seed("g = np.random.default_rng(7)\n")
+       and draws_without_seed("g = np.random.default_rng()\n"))
+    ck("secrets.randbelow is a draw that can never be seeded",
+       draws_without_seed("import secrets\nx = secrets.randbelow(10)\n"))
+    ck("secrets.token_hex is a nonce, not a draw (known limit)",
+       not draws_without_seed("name = f'ci-{secrets.token_hex(16)}'\n"))
     ck("a file that never draws is not counted", not draws_without_seed("x = 1"))
-    ck("a C rand() with no srand is caught", draws_without_seed("int x = rand();"))
-    ck("a C rand() with srand is not", not draws_without_seed("srand(7); int x = rand();"))
+    ck("a C rand() with no srand is caught", draws_without_seed("int x = rand();", ".cpp"))
+    ck("a C rand() with srand is not", not draws_without_seed("srand(7); int x = rand();", ".cpp"))
+    ck("std::rand() is caught", draws_without_seed("static int p = std::rand();", ".cpp"))
+    ck("srand(time(NULL)) is not a recorded seed",
+       draws_without_seed("srand(time(NULL)); int x = rand();", ".cpp"))
+    ck("mt19937(random_device) is caught",
+       draws_without_seed("std::mt19937 _g(std::random_device{}()); int x = _g();", ".cpp"))
+    ck("...unless the seed it produced is recorded",
+       not draws_without_seed('unsigned seed = std::random_device{}(); printf("seed=%u\\n", seed);'
+                              ' std::mt19937 g(seed);', ".cpp"))
+    ck("a literally seeded engine is deterministic",
+       not draws_without_seed("std::mt19937 rng(0xC0FFEE); int x = rng();", ".cpp"))
+    ck("$urandom with no seed is caught", draws_without_seed("a = $urandom;", ".sv"))
+    ck("$urandom_range and $random are caught",
+       draws_without_seed("a = $urandom_range(0, 7);", ".sv") and draws_without_seed("b = $random;", ".sv"))
+    ck("randomize() is a draw", draws_without_seed("if (!pkt.randomize()) $error;", ".svh"))
+    ck("srandom(seed) makes SystemVerilog draws replayable",
+       not draws_without_seed("initial begin $display(seed); process::self().srandom(seed);"
+                              " a = $urandom; end", ".sv"))
+    ck("$urandom(seed) is a seeded draw",
+       not draws_without_seed("a = $urandom(seed); b = $urandom_range(0, 7);", ".sv"))
+    ck("a +seed plusarg records the seed",
+       not draws_without_seed('if (!$value$plusargs("seed=%d", seed)) seed = 1; a = $urandom;', ".sv"))
+    ck("a draw in a comment is not a draw",
+       not draws_without_seed("// calls rand() nowhere\nint x = 1;", ".cpp")
+       and not draws_without_seed("# random.randint(0, 9) would be wrong here\nx = 1\n"))
+    ck("a draw inside a string literal is not a draw",
+       not draws_without_seed('msg = "x = random.randint(0, 9)"\n'))
+    population = seed_population()
+    ck("a depth-1 file of each tb/tests root is in the seed population",
+       "gptp-processor/tb/check_phc_contract.py" in population
+       and "tests/environment.py" in population, f"{len(population)} files")
+    ck("SystemVerilog under tb/ is in the seed population",
+       any(rel.endswith(".sv") for rel in population))
 
+    # -- 3. DUT-source oracles, one arm per idiom ------------------------
     ck("a test reading an HDL source is an oracle-review candidate",
        reads_dut_source('RTL = ROOT / "hdl/block.sv"\nsrc = RTL.read_text()'))
+    ck("open(...hdl...).read() is a reader",
+       reads_dut_source('_s = open("../../hdl/packet_engine/KL_pp_nvm_port.sv").read()\n'))
+    ck("readlines() over an hdl path is a reader",
+       reads_dut_source('lines = open(RTL_PATH).readlines()\nRTL_PATH = "../hdl/x.sv"\n'))
+    ck("a C++ ifstream over an hdl path is a reader",
+       reads_dut_source('std::ifstream f("../../hdl/x.sv");', ".cpp"))
+    ck("an SV `include of production HDL is a reader",
+       reads_dut_source('`include "../../hdl/pkg/x_pkg.svh"', ".sv"))
+    ck("a Makefile grep over $(RTL_DIR) is a reader",
+       reads_dut_source("check:\n\tgrep -c localparam $(RTL_DIR)/x.sv\n", ""))
+    ck("a package import is a binding, not a reader (known limit)",
+       not reads_dut_source("import x_pkg::*;\nmodule wrap;\nendmodule\n", ".sv"))
     ck("an ordinary behavioral harness is not a source-reader candidate",
-       not reads_dut_source("expect(got, 7);"))
+       not reads_dut_source("expect(got, 7);", ".cpp"))
+    ck("a reader mentioned only in a comment is not one",
+       not reads_dut_source('# src = open("../hdl/x.sv").read()\nx = 1\n'))
+
+    # -- 4. wall-clock dependence, one arm per idiom ---------------------
     ck("host sleep is wall-clock dependent", uses_wall_clock("time.sleep(0.02)"))
     ck("a cycle timeout is deterministic",
-       not uses_wall_clock("for (int timeout_cycles = 0; timeout_cycles < 32; ++timeout_cycles) tick();"))
+       not uses_wall_clock("for (int timeout_cycles = 0; timeout_cycles < 32; ++timeout_cycles) tick();", ".cpp"))
+    ck("an int named timeout is not a deadline", not uses_wall_clock("int timeout = 100;", ".cpp"))
+    ck("std::chrono is a host clock", uses_wall_clock("auto t = std::chrono::steady_clock::now();", ".cpp"))
+    ck("clock() and usleep() are host time",
+       uses_wall_clock("double t = clock();", ".cpp") and uses_wall_clock("usleep(1000);", ".cpp"))
+    ck("check_output(..., timeout=) is a process deadline",
+       uses_wall_clock('subprocess.check_output(["true"], timeout=5)'))
+    ck("a timeout keyword after a nested call is still seen",
+       uses_wall_clock("subprocess.run(build(x), timeout=30)"))
+    ck("communicate(timeout=) and select.select are deadlines",
+       uses_wall_clock("out, _ = p.communicate(timeout=10)") and uses_wall_clock("select.select([s], [], [], 1)"))
+    ck("asyncio.wait_for(..., timeout=) is a deadline; a cycle-bounded wait_for is not",
+       uses_wall_clock("await asyncio.wait_for(evt.wait(), timeout=2)")
+       and not uses_wall_clock("wait_for(dut, done, 200);", ".cpp"))
+    ck("SO_RCVTIMEO is a socket deadline", uses_wall_clock("s.setsockopt(SOL_SOCKET, SO_RCVTIMEO, tv)"))
+    ck("a shell sleep and a Makefile timeout are host time",
+       uses_wall_clock("sleep 2\n", ".sh") and uses_wall_clock("run:\n\ttimeout 60 ./obj_dir/Vsim\n", ""))
+    ck("a comment about sleeping is not host time", not uses_wall_clock("# time.sleep(1) removed\n"))
+
+    # -- tally evidence: the superproject reader refuses the processor shapes
+    scan, nocount = suite_tally.scan, suite_tally.is_nocount
+    c, f, matched, _u, skipped = scan("0 checks: 0 PASS, 0 FAIL\n")
+    ck("a zero tally is NOCOUNT, not a pass", nocount(c, f, matched, skipped))
+    ck("every tally line is summed, not only the last",
+       scan("12 checks: 12 PASS, 0 FAIL\n3 checks: 3 PASS, 0 FAIL\n")[0] == 15)
+    ck("both processor tally shapes are read",
+       scan("checks: 19   failures: 0\n")[0] == 19 and scan("== co-sim: 42 pass, 0 fail ==\n")[0] == 42)
+    ck("a [FAIL] line contradicts a green exit",
+       suite_tally.log_reports_failure("  [FAIL] priority   got=1 exp=0\n")[1])
 
     runner = (REPO / "scripts/run_all_suites.sh").read_text()
     ck("the live runner preserves timeout and tally verdicts",
@@ -248,17 +800,18 @@ def selftest():
     ck("both sides of the mutation split are non-empty",
        bool(armed) and bool(unarmed),
        "an inert classifier would put every suite on one side")
+    ck("every live arm sits on a target the entry executes",
+       all(found for found in armed.values()))
     ck("every DUT-source reader has a current disposition",
        not unexplained and not stale, f"unexplained={unexplained}, stale={stale}")
 
-    n = 20
-    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    print(f"\n{total} checks: {total - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--check", action="store_true", help="ratchet both counts")
+    ap.add_argument("--check", action="store_true", help="ratchet the four counts")
     ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
     args = ap.parse_args()
 
@@ -266,14 +819,25 @@ def main():
         return selftest()
 
     armed, unarmed, unseeded, readers, unexplained, stale, wallclock = audit()
-    print(f"RTL suites with an executable mutation or negative arm: "
-          f"{len(armed)} of {len(armed) + len(unarmed)}")
+    population = len(armed) + len(unarmed)
+    if population == 0:
+        print("REFUSED: no RTL suite found under the suite trees; an empty population "
+              "is not a pass", file=sys.stderr)
+        return 2
+    print(f"RTL suites with an executable mutation or negative arm: {len(armed)} of {population}")
+    for tree, _root, entries in SUITE_TREES:
+        n = sum(1 for s in list(armed) + unarmed if s.startswith(tree + "/"))
+        print(f"   {n:3d} under {tree}  (entry: {', '.join(entries)})")
+    print(f"\narmed suites, and the executed target that arms them ({len(armed)}):")
+    for name, found in sorted(armed.items()):
+        target, kind, detail = found[0]
+        print(f"   {name}: `{target}` {kind} {detail}")
     print(f"\nsuites with none ({len(unarmed)}):")
     for name in unarmed:
         print(f"   {name}")
     print(f"\nfiles that draw random values without recording a seed ({len(unseeded)}):")
-    for rel in unseeded:
-        print(f"   {rel}")
+    for rel, shapes in sorted(unseeded.items()):
+        print(f"   {rel}: {shapes[0]}")
     print(f"\ntest programs that read production HDL ({len(readers)}):")
     for rel in readers:
         print(f"   {rel}: {DUT_READER_DISPOSITIONS.get(rel, 'UNEXPLAINED')}")
@@ -320,8 +884,11 @@ def main():
           f"draw site(s), {len(unexplained)} <= {b_unexplained} unexplained "
           f"DUT-source reader(s), {len(wallclock)} <= {b_wallclock} "
           "wall-clock-dependent suite file(s))")
-    if len(unarmed) < b_unarmed:
-        print(f"  the mutation ratchet can be lowered to {len(unarmed)}")
+    for label, have, budget in (("mutation", len(unarmed), b_unarmed),
+                                ("unseeded-draw", len(unseeded), b_unseeded),
+                                ("wall-clock", len(wallclock), b_wallclock)):
+        if have < budget:
+            print(f"  the {label} ratchet can be lowered to {have}")
     return 0
 
 

--- a/scripts/measure_test_evidence.py
+++ b/scripts/measure_test_evidence.py
@@ -19,7 +19,14 @@ Four things are counted or refused.
      a mutation/negative driver script the recipe invokes, a compile-time
      mutation define the recipe passes, or a negative-case table the recipe
      consumes. A README sentence, a comment naming `mutants.py`, an empty
-     `mutants:` target and an unrelated `-DUSE_MUTEX` all count for nothing.
+     `mutants:` target and an unrelated `-DUSE_MUTEX` all count for nothing,
+     and so does an arm whose recipe's own error control keeps it from ever
+     failing the suite: Make ignores the errors of a line whose prefix carries
+     `-` and of a target `.IGNORE` names, and the shell reports the fallback's
+     status after `||` (`|| true`, `|| :`, `|| echo`), the next command's
+     after `;` and the consumer's after `|`. A plain driver, an `&&` chain, a
+     driver run under `set -e` as the last element of its own list, and a
+     `||` fallback that ends in `exit`/`false` carry the failure and count.
      The inventory includes the superproject's Verilator suites and the
      processor submodules' own RTL suites. This is a RATCHET: the number
      without an arm may only fall.
@@ -66,7 +73,13 @@ KNOWN LIMITS, by name, so nobody rediscovers them:
     `ifeq` counts even when that branch would not be taken on the sweep host;
   - a default-constructed C++ engine (`std::mt19937 g;`) is deterministic by
     the standard and is not flagged; `srand(time(NULL))` is not a recorded
-    seed and is.
+    seed and is;
+  - recipe error control is read as Make and `sh -c` read it, no further: a
+    status captured and re-raised later (`x || rc=1; ...; exit $$rc`), a
+    driver used as an `if`/`while` condition, a driver inside `$(...)`,
+    backticks or `$(shell ...)`, `set -o pipefail` (Make's shell is /bin/sh)
+    and `make -i`/`MAKEFLAGS` at the entry are not followed, so a driver in
+    those shapes is not credited; write the arm plain or `&&`-chained.
 
 Usage:
     python3 scripts/measure_test_evidence.py            # the inventories
@@ -165,7 +178,13 @@ MAKE_SKIP = re.compile(r"^(?:ifeq|ifneq|ifdef|ifndef|else|endif|include|-include
 MAKE_CALL = re.compile(r"(?:\$\(MAKE\)|(?<![\w/.-])make)\s+([^;&|)>\n]*)")
 CD_MAKE_CALL = re.compile(r"cd\s+\"?(\$\{?\w+\}?)\"?/?\s*&&\s*make\b([^;&|)>\n]*)")
 SHELL_WORDS = {"if", "then", "else", "elif", "fi", "do", "done", "for", "while",
-               "until", "!", "{", "}", "in", "case", "esac", "exec", "time"}
+               "until", "!", "{", "}", "(", ")", "in", "case", "esac", "exec", "time"}
+#: A keyword whose command's status the shell consumes instead of reporting.
+CONDITION = {"if", "elif", "while", "until", "!"}
+#: A recipe line's prefix, read after expansion the way Make reads it (the
+#: kernel's `$(Q)` idiom): `@` silences, `+` runs under -n, `-` IGNORES ERRORS.
+RECIPE_PREFIX = re.compile(r"^[\s@+-]*")
+SHELL_OP = re.compile(r"\s*(;|&&|\|\||\|)\s*")
 INTERPRETERS = re.compile(r"^(?:python[\d.]*|sh|bash|dash|env)$")
 #: A define that means "mutate", as a whole `_`-delimited word: NVM_MUT_MAP_ALIAS
 #: and X_MUTANT are; USE_MUTEX and COMMUTE are not.
@@ -307,20 +326,96 @@ def reachable_targets(variables, rules, first, goals):
     return seen
 
 
-def commands(line):
-    """The (command, argument) pairs a recipe line runs, per shell segment."""
-    pairs = []
-    for segment in re.split(r"\s*(?:;|&&|\|\||\|)\s*", line):
-        words = [w for w in segment.split() if w]
-        while words and (words[0].lstrip("@-+") in SHELL_WORDS
-                         or re.match(r"^\w+=", words[0]) or not words[0].lstrip("@-+")):
-            words.pop(0)
+def shell_words(segment):
+    """(leading keywords, command words) of one shell segment. Keywords,
+    assignments and a group opener come off the front and a closer off the
+    end, so `{ exit 1` and `(exit 1)` both read as `exit 1`."""
+    words = segment.split()
+    if words and len(words[0]) > 1 and words[0][0] in "{(":
+        words[0:1] = [words[0][0], words[0][1:]]
+    if words and len(words[-1]) > 1 and words[-1][-1] in "})" \
+            and {"}": "{", ")": "("}[words[-1][-1]] not in words[-1]:
+        words[-1:] = [words[-1][:-1], words[-1][-1]]
+    lead = []
+    while words and (words[0] in SHELL_WORDS or re.match(r"^\w+=", words[0])):
+        lead.append(words.pop(0))
+    while words and words[-1] in ("}", ")"):
+        words.pop()
+    return lead, words
+
+
+def set_errexit(words, errexit):
+    """errexit after this command: `set -e`/`set +e`, `set -o/+o errexit`."""
+    if not words or words[0] != "set":
+        return errexit
+    for i, flag in enumerate(words[1:], 1):
+        if flag in ("-o", "+o"):
+            if i + 1 < len(words) and words[i + 1] == "errexit":
+                errexit = flag == "-o"
+        elif flag[:1] in "-+" and "e" in flag[1:]:
+            errexit = flag[0] == "-"
+    return errexit
+
+
+def reraises(segments, k):
+    """Does the `||` fallback beginning at segment k end in `exit`/`false`,
+    so the failure it caught still reaches Make? `|| true`, `|| :` and
+    `|| echo ...` do not; `|| exit 1` and `|| { echo ...; exit 1; }` do."""
+    if k >= len(segments):
+        return False
+    closer = {"{": "}", "(": ")"}.get(segments[k].lstrip()[:1])
+    last = None
+    for m in range(k, len(segments)):
+        last = shell_words(segments[m])[1] or last
+        if closer is None or segments[m].rstrip().endswith(closer):
+            break
+    if not last:
+        return False
+    return last[0] == "false" or (last[0] == "exit" and (len(last) < 2 or last[1] != "0"))
+
+
+def reaches_make(segments, ops, leads, cmds, i, errexit):
+    """Does a non-zero exit of segment i become the recipe line's status?
+
+    Make runs the line as one `sh -c` and reads that shell's exit status: an
+    `&&` chain carries the first failure, `A || B` reports B's status, `A | B`
+    reports B's, `A; B` reports B's unless errexit is on and A is the last
+    element of its own and-or list, and a condition's status is consumed."""
+    if CONDITION & set(leads[i]):
+        return False
+    j = i
+    while ops[j] == "&&" or (ops[j] == "|" and j > i):
+        j += 1
+    if ops[j] is None:
+        return True
+    if ops[j] == "|":
+        return False
+    if ops[j] == "||":
+        return reraises(segments, j + 1)
+    if any(cmds[k] for k in range(j + 1, len(cmds))):
+        return errexit and j == i
+    return True
+
+
+def commands(line, errexit=False):
+    """The (command, argument, counts) triples a recipe line runs, per shell
+    segment. `counts` is False where the recipe's own error control (the `-`
+    prefix, `||`, `|`, `;`, a condition) keeps the command's failure from
+    Make, so a failed campaign there would leave the suite green."""
+    prefix = RECIPE_PREFIX.match(line).group(0)
+    parts = SHELL_OP.split(line[len(prefix):])
+    segments, ops = parts[0::2], parts[1::2] + [None]
+    peeled = [shell_words(segment) for segment in segments]
+    leads, cmds = [lead for lead, _ in peeled], [words for _, words in peeled]
+    triples = []
+    for i, words in enumerate(cmds):
         if not words:
             continue
-        cmd = words[0].lstrip("@-+")
         rest = [w for w in words[1:] if not w.startswith("-")]
-        pairs.append((cmd, rest[0] if rest else None))
-    return pairs
+        counts = "-" not in prefix and reaches_make(segments, ops, leads, cmds, i, errexit)
+        triples.append((words[0], rest[0] if rest else None, counts))
+        errexit = set_errexit(words, errexit)
+    return triples
 
 
 def is_driver(text, suffix):
@@ -335,19 +430,33 @@ def is_driver(text, suffix):
 
 def arms(makefile, goals, scripts):
     """Every executable arm: (target, kind, detail). `scripts` maps a script's
-    basename to its text; only .py/.sh files are consulted, never prose."""
+    basename to its text; only .py/.sh files are consulted, never prose. A
+    recipe whose error control keeps the arm from failing the suite is not
+    one: a `-` prefix or `.IGNORE` for a whole line or target, and per
+    command whatever `commands()` marks as not counting."""
     variables, rules, first = parse_makefile(makefile)
+    errexit = ".POSIX" in rules or any(
+        flag.startswith("-") and "e" in flag[1:]
+        for flag in expand(variables.get(".SHELLFLAGS", ""), variables).split())
+    ignore = rules.get(".IGNORE")
+    ignored = None if ignore is None else set(expand(" ".join(ignore[0]), variables).split())
     found = []
     for target in sorted(reachable_targets(variables, rules, first, goals)):
+        if ignored is not None and (not ignored or target in ignored):
+            continue
         for raw in rules[target][1]:
             line = expand(raw, variables)
+            if "-" in RECIPE_PREFIX.match(line).group(0):
+                continue
             for m in MUT_DEFINE.finditer(line):
                 if MUT_NAME.search(m.group(1)):
                     found.append((target, "define", m.group(0)))
             for m in TABLE_VAR.finditer(raw):
                 if expand(m.group(0), variables).strip() not in ("", m.group(0)):
                     found.append((target, "table", m.group(0)))
-            for cmd, arg in commands(line):
+            for cmd, arg, counts in commands(line, errexit):
+                if not counts:
+                    continue
                 candidate = arg if INTERPRETERS.match(cmd) and arg else cmd
                 name = candidate.rsplit("/", 1)[-1].strip("\"'")
                 suffix = Path(name).suffix
@@ -665,6 +774,43 @@ def selftest():
        not arms("all:\n\t./sim\n# the mutation was run by hand and failed\n", default, {}))
     ck("a comment marker inside the driver does not make it one",
        not arms("all:\n\tpython3 x.py\n", default, {"x.py": "# MUTATIONS = none yet\nrun()\n"}))
+    # -- error control: a failure Make never sees is not evidence -------------
+    mut = {"mutants.py": driver}
+    ck("(G) a `-` recipe line ignores errors: `-python3 mutants.py` is not an arm",
+       not arms("all: mutants\nmutants:\n\t-python3 mutants.py\n", default, mut)
+       and not arms("all:\n\t-verilator +define+NVM_MUT_MAP_ALIAS x.sv\n", default, {}))
+    ck("(H) `python3 mutants.py || true` is not an arm: the fallback masks the driver",
+       not arms("all: mutants\nmutants:\n\tpython3 mutants.py || true\n", default, mut))
+    ck("`|| :` and `|| echo ...` mask the same way",
+       not arms("all:\n\tpython3 mutants.py || :\n", default, mut)
+       and not arms("all:\n\tpython3 mutants.py || echo 'mutants failed'\n", default, mut))
+    ck("a `-` on another line of the same target leaves the driver's line evidence",
+       arms("all: mutants\nmutants:\n\t-rm -rf obj_mut\n\tpython3 mutants.py\n", default, mut)
+       == [("mutants", "driver", "mutants.py")])
+    ck("an && chain carries the driver's failure, so it still counts",
+       bool(arms("all:\n\t./sim && python3 mutants.py && echo ok\n", default, mut)))
+    ck("`@-` and `-@` are both the ignore prefix, before and after expansion",
+       not arms("all:\n\t@-python3 mutants.py\n", default, mut)
+       and not arms("all:\n\t-@python3 mutants.py\n", default, mut)
+       and not arms("Q = -\nall:\n\t$(Q)python3 mutants.py\n", default, mut))
+    ck("a `; true` tail masks; `set -e` restores the driver's failure, `set +e` drops it",
+       not arms("all:\n\tpython3 mutants.py; true\n", default, mut)
+       and bool(arms("all:\n\tset -e; python3 mutants.py; rm -rf obj_mut\n", default, mut))
+       and not arms("all:\n\tset -e; set +e; python3 mutants.py; rm -rf obj_mut\n", default, mut))
+    ck("a driver feeding a pipe reports the consumer's status, not its own",
+       not arms("all:\n\tpython3 mutants.py | tee mutants.log\n", default, mut))
+    ck("a fallback that re-raises (`|| exit 1`, `|| { ...; exit 1; }`) still counts",
+       bool(arms("all:\n\tpython3 mutants.py || exit 1\n", default, mut))
+       and bool(arms("all:\n\tpython3 mutants.py || { echo FAIL; exit 1; }\n", default, mut))
+       and not arms("all:\n\tpython3 mutants.py || { echo FAIL; exit 0; }\n", default, mut))
+    ck("an if condition, a $$(...) and a backtick substitution are not arms",
+       not arms("all:\n\tif python3 mutants.py; then echo ok; fi\n", default, mut)
+       and not arms("all:\n\techo $$(python3 mutants.py)\n", default, mut)
+       and not arms("all:\n\techo `python3 mutants.py`\n", default, mut))
+    ck(".IGNORE makes a target's, or every, recipe non-evidence",
+       not arms(".IGNORE: mutants\nall: mutants\nmutants:\n\tpython3 mutants.py\n", default, mut)
+       and not arms(".IGNORE:\nall:\n\tpython3 mutants.py\n", default, mut)
+       and bool(arms(".IGNORE: clean\nall:\n\tpython3 mutants.py\n", default, mut)))
     calls = make_invocations('for d in tb/*/; do\n  if (cd "$d" && make) >"$log" 2>&1; then\n'
                              'make -C tb/nvm_port figures\n$(MAKE) -C tb/verilator/ucpu\n')
     ck("the entry reader sees the loop, the named target and the sub-make",

--- a/scripts/measure_test_evidence.py
+++ b/scripts/measure_test_evidence.py
@@ -9,7 +9,7 @@ specification, its assertions are mutation-proven, and a pass publishes a
 non-zero tally. A suite can be green and prove nothing: assertions that have
 never been observed to fail are indistinguishable from assertions that cannot.
 
-Two things are counted, and one is already clean.
+Four things are counted or refused, and one is already clean.
 
   1. MUTATION COVERAGE. A suite carries an executable arm that deliberately breaks
      something and requires the suite to notice - a mutated DUT, an illegal
@@ -22,6 +22,18 @@ Two things are counted, and one is already clean.
      that draws already seeds - this is measured and reported as ZERO, and it
      must stay zero, because the cost of finding out otherwise is a flaky
      failure nobody can reproduce.
+
+  3. DUT-SOURCE ORACLES. A high-signal inventory finds test programs that read
+     production HDL text. The current readers are structural contract or
+     mutation tools, each explicitly classified; an unexplained reader is
+     refused because copying expected values out of the implementation would
+     make a test agree with the same defect.
+
+  4. WALL-CLOCK DEPENDENCE. Suite files that use host time or process/socket
+     deadlines are ratcheted. Cycle-bounded protocol timeouts are deterministic
+     and do not enter this population. The common runner must classify a suite
+     killed by its wall-clock guard as UNKNOWN, never pass or fail, and must run
+     the tally self-test before starting the sweep.
 
 Not counted here, because another gate already owns it: a missing or malformed
 tally is `NOCOUNT` in `scripts/suite_tally.py`, which refuses to let an unknown
@@ -59,6 +71,32 @@ DRAW = re.compile(r"(?<![\w.])random\.(?:random|randint|choice|shuffle|randrange
                   r"|uniform|sample|getrandbits)\s*\(|(?<![\w:])rand\s*\(\s*\)")
 SEED = re.compile(r"random\.Random\s*\(\s*\d|random\.seed\s*\(\s*\d|srand\s*\(\s*\d")
 
+# Reading the DUT is not automatically wrong: mutation arms must rewrite the
+# DUT and structural contract checks must inspect it. It is, however, the
+# smallest useful static population for an implementation-derived-oracle
+# review. Every present reader has a narrow recorded reason; a new one is debt
+# until it is classified.
+DUT_READ = re.compile(r"\bread_text\s*\(")
+DUT_PATH = re.compile(r"\b(?:RTL|FILTER)\s*=|[\"'][^\"'\n]*hdl/")
+DUT_READER_DISPOSITIONS = {
+    "gptp-processor/tb/check_phc_contract.py":
+        "structural boundary check; it asserts required/forbidden tokens, not behavior",
+    "protocol-processor/tb/nvm_port/measure_figures.py":
+        "mutation campaign; it rewrites one RTL arm and requires the suite to fail",
+    "tb/verilator/rx_filter/binding_mutant.py":
+        "mutation campaign; it ties a real named binding low and requires failure",
+    "tb/verilator/tcam/mutants.py":
+        "mutation campaign; it injects three RTL defects and requires failure",
+}
+
+# Host time can vary with machine load. This deliberately ignores identifiers
+# such as `timeout_cycles`: protocol time advanced by explicit DUT ticks is a
+# deterministic oracle. It catches actual host clocks, sleeps, socket deadlines
+# and subprocess deadlines.
+WALL_CLOCK = re.compile(
+    r"\btime\.(?:time|monotonic|sleep)\s*\(|\.settimeout\s*\("
+    r"|\b(?:subprocess\.)?(?:run|wait)\s*\([^)]*\btimeout\s*=", re.S)
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from code_quality_scope import tracked, tracked_exact
 
@@ -88,6 +126,49 @@ def draws_without_seed(text):
     return bool(DRAW.search(text)) and not SEED.search(text)
 
 
+def test_sources():
+    suffixes = {".py", ".cpp", ".cc", ".c", ".sv", ".v", ".sh"}
+    return sorted(rel for rel in tracked("tb/*", "tb/**/*")
+                  if Path(rel).suffix in suffixes or Path(rel).name == "Makefile")
+
+
+def suite_sources():
+    """Executable files owned by a directory that the suite inventory names."""
+    suffixes = {".py", ".cpp", ".cc", ".c", ".sv", ".v", ".sh"}
+    paths = {rel for name in suites() for rel in tracked_exact(f"{name}/*")}
+    return sorted(rel for rel in paths
+                  if Path(rel).suffix in suffixes or Path(rel).name == "Makefile")
+
+
+def reads_dut_source(text):
+    return bool(DUT_READ.search(text) and DUT_PATH.search(text))
+
+
+def uses_wall_clock(text):
+    return bool(WALL_CLOCK.search(text))
+
+
+def runner_contract(text):
+    """Problems in the common sweep's timeout and tally evidence contract."""
+    problems = []
+    launch = text.find('timeout "$TMO" make')
+    tally_selftest = text.find('suite_tally.py" --selftest')
+    tally_run = text.find('suite_tally.py" "$OUT" --quiet')
+    if launch < 0:
+        problems.append("the per-suite wall-clock guard is missing")
+    if tally_selftest < 0 or (launch >= 0 and tally_selftest > launch):
+        problems.append("the tally self-test does not run before the first suite")
+    if tally_run < 0 or (launch >= 0 and tally_run < launch):
+        problems.append("the final log tally does not run after the suites")
+    if "124|137)" not in text or "tmo=$((tmo + 1))" not in text:
+        problems.append("timeout/OOM exits are not classified separately")
+    if '[ "$tmo"  -gt 0 ] && exit 92' not in text:
+        problems.append("an unknown timeout result does not return exit 92")
+    if '[ "$tally_rc" -ne 0 ] && exit 90' not in text:
+        problems.append("a malformed or missing tally does not return exit 90")
+    return problems
+
+
 def audit():
     armed, unarmed = [], []
     for name in suites():
@@ -98,14 +179,27 @@ def audit():
                        "tb/**/*.cpp"):
         if draws_without_seed((REPO / rel).read_text(errors="replace")):
             unseeded.append(rel)
-    return armed, unarmed, unseeded
+
+    readers = []
+    for rel in test_sources():
+        text = (REPO / rel).read_text(errors="replace")
+        if reads_dut_source(text):
+            readers.append(rel)
+    wallclock = []
+    for rel in suite_sources():
+        text = (REPO / rel).read_text(errors="replace")
+        if uses_wall_clock(text):
+            wallclock.append(rel)
+    unexplained = sorted(set(readers) - set(DUT_READER_DISPOSITIONS))
+    stale = sorted(set(DUT_READER_DISPOSITIONS) - set(readers))
+    return armed, unarmed, unseeded, readers, unexplained, stale, wallclock
 
 
 def read_budget():
     if not BUDGET.is_file():
-        return None, None
+        return None, None, None, None
     vals = [int(x) for x in re.findall(r"^\s*(\d+)\s*$", BUDGET.read_text(), re.M)]
-    return (vals + [None, None])[:2]
+    return (vals + [None, None, None, None])[:4]
 
 
 def selftest():
@@ -134,14 +228,30 @@ def selftest():
     ck("a C rand() with no srand is caught", draws_without_seed("int x = rand();"))
     ck("a C rand() with srand is not", not draws_without_seed("srand(7); int x = rand();"))
 
-    armed, unarmed, unseeded = audit()
+    ck("a test reading an HDL source is an oracle-review candidate",
+       reads_dut_source('RTL = ROOT / "hdl/block.sv"\nsrc = RTL.read_text()'))
+    ck("an ordinary behavioral harness is not a source-reader candidate",
+       not reads_dut_source("expect(got, 7);"))
+    ck("host sleep is wall-clock dependent", uses_wall_clock("time.sleep(0.02)"))
+    ck("a cycle timeout is deterministic",
+       not uses_wall_clock("for (int timeout_cycles = 0; timeout_cycles < 32; ++timeout_cycles) tick();"))
+
+    runner = (REPO / "scripts/run_all_suites.sh").read_text()
+    ck("the live runner preserves timeout and tally verdicts",
+       not runner_contract(runner), "; ".join(runner_contract(runner)))
+    ck("a timeout reported as failure is rejected",
+       bool(runner_contract(runner.replace("exit 92", "exit 1"))))
+
+    armed, unarmed, unseeded, readers, unexplained, stale, wallclock = audit()
     ck("the live scan sees the suites", len(armed) + len(unarmed) > 40,
        f"{len(armed) + len(unarmed)} suites")
     ck("both sides of the mutation split are non-empty",
        bool(armed) and bool(unarmed),
        "an inert classifier would put every suite on one side")
+    ck("every DUT-source reader has a current disposition",
+       not unexplained and not stale, f"unexplained={unexplained}, stale={stale}")
 
-    n = 13
+    n = 20
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -155,7 +265,7 @@ def main():
     if args.selftest:
         return selftest()
 
-    armed, unarmed, unseeded = audit()
+    armed, unarmed, unseeded, readers, unexplained, stale, wallclock = audit()
     print(f"RTL suites with an executable mutation or negative arm: "
           f"{len(armed)} of {len(armed) + len(unarmed)}")
     print(f"\nsuites with none ({len(unarmed)}):")
@@ -164,13 +274,25 @@ def main():
     print(f"\nfiles that draw random values without recording a seed ({len(unseeded)}):")
     for rel in unseeded:
         print(f"   {rel}")
+    print(f"\ntest programs that read production HDL ({len(readers)}):")
+    for rel in readers:
+        print(f"   {rel}: {DUT_READER_DISPOSITIONS.get(rel, 'UNEXPLAINED')}")
+    print(f"\nsuite files using host wall-clock/process deadlines ({len(wallclock)}):")
+    for rel in wallclock:
+        print(f"   {rel}")
+
+    runner_problems = runner_contract((REPO / "scripts/run_all_suites.sh").read_text())
+    print("\nrunner evidence contract: " + ("OK" if not runner_problems else "FAIL"))
+    for problem in runner_problems:
+        print(f"   {problem}")
 
     if not args.check:
         return 0
 
-    b_unarmed, b_unseeded = read_budget()
-    if b_unarmed is None or b_unseeded is None:
-        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} must hold two counts")
+    b_unarmed, b_unseeded, b_unexplained, b_wallclock = read_budget()
+    if any(value is None for value in
+           (b_unarmed, b_unseeded, b_unexplained, b_wallclock)):
+        print(f"\nNO RATCHET: {BUDGET.relative_to(REPO)} must hold four counts")
         return 1
     bad = False
     if len(unarmed) > b_unarmed:
@@ -181,10 +303,23 @@ def main():
         print(f"\nFAIL: {len(unseeded)} unseeded random draw site(s) > ratchet "
               f"{b_unseeded}. A random test records the seed it can be replayed from.")
         bad = True
+    if len(unexplained) > b_unexplained or stale:
+        print(f"\nFAIL: {len(unexplained)} unexplained DUT-source reader(s) > "
+              f"ratchet {b_unexplained}; stale dispositions: {stale}")
+        bad = True
+    if len(wallclock) > b_wallclock:
+        print(f"\nFAIL: {len(wallclock)} wall-clock-dependent suite file(s) > "
+              f"ratchet {b_wallclock}. New behavioral tests use DUT cycles, not host time.")
+        bad = True
+    if runner_problems:
+        bad = True
     if bad:
         return 1
     print(f"\nTEST-EVIDENCE RATCHET: PASS ({len(unarmed)} <= {b_unarmed} suite(s) "
-          f"without a mutation arm, {len(unseeded)} <= {b_unseeded} unseeded draw site(s))")
+          f"without a mutation arm, {len(unseeded)} <= {b_unseeded} unseeded "
+          f"draw site(s), {len(unexplained)} <= {b_unexplained} unexplained "
+          f"DUT-source reader(s), {len(wallclock)} <= {b_wallclock} "
+          "wall-clock-dependent suite file(s))")
     if len(unarmed) < b_unarmed:
         print(f"  the mutation ratchet can be lowered to {len(unarmed)}")
     return 0

--- a/scripts/test_evidence.budget
+++ b/scripts/test_evidence.budget
@@ -7,8 +7,11 @@
 #    from the suite's Makefile: a recipe on a target the suite's entry runs,
 #    invoking a mutation/negative driver, passing a mutation define, or
 #    consuming a negative-case table. Prose, comments and empty targets count
-#    for nothing (review of #282). A suite whose assertions have never been
-#    observed to fail is indistinguishable from a suite that asserts nothing.
+#    for nothing (review of #282), and so does a recipe whose error control
+#    keeps the arm's failure from Make: a `-` prefix, `.IGNORE`, a `|| true`
+#    fallback, a `; cmd` tail without errexit, a pipe (second review of
+#    #282). A suite whose assertions have never been observed to fail is
+#    indistinguishable from a suite that asserts nothing.
 82
 # 2. First-party files that draw random values without recording a seed.
 #    The population widened in the review of #282 to every language the test

--- a/scripts/test_evidence.budget
+++ b/scripts/test_evidence.budget
@@ -1,10 +1,11 @@
 # Rule 8 ratchets, in order. See scripts/measure_test_evidence.py.
 # BOTH NUMBERS MAY ONLY GO DOWN.
 #
-# 1. Verilator suites with no mutation or negative arm. A suite whose
+# 1. RTL suites with no executable mutation or negative arm. This covers the
+#    superproject and both project-owned processor submodules. A suite whose
 #    assertions have never been observed to fail is indistinguishable from a
 #    suite that asserts nothing.
-33
+82
 # 2. First-party files that draw random values without recording a seed.
 #    Currently zero, and it must stay zero: the cost of finding out otherwise
 #    is a flaky failure nobody can reproduce.

--- a/scripts/test_evidence.budget
+++ b/scripts/test_evidence.budget
@@ -1,5 +1,5 @@
 # Rule 8 ratchets, in order. See scripts/measure_test_evidence.py.
-# BOTH NUMBERS MAY ONLY GO DOWN.
+# ALL FOUR NUMBERS MAY ONLY GO DOWN.
 #
 # 1. RTL suites with no executable mutation or negative arm. This covers the
 #    superproject and both project-owned processor submodules. A suite whose
@@ -10,3 +10,11 @@
 #    Currently zero, and it must stay zero: the cost of finding out otherwise
 #    is a flaky failure nobody can reproduce.
 0
+# 3. Test programs that read production HDL without an explicit structural or
+#    mutation-only disposition. Reading expected values from the DUT is not an
+#    independent oracle. The four classified readers do not consume budget.
+0
+# 4. Suite files that use host time, sleep, or process/socket deadlines. The
+#    two current files belong to the external tsn_fuzz cosimulation boundary;
+#    behavioral protocol timeouts elsewhere advance explicit DUT cycles.
+2

--- a/scripts/test_evidence.budget
+++ b/scripts/test_evidence.budget
@@ -1,20 +1,45 @@
 # Rule 8 ratchets, in order. See scripts/measure_test_evidence.py.
-# ALL FOUR NUMBERS MAY ONLY GO DOWN.
+# ALL FOUR NUMBERS MAY ONLY GO DOWN. A number here is the tool's measured
+# value at the commit that wrote it, never a hand-chosen target.
 #
 # 1. RTL suites with no executable mutation or negative arm. This covers the
-#    superproject and both project-owned processor submodules. A suite whose
-#    assertions have never been observed to fail is indistinguishable from a
-#    suite that asserts nothing.
+#    superproject and both project-owned processor submodules. An arm is read
+#    from the suite's Makefile: a recipe on a target the suite's entry runs,
+#    invoking a mutation/negative driver, passing a mutation define, or
+#    consuming a negative-case table. Prose, comments and empty targets count
+#    for nothing (review of #282). A suite whose assertions have never been
+#    observed to fail is indistinguishable from a suite that asserts nothing.
 82
 # 2. First-party files that draw random values without recording a seed.
-#    Currently zero, and it must stay zero: the cost of finding out otherwise
-#    is a flaky failure nobody can reproduce.
-0
+#    The population widened in the review of #282 to every language the test
+#    trees carry (SystemVerilog `$urandom`/`$random`/`randomize`, C `rand()`
+#    and `random_device`, Python instance/numpy/`from random import` draws),
+#    and the ten it then found are all legacy xsim benches under tb/utests,
+#    tb/itests and tb/avtp_packet_gen_sv that draw `$urandom` with no seed
+#    (docs/testing/TESTING.md section 5: superseded, not exit-code gating).
+#    Every gating harness is seeded. Ten was measured, not chosen; it may
+#    only fall, and seeding one of those benches lowers it.
+10
 # 3. Test programs that read production HDL without an explicit structural or
 #    mutation-only disposition. Reading expected values from the DUT is not an
 #    independent oracle. The four classified readers do not consume budget.
 0
-# 4. Suite files that use host time, sleep, or process/socket deadlines. The
-#    two current files belong to the external tsn_fuzz cosimulation boundary;
-#    behavioral protocol timeouts elsewhere advance explicit DUT cycles.
-2
+# 4. Suite files that use host time, sleep, or process/socket deadlines. Two
+#    belong to the external tsn_fuzz cosimulation boundary. The third is the
+#    tcam mutation driver's per-mutant guard (review of #282): a livelocking
+#    mutant is reported TIMEOUT and NOT caught, so the arm fails in seconds
+#    instead of hanging the sweep; the bound is a guard, never an oracle.
+#    Behavioral protocol timeouts elsewhere advance explicit DUT cycles.
+3
+#
+# Known processor debt, recorded here so it is inventoried and not implied
+# covered (review of #282); the fix is upstream, in the submodule:
+#  - protocol-processor/scripts/run_suites.sh reads each suite log with a
+#    single `grep | tail -1`: a zero tally (`0 checks: 0 PASS, 0 FAIL`) reads
+#    as PASS, only the LAST tally line of a multi-executable suite is counted,
+#    and only one shape is known. The superproject reader
+#    (scripts/suite_tally.py) refuses all three, and measure_test_evidence.py
+#    --selftest proves that; the upstream fix is to sum every tally line in
+#    every shape and treat zero as NOCOUNT, or to call suite_tally.py's scan.
+#  - gptp-processor has no CI of its own; its three suites run only from
+#    gptp-processor/Makefile (`tb`), which reads no tally at all.

--- a/scripts/test_evidence.budget
+++ b/scripts/test_evidence.budget
@@ -1,0 +1,11 @@
+# Rule 8 ratchets, in order. See scripts/measure_test_evidence.py.
+# BOTH NUMBERS MAY ONLY GO DOWN.
+#
+# 1. Verilator suites with no mutation or negative arm. A suite whose
+#    assertions have never been observed to fail is indistinguishable from a
+#    suite that asserts nothing.
+33
+# 2. First-party files that draw random values without recording a seed.
+#    Currently zero, and it must stay zero: the cost of finding out otherwise
+#    is a flaky failure nobody can reproduce.
+0

--- a/tb/verilator/tcam/Makefile
+++ b/tb/verilator/tcam/Makefile
@@ -19,13 +19,22 @@ VFLAGS = --cc --exe --build -j 0 \
 SRCS = $(RTL_DIR)/ieee8021q/filtering/tcam.sv
 CPP  = sim_main.cpp
 
-.PHONY: all run clean
-all: run
+.PHONY: all run mutants clean
+.DEFAULT_GOAL := all
+all: run mutants
 
 run:
 	$(VERILATOR) $(VFLAGS) $(SRCS) $(CPP) -o Vtcam_sim
 	@echo "======================================================================"
 	./obj_dir/Vtcam_sim
+
+# Rule 8: prove the harness above is load-bearing. Three defects are injected
+# into the real RTL, one at a time, and each must make the SAME harness fail;
+# the unmutated build must still pass. Mutants are built in a temporary
+# directory, so nothing is written into the tree.
+mutants:
+	@echo "======================================================================"
+	python3 mutants.py
 
 clean:
 	rm -rf obj_dir

--- a/tb/verilator/tcam/mutants.py
+++ b/tb/verilator/tcam/mutants.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Mutation arm for the tcam suite: prove its assertions are load-bearing.
+
+Why this exists. `sim_main.cpp` checks exact match, ternary match, priority,
+the multi-hit vector, add/remove/update and a clean miss - and nothing proved
+any of those checks could fail. A harness whose assertions never fail is
+indistinguishable from a harness that asserts nothing, and the TCAM is the
+match engine behind the receive shield: a silently vacuous test here is a
+silently unguarded filter.
+
+So the real RTL is mutated, one defect at a time, and the SAME harness is run
+against each mutant. Every mutant must make it FAIL. The unmutated build must
+still PASS - without that control the arm would be satisfied by a harness that
+fails on everything.
+
+Each mutation names the assertion it should break, and the pattern it rewrites
+is REQUIRED to be present exactly once. A refactor that moves the priority
+encoder does not silently skip its mutant; it fails here, which is the point -
+a mutation arm that quietly stops mutating is the defect it exists to catch.
+
+Usage: python3 mutants.py      (run from tb/verilator/tcam)
+Exit 0 = every mutant was caught and the clean build still passes.
+"""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+RTL = HERE / "../../../hdl/ieee8021q/filtering/tcam.sv"
+
+#: (name, pattern, replacement, the assertion this defect should break)
+MUTATIONS = [
+    ("priority inverted",
+     "for (p = NUM_ENTRIES-1; p >= 0; p = p - 1) begin",
+     "for (p = 0; p < NUM_ENTRIES; p = p + 1) begin",
+     "lowest matching index wins (index 0 = highest priority)"),
+    ("care mask ignored",
+     "(((lookup_key_i ^ ent_key[m]) & ent_mask[m]) == {KEY_WIDTH{1'b0}})",
+     "((lookup_key_i ^ ent_key[m]) == {KEY_WIDTH{1'b0}})",
+     "a wildcard entry matches a range, not just its exact key"),
+    ("entry validity ignored",
+     "hit[m] = ent_valid[m] && ",
+     "hit[m] = 1'b1 && ",
+     "a removed entry stops matching"),
+]
+
+VFLAGS = [
+    "--cc", "--exe", "--build", "-j", "0", "--top-module", "tcam",
+    "-Wall", "-Wno-fatal", "-Wno-DECLFILENAME", "-Wno-UNUSEDSIGNAL",
+    "-Wno-WIDTHEXPAND", "-Wno-WIDTHTRUNC", "-Wno-UNUSEDPARAM",
+    "-CFLAGS", "-std=c++17 -O2",
+]
+
+
+def build_and_run(rtl_path, workdir, tag):
+    """Build the harness against `rtl_path` and return its exit status."""
+    mdir = workdir / f"obj_{tag}"
+    #: verilator resolves -o RELATIVE TO --Mdir, so the name is bare and the
+    #: binary is looked up inside that directory
+    exe_name = f"Vtcam_{tag}"
+    out = subprocess.run(
+        ["verilator", *VFLAGS, "--Mdir", str(mdir), str(rtl_path),
+         str(HERE / "sim_main.cpp"), "-o", exe_name],
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        return None, out.stderr[-400:]
+    exe = mdir / exe_name
+    if not exe.is_file():
+        return None, f"verilator produced no {exe}"
+    run = subprocess.run([str(exe)], capture_output=True, text=True)
+    return run.returncode, run.stdout
+
+
+def main():
+    src = RTL.read_text()
+    passes = fails = 0
+
+    with tempfile.TemporaryDirectory(prefix="tcam-mutants-") as td:
+        work = Path(td)
+
+        # -- positive control: the real RTL must still pass -------------------
+        clean = work / "tcam.sv"
+        clean.write_text(src)
+        rc, _ = build_and_run(clean, work, "clean")
+        if rc == 0:
+            passes += 1
+            print("[PASS] the unmutated RTL still passes the harness")
+        else:
+            fails += 1
+            print(f"[FAIL] the unmutated RTL does NOT pass (rc={rc}) - every "
+                  f"mutant result below is meaningless")
+
+        # -- each mutant must be caught ---------------------------------------
+        for name, pattern, replacement, breaks in MUTATIONS:
+            if src.count(pattern) != 1:
+                fails += 1
+                print(f"[FAIL] mutation {name!r}: its pattern appears "
+                      f"{src.count(pattern)} time(s), expected exactly 1. The "
+                      f"RTL moved and this mutant is no longer mutating "
+                      f"anything - fix the pattern, do not delete the arm.")
+                continue
+            mpath = work / f"tcam_{name.replace(' ', '_')}.sv"
+            mpath.write_text(src.replace(pattern, replacement))
+            rc, _out = build_and_run(mpath, work, name.replace(" ", "_"))
+            if rc is None:
+                fails += 1
+                print(f"[FAIL] mutation {name!r} did not compile; a mutant that "
+                      f"cannot build proves nothing about the harness")
+            elif rc != 0:
+                passes += 1
+                print(f"[PASS] mutant caught: {name} — breaks \"{breaks}\"")
+            else:
+                fails += 1
+                print(f"[FAIL] mutant SURVIVED: {name}. The harness does not "
+                      f"prove \"{breaks}\".")
+
+    total = passes + fails
+    print(f"\n{total} checks: {passes} PASS, {fails} FAIL")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tb/verilator/tcam/mutants.py
+++ b/tb/verilator/tcam/mutants.py
@@ -15,6 +15,14 @@ against each mutant. Every mutant must make it FAIL. The unmutated build must
 still PASS - without that control the arm would be satisfied by a harness that
 fails on everything.
 
+"Caught" means the harness's OWN verdict says so: a `[FAIL]` line or a tally
+with a non-zero failure count in its stdout, read by the same reader the sweep
+uses (scripts/suite_tally.py). A non-zero exit on its own is not a catch: a
+mutant that makes the DUT abort or the process die by a signal has told us
+nothing about the assertions, and is reported as exactly that. A mutant that
+hangs is killed after MUTANT_RUN_TIMEOUT_S and reported TIMEOUT - not caught,
+so the arm fails in seconds instead of hanging the sweep.
+
 Each mutation names the assertion it should break, and the pattern it rewrites
 is REQUIRED to be present exactly once. A refactor that moves the priority
 encoder does not silently skip its mutant; it fails here, which is the point -
@@ -24,6 +32,8 @@ Usage: python3 mutants.py      (run from tb/verilator/tcam)
 Exit 0 = every mutant was caught and the clean build still passes.
 """
 
+import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -31,6 +41,12 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 RTL = HERE / "../../../hdl/ieee8021q/filtering/tcam.sv"
+sys.path.insert(0, str(HERE / "../../../scripts"))
+from suite_tally import log_reports_failure  # noqa: E402
+
+#: The harness runs in well under a second; a mutant still running after this
+#: many seconds is livelocked (a loop that no longer advances), not slow.
+MUTANT_RUN_TIMEOUT_S = 60
 
 #: (name, pattern, replacement, the assertion this defect should break)
 MUTATIONS = [
@@ -56,8 +72,8 @@ VFLAGS = [
 ]
 
 
-def build_and_run(rtl_path, workdir, tag):
-    """Build the harness against `rtl_path` and return its exit status."""
+def build(rtl_path, workdir, tag):
+    """Build the harness against `rtl_path`; the executable path, or None."""
     mdir = workdir / f"obj_{tag}"
     #: verilator resolves -o RELATIVE TO --Mdir, so the name is bare and the
     #: binary is looked up inside that directory
@@ -66,32 +82,72 @@ def build_and_run(rtl_path, workdir, tag):
         ["verilator", *VFLAGS, "--Mdir", str(mdir), str(rtl_path),
          str(HERE / "sim_main.cpp"), "-o", exe_name],
         capture_output=True, text=True)
-    if out.returncode != 0:
-        return None, out.stderr[-400:]
     exe = mdir / exe_name
-    if not exe.is_file():
-        return None, f"verilator produced no {exe}"
-    run = subprocess.run([str(exe)], capture_output=True, text=True)
-    return run.returncode, run.stdout
+    if out.returncode != 0 or not exe.is_file():
+        return None
+    return exe
+
+
+def run_harness(exe):
+    """(rc, stdout) of one harness run; rc is "TIMEOUT" when it was killed.
+
+    The harness is its own process group, so the kill on timeout reaches
+    anything it spawned, and nothing outlives the temporary directory.
+    """
+    proc = subprocess.Popen([str(exe)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            text=True, start_new_session=True)
+    try:
+        out, _ = proc.communicate(timeout=MUTANT_RUN_TIMEOUT_S)
+        return proc.returncode, out
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        out, _ = proc.communicate()
+        return "TIMEOUT", out
+    finally:
+        #: also on SIGTERM from the sweep's wall clock: no orphaned mutant
+        if proc.poll() is None:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait()
+
+
+def verdict(rc, out):
+    """How the harness answered: 'pass', 'caught', or why it is not evidence."""
+    reason, failed = log_reports_failure(out)
+    if rc == "TIMEOUT":
+        return f"TIMEOUT after {MUTANT_RUN_TIMEOUT_S}s - a hang is not a catch"
+    if rc == 0 and not failed:
+        return "pass"
+    if rc == 0 and failed:
+        return f"exited 0 but {reason} - a masked verdict is not evidence"
+    if failed:
+        return "caught"
+    if rc < 0:
+        return f"died by signal {-rc} with no harness verdict - a crash is not a catch"
+    return f"exited {rc} with no harness verdict - a DUT abort is not a catch"
 
 
 def main():
     src = RTL.read_text()
     passes = fails = 0
 
+    #: The context manager removes the directory on any exception, and the
+    #: SIGTERM handler turns the sweep's `timeout` kill into one, so a killed
+    #: run leaves no tcam-mutants-* directory behind either.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(143))
     with tempfile.TemporaryDirectory(prefix="tcam-mutants-") as td:
         work = Path(td)
 
         # -- positive control: the real RTL must still pass -------------------
         clean = work / "tcam.sv"
         clean.write_text(src)
-        rc, _ = build_and_run(clean, work, "clean")
-        if rc == 0:
+        exe = build(clean, work, "clean")
+        answer = verdict(*run_harness(exe)) if exe else "did not compile"
+        if answer == "pass":
             passes += 1
             print("[PASS] the unmutated RTL still passes the harness")
         else:
             fails += 1
-            print(f"[FAIL] the unmutated RTL does NOT pass (rc={rc}) - every "
+            print(f"[FAIL] the unmutated RTL does NOT pass ({answer}) - every "
                   f"mutant result below is meaningless")
 
         # -- each mutant must be caught ---------------------------------------
@@ -103,20 +159,26 @@ def main():
                       f"RTL moved and this mutant is no longer mutating "
                       f"anything - fix the pattern, do not delete the arm.")
                 continue
-            mpath = work / f"tcam_{name.replace(' ', '_')}.sv"
+            tag = name.replace(" ", "_")
+            mpath = work / f"tcam_{tag}.sv"
             mpath.write_text(src.replace(pattern, replacement))
-            rc, _out = build_and_run(mpath, work, name.replace(" ", "_"))
-            if rc is None:
+            exe = build(mpath, work, tag)
+            if exe is None:
                 fails += 1
                 print(f"[FAIL] mutation {name!r} did not compile; a mutant that "
                       f"cannot build proves nothing about the harness")
-            elif rc != 0:
+                continue
+            answer = verdict(*run_harness(exe))
+            if answer == "caught":
                 passes += 1
                 print(f"[PASS] mutant caught: {name} — breaks \"{breaks}\"")
-            else:
+            elif answer == "pass":
                 fails += 1
                 print(f"[FAIL] mutant SURVIVED: {name}. The harness does not "
                       f"prove \"{breaks}\".")
+            else:
+                fails += 1
+                print(f"[FAIL] mutant {name!r} {answer}")
 
     total = passes + fails
     print(f"\n{total} checks: {passes} PASS, {fails} FAIL")


### PR DESCRIPTION
> [!IMPORTANT]
> **Post-review correction (2026-08-28, head `f7d7a2f5`).** Test evidence covers all 87 RTL suites across the superproject and both processors and now audits vacuous passes, DUT-source oracle candidates, host wall-clock dependence, and malformed/missing tallies. Result: 5 armed / 82 ratcheted suites, zero unseeded draws, zero unexplained DUT readers, two ratcheted wall-clock files, runner contract green; self-test 20/20. Earlier figures below are superseded.

Closes #256

Rule 8 of the #248 contract. **Stacked on #281 (Rule 7) → #280 → #279 → #278 → #277 → #276 → #275.**

## What changed

| Area | Change |
|---|---|
| Guide | Rule 8 section: why a green suite can prove nothing, the three injected defects, the two ratchets, what was already clean. |
| Mutation arm | `tb/verilator/tcam/mutants.py` + a `mutants` target — permanent. |
| Measurement | `scripts/measure_test_evidence.py` + `scripts/test_evidence.budget`. |
| CI | The ratchet and its self-test run in `docs.yml`. |

## Three defects, to show the harness is load-bearing

`tb/verilator/tcam` checked exact match, ternary match, priority, the multi-hit vector, add/remove/update and a clean miss — and **nothing proved any of those checks could fail**. The TCAM is the match engine behind the receive shield, so a silently vacuous test there is a silently unguarded filter.

```
[PASS] the unmutated RTL still passes the harness
[PASS] mutant caught: priority inverted — breaks "lowest matching index wins"
[PASS] mutant caught: care mask ignored — breaks "a wildcard entry matches a range"
[PASS] mutant caught: entry validity ignored — breaks "a removed entry stops matching"

4 checks: 4 PASS, 0 FAIL
```

The unmutated control is what stops the arm being satisfied by a harness that fails on everything. Two details keep it honest: each mutation's pattern must appear in the RTL **exactly once**, so a refactor that moves the priority encoder fails loudly rather than silently mutating nothing; and mutants are built in a temporary directory, so a mutated source is never written into the tree.

## The two ratchets

| Population | Count | Disposition |
|---|---:|---|
| Verilator suites with no mutation or negative arm | **33 of 54** (was 34) | Ratchet |
| First-party files drawing random values with no recorded seed | **0** | Ratchet at zero |

## Two things found already clean — verified, not rebuilt

**Replayable randomness.** The first pass of this audit reported five unseeded draws in `sw/litex/test_tx_bd.py`. That was a defect in *the audit*: it flagged the draws without checking whether the file seeded, and `random.seed(11)` / `(23)` / `(7)` sit immediately above them. The true count is **zero**, across every first-party file that draws. The ratchet holds it there.

**Tally integrity.** The issue asks that missing or malformed evidence be treated as failure rather than zero checks. `scripts/suite_tally.py` already does — `NOCOUNT`, which a skip marker cannot suppress. Confirmed by running its self-test rather than writing a second one.

## Evidence

- `scripts/measure_test_evidence.py --selftest` — **12/12**, including an arm requiring both sides of the mutation split to be non-empty (an inert classifier would put every suite on one side).
- `scripts/measure_test_evidence.py --check` — PASS (33 ≤ 33, 0 ≤ 0).
- `tb/verilator/tcam` full suite — 19 checks 0 failures, plus 4/4 mutation arms.
- Before/after of the mutation-arm count measured with the same classifier against `HEAD`: 34 → 33.
- `docs_check` 0 findings / `gen_toc --check` OK / `check_doc_paths` OK / `ci_events --check` OK / traceability matrix up to date.

## Not covered

- The other 33 suites' arms; that is the ratchet's job.
- `tsn_fuzz` declared SKIP; builder gate 23h pre-existing on this host and on a pristine `dev` checkout.
