### PR TITLE
Preload jemalloc for the Yosys portability gate, and record why -defer is not the lever here

### DIFF
--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -132,11 +132,13 @@ pool. Before applying it there, read that repository's issue #25: six of its
 modules are not in its `tops` array at all, so nothing ever elaborates them as
 a top, and that array should be completed first.
 
-One thing `-defer` does **not** cost, measured rather than assumed: it still
-parses every module. Four fault classes injected into a module no top
-instantiates — a syntax error, a negative-width vector, an undefined
-submodule, and a `$fatal` — are caught identically with and without the flag.
-`-defer` postpones elaboration, not parsing.
+One thing `-defer` does **not** cost, controlled on that gate by injecting a
+fault into a module no top instantiates and running both forms over it:
+coverage. A syntax error is caught either way — by `sv2v`, before Yosys reads
+anything — and an instance of an undefined module is missed either way,
+because nothing elaborates a module that is in no top. `-defer` postpones
+elaboration; what provides elaboration coverage is the `tops` array, not the
+reading mode.
 
 The rule to carry to the next script: **`-defer` is a fix for re-reading, not
 a fix for synthesis.** Check the `read_verilog` line in `yosys -d` output

--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -128,9 +128,15 @@ nothing. The flag belongs in the control plane's own portability gate
 (`syn/yosys/run.sh` inside the `protocol-processor` submodule), which lowers
 its whole `hdl/` tree into a single `all.v` and then re-reads it once per top,
 32 times — there it is 39.65 s → 10.31 s, and 1.25 s with a bounded process
-pool. Before applying it there, read that repository's issue #25: the
-redundant re-parse is currently the only front-end coverage six of its modules
-get, so the tops array has to be completed first.
+pool. Before applying it there, read that repository's issue #25: six of its
+modules are not in its `tops` array at all, so nothing ever elaborates them as
+a top, and that array should be completed first.
+
+One thing `-defer` does **not** cost, measured rather than assumed: it still
+parses every module. Four fault classes injected into a module no top
+instantiates — a syntax error, a negative-width vector, an undefined
+submodule, and a `$fatal` — are caught identically with and without the flag.
+`-defer` postpones elaboration, not parsing.
 
 The rule to carry to the next script: **`-defer` is a fix for re-reading, not
 a fix for synthesis.** Check the `read_verilog` line in `yosys -d` output

