### PR TITLE
[Code quality] Rule 10: say what the block is

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -159,10 +159,11 @@ jobs:
           python3 scripts/check_hygiene.py --check
           python3 scripts/check_hygiene.py --selftest
 
-      # Rule 10: ordinary first-party `.v` files and generic `always @` are
-      # refused outright. `reg` and untyped parameters are ratcheted; a `wire`
-      # is deliberately not a finding. The shared scope includes both pinned
-      # project-owned processor submodules.
+      # Rule 10: first-party HDL that is not lower-case .sv/.svh and generic
+      # `always` are refused outright. `reg`, untyped parameters and untyped
+      # localparams are ratcheted; a `wire` is deliberately not a finding. The
+      # shared scope includes both pinned project-owned processor submodules,
+      # and an empty or partial population is refused (exit 2) by the bare gate.
       - name: SystemVerilog idiom gate
         run: |
           python3 scripts/check_sv_idiom.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -159,6 +159,15 @@ jobs:
           python3 scripts/check_hygiene.py --check
           python3 scripts/check_hygiene.py --selftest
 
+      # Rule 10: a generic `always @` is refused outright - it is the one
+      # construct that asks no tool to enforce a single driver, and it does not
+      # say whether the block is sequential. `reg` and untyped parameters are
+      # ratcheted; a `wire` is deliberately not a finding.
+      - name: SystemVerilog idiom gate
+        run: |
+          python3 scripts/check_sv_idiom.py
+          python3 scripts/check_sv_idiom.py --selftest
+
       # CI event and SHA contract gate (#174, #181): the four workflow files
       # and docs/testing/CI_WORKFLOWS.md must agree on the triggers, the cron
       # time, the public check names, cancel-in-progress and the one-SHA rule

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -159,10 +159,10 @@ jobs:
           python3 scripts/check_hygiene.py --check
           python3 scripts/check_hygiene.py --selftest
 