--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -21,6 +21,7 @@ make ecp5       # map to a real non-Xilinx device: Lattice ECP5 (TRELLIS_FF/LUT4
 
 - **[How it works](#how-it-works)** — The two-stage pipeline and why each stage is there: sv2v converts the SystemVerilog Yosys cannot parse (interfaces, packages, assignment patterns), then `hierarchy -check` is what makes a PASS mean something — it fails on any surviving vendor primitive, so green = fully mapped to generic logic with nothing Xilinx-specific left.
 - **[Tooling](#tooling)** — The two binaries you need and where to get them. No Xilinx tools are required, which is the point — this flow is the evidence that the RTL is not tied to one vendor's toolchain.
+- **[Runtime levers](#runtime-levers)** — Why this gate is optimisation-bound and not parse-bound, which is the one fact that decides every speed question here: the jemalloc preload it now runs under (−45% on the heaviest top, −42% on the whole sharded gate, byte-identical netlist) and how to turn it off, and the measured reason `read_verilog -defer` is *not* used — it removes 85% of a step that is 0.5% of the run, and changes the cell count by 1.3% while doing it.
 - **[Coverage](#coverage)** — What the tops actually span, and the standing rule that the `tops=()` array is the count while this prose is not. Also names the one deliberate gap: `milan_top`, which pulls in the RGMII SelectIO and PS block design.
 - **[Notes](#notes)** — Two facts that stop you misreading the output: the concrete non-Xilinx targets (`synth_ecp5`, `synth_ice40`) with real cell counts, and why `axis_fifo` looks enormous — its 4096-deep default, which no instance in the design uses.
 - **[ooc.sh — AREA measurement (a different question from run.sh)](#oocsh--area-measurement-a-different-question-from-runsh)** — `run.sh` asks *does it map*; this asks *what does it cost*, which is the only number an area lever may be judged on. Three traps it exists to avoid, and the third is the sharpest: `-flatten` can read a genuinely deleted block as **−1 LUT / −0 FF**, so a structural lever needs the hierarchy-preserving form as well. Ends with the honest caveat — these are estimates with a yosys→Vivado ratio between 0.25 and 0.86, and control sets are not measurable here at all.
@@ -40,6 +41,100 @@ make ecp5       # map to a real non-Xilinx device: Lattice ECP5 (TRELLIS_FF/LUT4
 - `sv2v` on `PATH` — pinned prebuilt release from
   [github.com/zachjs/sv2v/releases](https://github.com/zachjs/sv2v/releases)
   (drop into `~/.local/bin`). No Xilinx tools required.
+
+## Runtime levers
+
+This gate is **optimisation-bound, not parse-bound**. `yosys -d` on
+`milan_datapath` — 1,137,752 wires and 1,597,718 cells in one single-threaded
+process — spends its time like this ([#286](https://github.com/kebag-logic/milan-fpga/issues/286)):
+
+| pass | share |
+| --- | ---: |
+| `opt_dff` | 25% |
+| `opt_clean` | 23% |
+| `abc` | 16% |
+| `opt_expr` | 14% |
+| `opt_merge`, `opt_muxtree`, … | 9% |
+| `read_verilog` | **0.5%** |
+
+Everything below follows from that one table. **The front end is not the
+cost**, so no front-end change — `-defer`, a faster parser, or a commercial
+one — can move this gate much. `sv2v` over the *whole* 46-top inventory is
+34.6 s.
+
+### The allocator: on by default, worth ~45%
+
+Yosys allocates constantly, and glibc's allocator is where a large share of
+the `opt*` time goes. `run.sh` therefore preloads **jemalloc** for its `yosys`
+children when the library is installed:
+
+| scope | glibc | jemalloc |
+| --- | ---: | ---: |
+| `milan_datapath`, one process | 656.3 s | **361.5 s** (−44.9%) |
+| `KL_pp_shadow`, one process | 273.9 s | 171.8 s (−37.3%) |
+| whole gate, 8 shards, 46/46 pass | 616.2 s | **357.8 s** (−41.9%) |
+
+Peak RSS *falls* as well (3033 → 2786 MiB on `milan_datapath`), so this does
+not spend the memory a parallel shard run needs.
+
+**It changes speed and never results**, and that was measured, not assumed:
+`write_rtlil` after this gate's own program is byte-identical under glibc,
+tcmalloc, jemalloc and mimalloc (`sha256 cc79dc89adbce892…`, 43,920,712 bytes
+on `KL_gptp_shadow`).
+
+It is optional in both directions — the tool requirement above is still just
+`yosys` and `sv2v`, and a machine without jemalloc runs exactly as before:
+
+```sh
+YOSYS_MALLOC=none  ./run.sh     # system allocator
+YOSYS_MALLOC=/path/to/lib.so ./run.sh
+./run.sh --selftest-alloc       # check the selection rules; needs nothing else
+```
+
+A **named** library that is absent refuses rather than falling back, so a run
+asked to reproduce one allocator cannot quietly report another one's timing.
+The header line prints which allocator was in effect, because a wall-clock
+figure quoted from this output is only reproducible with it. The preload
+reaches `yosys` and the `abc` it spawns; `sv2v` and the `python3` helpers run
+under the system allocator.
+
+### `read_verilog -defer`: right instrument, wrong script
+
+`-defer` postpones turning a parsed module into RTLIL until something
+instantiates it. **It only pays where one file holding many modules is read
+once per top**, so the reader spends time elaborating modules that top will
+never use.
+
+That is not this gate. `run.sh` gives every top its *own* `sv2v` output, built
+from that top's own source list, so there is almost nothing to defer. Measured
+on the two tops with the largest surplus — both are handed the entire
+protocol-processor tree and instantiate a subset of it:
+
+| top | plain | `-defer` | `read_verilog` step | cells |
+| --- | ---: | ---: | ---: | ---: |
+| `milan_datapath` | 353.5 s | 350.0 s (−1.0%) | 2.30 s → 0.26 s | 1,597,718 → 1,598,979 |
+| `KL_pp_shadow` | 165.9 s | 166.4 s (+0.3%) | 0.89 s → 0.16 s | 1,133,318 → 1,148,270 |
+
+`-defer` does what it says — it removes 82–89% of the `read_verilog` step —
+and that step is 0.5% of the run, so the gate does not get faster. Worse, the
+result is **not** the same netlist: +0.08% cells on `milan_datapath` and
++1.3% on `KL_pp_shadow`, because deferring changes which parameterised
+specialisations exist by the time the `opt*` passes run. The same binary run
+twice reproduces its own digest, so that is the flag and not run-to-run
+variation.
+
+So `run.sh` does **not** use `-defer`: it costs a changed answer and buys
+nothing. The flag belongs in
+[`protocol-processor/syn/yosys/run.sh`](../../protocol-processor/syn/yosys/run.sh),
+which lowers its whole `hdl/` tree into a single `all.v` and then re-reads it
+once per top, 32 times — there it is 39.65 s → 10.31 s, and 1.25 s with a
+bounded process pool. Before applying it there, read that repository's issue
+#25: the redundant re-parse is currently the only front-end coverage six of
+its modules get, so the tops array has to be completed first.
+
+The rule to carry to the next script: **`-defer` is a fix for re-reading, not
+a fix for synthesis.** Check the `read_verilog` line in `yosys -d` output
+before reaching for it.
 
 ## Coverage
 44 tops as of 2026-08-13 (the `tops=()` array in `run.sh` is authoritative — that

--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -124,13 +124,13 @@ twice reproduces its own digest, so that is the flag and not run-to-run
 variation.
 
 So `run.sh` does **not** use `-defer`: it costs a changed answer and buys
-nothing. The flag belongs in
-[`protocol-processor/syn/yosys/run.sh`](../../protocol-processor/syn/yosys/run.sh),
-which lowers its whole `hdl/` tree into a single `all.v` and then re-reads it
-once per top, 32 times — there it is 39.65 s → 10.31 s, and 1.25 s with a
-bounded process pool. Before applying it there, read that repository's issue
-#25: the redundant re-parse is currently the only front-end coverage six of
-its modules get, so the tops array has to be completed first.
+nothing. The flag belongs in the control plane's own portability gate
+(`syn/yosys/run.sh` inside the `protocol-processor` submodule), which lowers
+its whole `hdl/` tree into a single `all.v` and then re-reads it once per top,
+32 times — there it is 39.65 s → 10.31 s, and 1.25 s with a bounded process
+pool. Before applying it there, read that repository's issue #25: the
+redundant re-parse is currently the only front-end coverage six of its modules
+get, so the tops array has to be completed first.
 
 The rule to carry to the next script: **`-defer` is a fix for re-reading, not
 a fix for synthesis.** Check the `read_verilog` line in `yosys -d` output

--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -91,12 +91,24 @@ YOSYS_MALLOC=/path/to/lib.so ./run.sh
 ./run.sh --selftest-alloc       # check the selection rules; needs nothing else
 ```
 
-A **named** library that is absent refuses rather than falling back, so a run
-asked to reproduce one allocator cannot quietly report another one's timing.
+A **named** library is refused rather than quietly ignored if it is absent, or
+if the dynamic loader will not take it — an existing file that is not a shared
+object counts. The loader drops such a preload by *ignoring* it: the process
+still exits 0 and the complaint goes to stderr, which for a `yosys` child lands
+in that top's log and is never read, so the check is that stderr stayed empty.
+A relative path is made absolute first, because `yosys` runs from the gate's
+own temporary directory and would otherwise resolve it there. All three cases
+are the same defect: a run asked to reproduce one allocator reporting another
+one's timing under its name.
+
+`YOSYS_MALLOC=none` **unsets** `LD_PRELOAD` for the `yosys` child rather than
+merely declining to set it, so it still means "system allocator" in a shell
+that already exports one.
+
 The header line prints which allocator was in effect, because a wall-clock
 figure quoted from this output is only reproducible with it. The preload
-reaches `yosys` and the `abc` it spawns; `sv2v` and the `python3` helpers run
-under the system allocator.
+reaches `yosys` and the `abc` it spawns; `sv2v` and the `python3` helpers are
+left alone and keep whatever the caller's environment gives them.
 
 ### `read_verilog -defer`: right instrument, wrong script
 

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -124,16 +124,60 @@ ldconfig_path() {
   return 1
 }
 
+# EVERY PATH IS MADE ABSOLUTE BEFORE IT IS BELIEVED. yosys runs after `cd
+# "$TMP"`, so a relative LD_PRELOAD the caller checked from their own directory
+# resolves against $TMP instead, where it is not there: the loader drops it and
+# the header line reports an allocator that never ran.
+abs_path() {
+  local p="$1" out d b
+  if out="$(readlink -f -- "$p" 2>/dev/null)" && [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  d="$(cd -- "$(dirname -- "$p")" 2>/dev/null && pwd)" || return 1
+  b="$(basename -- "$p")"
+  printf '%s/%s\n' "$d" "$b"
+}
+
+# EXISTING IS NOT LOADABLE. The loader takes an unusable LD_PRELOAD by IGNORING
+# it: the process still exits 0 and the complaint goes to stderr, which for a
+# yosys child lands in that top's log and is never read - so `/etc/hosts` was
+# accepted, the gate passed, and the header named it. The test is therefore
+# "stderr stayed empty", never "the command succeeded".
+TRUE_BIN="$(type -P true 2>/dev/null || printf '')"
+preload_is_usable() {
+  local lib="$1" err
+  [ -n "$TRUE_BIN" ] && [ -x "$TRUE_BIN" ] || return 1
+  err="$(LD_PRELOAD="$lib" "$TRUE_BIN" 2>&1 >/dev/null)" || return 1
+  [ -z "$err" ]
+}
+preload_refusal() {
+  [ -n "$TRUE_BIN" ] && [ -x "$TRUE_BIN" ] || { printf 'no external true(1) to probe with\n'; return 0; }
+  LD_PRELOAD="$1" "$TRUE_BIN" 2>&1 >/dev/null | head -1
+}
+
 select_malloc() {
-  local want="${YOSYS_MALLOC-}" cand lc
+  local want="${YOSYS_MALLOC-}" cand lc abs
   case "$want" in
     none) return 0 ;;
     "")   ;;
-    *)    [ -e "$want" ] || {
+    *)    # Existence is checked BEFORE canonicalisation so a relative request
+          # is judged against the caller's directory, which is where they meant
+          # it, and so the message says what is actually wrong.
+          [ -e "$want" ] || {
             echo "YOSYS_MALLOC=$want: no such file" >&2
             return 2
           }
-          printf '%s\n' "$want"
+          abs="$(abs_path "$want")" || {
+            echo "YOSYS_MALLOC=$want: cannot be resolved to an absolute path" >&2
+            return 2
+          }
+          preload_is_usable "$abs" || {
+            echo "YOSYS_MALLOC=$want: the loader will not preload it ($abs)" >&2
+            echo "  $(preload_refusal "$abs")" >&2
+            return 2
+          }
+          printf '%s\n' "$abs"
           return 0 ;;
   esac
   # ldconfig answers for the loader's own search path, which is the only
@@ -141,42 +185,87 @@ select_malloc() {
   # included, which is why no such path is spelled below. The literal list is
   # only the fallback for a machine whose ldconfig a normal user cannot run,
   # and an empty answer is a valid one: the gate then runs unchanged.
+  # A candidate that the loader will not take is SKIPPED here rather than
+  # refused: the documented default is "use jemalloc when it is installed", and
+  # a broken one is simply not installed. An explicit request is refused above,
+  # because there the caller named it and is owed an answer.
   if lc="$(ldconfig_path)"; then
     while IFS= read -r cand; do
-      [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
+      [ -e "$cand" ] && preload_is_usable "$cand" && { printf '%s\n' "$cand"; return 0; }
     done < <("$lc" -p 2>/dev/null | sed -n 's/^.* => //p' | grep -F libjemalloc.so.2)
   fi
   for cand in /usr/lib/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2 \
               /usr/local/lib/libjemalloc.so.2; do
-    [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
+    [ -e "$cand" ] && preload_is_usable "$cand" && { printf '%s\n' "$cand"; return 0; }
   done
   return 0
+}
+
+# THE ONLY PLACE that decides what a yosys child sees, so the self-test below
+# exercises the same code the gate runs. An EMPTY selection must actively UNSET
+# LD_PRELOAD rather than merely decline to set it: a caller who already exported
+# one would otherwise have it inherited while the header line said "system",
+# which is the same silent misattribution the refusal above exists to prevent -
+# and it would invalidate any with-versus-without comparison run in that shell.
+apply_malloc_env() {
+  local lib="${1-}"
+  if [ -n "$lib" ]; then
+    export LD_PRELOAD="$lib"
+  else
+    unset LD_PRELOAD
+  fi
 }
 
 # The interesting case is the machine WITHOUT jemalloc, because that is the one
 # the documented tool requirement covers and the one nobody runs by accident.
 # This self-test needs neither jemalloc, nor yosys, nor sv2v, nor a submodule.
 selftest_alloc() {
-  local rc=0 out probe
-  probe="$(mktemp)"
+  local rc=0 skipped=0 out probe found dir base
 
   out="$(YOSYS_MALLOC=none select_malloc)" || rc=1
   [ -z "$out" ] || { echo "selftest: YOSYS_MALLOC=none selected '$out'" >&2; rc=1; }
 
-  out="$(YOSYS_MALLOC="$probe" select_malloc)" || rc=1
-  [ "$out" = "$probe" ] || { echo "selftest: explicit path selected '$out'" >&2; rc=1; }
-
+  # An EXISTING file the loader will not take must be refused, not reported as
+  # the allocator in effect. An empty temp file is exactly that case.
+  probe="$(mktemp)"
+  if out="$(YOSYS_MALLOC="$probe" select_malloc 2>/dev/null)"; then
+    echo "selftest: an unloadable YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
+  fi
   if out="$(YOSYS_MALLOC="$probe.absent" select_malloc 2>/dev/null)"; then
     echo "selftest: a missing YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
   fi
+  rm -f "$probe"
 
-  out="$(unset YOSYS_MALLOC; select_malloc)" || rc=1
-  [ -z "$out" ] || [ -e "$out" ] || {
-    echo "selftest: the default selected a non-existent '$out'" >&2; rc=1
+  # The default never names something the loader would drop.
+  found="$(unset YOSYS_MALLOC; select_malloc)" || rc=1
+  if [ -n "$found" ]; then
+    { [ -e "$found" ] && preload_is_usable "$found"; } || {
+      echo "selftest: the default selected an unusable '$found'" >&2; rc=1
+    }
+    # A RELATIVE request must come back absolute, because yosys runs from $TMP.
+    dir="$(dirname -- "$found")"; base="$(basename -- "$found")"
+    out="$(cd "$dir" && YOSYS_MALLOC="./$base" select_malloc)" || rc=1
+    [ "$out" = "$found" ] || {
+      echo "selftest: relative path resolved to '$out', expected '$found'" >&2; rc=1
+    }
+  else
+    echo "selftest: SKIPPED the relative-path and usable-default arms" \
+         "(no preloadable jemalloc on this machine)"
+    skipped=1
+  fi
+
+  # The child environment, through the same function the per-top run uses.
+  out="$(export LD_PRELOAD=/inherited/from/the/caller.so
+         apply_malloc_env ""; printf '%s' "${LD_PRELOAD-<unset>}")"
+  [ "$out" = "<unset>" ] || {
+    echo "selftest: an inherited LD_PRELOAD survived an empty selection as '$out'" >&2; rc=1
+  }
+  out="$(unset LD_PRELOAD; apply_malloc_env /x/y.so; printf '%s' "${LD_PRELOAD-<unset>}")"
+  [ "$out" = "/x/y.so" ] || {
+    echo "selftest: a selected library did not reach the child env ('$out')" >&2; rc=1
   }
 
-  rm -f "$probe"
-  [ "$rc" -eq 0 ] && echo "allocator selection self-test: PASS"
+  [ "$rc" -eq 0 ] && echo "allocator selection self-test: PASS$([ "$skipped" -eq 1 ] && echo ' (with skips)')"
   return "$rc"
 }
 
@@ -488,7 +577,7 @@ for name in "${selected_names[@]}"; do
   # over one top logs yosys, sh and abc, and neither sv2v nor python3.
   (
     cd "$TMP" || exit 2
-    [ -z "$MALLOC_LIB" ] || export LD_PRELOAD="$MALLOC_LIB"
+    apply_malloc_env "$MALLOC_LIB"
     yosys -p "$program"
   ) > "$TMP/$top.yos.log" 2>&1
   rc=$?

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -30,7 +30,15 @@ usage: syn/yosys/run.sh [options]
   --mode full|elaborate  full synthesis or fast hierarchy/process smoke
   --results DIRECTORY    write one machine-readable result per top/gate
   --no-structural        do not run the tied-input and tap-purity checks
+  --selftest-alloc       check the YOSYS_MALLOC selection rules and exit;
+                         needs neither jemalloc, yosys, sv2v nor a submodule
   -h, --help             show this help
+
+environment:
+
+  YOSYS_MALLOC=<path>    preload that allocator for yosys (speed only)
+  YOSYS_MALLOC=none      run yosys under the system allocator
+  (unset)                use jemalloc when it is installed
 EOF
 }
 
@@ -40,6 +48,7 @@ LIST=0
 EMIT=""
 RESULTS=""
 NO_STRUCTURAL=0
+SELFTEST_ALLOC=0
 REQUESTED_TOPS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -65,6 +74,7 @@ while [ "$#" -gt 0 ]; do
       EMIT="$2"; shift 2 ;;
     --emit=*) EMIT="${1#--emit=}"; shift ;;
     --no-structural) NO_STRUCTURAL=1; shift ;;
+    --selftest-alloc) SELFTEST_ALLOC=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -83,6 +93,95 @@ fi
 if [ -n "$EMIT" ] && [ "$LIST" -eq 1 ]; then
   echo "--emit and --list are mutually exclusive" >&2
   exit 2
+fi
+
+# THIS GATE IS ALLOCATION-BOUND, NOT PARSE-BOUND (#286, #288). On the heaviest
+# top Yosys spends about three quarters of its time in the `opt*` family and
+# 0.5% in `read_verilog`, and a large share of that is glibc's allocator:
+# preloading jemalloc takes milan_datapath from 656 s to 361 s and the whole
+# eight-way sharded gate from 616 s to 358 s, on the same machine, with all 46
+# tops still passing.
+#
+# It is a SPEED knob and never a correctness one: `write_rtlil` after this
+# script's own program is BYTE-IDENTICAL under glibc, tcmalloc, jemalloc and
+# mimalloc (#286). So it is optional in both directions - the documented tool
+# requirement stays "yosys and sv2v on PATH" (README "Tooling") and a machine
+# without jemalloc runs exactly as it did before, with no warning to silence.
+#
+#   YOSYS_MALLOC=<path>   preload that library
+#   YOSYS_MALLOC=none     run yosys under the system allocator
+#   unset                 use jemalloc when it is installed
+#
+# A NAMED library that is absent REFUSES rather than falling back. Falling back
+# would let a run that was asked to reproduce one allocator quietly report
+# another one's timing, which is the measurement defect this whole lane exists
+# to remove.
+ldconfig_path() {
+  local p
+  for p in ldconfig /usr/sbin/ldconfig /sbin/ldconfig; do
+    command -v "$p" >/dev/null 2>&1 && { printf '%s\n' "$p"; return 0; }
+  done
+  return 1
+}
+
+select_malloc() {
+  local want="${YOSYS_MALLOC-}" cand lc
+  case "$want" in
+    none) return 0 ;;
+    "")   ;;
+    *)    [ -e "$want" ] || {
+            echo "YOSYS_MALLOC=$want: no such file" >&2
+            return 2
+          }
+          printf '%s\n' "$want"
+          return 0 ;;
+  esac
+  # ldconfig answers for the loader's own search path, which is the only
+  # authority on where a distribution put the library. The literal list below
+  # is the fallback for a machine whose ldconfig a normal user cannot run.
+  if lc="$(ldconfig_path)"; then
+    while IFS= read -r cand; do
+      [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
+    done < <("$lc" -p 2>/dev/null | sed -n 's/^.* => //p' | grep -F libjemalloc.so.2)
+  fi
+  for cand in /usr/lib/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2 \
+              /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+              /usr/local/lib/libjemalloc.so.2; do
+    [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
+  done
+  return 0
+}
+
+# The interesting case is the machine WITHOUT jemalloc, because that is the one
+# the documented tool requirement covers and the one nobody runs by accident.
+# This self-test needs neither jemalloc, nor yosys, nor sv2v, nor a submodule.
+selftest_alloc() {
+  local rc=0 out probe
+  probe="$(mktemp)"
+
+  out="$(YOSYS_MALLOC=none select_malloc)" || rc=1
+  [ -z "$out" ] || { echo "selftest: YOSYS_MALLOC=none selected '$out'" >&2; rc=1; }
+
+  out="$(YOSYS_MALLOC="$probe" select_malloc)" || rc=1
+  [ "$out" = "$probe" ] || { echo "selftest: explicit path selected '$out'" >&2; rc=1; }
+
+  if out="$(YOSYS_MALLOC="$probe.absent" select_malloc 2>/dev/null)"; then
+    echo "selftest: a missing YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
+  fi
+
+  out="$(unset YOSYS_MALLOC; select_malloc)" || rc=1
+  [ -z "$out" ] || [ -e "$out" ] || {
+    echo "selftest: the default selected a non-existent '$out'" >&2; rc=1
+  }
+
+  rm -f "$probe"
+  [ "$rc" -eq 0 ] && echo "allocator selection self-test: PASS"
+  return "$rc"
+}
+
+if [ "$SELFTEST_ALLOC" -eq 1 ]; then
+  selftest_alloc
+  exit $?
 fi
 
 export PATH="$HOME/.local/bin:$PATH"
@@ -298,6 +397,10 @@ for tool in sv2v yosys; do
   }
 done
 
+# Resolved once, after the tool check, so a machine missing yosys is told that
+# and not something about an allocator.
+MALLOC_LIB="$(select_malloc)" || exit 2
+
 [ -z "$RESULTS" ] || mkdir -p "$RESULTS"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -353,6 +456,9 @@ if [ "$MODE" = full ]; then
 else
   echo "== Yosys fast elaboration check (via sv2v) =="
 fi
+# Named, because a wall-clock figure quoted from this output is only
+# reproducible if the allocator that produced it is on the record (#286).
+echo "   yosys allocator: ${MALLOC_LIB:-system}"
 pass=0
 fail=0
 for name in "${selected_names[@]}"; do
@@ -373,7 +479,17 @@ for name in "${selected_names[@]}"; do
   else
     program="read_verilog $TMP/$top.v; hierarchy -check -top $top; proc; opt_clean; check -assert; stat -top $top"
   fi
-  (cd "$TMP" && yosys -p "$program") > "$TMP/$top.yos.log" 2>&1
+  # The preload is exported INSIDE the subshell, so it reaches yosys and the
+  # children yosys spawns - `abc`, which is 16% of the heaviest top - and dies
+  # with them. sv2v above is a GHC binary and the helpers are python3, and
+  # neither was measured under a replacement allocator. Proved rather than
+  # asserted: preloading a library that records `program_invocation_short_name`
+  # over one top logs yosys, sh and abc, and neither sv2v nor python3.
+  (
+    cd "$TMP" || exit 2
+    [ -z "$MALLOC_LIB" ] || export LD_PRELOAD="$MALLOC_LIB"
+    yosys -p "$program"
+  ) > "$TMP/$top.yos.log" 2>&1
   rc=$?
   cells="$(awk '/=== design hierarchy ===/{f=1} f && /^[[:space:]]+[0-9]+ cells$/{print $1; exit}' "$TMP/$top.yos.log")"
   if [ "$rc" -eq 0 ]; then

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -137,15 +137,16 @@ select_malloc() {
           return 0 ;;
   esac
   # ldconfig answers for the loader's own search path, which is the only
-  # authority on where a distribution put the library. The literal list below
-  # is the fallback for a machine whose ldconfig a normal user cannot run.
+  # authority on where a distribution put the library - multiarch layouts
+  # included, which is why no such path is spelled below. The literal list is
+  # only the fallback for a machine whose ldconfig a normal user cannot run,
+  # and an empty answer is a valid one: the gate then runs unchanged.
   if lc="$(ldconfig_path)"; then
     while IFS= read -r cand; do
       [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
     done < <("$lc" -p 2>/dev/null | sed -n 's/^.* => //p' | grep -F libjemalloc.so.2)
   fi
   for cand in /usr/lib/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2 \
-              /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
               /usr/local/lib/libjemalloc.so.2; do
     [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
   done


### PR DESCRIPTION
Closes #288.

`syn/yosys/run.sh` now preloads jemalloc for its `yosys` children when the
library is installed, and `syn/yosys/README.md` gains a **Runtime levers**
section that records why that is the lever worth having here — and why
`read_verilog -defer`, measured on the same tops, is not.

## What changed

- `syn/yosys/run.sh`: resolve an allocator once, after the tool check, and
  export `LD_PRELOAD` inside the per-top subshell so it reaches `yosys` and
  the `abc` it spawns, and nothing else. New `--selftest-alloc`. New
  `YOSYS_MALLOC` environment knob. The header line names the allocator in
  effect.
- `syn/yosys/README.md`: the pass profile that makes this gate
  optimisation-bound, the allocator numbers, and the `-defer` null result with
  the rule for when that flag *does* pay.

No RTL, no top inventory, no `synth` + `hierarchy -check` criterion, no
`cells=` record, no shard selector, no workflow.

## Why: the gate is allocation-bound, not parse-bound

`yosys -d` on `milan_datapath` (1,137,752 wires / 1,597,718 cells, one
single-threaded process): `opt_dff` 25%, `opt_clean` 23%, `abc` 16%,
`opt_expr` 14% — and `read_verilog` **0.5%**.

| scope | glibc | jemalloc |
| --- | ---: | ---: |
| `milan_datapath`, one process | 656.3 s | **361.5 s** (−44.9%) |
| `KL_pp_shadow`, one process | 273.9 s | 171.8 s (−37.3%) |
| whole gate, 8 shards, 46/46 pass | 616.2 s | **357.8 s** (−41.9%) |

Peak RSS falls too — 3033 → 2786 MiB on `milan_datapath` — so this does not
spend the headroom a parallel shard run needs. Full measurement in #286.

## It changes speed and not results

Not asserted, measured. `write_rtlil` after this script's own program on
`KL_gptp_shadow` is **byte-identical** across allocators:

```
distro + glibc      cc79dc89adbce892  43920712 bytes
distro + jemalloc   cc79dc89adbce892  43920712 bytes
distro + tcmalloc   cc79dc89adbce892  43920712 bytes
distro + mimalloc   cc79dc89adbce892  43920712 bytes
```

And the gate's own evidence is identical with and without the preload — the
full 46-top run was done twice on this branch, once each way, and the
`--results` trees compared byte for byte:

```
$ for i in 0..7; do ./syn/yosys/run.sh --shard $i/8 --no-structural --results with     ; done
$ for i in 0..7; do YOSYS_MALLOC=none ./syn/yosys/run.sh --shard $i/8 --no-structural --results without ; done
with:    46 tops 46 pass 0 fail
without: 46 tops 46 pass 0 fail
$ diff -r with without
IDENTICAL
```

## The other half: `read_verilog -defer` is deliberately NOT used here

The ticket asked for `-defer` to be applied and documented. Measured on the
two tops with the largest surplus of unused modules — both are handed the
entire protocol-processor tree and instantiate a subset — same allocator, one
matched batch:

| top | plain | `-defer` | `read_verilog` step | cells |
| --- | ---: | ---: | ---: | ---: |
| `milan_datapath` | 353.5 s | 350.0 s (−1.0%) | 2.30 s → 0.26 s | 1,597,718 → 1,598,979 |
| `KL_pp_shadow` | 165.9 s | 166.4 s (+0.3%) | 0.89 s → 0.16 s | 1,133,318 → 1,148,270 |

`-defer` does exactly what it claims — it removes 82–89% of the
`read_verilog` step — and that step is 0.5% of the run, so the gate does not
get faster. It also **changes the netlist**: +0.08% cells on `milan_datapath`
and +1.3% on `KL_pp_shadow`, because deferring changes which parameterised
specialisations exist by the time the `opt*` passes run. The control rules out
noise: the same binary run twice on `milan_datapath` reproduces its own digest
(`0d541ffab0a4cef7`), while the `-defer` run gives `ffcca31dd036de26`.

Buying nothing and changing the answer is a no-go, so the flag is not added
and the reason is in the README instead of being re-derived by the next
reader. Where it *does* belong is stated there too: a script that reads one
file holding many modules once per top. That is the control plane's own
portability gate (39.65 s → 10.31 s, and 1.25 s with a pool), tracked in that
repository's issue #25 — which should complete its `tops` array first, since
six of its modules are in no top at all.

One thing `-defer` does **not** cost, and this corrects an assumption I made
in #25 before measuring it: **it still parses every module.** Four fault
classes injected into a module that no top instantiates — a syntax error, a
negative-width vector, an undefined submodule and a `$fatal` — are caught
identically with and without the flag. `-defer` postpones elaboration, not
parsing. So the objection to `-defer` here is purely that it buys nothing and
moves the netlist; it is not a coverage objection.

## Compatibility

The documented tool requirement is unchanged: `yosys` and `sv2v` on `PATH`. A
machine without jemalloc runs exactly as before and prints
`yosys allocator: system`. A **named** library that is absent refuses rather
than falling back, so a run asked to reproduce one allocator cannot quietly
report another one's timing.

CI is untouched. Its Yosys is not even pinned yet (#287); exporting an
allocator into a floating toolchain is the wrong order.

## Validation

```
$ ./syn/yosys/run.sh --selftest-alloc
allocator selection self-test: PASS

$ python3 scripts/yosys_shards.py --selftest
selftest: PASS

$ python3 scripts/lint_rtl.py --check
LINT GATE: PASS (99 violation(s) <= ratchet 99; 22 waived, 0 justified lint_off)

$ python3 scripts/pp_srcs.py --check        # rc=0
$ python3 scripts/gen_toc.py --check
TOC gate: OK (131 page(s) carry an annotated contents list, 18 below the 3-section threshold)

$ python3 scripts/docs_check.py
docs_check: 0 finding(s) across 181 md files + 785 scrubbed text files, scrub self-test 17/17

$ ./syn/yosys/run.sh --list | wc -l
46
```

`xvlog_gate.py` was not run: this change touches no `.sv` or `.v` file.