-      # Rule 10: a generic `always @` is refused outright - it is the one
-      # construct that asks no tool to enforce a single driver, and it does not
-      # say whether the block is sequential. `reg` and untyped parameters are
-      # ratcheted; a `wire` is deliberately not a finding.
+      # Rule 10: ordinary first-party `.v` files and generic `always @` are
+      # refused outright. `reg` and untyped parameters are ratcheted; a `wire`
+      # is deliberately not a finding. The shared scope includes both pinned
+      # project-owned processor submodules.
       - name: SystemVerilog idiom gate
         run: |
           python3 scripts/check_sv_idiom.py

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -33,7 +33,8 @@ shape rather than guess at it.
 - **[Rule 7: comments explain why, and dead code goes](#rule-7-comments-explain-why-and-dead-code-goes)** -- What a comment is for, why a marker names its issue or is resolved, the near-misses that forced a narrow definition of "marker" and what the gate reads to find one, the two stale markers removed, and the dead code the inventory found.
 - **[Rule 8: tests prove something, and prove they can fail](#rule-8-tests-prove-something-and-prove-they-can-fail)** -- Why a green suite can prove nothing, the three defects injected into the TCAM to show its harness is load-bearing, what counts as an executed arm, the four evidence ratchets, and what was found already clean.
 - **[Rule 9: automate mechanical hygiene with measured ratchets](#rule-9-automate-mechanical-hygiene-with-measured-ratchets)** -- The six candidate checks measured before any was adopted, why the highest-volume one was rejected on the record, why three checks are adopted at zero, and how the formatting-only rewrite was isolated and proven.
-- **[Rules not yet landed](#rules-not-yet-landed)** -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
+- **[Rule 10: prefer idiomatic SystemVerilog](#rule-10-prefer-idiomatic-systemverilog)** -- Which construct is refused outright and why it is the only one that discards a real check, what is ratcheted instead, why a `wire` is deliberately not a finding, and the reset-less canary converted without gaining a reset. -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
+- **[The contract is complete](#the-contract-is-complete)** -- What every landed rule carries, and why each of the nine gates that enforce them ships with a self-test proving it can fail.
 
 ## The governing rule
 
@@ -2023,11 +2024,85 @@ content change, and the reviewer reads it as one.
 - A repaired line inside a string literal is a content change, not formatting:
   was every line `--fix` reported reviewed as one?
 
-## Rules not yet landed
+## Rule 10: prefer idiomatic SystemVerilog
 
-The contract is ten rules. Rules 1 to 9 are above; Rule 10 keeps its number
-so citations stay stable when it lands:
+> New first-party HDL MUST be SystemVerilog. New and touched synthesizable HDL
+> SHOULD use the strongest appropriate SystemVerilog constructs to make
+> ownership, state, width and interfaces explicit. Legacy code migrates
+> incrementally in behavior-preserving changes; generated, vendored, primitive
+> and tool-boundary code keeps the representation its owner requires, and
+> records the exception.
 
-| Rule | Subject |
-|---|---|
-| 10 | Idiomatic SystemVerilog and explicit HDL boundaries |
+[CONTRIBUTING.md](../../CONTRIBUTING.md) already requires SystemVerilog for new
+HDL. This rule is about what happens after the file extension: a `.sv` file can
+still be written as Verilog-2001, and what is lost is exactly the compile-time
+checking that makes ownership reviewable.
+
+### One refusal, two ratchets
+
+**A generic `always @` is refused.** It is the only construct here that discards
+a real check. `always_ff` asks every tool in the path to enforce a single driver
+and to reject a block that is not sequential; `always_comb` asks for a complete
+combinational block. `always @` asks for neither, and the difference is silent.
+
+**`reg` declarations are ratcheted at 48**, across twelve modules. A `reg` in a
+`.sv` file is legal and usually harmless; `logic` is the SystemVerilog spelling
+and new code uses it. Rewriting all forty-eight in one change is the churn the
+governing rule forbids.
+
+**Untyped `parameter` declarations are ratcheted at 4.** `parameter W = 8` takes
+an implementation-defined type; `parameter int W = 8` does not.
+
+### A `wire` is deliberately not a finding
+
+A net type is the correct model for module, primitive, continuous-assignment and
+multiple-driver connectivity. Mechanically rewriting `wire` to `logic` across
+the tree would touch nearly every file and change nothing a reader or a tool can
+use. The check does not look for it, and this paragraph exists so that decision
+is visible rather than an omission.
+
+### The one generic `always`, and why converting it was delicate
+
+`hdl/common/csr/milan_csr.sv` carried exactly one, and it was the reset-epoch
+canary: two flops that count datapath reset **releases** and therefore must have
+no reset clause at all, so their bitstream initialisation survives every axis
+reset. Adding a reset would silently destroy the only thing they measure — the
+`reset_less` rule in [CONTRIBUTING.md](../../CONTRIBUTING.md) is about exactly
+this class of observer.
+
+`always_ff` with no reset clause is still reset-less: the keyword states
+sequential intent and asks for single-driver enforcement, and it adds nothing
+else. The block is converted, `reg` becomes `logic`, and the comment now says
+that a reset must never be added there — because the next reader's instinct on
+seeing `always_ff` with no reset will be to add one.
+
+The CSR suite passes unchanged across all four of its windows (385, 385, 104 and
+31 checks), the lint ratchet is unmoved, and `milan_datapath` still elaborates
+with the tied-input and tap-purity gates green.
+
+### Exceptions, recorded rather than assumed
+
+`hdl/milan/milan_dma_wrapper.v` is a Vivado-generated IP wrapper and keeps the
+representation its tool requires. It is not excluded by this gate's own judgement:
+the exclusion list is imported from
+[`scripts/lint_rtl.py`](../../scripts/lint_rtl.py), which already records a reason
+for every entry — the same list Rules 5 and 6 use.
+
+### Review checklist
+
+- Does the procedural block say whether it is sequential or combinational?
+- Does each variable's declaration say who owns it?
+- Do parameters carry a type?
+- If this is a net, is it connectivity — or a variable spelled as one?
+- If a construct is avoided for a tool, is the tool and the reason written down?
+
+## The contract is complete
+
+All ten rules are above. Each carries wording, a repository interpretation,
+worked examples, exceptions, a review checklist, and — where the rule can be
+measured — a tool and a ratchet that only moves downward.
+
+Nine gates run in [the documentation workflow](../../.github/workflows/docs.yml)
+and each one carries a self-test that proves it can fail, because a gate whose
+population is empty is otherwise indistinguishable from a gate that does
+nothing.

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -12,10 +12,10 @@ spec" are not restated here as weaker preferences. This page adds the rules
 those house rules do not cover, and gives each one wording, examples,
 exceptions, a measurement and a review checklist.
 
-Rules land one at a time. Each rule that has landed carries its own section
-below; the rules still to come are listed under
-[Rules not yet landed](#rules-not-yet-landed) so a reader can see the whole
-shape rather than guess at it.
+The rules landed one at a time, and all ten are now below, each in its own
+section. [The contract is complete](#the-contract-is-complete) at the end says
+what every landed rule ships with and which of them a workflow gate enforces,
+so a reader can see the whole shape rather than guess at it.
 
 ## Contents
 
@@ -34,7 +34,7 @@ shape rather than guess at it.
 - **[Rule 8: tests prove something, and prove they can fail](#rule-8-tests-prove-something-and-prove-they-can-fail)** -- Why a green suite can prove nothing, the three defects injected into the TCAM to show its harness is load-bearing, what counts as an executed arm, the four evidence ratchets, and what was found already clean.
 - **[Rule 9: automate mechanical hygiene with measured ratchets](#rule-9-automate-mechanical-hygiene-with-measured-ratchets)** -- The six candidate checks measured before any was adopted, why the highest-volume one was rejected on the record, why three checks are adopted at zero, and how the formatting-only rewrite was isolated and proven.
 - **[Rule 10: prefer idiomatic SystemVerilog](#rule-10-prefer-idiomatic-systemverilog)** -- Why ordinary `.v` files and generic `always @` are refused, what is ratcheted instead, why a `wire` is deliberately not a finding, and the representative boundaries modernized without changing behavior.
-- **[The contract is complete](#the-contract-is-complete)** -- What every landed rule carries, and why each of the nine gates that enforce them ships with a self-test proving it can fail.
+- **[The contract is complete](#the-contract-is-complete)** -- What every landed rule carries, which eight of the ten rules a gate in the documentation workflow enforces and why each of those gates ships with a self-test proving it can fail, and why Rules 1 and 2 are measurements rather than gates.
 
 ## The governing rule
 
@@ -2038,17 +2038,27 @@ HDL. This rule is about what happens after the file extension: a `.sv` file can
 still be written as Verilog-2001, and what is lost is exactly the compile-time
 checking that makes ownership reviewable.
 
-### Two refusals, two ratchets
+### Two refusals, three ratchets
 
-**An ordinary first-party `.v` file is refused.** The one checked-in `.v` file
-is a documented Vivado boundary in the shared exclusion inventory. A new `.v`
-file cannot silently bypass the SystemVerilog-only rule: it must become `.sv`,
-or its generator/tool owner and evidence must be recorded in `LINT_EXCLUDE`.
+**A first-party HDL file that is not SystemVerilog is refused.** The accepted
+spellings are a lower-case `.sv` or `.svh`; every other tracked file under
+`hdl/` whose extension names an HDL source — `.v`, `.vh`, `.vhd`, an upper-case
+`.V` or `.SV`, compared case-insensitively — is refused, because each of them is
+invisible to the `*.sv` globs every other tool in this repository matches. The
+one checked-in `.v` file is a documented Vivado boundary in the shared exclusion
+inventory. A new file cannot silently bypass the SystemVerilog-only rule: it
+must become `.sv`, or its generator/tool owner and evidence must be recorded in
+`LINT_EXCLUDE`. Only tracked files are scanned, so a new file is invisible to
+the gate until it is `git add`ed.
 
-**A generic `always @` is refused.** It is the only construct here that discards
-a real check. `always_ff` asks every tool in the path to enforce a single driver
-and to reject a block that is not sequential; `always_comb` asks for a complete
-combinational block. `always @` asks for neither, and the difference is silent.
+**A generic `always` is refused** — the bare keyword, whatever follows it:
+`always @(posedge clk)`, `always @*`, `always begin @(...)`, `always #5`. It is
+the only construct here that discards a real check. `always_ff` asks every tool
+in the path to enforce a single driver and to reject a block that is not
+sequential; `always_comb` asks for a complete combinational block. `always`
+asks for neither, and the difference is silent. The first gate looked for
+`always` followed by `@`, which a legal `always begin @(...)` walked past; the
+keyword itself is now the finding, and a fixture holds that spelling.
 
 **`reg` declarations are ratcheted at 58**, across fifteen files. A `reg` in a
 `.sv` file is legal and usually harmless; `logic` is the SystemVerilog spelling
@@ -2065,16 +2075,70 @@ specifically kills the old `output reg` blind spot. The corrected baseline is
 **Untyped `parameter` declarations are held at zero.** `parameter W = 8` takes
 an implementation-defined type; `parameter int unsigned W = 8` does not. The
 four parameters of `axi_stream_if` were the complete measured population and
-are now typed, so the ratchet admits no new ones.
+are now typed, so the ratchet admits no new ones — in any spelling: a
+`parameter W;` with no default (the must-override form) counts, and every name
+of a `parameter A = 1, B = 2;` list counts once, both of which the first gate's
+expression missed. A packed range (`parameter [3:0] W = 4`) is an explicit
+width and is not counted, and a user-defined type ahead of the name is a type.
+
+**Untyped `localparam` declarations are ratcheted at 2**, as their own entry.
+The rule the issue wrote names parameters and localparams together; the two
+that remain are the `$clog2`-derived `TDEST_WIDTH` constants in
+`hdl/ieee8021q/ts/traffic_queues.sv` and
+`hdl/ieee8021q/ts/traffic_controller_802_1q.sv`. A localparam crosses no
+boundary, so this is a smaller debt than an untyped port parameter would be,
+but it is counted rather than left out, and the entry is separate so localparam
+debt is never traded against port parameters.
 
 ### Inventory and repository examples
 
 The gate follows the same submodule-aware first-party scope as the other rules
-and refuses an absent or off-pin processor checkout. The tracked inventory is
+and refuses an absent or off-pin processor checkout. It also refuses, with exit
+code 2 and the state named, a population that is empty or reaches no tracked
+file under `hdl/` or under either processor's `hdl/`, before the budget is read:
+a scan over a missing tree reports zero of everything, and zero of everything
+is a clean ratchet unless the gate refuses to count it. The tracked inventory is
 117 `.sv` files, four `.svh` headers, and one `.v` file: 122 total. Of those,
 120 are gated (116 `.sv`, four `.svh`); the two excluded tool boundaries are
 listed below. Forty-eight of the gated files live in `protocol-processor` or
 `gptp-processor`, so processor RTL is not silently outside the rule.
+
+Three populations the rule names sit beside the counts above, each with a
+recorded decision rather than an omission:
+
+- **The excluded Zynq top carries debt of its own.** `hdl/milan/milan_top.sv`
+  holds three untyped string-valued parameters (`MAC_TARGET`, `MAC_IODDR_STYLE`
+  and `MAC_CLK_STYLE`) and seven `reg` declarations on six lines. They are
+  outside both ratchets because the file is outside every build, for the reason
+  `LINT_EXCLUDE` records; they are quantified here so the exclusion is not a
+  blind spot, and whoever revives the top pays them then.
+- **The generated CSR headers are gated on purpose.**
+  `hdl/common/csr/gen/adp_shape_defaults.svh` and
+  `hdl/common/csr/gen/lwsrp_csr_defaults.svh` are written by
+  `sw/builder/endstation_builder.py`; they hold 32 and 7 typed localparams and
+  no finding. They are inside the 120 rather than excluded, because a finding in
+  generator output is fixed in the generator, and the gate reading the output is
+  how a generator regression would be seen. `LINT_EXCLUDE` lists whole files
+  with a reason each and names neither header.
+- **Untyped `localparam`s are counted**, two of them, as their own ratchet
+  above.
+
+One tooling exception on the processor side is recorded here rather than fixed,
+because the fix belongs upstream. `gptp-processor`'s own lint target
+(`gptp-processor/Makefile` and `gptp-processor/bench/arty/Makefile`) passes
+`-Wno-WIDTHEXPAND -Wno-WIDTHTRUNC`, so the implicit width conversions this
+rule's table asks to make explicit are visible to no lint in this repository:
+the superproject ratchet sweeps `hdl/` only (its census names no processor
+file), and `protocol-processor`'s `lint_hdl.sh`, whose flag set carries no
+width suppression, does not run over gptp. Re-running gptp's own command without
+the two flags reports six warnings at four sites: one `WIDTHTRUNC` and one
+`WIDTHEXPAND` in `gptp-processor/hdl/wire/KL_gptp_rx_parser.sv` (lines 297 and
+298) and two `WIDTHEXPAND` each in `gptp-processor/hdl/top/KL_gptp_engine.sv`
+(lines 261 and 680). The upstream fix is a sized cast or a waiver with its
+reason at each of those sites and the removal of the two flags from both
+Makefiles; until it lands, the `SW_C'(SLOTS_P - 1)` row in the table is one
+explicit cast in that processor, not evidence that its width conversions are all
+explicit.
 
 | Concern | Avoid | Prefer / repository proof |
 |---|---|---|
@@ -2093,6 +2157,33 @@ multiple-driver connectivity. Mechanically rewriting `wire` to `logic` across
 the tree would touch nearly every file and change nothing a reader or a tool can
 use. The check does not look for it, and this paragraph exists so that decision
 is visible rather than an omission.
+
+### The `default_nettype` directive is CONTRIBUTING's rule already
+
+The issue's interpretation asks for `` `default_nettype none `` around every
+first-party compilation unit. [CONTRIBUTING.md](../../CONTRIBUTING.md) already
+requires it — `none` at the top of the file and `wire` at the bottom — and this
+page does not restate a house rule as a weaker preference, so what is recorded
+here is the measured state and why no third refusal was added. Of the 120 gated
+files, 113 carry the directive. The seven that do not are two packages
+(`hdl/common/ethernet_packet_pkg.sv` and
+`hdl/ieee1722/avtp/avtp_subtype_pkg.sv`), four include headers
+(`hdl/common/parameters.svh`,
+`hdl/common/eth_event_counter/ethernet_events.svh` and the two generated CSR
+headers) and one interface (`hdl/common/axi_stream_if.sv`). The packages and
+headers are correct as they are: a package instantiates nothing and has no
+continuous assignment, so no implicit net can arise in it, and an included
+header must not carry the pair at all, because the directive is
+compilation-unit state and a `wire` at the bottom of a header would silently
+re-enable implicit nets in the module that included it; the generated headers'
+banner records that they are include-only and carry none. The interface is
+genuine debt: an interface can instantiate and assign, and it is recorded here
+for the next functional touch of that file under this rule's "touched" clause
+rather than edited inside a language-modernization change. No gate is added
+for the directive: the failure
+it prevents, a misspelled port becoming an implicit net, is Verilator's
+`IMPLICIT` class, which the lint sweep behind `scripts/lint_rtl.py` reports
+whether or not the directive is present.
 
 ### The one generic `always`, and why converting it was delicate
 
@@ -2163,7 +2254,20 @@ All ten rules are above. Each carries wording, a repository interpretation,
 worked examples, exceptions, a review checklist, and — where the rule can be
 measured — a tool and a ratchet that only moves downward.
 
-Nine gates run in [the documentation workflow](../../.github/workflows/docs.yml)
-and each one carries a self-test that proves it can fail, because a gate whose
-population is empty is otherwise indistinguishable from a gate that does
-nothing.
+Eight of the ten rules are enforced by a gate that runs in
+[the documentation workflow](../../.github/workflows/docs.yml) — Rules 3 to 10,
+one script each: `scripts/check_rtl_source_lists.py`,
+`scripts/measure_naming.py`, `scripts/check_port_contracts.py`,
+`scripts/measure_fail_fast.py`, `scripts/check_todo_ownership.py`,
+`scripts/measure_test_evidence.py`, `scripts/check_hygiene.py` and
+`scripts/check_sv_idiom.py`. Every one of those steps runs the gate and then its
+`--selftest`, because a gate whose population is empty is otherwise
+indistinguishable from a gate that does nothing. Rule 10's gate also refuses
+(exit 2, the state named) a population that is empty or reaches none of its
+three trees, so the bare gate, run without its self-test, cannot read a missing
+tree as a clean ratchet either.
+
+Rules 1 and 2 are measurements, not gates. `scripts/measure_cohesion.py` and
+`scripts/measure_control_flow.py` propose no threshold and refuse nothing, so
+they have no verdict for the workflow to take; each still carries a `--selftest`
+whose fixture answers are known by construction.

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -33,7 +33,7 @@ shape rather than guess at it.
 - **[Rule 7: comments explain why, and dead code goes](#rule-7-comments-explain-why-and-dead-code-goes)** -- What a comment is for, why a marker names its issue or is resolved, the near-misses that forced a narrow definition of "marker" and what the gate reads to find one, the two stale markers removed, and the dead code the inventory found.
 - **[Rule 8: tests prove something, and prove they can fail](#rule-8-tests-prove-something-and-prove-they-can-fail)** -- Why a green suite can prove nothing, the three defects injected into the TCAM to show its harness is load-bearing, what counts as an executed arm, the four evidence ratchets, and what was found already clean.
 - **[Rule 9: automate mechanical hygiene with measured ratchets](#rule-9-automate-mechanical-hygiene-with-measured-ratchets)** -- The six candidate checks measured before any was adopted, why the highest-volume one was rejected on the record, why three checks are adopted at zero, and how the formatting-only rewrite was isolated and proven.
-- **[Rule 10: prefer idiomatic SystemVerilog](#rule-10-prefer-idiomatic-systemverilog)** -- Which construct is refused outright and why it is the only one that discards a real check, what is ratcheted instead, why a `wire` is deliberately not a finding, and the reset-less canary converted without gaining a reset. -- The remaining nine rules of the contract, named so the numbering is stable and a reader knows what is still coming.
+- **[Rule 10: prefer idiomatic SystemVerilog](#rule-10-prefer-idiomatic-systemverilog)** -- Why ordinary `.v` files and generic `always @` are refused, what is ratcheted instead, why a `wire` is deliberately not a finding, and the representative boundaries modernized without changing behavior.
 - **[The contract is complete](#the-contract-is-complete)** -- What every landed rule carries, and why each of the nine gates that enforce them ships with a self-test proving it can fail.
 
 ## The governing rule
@@ -2038,20 +2038,53 @@ HDL. This rule is about what happens after the file extension: a `.sv` file can
 still be written as Verilog-2001, and what is lost is exactly the compile-time
 checking that makes ownership reviewable.
 
-### One refusal, two ratchets
+### Two refusals, two ratchets
+
+**An ordinary first-party `.v` file is refused.** The one checked-in `.v` file
+is a documented Vivado boundary in the shared exclusion inventory. A new `.v`
+file cannot silently bypass the SystemVerilog-only rule: it must become `.sv`,
+or its generator/tool owner and evidence must be recorded in `LINT_EXCLUDE`.
 
 **A generic `always @` is refused.** It is the only construct here that discards
 a real check. `always_ff` asks every tool in the path to enforce a single driver
 and to reject a block that is not sequential; `always_comb` asks for a complete
 combinational block. `always @` asks for neither, and the difference is silent.
 
-**`reg` declarations are ratcheted at 48**, across twelve modules. A `reg` in a
+**`reg` declarations are ratcheted at 58**, across fifteen files. A `reg` in a
 `.sv` file is legal and usually harmless; `logic` is the SystemVerilog spelling
-and new code uses it. Rewriting all forty-eight in one change is the churn the
+and new code uses it. Rewriting all fifty-eight in one change is the churn the
 governing rule forbids.
 
-**Untyped `parameter` declarations are ratcheted at 4.** `parameter W = 8` takes
-an implementation-defined type; `parameter int W = 8` does not.
+The first checker reported 48 because its expression only recognized `reg` at
+the beginning of a line. It missed fourteen ANSI `output reg` declarations and
+attribute-prefixed declarations. The gate now blanks comments and strings and
+recognizes the reserved `reg` keyword in every declaration context; a fixture
+specifically kills the old `output reg` blind spot. The corrected baseline is
+58 after the four variables modernized in `rx_mac_filter` below.
+
+**Untyped `parameter` declarations are held at zero.** `parameter W = 8` takes
+an implementation-defined type; `parameter int unsigned W = 8` does not. The
+four parameters of `axi_stream_if` were the complete measured population and
+are now typed, so the ratchet admits no new ones.
+
+### Inventory and repository examples
+
+The gate follows the same submodule-aware first-party scope as the other rules
+and refuses an absent or off-pin processor checkout. The tracked inventory is
+117 `.sv` files, four `.svh` headers, and one `.v` file: 122 total. Of those,
+120 are gated (116 `.sv`, four `.svh`); the two excluded tool boundaries are
+listed below. Forty-eight of the gated files live in `protocol-processor` or
+`gptp-processor`, so processor RTL is not silently outside the rule.
+
+| Concern | Avoid | Prefer / repository proof |
+|---|---|---|
+| Typed ANSI boundary | `output reg [7:0] data` or an implicit-width port | An ANSI direction plus an intentional net/variable type and explicit width; `rx_mac_filter` documents every stream and TCAM port. |
+| Named instantiation | `child u (clk, data)` or `child u (.*)` | `.clk_i(clk_i)` and `.lookup_key_i(dmac)` at the `rx_mac_filter`/`tcam` seam; Rule 5 refuses positional and wildcard bindings. |
+| Variable versus net | `reg` for procedural state, or blind `wire` replacement | `logic pass_r` for `always_ff` state and `wire dmac` for continuous connectivity in `rx_mac_filter`. |
+| Procedural intent | `always @(posedge clk)` or `always @*` | `always_ff` for owned state and `always_comb` for complete combinational logic, as in `axis_mux_rr_2in_1out`. |
+| Domain types | Magic integer state and repeated bit slicing | The typed enum in `axis_mux_rr_2in_1out` and structs/packages in `ethernet_packet_pkg`. |
+| Width/sign conversion | Relying on assignment truncation or promotion | Sized casts such as `SW_C'(SLOTS_P - 1)` in `gptp-processor/hdl/common/KL_gptp_timer.sv`. |
+| Repeated protocol | An interface merely to reduce port count | Existing `axi_stream_if`/modports only where the real `milan_datapath` tool path accepts it; otherwise named discrete ports remain clearer. |
 
 ### A `wire` is deliberately not a finding
 
@@ -2080,13 +2113,34 @@ The CSR suite passes unchanged across all four of its windows (385, 385, 104 and
 31 checks), the lint ratchet is unmoved, and `milan_datapath` still elaborates
 with the tied-input and tap-purity gates green.
 
+### Representative module and integration boundaries
+
+The cumulative rule stack modernizes a real, tested seam rather than a sample
+module. Rule 5 documents the `rx_mac_filter` stream and TCAM boundary end to end;
+Rule 6 mutation-proves its four illegal parameter contracts; this rule changes
+its four procedural state declarations from `reg` to `logic` while retaining
+the intentional `wire` connectivity and named `tcam` binding. The focused
+`rx_filter` suite exercises that boundary and its negative elaboration arms.
+
+The shared `axi_stream_if` boundary is also real: `milan_datapath` instantiates
+it on its shipping stream path. Its four width parameters now use `int unsigned`
+instead of an implementation-defined type. Neither change adopts a new language
+construct: `logic`, typed parameters, interfaces, modports, and explicit casts
+already exist in the required build paths. Verilator, the Yosys/sv2v path, and
+the Vivado/xvlog gate are therefore validation targets for these edits, not
+assumptions used to introduce an unproven construct.
+
 ### Exceptions, recorded rather than assumed
 
-`hdl/milan/milan_dma_wrapper.v` is a Vivado-generated IP wrapper and keeps the
-representation its tool requires. It is not excluded by this gate's own judgement:
-the exclusion list is imported from
-[`scripts/lint_rtl.py`](../../scripts/lint_rtl.py), which already records a reason
-for every entry — the same list Rules 5 and 6 use.
+The gate imports [`scripts/lint_rtl.py`](../../scripts/lint_rtl.py)'s
+`LINT_EXCLUDE` instead of inventing another exception list. Each `.v` exception
+must contain both a reason and repository evidence; an empty rationale is a
+hard failure.
+
+| File | Recorded boundary |
+|---|---|
+| `hdl/milan/milan_dma_wrapper.v` | Vivado-generated Zynq AXI-DMA wrapper; its tool/version header and `bd/milan-dma.tcl` own regeneration. |
+| `hdl/milan/milan_top.sv` | Archived, non-elaboratable Zynq top whose external MAC and generated DMA IP are unavailable; the local banner and `milan_soc.py` exclusion record why it is not a gated fabric source. |
 
 ### Review checklist
 

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -2130,6 +2130,13 @@ already exist in the required build paths. Verilator, the Yosys/sv2v path, and
 the Vivado/xvlog gate are therefore validation targets for these edits, not
 assumptions used to introduce an unproven construct.
 
+The final candidate records the compatibility result: all 54 local Verilator
+suites passed (2,116,640 checks, zero in-suite failures), all 46 full Yosys/sv2v
+synthesis tops passed with the tied-input and observer-purity gates, and the
+xvlog compatibility gate held its existing four processor findings with no new
+finding in `hdl/`. No new interface/modport form was proposed, so there is no
+rejected construct to disguise as an accepted experiment.
+
 ### Exceptions, recorded rather than assumed
 
 The gate imports [`scripts/lint_rtl.py`](../../scripts/lint_rtl.py)'s

--- a/hdl/common/axi_stream_if.sv
+++ b/hdl/common/axi_stream_if.sv
@@ -19,10 +19,10 @@
 //! `lint_off SELRANGE` pragmas in hdl/ieee17221/aecp/ to paper over.  A
 //! default that no caller uses should name the tree it lives in.
 interface axi_stream_if #(
-  parameter TDATA_WIDTH_P = 64,
-  parameter TID_WIDTH_P = 1,
-  parameter TDEST_WIDTH_P = 1,
-  parameter TUSER_WIDTH_P = 1
+parameter int unsigned TDATA_WIDTH_P = 64,
+parameter int unsigned TID_WIDTH_P = 1,
+parameter int unsigned TDEST_WIDTH_P = 1,
+parameter int unsigned TUSER_WIDTH_P = 1
   )
   (
     input bit clk,

--- a/hdl/common/axi_stream_if.sv
+++ b/hdl/common/axi_stream_if.sv
@@ -19,10 +19,10 @@
 //! `lint_off SELRANGE` pragmas in hdl/ieee17221/aecp/ to paper over.  A
 //! default that no caller uses should name the tree it lives in.
 interface axi_stream_if #(
-parameter int unsigned TDATA_WIDTH_P = 64,
-parameter int unsigned TID_WIDTH_P = 1,
-parameter int unsigned TDEST_WIDTH_P = 1,
-parameter int unsigned TUSER_WIDTH_P = 1
+  parameter int unsigned TDATA_WIDTH_P = 64,
+  parameter int unsigned TID_WIDTH_P = 1,
+  parameter int unsigned TDEST_WIDTH_P = 1,
+  parameter int unsigned TUSER_WIDTH_P = 1
   )
   (
     input bit clk,

--- a/hdl/common/csr/milan_csr.sv
+++ b/hdl/common/csr/milan_csr.sv
@@ -2236,7 +2236,7 @@ module milan_csr #(
   //! Reset-epoch canary (documented with epoch_cnt below, which drives it):
   //! a flop WITHOUT a reset clause, bitstream-initialised. Declared here
   //! ahead of read_mux, its first reader (#193).
-  reg [7:0] rst_epoch_r = 8'd0;
+  logic [7:0] rst_epoch_r = 8'd0;
   logic        live_hit;
 
   always_comb begin : read_mux
@@ -2708,8 +2708,14 @@ module milan_csr #(
   //! epochs to detect hidden fabric resets that the config shadow masks
   //! (the 2026-07-19 link-bounce forensics: CSR reads lied after a reset).
   //! rst_epoch_r is declared above read_mux, its first reader (#193)
-  reg       rstn_seen_r = 1'b0;
-  always @(posedge aclk) begin : epoch_cnt
+  //! RESET-LESS BY CONSTRUCTION, and `always_ff` keeps it that way. The block
+  //! has no reset clause on purpose - these two flops carry their bitstream
+  //! init across every axis reset, which is the only reason the epoch can
+  //! count resets at all. `always_ff` states the sequential intent and asks
+  //! the tools to enforce a single driver; it does NOT add a reset, and one
+  //! must never be added here (the reset_less rule in CONTRIBUTING.md).
+  logic     rstn_seen_r = 1'b0;
+  always_ff @(posedge aclk) begin : epoch_cnt
     rstn_seen_r <= aresetn;
     if (aresetn && !rstn_seen_r) rst_epoch_r <= rst_epoch_r + 8'd1;
   end : epoch_cnt

--- a/hdl/ieee8021q/filtering/rx_mac_filter.sv
+++ b/hdl/ieee8021q/filtering/rx_mac_filter.sv
@@ -226,10 +226,10 @@ module rx_mac_filter #(
   // -----------------------------------------------------------------------
   //  Per-frame decision, latched at start-of-frame (SOF) and held to tlast.
   // -----------------------------------------------------------------------
-  reg                    in_frame;   //! high after SOF, until tlast accepted
-  reg                    pass_r;     //! latched pass decision for the frame
-  reg [ACTION_WIDTH-1:0] action_r;   //! latched action for the frame
-  reg                    match_r;    //! latched match flag for the frame
+  logic                    in_frame; //! high after SOF, until tlast accepted
+  logic                    pass_r;   //! latched pass decision for the frame
+  logic [ACTION_WIDTH-1:0] action_r; //! latched action for the frame
+  logic                    match_r;  //! latched match flag for the frame
 
   wire sof       = s_tvalid && !in_frame;                          //! first beat of a frame
   //! Runt guard: a frame whose FIRST beat carries tlast is at most 8 bytes, so

--- a/scripts/check_sv_idiom.py
+++ b/scripts/check_sv_idiom.py
@@ -10,20 +10,24 @@ requires SystemVerilog for new HDL - but a `.sv` file can still be written as
 Verilog-2001, and the compile-time checks that make ownership and intent
 reviewable are exactly what is lost when it is.
 
-Three things are checked, at two different strengths.
+Four things are checked, at two different strengths.
 
-  1. A GENERIC `always @` in synthesizable first-party HDL is REFUSED. It is
+  1. An ordinary first-party `.v` file is REFUSED. The one checked-in Verilog
+     wrapper is a documented Vivado boundary in `LINT_EXCLUDE`; a new file may
+     not quietly bypass the repository's SystemVerilog-only rule.
+
+  2. A GENERIC `always @` in synthesizable first-party HDL is REFUSED. It is
      the one construct here that discards a real check: `always_ff` asks every
      tool to enforce a single driver and to reject a procedural block that is
      not sequential, and `always @` asks for neither. The tree has none, and
      the arm below proves the check bites.
 
-  2. `reg` DECLARATIONS are RATCHETED. A `reg` in a `.sv` file is legal and
-     usually harmless, and 48 of them across twelve modules cannot be rewritten
-     in one change without exactly the churn the governing rule forbids.
+  3. `reg` DECLARATIONS are RATCHETED. A `reg` in a `.sv` file is legal and
+     usually harmless, and the remaining population cannot be rewritten in
+     one change without exactly the churn the governing rule forbids.
      `logic` is the SystemVerilog spelling and new code uses it.
 
-  3. UNTYPED `parameter` declarations are RATCHETED. `parameter W = 8` takes an
+  4. UNTYPED `parameter` declarations are RATCHETED. `parameter W = 8` takes an
      implementation-defined type; `parameter int W = 8` does not.
 
 WHAT IS NOT CHECKED, deliberately. A `wire` is NOT a finding. A net type is the
@@ -47,7 +51,6 @@ Exit 0 = no generic `always`, and the ratchets in scripts/sv_idiom.budget hold.
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -56,33 +59,38 @@ BUDGET = Path(__file__).resolve().parent / "sv_idiom.budget"
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lint_rtl import LINT_EXCLUDE
+from code_quality_scope import tracked
 
-COMMENT = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
+NON_CODE = re.compile(r'//[^\n]*|/\*.*?\*/|"(?:\\.|[^"\\])*"', re.S)
 #: `always @` that is NOT always_ff/always_comb/always_latch. The suffixed forms
 #: are separate keywords, so a plain `always` followed by `@` is unambiguous.
 GENERIC_ALWAYS = re.compile(r"(?<![\w_])always\s*@")
-REG_DECL = re.compile(r"^\s*reg\s+", re.M)
+#: `reg` is a reserved keyword and therefore unambiguously denotes a legacy
+#: variable declaration once comments and string literals have been blanked.
+#: Looking only at the start of a line misses ANSI declarations such as
+#: ``output reg ready_o`` and declarations preceded by synthesis attributes.
+REG_DECL = re.compile(r"\breg\b")
 UNTYPED_PARAM = re.compile(
     r"\bparameter\s+(?!int\b|logic\b|bit\b|integer\b|byte\b|real\b|shortreal\b"
     r"|string\b|type\b|signed\b|unsigned\b)(\w+)\s*=")
 
 
-def blank_comments(text):
-    return COMMENT.sub(lambda m: "".join(c if c == "\n" else " " for c in m.group(0)),
-                       text)
+def blank_non_code(text):
+    return NON_CODE.sub(
+        lambda m: "".join(c if c == "\n" else " " for c in m.group(0)), text)
 
 
 def sources():
-    out = subprocess.run(["git", "ls-files", "hdl"], cwd=REPO,
-                         capture_output=True, text=True, check=True).stdout.split()
+    out = tracked("hdl")
     return [p for p in out
             if p.endswith((".sv", ".svh", ".v")) and p not in LINT_EXCLUDE]
 
 
-def scan(text):
-    """{finding: count} for one HDL source, comments removed first."""
-    code = blank_comments(text)
+def scan(text, path="x.sv"):
+    """{finding: count} for one HDL source, non-code text removed first."""
+    code = blank_non_code(text)
     return {
+        "ordinary .v": int(path.endswith(".v")),
         "generic always": len(GENERIC_ALWAYS.findall(code)),
         "reg declaration": len(REG_DECL.findall(code)),
         "untyped parameter": len(UNTYPED_PARAM.findall(code)),
@@ -90,20 +98,36 @@ def scan(text):
 
 
 def audit():
-    totals = {"generic always": 0, "reg declaration": 0, "untyped parameter": 0}
-    per_file, sites = {}, []
+    totals = {"ordinary .v": 0, "generic always": 0,
+              "reg declaration": 0, "untyped parameter": 0}
+    per_file, sites, ordinary_v = {}, [], []
     for rel in sources():
         text = (REPO / rel).read_text(errors="replace")
-        found = scan(text)
+        found = scan(text, rel)
         if any(found.values()):
             per_file[rel] = found
         for k, v in found.items():
             totals[k] += v
+        if found["ordinary .v"]:
+            ordinary_v.append(rel)
         if found["generic always"]:
-            code = blank_comments(text)
+            code = blank_non_code(text)
             for m in GENERIC_ALWAYS.finditer(code):
                 sites.append((rel, code[:m.start()].count("\n") + 1))
-    return totals, per_file, sites
+    return totals, per_file, sites, ordinary_v
+
+
+def undocumented_v_exceptions():
+    """Return excluded Verilog files whose required local rationale is absent."""
+    bad = []
+    for rel, rationale in LINT_EXCLUDE.items():
+        if not rel.endswith(".v"):
+            continue
+        if (not isinstance(rationale, tuple) or len(rationale) < 2
+                or not all(isinstance(item, str) and item.strip()
+                           for item in rationale)):
+            bad.append(rel)
+    return bad
 
 
 def read_budget():
@@ -141,8 +165,13 @@ def selftest():
     ck("a generic always inside a COMMENT is not counted",
        scan("// always @(posedge c) x <= 1;")["generic always"] == 0,
        "comments are blanked before the search")
+    ck("a generic always inside a string is not counted",
+       scan('$display("always @(posedge c)");')["generic always"] == 0,
+       "string literals are blanked before the search")
 
     ck("a reg declaration is caught", scan("  reg [7:0] x_r;")["reg declaration"] == 1)
+    ck("an ANSI output reg declaration is caught",
+       scan("  output reg [7:0] x_o")["reg declaration"] == 1)
     ck("a wire declaration is NOT a finding",
        scan("  wire [7:0] x_w;")["reg declaration"] == 0,
        "a net type is the right model for connectivity")
@@ -150,6 +179,13 @@ def selftest():
        scan("  logic [7:0] x_r;")["reg declaration"] == 0)
     ck("a bare reg declaration with no width is caught",
        scan("  reg x_r;")["reg declaration"] == 1)
+    ck("the word reg inside a string is not counted",
+       scan('$display("reg declaration");')["reg declaration"] == 0)
+
+    ck("an ordinary Verilog file is refused",
+       scan("module x; endmodule", "hdl/x.v")["ordinary .v"] == 1)
+    ck("a SystemVerilog file is not refused by extension",
+       scan("module x; endmodule", "hdl/x.sv")["ordinary .v"] == 0)
 
     ck("an untyped parameter is caught",
        scan("parameter W = 8;")["untyped parameter"] == 1)
@@ -157,15 +193,20 @@ def selftest():
     ck("a logic-typed parameter is not",
        scan("parameter logic [7:0] M = 8'hFF;")["untyped parameter"] == 0)
 
-    totals, per_file, sites = audit()
-    ck("the live scan reads the tree", len(sources()) > 40, f"{len(sources())} files")
+    totals, per_file, sites, ordinary_v = audit()
+    ck("the live scan reads the tree", len(sources()) > 100, f"{len(sources())} files")
+    ck("the live scan reaches both project processor submodules",
+       any(p.startswith("protocol-processor/") for p in sources())
+       and any(p.startswith("gptp-processor/") for p in sources()))
     ck("the excluded list is shared with lint_rtl",
        "hdl/milan/milan_dma_wrapper.v" in LINT_EXCLUDE)
+    ck("the checked-in Verilog exception has a reason and evidence",
+       not undocumented_v_exceptions())
     ck("the ratcheted populations are non-empty",
        totals["reg declaration"] > 0,
        "an inert scan would report zero everywhere and ratchet to nothing")
 
-    n = 15
+    n = 22
     print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
@@ -179,8 +220,19 @@ def main():
     if args.selftest:
         return selftest()
 
-    totals, per_file, sites = audit()
+    totals, per_file, sites, ordinary_v = audit()
     bad = False
+
+    for rel in ordinary_v:
+        bad = True
+        print(f"ORDINARY VERILOG: {rel} — new first-party HDL must use a .sv "
+              "extension, or a generated/tool boundary must carry a rationale "
+              "in scripts/lint_rtl.py:LINT_EXCLUDE.")
+
+    for rel in undocumented_v_exceptions():
+        bad = True
+        print(f"UNDOCUMENTED VERILOG EXCEPTION: {rel} — record both the owner/tool "
+              "reason and repository evidence in scripts/lint_rtl.py:LINT_EXCLUDE.")
 
     for rel, line in sites:
         bad = True
@@ -207,7 +259,8 @@ def main():
     if bad:
         return 1
 
-    print(f"SystemVerilog idiom gate: OK ({len(sources())} first-party HDL file(s); "
+    print(f"SystemVerilog idiom gate: OK ({len(sources())} first-party HDL file(s) "
+          f"across the superproject and processor submodules; 0 ordinary `.v`; "
           f"0 generic `always`; {totals['reg declaration']} reg <= "
           f"{budget['reg declaration']}; {totals['untyped parameter']} untyped "
           f"parameter <= {budget['untyped parameter']})")

--- a/scripts/check_sv_idiom.py
+++ b/scripts/check_sv_idiom.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+"""Gate: first-party HDL uses the SystemVerilog construct that says what it means.
+
+Why this exists. Rule 10 of the maintainability guide
+(docs/development/CODE_QUALITY.md) says new and touched synthesizable HDL uses
+the strongest appropriate SystemVerilog construct. `CONTRIBUTING.md` already
+requires SystemVerilog for new HDL - but a `.sv` file can still be written as
+Verilog-2001, and the compile-time checks that make ownership and intent
+reviewable are exactly what is lost when it is.
+
+Three things are checked, at two different strengths.
+
+  1. A GENERIC `always @` in synthesizable first-party HDL is REFUSED. It is
+     the one construct here that discards a real check: `always_ff` asks every
+     tool to enforce a single driver and to reject a procedural block that is
+     not sequential, and `always @` asks for neither. The tree has none, and
+     the arm below proves the check bites.
+
+  2. `reg` DECLARATIONS are RATCHETED. A `reg` in a `.sv` file is legal and
+     usually harmless, and 48 of them across twelve modules cannot be rewritten
+     in one change without exactly the churn the governing rule forbids.
+     `logic` is the SystemVerilog spelling and new code uses it.
+
+  3. UNTYPED `parameter` declarations are RATCHETED. `parameter W = 8` takes an
+     implementation-defined type; `parameter int W = 8` does not.
+
+WHAT IS NOT CHECKED, deliberately. A `wire` is NOT a finding. A net type is the
+correct model for module, primitive, continuous-assignment and multiple-driver
+connectivity, and mechanically rewriting `wire` to `logic` would be a
+repository-wide edit that changes nothing a reader or a tool can use. The
+issue that asked for this rule says so in as many words.
+
+Vendored, generated and archived sources are excluded through
+`scripts/lint_rtl.py`'s `LINT_EXCLUDE`, the same list Rules 5, 6 and this rule
+share - `hdl/milan/milan_dma_wrapper.v` is a Vivado-generated IP wrapper and
+keeps the representation its tool requires.
+
+Usage:
+    python3 scripts/check_sv_idiom.py            # gate
+    python3 scripts/check_sv_idiom.py --list     # per-file counts
+    python3 scripts/check_sv_idiom.py --selftest # fixture arms
+
+Exit 0 = no generic `always`, and the ratchets in scripts/sv_idiom.budget hold.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BUDGET = Path(__file__).resolve().parent / "sv_idiom.budget"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lint_rtl import LINT_EXCLUDE
+
+COMMENT = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
+#: `always @` that is NOT always_ff/always_comb/always_latch. The suffixed forms
+#: are separate keywords, so a plain `always` followed by `@` is unambiguous.
+GENERIC_ALWAYS = re.compile(r"(?<![\w_])always\s*@")
+REG_DECL = re.compile(r"^\s*reg\s+", re.M)
+UNTYPED_PARAM = re.compile(
+    r"\bparameter\s+(?!int\b|logic\b|bit\b|integer\b|byte\b|real\b|shortreal\b"
+    r"|string\b|type\b|signed\b|unsigned\b)(\w+)\s*=")
+
+
+def blank_comments(text):
+    return COMMENT.sub(lambda m: "".join(c if c == "\n" else " " for c in m.group(0)),
+                       text)
+
+
+def sources():
+    out = subprocess.run(["git", "ls-files", "hdl"], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout.split()
+    return [p for p in out
+            if p.endswith((".sv", ".svh", ".v")) and p not in LINT_EXCLUDE]
+
+
+def scan(text):
+    """{finding: count} for one HDL source, comments removed first."""
+    code = blank_comments(text)
+    return {
+        "generic always": len(GENERIC_ALWAYS.findall(code)),
+        "reg declaration": len(REG_DECL.findall(code)),
+        "untyped parameter": len(UNTYPED_PARAM.findall(code)),
+    }
+
+
+def audit():
+    totals = {"generic always": 0, "reg declaration": 0, "untyped parameter": 0}
+    per_file, sites = {}, []
+    for rel in sources():
+        text = (REPO / rel).read_text(errors="replace")
+        found = scan(text)
+        if any(found.values()):
+            per_file[rel] = found
+        for k, v in found.items():
+            totals[k] += v
+        if found["generic always"]:
+            code = blank_comments(text)
+            for m in GENERIC_ALWAYS.finditer(code):
+                sites.append((rel, code[:m.start()].count("\n") + 1))
+    return totals, per_file, sites
+
+
+def read_budget():
+    if not BUDGET.is_file():
+        return {}
+    out = {}
+    for line in BUDGET.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if "=" in line:
+            k, v = line.split("=", 1)
+            if v.strip().isdigit():
+                out[k.strip()] = int(v.strip())
+    return out
+
+
+def selftest():
+    failures = 0
+
+    def ck(name, ok, detail=""):
+        nonlocal failures
+        if ok:
+            print(f"[PASS] {name}")
+        else:
+            failures += 1
+            print(f"[FAIL] {name}{': ' + detail if detail else ''}")
+
+    ck("a generic always is caught",
+       scan("always @(posedge c) x <= 1;")["generic always"] == 1)
+    ck("always_ff is not a generic always",
+       scan("always_ff @(posedge c) x <= 1;")["generic always"] == 0)
+    ck("always_comb is not a generic always",
+       scan("always_comb begin x = 1; end")["generic always"] == 0)
+    ck("always_latch is not a generic always",
+       scan("always_latch @(*) x = 1;")["generic always"] == 0)
+    ck("a generic always inside a COMMENT is not counted",
+       scan("// always @(posedge c) x <= 1;")["generic always"] == 0,
+       "comments are blanked before the search")
+
+    ck("a reg declaration is caught", scan("  reg [7:0] x_r;")["reg declaration"] == 1)
+    ck("a wire declaration is NOT a finding",
+       scan("  wire [7:0] x_w;")["reg declaration"] == 0,
+       "a net type is the right model for connectivity")
+    ck("a logic declaration is not a finding",
+       scan("  logic [7:0] x_r;")["reg declaration"] == 0)
+    ck("a bare reg declaration with no width is caught",
+       scan("  reg x_r;")["reg declaration"] == 1)
+
+    ck("an untyped parameter is caught",
+       scan("parameter W = 8;")["untyped parameter"] == 1)
+    ck("a typed parameter is not", scan("parameter int W = 8;")["untyped parameter"] == 0)
+    ck("a logic-typed parameter is not",
+       scan("parameter logic [7:0] M = 8'hFF;")["untyped parameter"] == 0)
+
+    totals, per_file, sites = audit()
+    ck("the live scan reads the tree", len(sources()) > 40, f"{len(sources())} files")
+    ck("the excluded list is shared with lint_rtl",
+       "hdl/milan/milan_dma_wrapper.v" in LINT_EXCLUDE)
+    ck("the ratcheted populations are non-empty",
+       totals["reg declaration"] > 0,
+       "an inert scan would report zero everywhere and ratchet to nothing")
+
+    n = 15
+    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--list", action="store_true", help="per-file counts")
+    ap.add_argument("--selftest", action="store_true", help="run the fixture arms")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    totals, per_file, sites = audit()
+    bad = False
+
+    for rel, line in sites:
+        bad = True
+        print(f"GENERIC ALWAYS: {rel}:{line} — use always_ff or always_comb. "
+              f"`always @` asks no tool to enforce a single driver, and it does "
+              f"not say whether the block is sequential or combinational.")
+
+    if args.list:
+        for rel in sorted(per_file, key=lambda r: -sum(per_file[r].values())):
+            bits = ", ".join(f"{k} x{v}" for k, v in per_file[rel].items() if v)
+            print(f"  {rel}: {bits}")
+        print()
+
+    budget = read_budget()
+    for key in ("reg declaration", "untyped parameter"):
+        limit = budget.get(key)
+        if limit is None:
+            print(f"NO RATCHET for {key!r} in {BUDGET.relative_to(REPO)}")
+            bad = True
+        elif totals[key] > limit:
+            print(f"FAIL: {key} {totals[key]} > ratchet {limit}. New HDL uses "
+                  f"`logic` and typed parameters.")
+            bad = True
+    if bad:
+        return 1
+
+    print(f"SystemVerilog idiom gate: OK ({len(sources())} first-party HDL file(s); "
+          f"0 generic `always`; {totals['reg declaration']} reg <= "
+          f"{budget['reg declaration']}; {totals['untyped parameter']} untyped "
+          f"parameter <= {budget['untyped parameter']})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_sv_idiom.py
+++ b/scripts/check_sv_idiom.py
@@ -10,25 +10,42 @@ requires SystemVerilog for new HDL - but a `.sv` file can still be written as
 Verilog-2001, and the compile-time checks that make ownership and intent
 reviewable are exactly what is lost when it is.
 
-Four things are checked, at two different strengths.
+Five things are checked, at two different strengths.
 
-  1. An ordinary first-party `.v` file is REFUSED. The one checked-in Verilog
-     wrapper is a documented Vivado boundary in `LINT_EXCLUDE`; a new file may
-     not quietly bypass the repository's SystemVerilog-only rule.
+  1. A first-party HDL file that is NOT SystemVerilog is REFUSED. The accepted
+     spellings are a lower-case `.sv` or `.svh`. Every other tracked file under
+     `hdl/` whose extension names an HDL source - `.v`, `.vh`, `.vhd`, an
+     upper-case `.V` or `.SV`, the rest of `HDL_SUFFIXES`, compared
+     case-insensitively - is refused, because each of them is invisible to the
+     `*.sv` globs every other tool in this repository matches. The one
+     checked-in Verilog wrapper is a documented Vivado boundary in
+     `LINT_EXCLUDE`; a new file may not quietly bypass the repository's
+     SystemVerilog-only rule.
 
-  2. A GENERIC `always @` in synthesizable first-party HDL is REFUSED. It is
-     the one construct here that discards a real check: `always_ff` asks every
-     tool to enforce a single driver and to reject a procedural block that is
-     not sequential, and `always @` asks for neither. The tree has none, and
-     the arm below proves the check bites.
+  2. A GENERIC `always` in synthesizable first-party HDL is REFUSED: the bare
+     keyword, whatever follows it (`always @(posedge c)`, `always begin @(..)`,
+     `always #5`). It is the one construct here that discards a real check:
+     `always_ff` asks every tool to enforce a single driver and to reject a
+     procedural block that is not sequential, and `always` asks for neither.
+     The tree has none, and the arms below prove the check bites.
 
   3. `reg` DECLARATIONS are RATCHETED. A `reg` in a `.sv` file is legal and
      usually harmless, and the remaining population cannot be rewritten in
      one change without exactly the churn the governing rule forbids.
      `logic` is the SystemVerilog spelling and new code uses it.
 
-  4. UNTYPED `parameter` declarations are RATCHETED. `parameter W = 8` takes an
-     implementation-defined type; `parameter int W = 8` does not.
+  4. UNTYPED `parameter` declarations are RATCHETED, at zero. `parameter W = 8`
+     takes an implementation-defined type; `parameter int W = 8` does not. A
+     declaration with no default (`parameter W;`, the must-override form)
+     counts, and every name of a list (`parameter A = 1, B = 2;`) counts once.
+     A packed range (`parameter [3:0] W = 4`) is an explicit width and is not
+     counted; a user-defined type ahead of the name is a type.
+
+  5. UNTYPED `localparam` declarations are RATCHETED separately, by the same
+     matcher. A localparam crosses no boundary, so the two that remain are a
+     smaller debt than an untyped port parameter would be, but the rule the
+     issue wrote names both and a separate entry keeps the two populations
+     from being traded against each other.
 
 WHAT IS NOT CHECKED, deliberately. A `wire` is NOT a finding. A net type is the
 correct model for module, primitive, continuous-assignment and multiple-driver
@@ -36,17 +53,30 @@ connectivity, and mechanically rewriting `wire` to `logic` would be a
 repository-wide edit that changes nothing a reader or a tool can use. The
 issue that asked for this rule says so in as many words.
 
-Vendored, generated and archived sources are excluded through
-`scripts/lint_rtl.py`'s `LINT_EXCLUDE`, the same list Rules 5, 6 and this rule
-share - `hdl/milan/milan_dma_wrapper.v` is a Vivado-generated IP wrapper and
-keeps the representation its tool requires.
+WHAT THE POPULATION IS. Every tracked HDL file under `hdl/` in this repository
+and under the two pinned project processors, through the shared scope helper
+(`code_quality_scope.py`, which refuses an absent or off-pin processor), minus
+the whole-file exceptions `scripts/lint_rtl.py` records in `LINT_EXCLUDE` with a
+reason each: the Vivado-generated `hdl/milan/milan_dma_wrapper.v` and the
+archived Zynq top `hdl/milan/milan_top.sv`. Nothing else is excluded. The
+generated headers under `hdl/common/csr/gen/` are INSIDE the gated set on
+purpose - a finding there is fixed in `sw/builder/endstation_builder.py`, which
+writes them, and the gate reading them is how a generator regression would be
+seen - and the vendored trees (`third_party/`, `external/`) are outside the
+scope helper altogether. An empty population, or one that reaches no file under
+`hdl/` or under either processor's `hdl/`, is REFUSED (exit 2) before the budget
+is read: a gate over a missing tree would otherwise read as a clean ratchet.
+Only tracked files are seen (`git ls-files`), so a new file is invisible to the
+gate until it is `git add`ed.
 
 Usage:
     python3 scripts/check_sv_idiom.py            # gate
     python3 scripts/check_sv_idiom.py --list     # per-file counts
     python3 scripts/check_sv_idiom.py --selftest # fixture arms
 
-Exit 0 = no generic `always`, and the ratchets in scripts/sv_idiom.budget hold.
+Exit 0 = every file is SystemVerilog, no generic `always`, and the ratchets in
+scripts/sv_idiom.budget hold; 1 = a finding, or a missing/malformed ratchet;
+2 = the population was refused.
 """
 
 import argparse
@@ -59,20 +89,42 @@ BUDGET = Path(__file__).resolve().parent / "sv_idiom.budget"
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lint_rtl import LINT_EXCLUDE
-from code_quality_scope import tracked
+from code_quality_scope import PROJECT_SUBMODULES, tracked
+
+#: The accepted spellings, lower-case only: `*.sv` is what every glob in this
+#: repository's tooling matches, so a `.SV` would be linted, synthesized and
+#: simulated by nobody.
+SYSTEMVERILOG = (".sv", ".svh")
+#: Extensions that name an HDL source, compared case-insensitively. Anything
+#: else tracked under hdl/ (.md, .py, .svg, .json, .drawio) is not HDL.
+HDL_SUFFIXES = ("v", "vh", "vl", "vlg", "vlog", "verilog", "sv", "svh", "svi",
+                "svp", "vhd", "vhdl")
+#: The three trees a complete population reaches.
+POPULATION_ROOTS = ("hdl/",) + tuple(f"{sub}/hdl/" for sub in PROJECT_SUBMODULES)
+RATCHETED = ("reg declaration", "untyped parameter", "untyped localparam")
 
 NON_CODE = re.compile(r'//[^\n]*|/\*.*?\*/|"(?:\\.|[^"\\])*"', re.S)
-#: `always @` that is NOT always_ff/always_comb/always_latch. The suffixed forms
-#: are separate keywords, so a plain `always` followed by `@` is unambiguous.
-GENERIC_ALWAYS = re.compile(r"(?<![\w_])always\s*@")
+#: The bare keyword `always`. `always_ff`, `always_comb` and `always_latch` are
+#: separate keywords and `_` is a word character, so the lookahead excludes
+#: them. Nothing is required AFTER the keyword: requiring an `@` is what let
+#: `always begin @(posedge c) ... end` through.
+GENERIC_ALWAYS = re.compile(r"(?<![\w$])always(?![\w$])")
 #: `reg` is a reserved keyword and therefore unambiguously denotes a legacy
 #: variable declaration once comments and string literals have been blanked.
 #: Looking only at the start of a line misses ANSI declarations such as
 #: ``output reg ready_o`` and declarations preceded by synthesis attributes.
 REG_DECL = re.compile(r"\breg\b")
-UNTYPED_PARAM = re.compile(
-    r"\bparameter\s+(?!int\b|logic\b|bit\b|integer\b|byte\b|real\b|shortreal\b"
-    r"|string\b|type\b|signed\b|unsigned\b)(\w+)\s*=")
+#: A parameter or localparam keyword, and what a TYPED declaration puts right
+#: after it: a type keyword, a signing, or a packed range (an explicit width).
+PARAM_KW = re.compile(r"\b(parameter|localparam)\b")
+TYPED_HEAD = re.compile(
+    r"\s*(?:(?:int|integer|shortint|longint|byte|bit|logic|reg|real|shortreal|"
+    r"realtime|time|string|type|signed|unsigned)\b|\[)")
+#: An untyped item: the identifier right after the keyword or after a
+#: top-level comma, optionally dimensioned, then `=` or the end of the item.
+#: Anything else in that position is a user-defined type name ahead of the
+#: identifier, or the keyword of the next declaration in a port list.
+UNTYPED_NAME = re.compile(r"\s*([A-Za-z_]\w*)\s*(?:\[[^\]]*\]\s*)*(?:=|$)")
 
 
 def blank_non_code(text):
@@ -80,48 +132,116 @@ def blank_non_code(text):
         lambda m: "".join(c if c == "\n" else " " for c in m.group(0)), text)
 
 
+def hdl_suffix(path):
+    name = path.rsplit("/", 1)[-1]
+    return name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+
+def is_hdl(path):
+    return hdl_suffix(path) in HDL_SUFFIXES
+
+
+def not_systemverilog(path):
+    """True for an HDL file whose spelling is not a lower-case .sv/.svh."""
+    return is_hdl(path) and not path.endswith(SYSTEMVERILOG)
+
+
 def sources():
-    out = tracked("hdl")
-    return [p for p in out
-            if p.endswith((".sv", ".svh", ".v")) and p not in LINT_EXCLUDE]
+    return [p for p in tracked("hdl") if is_hdl(p) and p not in LINT_EXCLUDE]
+
+
+def population_problem(paths):
+    """Why this population may not be judged, or None when it is complete."""
+    if not paths:
+        return "the scan found no tracked HDL at all"
+    missing = [root for root in POPULATION_ROOTS
+               if not any(p.startswith(root) for p in paths)]
+    if missing:
+        return "no tracked HDL under " + ", ".join(missing)
+    return None
+
+
+def declaration_items(rest):
+    """Top-level comma-separated items of the declaration that starts at rest.
+
+    The declaration ends at a top-level `;`, or at the `)` that closes the
+    parameter port list it sits in. Parentheses, brackets and braces inside a
+    default expression are tracked, so `f(a, b)` and `{1, 2}` split nothing.
+    """
+    items, depth, start = [], 0, 0
+    for i, ch in enumerate(rest):
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            if depth == 0:
+                items.append(rest[start:i])
+                return items
+            depth -= 1
+        elif ch == ";" and depth == 0:
+            items.append(rest[start:i])
+            return items
+        elif ch == "," and depth == 0:
+            items.append(rest[start:i])
+            start = i + 1
+    items.append(rest[start:])
+    return items
+
+
+def untyped_names(code):
+    """{keyword: [names]} for the parameter/localparam declarations with no type."""
+    out = {"parameter": [], "localparam": []}
+    for m in PARAM_KW.finditer(code):
+        rest = code[m.end():]
+        if TYPED_HEAD.match(rest):
+            continue
+        for item in declaration_items(rest):
+            name = UNTYPED_NAME.match(item)
+            if not name:
+                break  # a user-defined type ahead of the name, or a keyword
+            out[m.group(1)].append(name.group(1))
+    return out
 
 
 def scan(text, path="x.sv"):
     """{finding: count} for one HDL source, non-code text removed first."""
     code = blank_non_code(text)
+    names = untyped_names(code)
     return {
-        "ordinary .v": int(path.endswith(".v")),
+        "not SystemVerilog": int(not_systemverilog(path)),
         "generic always": len(GENERIC_ALWAYS.findall(code)),
         "reg declaration": len(REG_DECL.findall(code)),
-        "untyped parameter": len(UNTYPED_PARAM.findall(code)),
+        "untyped parameter": len(names["parameter"]),
+        "untyped localparam": len(names["localparam"]),
     }
 
 
-def audit():
-    totals = {"ordinary .v": 0, "generic always": 0,
-              "reg declaration": 0, "untyped parameter": 0}
-    per_file, sites, ordinary_v = {}, [], []
-    for rel in sources():
+def audit(paths=None):
+    paths = sources() if paths is None else paths
+    totals = {"not SystemVerilog": 0, "generic always": 0,
+              "reg declaration": 0, "untyped parameter": 0,
+              "untyped localparam": 0}
+    per_file, sites, foreign = {}, [], []
+    for rel in paths:
         text = (REPO / rel).read_text(errors="replace")
         found = scan(text, rel)
         if any(found.values()):
             per_file[rel] = found
         for k, v in found.items():
             totals[k] += v
-        if found["ordinary .v"]:
-            ordinary_v.append(rel)
+        if found["not SystemVerilog"]:
+            foreign.append(rel)
         if found["generic always"]:
             code = blank_non_code(text)
             for m in GENERIC_ALWAYS.finditer(code):
                 sites.append((rel, code[:m.start()].count("\n") + 1))
-    return totals, per_file, sites, ordinary_v
+    return totals, per_file, sites, foreign
 
 
-def undocumented_v_exceptions():
-    """Return excluded Verilog files whose required local rationale is absent."""
+def undocumented_hdl_exceptions():
+    """Excluded non-SystemVerilog files whose required local rationale is absent."""
     bad = []
     for rel, rationale in LINT_EXCLUDE.items():
-        if not rel.endswith(".v"):
+        if not not_systemverilog(rel):
             continue
         if (not isinstance(rationale, tuple) or len(rationale) < 2
                 or not all(isinstance(item, str) and item.strip()
@@ -130,11 +250,10 @@ def undocumented_v_exceptions():
     return bad
 
 
-def read_budget():
-    if not BUDGET.is_file():
-        return {}
+def parse_budget(text):
+    """{key: int} from budget text; a malformed value simply has no entry."""
     out = {}
-    for line in BUDGET.read_text().splitlines():
+    for line in text.splitlines():
         line = line.split("#", 1)[0].strip()
         if "=" in line:
             k, v = line.split("=", 1)
@@ -143,25 +262,63 @@ def read_budget():
     return out
 
 
+def read_budget():
+    return parse_budget(BUDGET.read_text()) if BUDGET.is_file() else {}
+
+
+def ratchet(totals, budget):
+    """(failures, notes): the ratchet verdict for the measured totals.
+
+    A missing or malformed entry is a failure, because an absent budget must
+    not read as an unbounded one. A count below its entry is a note that the
+    entry can be lowered: a budget only moves downward, and slack in it is
+    exactly where the next regression hides.
+    """
+    failures, notes = [], []
+    for key in RATCHETED:
+        limit = budget.get(key)
+        if limit is None:
+            failures.append(f"NO RATCHET for {key!r} in {BUDGET.relative_to(REPO)} "
+                            f"(entry missing or not an integer)")
+        elif totals[key] > limit:
+            failures.append(f"FAIL: {key} {totals[key]} > ratchet {limit}. New HDL "
+                            f"uses `logic` and typed parameters.")
+        elif totals[key] < limit:
+            notes.append(f"  the {key} ratchet can be lowered to {totals[key]}")
+    return failures, notes
+
+
 def selftest():
-    failures = 0
+    failures = checks = 0
 
     def ck(name, ok, detail=""):
-        nonlocal failures
+        nonlocal failures, checks
+        checks += 1
         if ok:
             print(f"[PASS] {name}")
         else:
             failures += 1
             print(f"[FAIL] {name}{': ' + detail if detail else ''}")
 
+    def n_untyped(text):
+        found = scan(text)
+        return found["untyped parameter"], found["untyped localparam"]
+
     ck("a generic always is caught",
        scan("always @(posedge c) x <= 1;")["generic always"] == 1)
+    ck("a generic always with begin before the sensitivity list is caught",
+       scan("always begin @(posedge c) x <= 1; end")["generic always"] == 1,
+       "the keyword is the finding, not the `@` after it")
+    ck("a delay-driven generic always is caught",
+       scan("always #5 c = ~c;")["generic always"] == 1)
     ck("always_ff is not a generic always",
        scan("always_ff @(posedge c) x <= 1;")["generic always"] == 0)
     ck("always_comb is not a generic always",
        scan("always_comb begin x = 1; end")["generic always"] == 0)
     ck("always_latch is not a generic always",
        scan("always_latch @(*) x = 1;")["generic always"] == 0)
+    ck("an identifier containing the word is not a generic always",
+       scan("assign my_always_w = always_seen_r;")["generic always"] == 0)
     ck("a generic always inside a COMMENT is not counted",
        scan("// always @(posedge c) x <= 1;")["generic always"] == 0,
        "comments are blanked before the search")
@@ -182,32 +339,91 @@ def selftest():
     ck("the word reg inside a string is not counted",
        scan('$display("reg declaration");')["reg declaration"] == 0)
 
-    ck("an ordinary Verilog file is refused",
-       scan("module x; endmodule", "hdl/x.v")["ordinary .v"] == 1)
-    ck("a SystemVerilog file is not refused by extension",
-       scan("module x; endmodule", "hdl/x.sv")["ordinary .v"] == 0)
+    for path in ("hdl/x.v", "hdl/x.vh", "hdl/x.V", "hdl/x.SV", "hdl/x.vhd",
+                 "protocol-processor/hdl/x.vh"):
+        ck(f"a non-SystemVerilog HDL file is refused: {path}",
+           scan("module x; endmodule", path)["not SystemVerilog"] == 1)
+    for path in ("hdl/x.sv", "hdl/common/x.svh"):
+        ck(f"a SystemVerilog file is not refused by extension: {path}",
+           scan("module x; endmodule", path)["not SystemVerilog"] == 0)
+    ck("a non-HDL file under hdl/ is not in the population",
+       not is_hdl("hdl/README.md") and not is_hdl("hdl/x.py"))
 
-    ck("an untyped parameter is caught",
-       scan("parameter W = 8;")["untyped parameter"] == 1)
-    ck("a typed parameter is not", scan("parameter int W = 8;")["untyped parameter"] == 0)
+    ck("an untyped parameter is caught", n_untyped("parameter W = 8;") == (1, 0))
+    ck("an untyped parameter with no default is caught",
+       n_untyped("parameter X;") == (1, 0), "the must-override form")
+    ck("every name of an untyped parameter list is counted",
+       n_untyped("parameter A = 1, B = 2;") == (2, 0))
+    ck("a default expression with its own commas splits nothing",
+       n_untyped("parameter A = f(1, 2), B = {3, 4};") == (2, 0))
+    ck("untyped parameters without defaults in a port list are caught",
+       n_untyped("module zz #(parameter X, parameter Y) (input a);") == (2, 0))
+    ck("a typed parameter list types every name after it",
+       n_untyped("module zz #(parameter int A = 1, B = 2) (input a);") == (0, 0),
+       "`B` belongs to the same list_of_param_assignments as the typed `A`")
+    ck("a typed parameter is not", n_untyped("parameter int W = 8;") == (0, 0))
     ck("a logic-typed parameter is not",
-       scan("parameter logic [7:0] M = 8'hFF;")["untyped parameter"] == 0)
+       n_untyped("parameter logic [7:0] M = 8'hFF;") == (0, 0))
+    ck("a user-defined type ahead of the name is a type",
+       n_untyped("parameter my_t X = 1;") == (0, 0))
+    ck("a packed range is an explicit width, not an untyped parameter",
+       n_untyped("parameter [3:0] X = 4;") == (0, 0))
+    ck("an untyped localparam is counted in its own population",
+       n_untyped("localparam X = $clog2(N);") == (0, 1))
+    ck("a typed localparam is not", n_untyped("localparam int X = 4;") == (0, 0))
 
-    totals, per_file, sites, ordinary_v = audit()
-    ck("the live scan reads the tree", len(sources()) > 100, f"{len(sources())} files")
+    ck("an empty population is refused",
+       population_problem([]) is not None)
+    ck("a population without the processors names both",
+       (population_problem(["hdl/a.sv"]) or "").count("/hdl/") == 2)
+    ck("a population without one processor names it",
+       "gptp-processor/hdl/" in (population_problem(
+           ["hdl/a.sv", "protocol-processor/hdl/b.sv"]) or ""))
+    ck("a population without the superproject tree is refused",
+       "hdl/" in (population_problem(
+           ["protocol-processor/hdl/b.sv", "gptp-processor/hdl/c.sv"]) or ""))
+    ck("a complete population is not refused",
+       population_problem(["hdl/a.sv", "protocol-processor/hdl/b.sv",
+                           "gptp-processor/hdl/c.sv"]) is None)
+
+    measured = {"reg declaration": 2, "untyped parameter": 0, "untyped localparam": 0}
+    full = {"reg declaration": 2, "untyped parameter": 0, "untyped localparam": 0}
+    below = dict(full, **{"reg declaration": 1})
+    slack = dict(full, **{"reg declaration": 3})
+    ck("a count above its budget fails the ratchet",
+       ratchet(measured, below)[0] and "2 > ratchet 1" in ratchet(measured, below)[0][0])
+    ck("a count equal to its budget passes with no note",
+       ratchet(measured, full) == ([], []))
+    ck("a count below its budget passes and names the lowerable value",
+       not ratchet(measured, slack)[0]
+       and ratchet(measured, slack)[1] == ["  the reg declaration ratchet can be lowered to 2"])
+    ck("a missing budget entry fails the ratchet",
+       any("NO RATCHET for 'untyped localparam'" in f
+           for f in ratchet(measured, dict(full, **{"untyped localparam": None}))[0]))
+    ck("a malformed budget value is no entry",
+       parse_budget("reg declaration = lots\nuntyped parameter = 0") == {"untyped parameter": 0})
+    ck("an absent budget file is an empty budget",
+       all(k in ratchet(measured, {})[0][i] for i, k in enumerate(RATCHETED)))
+
+    paths = sources()
+    totals, per_file, sites, foreign = audit(paths)
+    ck("the live scan reads the tree", len(paths) > 100, f"{len(paths)} files")
     ck("the live scan reaches both project processor submodules",
-       any(p.startswith("protocol-processor/") for p in sources())
-       and any(p.startswith("gptp-processor/") for p in sources()))
+       any(p.startswith("protocol-processor/") for p in paths)
+       and any(p.startswith("gptp-processor/") for p in paths))
+    ck("the live population is complete", population_problem(paths) is None,
+       str(population_problem(paths)))
     ck("the excluded list is shared with lint_rtl",
        "hdl/milan/milan_dma_wrapper.v" in LINT_EXCLUDE)
     ck("the checked-in Verilog exception has a reason and evidence",
-       not undocumented_v_exceptions())
+       not undocumented_hdl_exceptions())
     ck("the ratcheted populations are non-empty",
        totals["reg declaration"] > 0,
        "an inert scan would report zero everywhere and ratchet to nothing")
+    ck("the checked-in budget carries every ratcheted key",
+       all(k in read_budget() for k in RATCHETED), str(read_budget()))
 
-    n = 22
-    print(f"\n{n} checks: {n - failures} PASS, {failures} FAIL")
+    print(f"\n{checks} checks: {checks - failures} PASS, {failures} FAIL")
     return 1 if failures else 0
 
 
@@ -220,16 +436,32 @@ def main():
     if args.selftest:
         return selftest()
 
-    totals, per_file, sites, ordinary_v = audit()
+    try:
+        paths = sources()
+    except RuntimeError as exc:
+        print(f"POPULATION: REFUSED - {exc}")
+        return 2
+    problem = population_problem(paths)
+    if problem:
+        print(f"POPULATION: REFUSED - {problem}. The gate reads the tracked files "
+              f"(`git ls-files --recurse-submodules`) under hdl/ in this repository "
+              f"and in both pinned processors, and a missing tree would otherwise "
+              f"read as a clean ratchet. Refused rather than counted, before the "
+              f"budget is read.")
+        return 2
+
+    totals, per_file, sites, foreign = audit(paths)
     bad = False
 
-    for rel in ordinary_v:
+    for rel in foreign:
         bad = True
-        print(f"ORDINARY VERILOG: {rel} — new first-party HDL must use a .sv "
-              "extension, or a generated/tool boundary must carry a rationale "
-              "in scripts/lint_rtl.py:LINT_EXCLUDE.")
+        print(f"NOT SYSTEMVERILOG: {rel} — first-party HDL carries a lower-case .sv "
+              "or .svh extension; an ordinary Verilog file, an include header or "
+              "an upper-case extension is seen by no tool here. Rename it, or "
+              "record the generated/tool boundary with its rationale in "
+              "scripts/lint_rtl.py:LINT_EXCLUDE.")
 
-    for rel in undocumented_v_exceptions():
+    for rel in undocumented_hdl_exceptions():
         bad = True
         print(f"UNDOCUMENTED VERILOG EXCEPTION: {rel} — record both the owner/tool "
               "reason and repository evidence in scripts/lint_rtl.py:LINT_EXCLUDE.")
@@ -237,8 +469,8 @@ def main():
     for rel, line in sites:
         bad = True
         print(f"GENERIC ALWAYS: {rel}:{line} — use always_ff or always_comb. "
-              f"`always @` asks no tool to enforce a single driver, and it does "
-              f"not say whether the block is sequential or combinational.")
+              f"A bare `always` asks no tool to enforce a single driver, and it "
+              f"does not say whether the block is sequential or combinational.")
 
     if args.list:
         for rel in sorted(per_file, key=lambda r: -sum(per_file[r].values())):
@@ -247,23 +479,21 @@ def main():
         print()
 
     budget = read_budget()
-    for key in ("reg declaration", "untyped parameter"):
-        limit = budget.get(key)
-        if limit is None:
-            print(f"NO RATCHET for {key!r} in {BUDGET.relative_to(REPO)}")
-            bad = True
-        elif totals[key] > limit:
-            print(f"FAIL: {key} {totals[key]} > ratchet {limit}. New HDL uses "
-                  f"`logic` and typed parameters.")
-            bad = True
-    if bad:
+    failures, notes = ratchet(totals, budget)
+    for line in failures:
+        print(line)
+    if bad or failures:
         return 1
 
-    print(f"SystemVerilog idiom gate: OK ({len(sources())} first-party HDL file(s) "
-          f"across the superproject and processor submodules; 0 ordinary `.v`; "
+    print(f"SystemVerilog idiom gate: OK ({len(paths)} first-party HDL file(s) across "
+          f"the superproject and both processor submodules, every one .sv/.svh; "
           f"0 generic `always`; {totals['reg declaration']} reg <= "
           f"{budget['reg declaration']}; {totals['untyped parameter']} untyped "
-          f"parameter <= {budget['untyped parameter']})")
+          f"parameter <= {budget['untyped parameter']}; "
+          f"{totals['untyped localparam']} untyped localparam <= "
+          f"{budget['untyped localparam']})")
+    for line in notes:
+        print(line)
     return 0
 
 

--- a/scripts/sv_idiom.budget
+++ b/scripts/sv_idiom.budget
@@ -1,0 +1,9 @@
+# Rule 10 ratchets. See scripts/check_sv_idiom.py. A generic `always @` is
+# refused outright and has no entry here; these two are debt.
+# BOTH NUMBERS MAY ONLY GO DOWN.
+#
+# `reg` in a .sv file is legal and usually harmless; `logic` is the
+# SystemVerilog spelling and new code uses it. A `wire` is NOT counted: a net
+# type is the right model for connectivity.
+reg declaration   = 48
+untyped parameter = 4

--- a/scripts/sv_idiom.budget
+++ b/scripts/sv_idiom.budget
@@ -1,9 +1,11 @@
-# Rule 10 ratchets. See scripts/check_sv_idiom.py. A generic `always @` is
-# refused outright and has no entry here; these two are debt.
+# Rule 10 ratchets across the superproject and both project-owned processor
+# submodules. See scripts/check_sv_idiom.py. Ordinary `.v` files and generic
+# `always @` are refused outright and have no entries here. The two populations
+# below are legacy debt.
 # BOTH NUMBERS MAY ONLY GO DOWN.
 #
 # `reg` in a .sv file is legal and usually harmless; `logic` is the
 # SystemVerilog spelling and new code uses it. A `wire` is NOT counted: a net
 # type is the right model for connectivity.
-reg declaration   = 48
-untyped parameter = 4
+reg declaration   = 58
+untyped parameter = 0

--- a/scripts/sv_idiom.budget
+++ b/scripts/sv_idiom.budget
@@ -1,11 +1,17 @@
 # Rule 10 ratchets across the superproject and both project-owned processor
-# submodules. See scripts/check_sv_idiom.py. Ordinary `.v` files and generic
-# `always @` are refused outright and have no entries here. The two populations
-# below are legacy debt.
-# BOTH NUMBERS MAY ONLY GO DOWN.
+# submodules. See scripts/check_sv_idiom.py. Files that are not lower-case
+# .sv/.svh and generic `always` are refused outright and have no entries here.
+# The three populations below are legacy debt, measured by the gate.
+# EVERY NUMBER MAY ONLY GO DOWN.
 #
 # `reg` in a .sv file is legal and usually harmless; `logic` is the
 # SystemVerilog spelling and new code uses it. A `wire` is NOT counted: a net
 # type is the right model for connectivity.
-reg declaration   = 58
-untyped parameter = 0
+reg declaration    = 58
+# The complete measured population (axi_stream_if's four) was typed in this
+# change, so the entry admits no new one: a `parameter W;` with no default and
+# every name of a `parameter A = 1, B = 2;` list count as well.
+untyped parameter  = 0
+# The two `$clog2`-derived TDEST_WIDTH constants in hdl/ieee8021q/ts/. Kept as
+# its own entry so localparam debt is never traded against port parameters.
+untyped localparam = 2


### PR DESCRIPTION
> [!IMPORTANT]
> **Post-review correction (2026-08-28, head `e70fd6ad`).** SystemVerilog idiom enforcement covers both processor submodules, refuses ordinary `.v`, catches ANSI `output reg`, and ignores comments/strings correctly. Result: 120 tracked HDL files, zero ordinary `.v`, zero generic `always`, 58 legacy regs, zero untyped parameters; self-test 22/22. Earlier figures below are superseded.

Closes #258

Rule 10 of the #248 contract — **the last one**. Stacked on #283 (Rule 9) → #282 → #281 → #280 → #279 → #278 → #277 → #276 → #275.

## What changed

| Area | Change |
|---|---|
| Guide | Rule 10 section, and the guide's closing note now that all ten rules have landed. |
| Gate | `scripts/check_sv_idiom.py` + `scripts/sv_idiom.budget`. |
| Cleanup | The tree's one generic `always @`, converted. |
| CI | The gate and its self-test run in `docs.yml`. |

## One refusal, two ratchets

| Finding | Count | Disposition |
|---|---:|---|
| Generic `always @` in synthesizable first-party HDL | **0** | Refused outright |
| `reg` declarations | 48 across 12 modules | Ratchet |
| Untyped `parameter` | 4, all in `axi_stream_if.sv` | Ratchet |
| `.v` files in the gated set | 0 | — |

A generic `always @` is the only construct here that discards a real check: `always_ff` asks every tool in the path to enforce a single driver and to reject a block that is not sequential; `always @` asks for neither, and the difference is silent.

## A `wire` is deliberately not a finding

A net type is the correct model for module, primitive, continuous-assignment and multiple-driver connectivity. Mechanically rewriting `wire` to `logic` would touch nearly every file and change nothing a reader or a tool can use. The issue that asked for this rule says so in as many words. The gate does not look for it, and the guide records that decision rather than leaving it as an omission.

## The one generic `always`, and why converting it was delicate

`hdl/common/csr/milan_csr.sv` carried exactly one — the **reset-epoch canary**: two flops that count datapath reset *releases*, and therefore must have no reset clause at all so their bitstream initialisation survives every axis reset. Adding a reset would silently destroy the only thing they measure. This is precisely the `reset_less` class of observer `CONTRIBUTING.md` warns about.

`always_ff` with no reset clause is still reset-less — the keyword states sequential intent and asks for single-driver enforcement, and adds nothing else. The block is converted, `reg` becomes `logic`, and the comment now says a reset must **never** be added there, because the next reader's instinct on seeing `always_ff` without one will be to add it.

## Exceptions imported, not re-decided

`hdl/milan/milan_dma_wrapper.v` is a Vivado-generated IP wrapper and keeps its tool's representation. It is not excluded by this gate's own judgement: the list is imported from `scripts/lint_rtl.py`, which records a reason per entry — the same list Rules 5 and 6 use.

## Also fixed in this stack (on #281, which the tail was rebased onto)

`check_todo_ownership.py` became a finding of **itself** once it was tracked: its fixture string `"  # FIXME: broken"` opens with a `#`, so the comment extractor read the string as a comment. My Rule 7 evidence line reported 0 unowned markers, and that measurement was taken before the file was added to git — it was wrong. The marker words are now **assembled** rather than spelled, following `docs_check.py`'s existing precedent for its denied tokens, the docstring no longer spells an owned form, and a new arm requires the checker to carry no marker of its own. 14/14.

## Evidence

- `scripts/check_sv_idiom.py --selftest` — **15/15**, including arms that `wire` is not a finding and that a bare `reg x;` is (the first version of the regex skipped it).
- `scripts/check_sv_idiom.py` — OK: 72 files, 0 generic `always`, 48 reg ≤ 48, 4 untyped ≤ 4.
- `scripts/lint_rtl.py --check` — PASS, 99 ≤ ratchet 99.
- `tb/verilator/csr` — all four windows: 385, 385, 104, 31 checks, 0 failures.
- `syn/yosys/run.sh --mode elaborate --top milan_datapath` — PASS; tied-input PASS; TAP-PURITY PASS.
- **All nine gates this stack added, run together at this head — every one rc 0.**
- `docs_check` 0 findings / `gen_toc --check` OK / `check_doc_paths` OK / `ci_events --check` OK / traceability matrix up to date.

## Not covered

- The 48 `reg` and 4 untyped parameters; that is the ratchet's job.
- `tsn_fuzz` declared SKIP; builder gate 23h pre-existing on this host and on a pristine `dev` checkout.
