### PR TITLE
Run syn/yosys/ooc.sh under the same allocator, and put the rules in one file

### DIFF
--- a/syn/yosys/README.md
+++ b/syn/yosys/README.md
@@ -110,6 +110,15 @@ figure quoted from this output is only reproducible with it. The preload
 reaches `yosys` and the `abc` it spawns; `sv2v` and the `python3` helpers are
 left alone and keep whatever the caller's environment gives them.
 
+The rules live in one place, [`malloc.sh`](malloc.sh), and `ooc.sh` below
+sources the same file and honours the same `YOSYS_MALLOC` values. That flow
+gains more, because `synth_xilinx -flatten` is the heavier program — 235.09 s
+to 177.85 s over `KL_pp_shadow`, `KL_crf_rx` and `tcam` together (−24.3%),
+with every reported area row identical to the digit. `run.sh --list` does
+**not** source it: `check_list_hermetic.sh` proves `--list` reads nothing but
+`run.sh` and `scripts/yosys_shards.py`, and that contract outranks the tidiness
+of an unconditional `source`.
+
 ### `read_verilog -defer`: right instrument, wrong script
 
 `-defer` postpones turning a parsed module into RTLIL until something

--- a/syn/yosys/malloc.sh
+++ b/syn/yosys/malloc.sh
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2026 Kebag Logic
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+#
+# Allocator selection for this directory's Yosys flows, sourced by run.sh
+# (portability) and ooc.sh (area). It defines functions and sets one variable
+# (TRUE_BIN); it starts nothing and changes no directory, so a caller may
+# source it before or after its own `cd`.
+#
+# It is NOT sourced on run.sh's `--list` path. syn/yosys/check_list_hermetic.sh
+# proves `--list` reads nothing but run.sh and scripts/yosys_shards.py, in a
+# tree built to hold only those two files (#190), and an unconditional source
+# here would break that contract rather than the other way round.
+
+# THESE FLOWS ARE ALLOCATION-BOUND, NOT PARSE-BOUND (#286, #288). On the heaviest
+# top Yosys spends about three quarters of its time in the `opt*` family and
+# 0.5% in `read_verilog`, and a large share of that is glibc's allocator:
+# preloading jemalloc takes milan_datapath from 656 s to 361 s and the whole
+# eight-way sharded gate from 616 s to 358 s, on the same machine, with all 46
+# tops still passing.
+#
+# It is a SPEED knob and never a correctness one: `write_rtlil` after this
+# script's own program is BYTE-IDENTICAL under glibc, tcmalloc, jemalloc and
+# mimalloc (#286). So it is optional in both directions - the documented tool
+# requirement stays "yosys and sv2v on PATH" (README "Tooling") and a machine
+# without jemalloc runs exactly as it did before, with no warning to silence.
+#
+#   YOSYS_MALLOC=<path>   preload that library
+#   YOSYS_MALLOC=none     run yosys under the system allocator
+#   unset                 use jemalloc when it is installed
+#
+# A NAMED library that is absent REFUSES rather than falling back. Falling back
+# would let a run that was asked to reproduce one allocator quietly report
+# another one's timing, which is the measurement defect this whole lane exists
+# to remove.
+ldconfig_path() {
+  local p
+  for p in ldconfig /usr/sbin/ldconfig /sbin/ldconfig; do
+    command -v "$p" >/dev/null 2>&1 && { printf '%s\n' "$p"; return 0; }
+  done
+  return 1
+}
+
+# EVERY PATH IS MADE ABSOLUTE BEFORE IT IS BELIEVED. yosys runs after `cd
+# "$TMP"`, so a relative LD_PRELOAD the caller checked from their own directory
+# resolves against $TMP instead, where it is not there: the loader drops it and
+# the header line reports an allocator that never ran.
+abs_path() {
+  local p="$1" out d b
+  if out="$(readlink -f -- "$p" 2>/dev/null)" && [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  d="$(cd -- "$(dirname -- "$p")" 2>/dev/null && pwd)" || return 1
+  b="$(basename -- "$p")"
+  printf '%s/%s\n' "$d" "$b"
+}
+
+# EXISTING IS NOT LOADABLE. The loader takes an unusable LD_PRELOAD by IGNORING
+# it: the process still exits 0 and the complaint goes to stderr, which for a
+# yosys child lands in that top's log and is never read - so `/etc/hosts` was
+# accepted, the gate passed, and the header named it. The test is therefore
+# "stderr stayed empty", never "the command succeeded".
+TRUE_BIN="$(type -P true 2>/dev/null || printf '')"
+preload_is_usable() {
+  local lib="$1" err
+  [ -n "$TRUE_BIN" ] && [ -x "$TRUE_BIN" ] || return 1
+  err="$(LD_PRELOAD="$lib" "$TRUE_BIN" 2>&1 >/dev/null)" || return 1
+  [ -z "$err" ]
+}
+preload_refusal() {
+  [ -n "$TRUE_BIN" ] && [ -x "$TRUE_BIN" ] || { printf 'no external true(1) to probe with\n'; return 0; }
+  LD_PRELOAD="$1" "$TRUE_BIN" 2>&1 >/dev/null | head -1
+}
+
+select_malloc() {
+  local want="${YOSYS_MALLOC-}" cand lc abs
+  case "$want" in
+    none) return 0 ;;
+    "")   ;;
+    *)    # Existence is checked BEFORE canonicalisation so a relative request
+          # is judged against the caller's directory, which is where they meant
+          # it, and so the message says what is actually wrong.
+          [ -e "$want" ] || {
+            echo "YOSYS_MALLOC=$want: no such file" >&2
+            return 2
+          }
+          abs="$(abs_path "$want")" || {
+            echo "YOSYS_MALLOC=$want: cannot be resolved to an absolute path" >&2
+            return 2
+          }
+          preload_is_usable "$abs" || {
+            echo "YOSYS_MALLOC=$want: the loader will not preload it ($abs)" >&2
+            echo "  $(preload_refusal "$abs")" >&2
+            return 2
+          }
+          printf '%s\n' "$abs"
+          return 0 ;;
+  esac
+  # ldconfig answers for the loader's own search path, which is the only
+  # authority on where a distribution put the library - multiarch layouts
+  # included, which is why no such path is spelled below. The literal list is
+  # only the fallback for a machine whose ldconfig a normal user cannot run,
+  # and an empty answer is a valid one: the gate then runs unchanged.
+  # A candidate that the loader will not take is SKIPPED here rather than
+  # refused: the documented default is "use jemalloc when it is installed", and
+  # a broken one is simply not installed. An explicit request is refused above,
+  # because there the caller named it and is owed an answer.
+  if lc="$(ldconfig_path)"; then
+    while IFS= read -r cand; do
+      [ -e "$cand" ] && preload_is_usable "$cand" && { printf '%s\n' "$cand"; return 0; }
+    done < <("$lc" -p 2>/dev/null | sed -n 's/^.* => //p' | grep -F libjemalloc.so.2)
+  fi
+  for cand in /usr/lib/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2 \
+              /usr/local/lib/libjemalloc.so.2; do
+    [ -e "$cand" ] && preload_is_usable "$cand" && { printf '%s\n' "$cand"; return 0; }
+  done
+  return 0
+}
+
+# THE ONLY PLACE that decides what a yosys child sees, so the self-test below
+# exercises the same code the gate runs. An EMPTY selection must actively UNSET
+# LD_PRELOAD rather than merely decline to set it: a caller who already exported
+# one would otherwise have it inherited while the header line said "system",
+# which is the same silent misattribution the refusal above exists to prevent -
+# and it would invalidate any with-versus-without comparison run in that shell.
+apply_malloc_env() {
+  local lib="${1-}"
+  if [ -n "$lib" ]; then
+    export LD_PRELOAD="$lib"
+  else
+    unset LD_PRELOAD
+  fi
+}
+
+# The interesting case is the machine WITHOUT jemalloc, because that is the one
+# the documented tool requirement covers and the one nobody runs by accident.
+# This self-test needs neither jemalloc, nor yosys, nor sv2v, nor a submodule.
+selftest_alloc() {
+  local rc=0 skipped=0 out probe found dir base
+
+  out="$(YOSYS_MALLOC=none select_malloc)" || rc=1
+  [ -z "$out" ] || { echo "selftest: YOSYS_MALLOC=none selected '$out'" >&2; rc=1; }
+
+  # An EXISTING file the loader will not take must be refused, not reported as
+  # the allocator in effect. An empty temp file is exactly that case.
+  probe="$(mktemp)"
+  if out="$(YOSYS_MALLOC="$probe" select_malloc 2>/dev/null)"; then
+    echo "selftest: an unloadable YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
+  fi
+  if out="$(YOSYS_MALLOC="$probe.absent" select_malloc 2>/dev/null)"; then
+    echo "selftest: a missing YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
+  fi
+  rm -f "$probe"
+
+  # The default never names something the loader would drop.
+  found="$(unset YOSYS_MALLOC; select_malloc)" || rc=1
+  if [ -n "$found" ]; then
+    { [ -e "$found" ] && preload_is_usable "$found"; } || {
+      echo "selftest: the default selected an unusable '$found'" >&2; rc=1
+    }
+    # A RELATIVE request must come back absolute, because yosys runs from $TMP.
+    dir="$(dirname -- "$found")"; base="$(basename -- "$found")"
+    out="$(cd "$dir" && YOSYS_MALLOC="./$base" select_malloc)" || rc=1
+    [ "$out" = "$found" ] || {
+      echo "selftest: relative path resolved to '$out', expected '$found'" >&2; rc=1
+    }
+  else
+    echo "selftest: SKIPPED the relative-path and usable-default arms" \
+         "(no preloadable jemalloc on this machine)"
+    skipped=1
+  fi
+
+  # The child environment, through the same function the per-top run uses.
+  out="$(export LD_PRELOAD=/inherited/from/the/caller.so
+         apply_malloc_env ""; printf '%s' "${LD_PRELOAD-<unset>}")"
+  [ "$out" = "<unset>" ] || {
+    echo "selftest: an inherited LD_PRELOAD survived an empty selection as '$out'" >&2; rc=1
+  }
+  out="$(unset LD_PRELOAD; apply_malloc_env /x/y.so; printf '%s' "${LD_PRELOAD-<unset>}")"
+  [ "$out" = "/x/y.so" ] || {
+    echo "selftest: a selected library did not reach the child env ('$out')" >&2; rc=1
+  }
+
+  [ "$rc" -eq 0 ] && echo "allocator selection self-test: PASS$([ "$skipped" -eq 1 ] && echo ' (with skips)')"
+  return "$rc"
+}
+

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -562,8 +562,12 @@ for spec in "${tops[@]}"; do
   # apply_malloc_env is INSIDE the subshell, so the preload reaches yosys and
   # the abc it spawns and dies with them: sv2v and the python3 ROM generators
   # above were not measured under a replacement allocator and keep the caller's
-  # environment. The `(cd "$rundir" && yosys` shape is load-bearing - the
-  # cwd-escape arm of ooc_selftest.py plants its mutation on exactly that text.
+  # environment. The opening of the line below - `(cd "$rundir" &&` followed
+  # by the apply_malloc_env call - is load-bearing: the cwd-escape and
+  # consume-shared-dir arms of ooc_selftest.py plant their mutations on
+  # exactly that text (and refuse if it appears twice, so do not quote it
+  # verbatim here), and its allocator arms read the model's record of what
+  # yosys and sv2v ran under.
   (cd "$rundir" && apply_malloc_env "$MALLOC_LIB" && yosys -p "read_verilog $TMP/$top.ooc.v;$chp synth_xilinx -family xc7$nodsp -top $top -flatten; stat; write_json $TMP/$top.ooc.json") \
     > "$TMP/$top.ooc.log" 2>&1
   yosys_rc=$?

--- a/syn/yosys/ooc.sh
+++ b/syn/yosys/ooc.sh
@@ -33,6 +33,12 @@
 # Self-test: syn/yosys/ooc_selftest.py drives the refusals on planted failures.
 
 set -u
+# The allocator rules, shared with run.sh. This script never moves the main
+# shell's directory - every yosys run happens in a `(cd "$rundir" && ...)`
+# subshell - so a relative YOSYS_MALLOC resolves against the caller's directory
+# as they meant it, and the selection below can sit anywhere before the runs.
+. "$(dirname "$0")/malloc.sh"
+if [ "${1:-}" = "--selftest-alloc" ]; then selftest_alloc; exit $?; fi
 export PATH="$HOME/.local/bin:$PATH"
 R="$(cd "$(dirname "$0")/../.." && pwd)"
 A="$R/third_party/verilog-axis/rtl"
@@ -126,6 +132,18 @@ tops=(
 RECORD=0
 if [ "${1:-}" = "--record-rom-digests" ]; then RECORD=1; shift; fi
 want=("$@")
+
+# THIS FLOW GAINS MORE FROM THE ALLOCATOR THAN THE PORTABILITY GATE DOES,
+# because `synth_xilinx -flatten` is the heavier program: `KL_pp_shadow` runs
+# 241.51 s under glibc and 171.00 s under jemalloc on one machine (-29.2%),
+# reporting the same area row to the digit. Speed only, never results - #286
+# proved the netlist byte-identical across glibc, tcmalloc, jemalloc and
+# mimalloc, and the rows below are what this script exists to publish.
+#
+#   YOSYS_MALLOC=<path>   preload that library
+#   YOSYS_MALLOC=none     run yosys under the system allocator
+#   unset                 use jemalloc when it is installed
+MALLOC_LIB="$(select_malloc)" || exit 2
 # A requested name that matches no list entry must refuse, not print a bare
 # header and exit 0 (#245): the silent no-op is the same false green as a
 # swallowed synth failure, and a typo is exactly how it happens.
@@ -459,6 +477,9 @@ if [ "$RECORD" -eq 1 ]; then
 fi
 status=0
 printf "== OOC area (synth_xilinx -family xc7 -flatten) ==\n"
+# Named, because a wall-clock figure quoted beside these rows is only
+# reproducible if the allocator that produced it is on the record (#290).
+printf "   yosys allocator: %s\n" "${MALLOC_LIB:-system}"
 printf "%-28s %8s %8s %8s %8s %8s %8s %8s %8s\n" \
        top LUT LUTRAM LUT_TOT FF RAMB36 RAMB18 DSP CARRY4
 for spec in "${tops[@]}"; do
@@ -538,7 +559,12 @@ for spec in "${tops[@]}"; do
       exit 2
     fi
   done
-  (cd "$rundir" && yosys -p "read_verilog $TMP/$top.ooc.v;$chp synth_xilinx -family xc7$nodsp -top $top -flatten; stat; write_json $TMP/$top.ooc.json") \
+  # apply_malloc_env is INSIDE the subshell, so the preload reaches yosys and
+  # the abc it spawns and dies with them: sv2v and the python3 ROM generators
+  # above were not measured under a replacement allocator and keep the caller's
+  # environment. The `(cd "$rundir" && yosys` shape is load-bearing - the
+  # cwd-escape arm of ooc_selftest.py plants its mutation on exactly that text.
+  (cd "$rundir" && apply_malloc_env "$MALLOC_LIB" && yosys -p "read_verilog $TMP/$top.ooc.v;$chp synth_xilinx -family xc7$nodsp -top $top -flatten; stat; write_json $TMP/$top.ooc.json") \
     > "$TMP/$top.ooc.log" 2>&1
   yosys_rc=$?
   for img in ucode.hex ltn_rom.hex gptp_ucode.hex; do

--- a/syn/yosys/ooc_selftest.py
+++ b/syn/yosys/ooc_selftest.py
@@ -51,7 +51,13 @@ THE STUBS ARE MODELS WITH TEETH, not silence:
     accumulator in any column is caught;
   - stat blocks appear only when the -p command carries their source,
     mapped cells only from `synth_xilinx`, JSON only from `write_json`, and
-    an empty JSON artifact is its own arm.
+    an empty JSON artifact is its own arm;
+  - the yosys and sv2v models can RECORD the LD_PRELOAD they ran under, so
+    the allocator preload (#290) is proved to reach yosys and not the front
+    end, and `YOSYS_MALLOC=none` to clear an inherited one for yosys only -
+    with libc as the fixture library, so no compiler and no jemalloc are
+    needed, and a mutant that exports the preload once for every child is
+    caught.
 
 Mutation copies of ooc.sh itself (report-phase deletions, the population
 replaced by a hand list, `cd "$TMP"` -> `cd "$R"`, the digest ledger
@@ -193,7 +199,7 @@ def ledger():
     return _LEDGER
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 72
+ARMS = 75
 
 #: The clean row the full-cell yosys model must produce for any top:
 #: 8 LUT4, 2 RAM32M (= 8 LUTRAM-LUT), 4 FDRE, 3 RAMB36E1, 2 RAMB18E1,
@@ -291,6 +297,40 @@ esac
 exit 0
 """
 YOSYS_OK = YOSYS_TMPL.replace("@PLANT@", "")
+#: The honest model plus a record of the allocator it ran under (#290): the
+#: preload is applied INSIDE the per-top subshell, so this is the only place
+#: that can testify whether it reached yosys - and the sv2v twin below is the
+#: only place that can testify it did NOT reach the front end.
+YOSYS_ENV = YOSYS_TMPL.replace("@PLANT@",
+    'printf \'%s\\n\' "${LD_PRELOAD-<unset>}" >> "$HOME/yosys-env.txt"')
+SV2V_ENV = SV2V_OK.replace('exit 0\n',
+    'printf \'%s\\n\' "${LD_PRELOAD-<unset>}" >> "$HOME/sv2v-env.txt"\nexit 0\n')
+
+
+def _preloadable_library():
+    """A shared object the loader will preload into any process, for the
+    allocator-scoping arms: libc itself, which every dynamically linked
+    process already maps. None when no such library can be found or the
+    loader complains about it (a static or exotic toolchain)."""
+    cands = []
+    try:
+        out = subprocess.run(["ldconfig", "-p"], capture_output=True, text=True)
+        cands += [ln.rsplit("=> ", 1)[1].strip() for ln in out.stdout.splitlines()
+                  if "libc.so.6" in ln and "=> " in ln]
+    except OSError:
+        pass
+    # ldconfig answers for multiarch layouts; the literal list is only the
+    # fallback for a machine whose ldconfig a normal user cannot run.
+    cands += ["/usr/lib/libc.so.6", "/lib64/libc.so.6", "/usr/lib64/libc.so.6"]
+    true_bin = shutil.which("true")
+    for c in cands:
+        if not (os.path.isfile(c) and true_bin):
+            continue
+        env = dict(os.environ, LD_PRELOAD=c)
+        r = subprocess.run([true_bin], env=env, capture_output=True, text=True)
+        if r.returncode == 0 and not r.stderr:
+            return c
+    return None
 #: A planted failure for ONE top of a multi-top run.
 YOSYS_FAIL_TCAM = YOSYS_TMPL.replace("@PLANT@",
     'case "$p" in *"-top tcam "*) '
@@ -437,8 +477,14 @@ def _stub(bindir, name, content):
     os.chmod(p, 0o755)
 
 
-def _run(script, tops, home, rundir, ooc_tmp):
+def _run(script, tops, home, rundir, ooc_tmp, extra_env=None):
     env = dict(os.environ)
+    if extra_env:
+        for k, v in extra_env.items():
+            if v is None:
+                env.pop(k, None)
+            else:
+                env[k] = v
     bindir = os.path.join(home, ".local", "bin")
     env["HOME"] = home
     env["PATH"] = bindir + os.pathsep + env.get("PATH", "")
@@ -490,7 +536,7 @@ def selftest():
 
     def arm(name, tops, want, expect_rc0, sv2v=SV2V_OK, yosys=YOSYS_OK,
             py=None, awk=None, git=None, chmod=None, script=OOC, setup=None,
-            check=None):
+            check=None, env=None):
         nonlocal ran
         ran += 1
         if isinstance(tops, str):
@@ -517,7 +563,7 @@ def selftest():
                 _stub(bindir, "git", git % {"real": REAL_GIT})
             if chmod:
                 _stub(bindir, "chmod", chmod % {"real": REAL_CHMOD})
-            rc, log = _run(script, tops, home, rundir, ooc_tmp)
+            rc, log = _run(script, tops, home, rundir, ooc_tmp, env)
             litter = os.listdir(rundir)
             if expect_rc0:
                 if rc != 0:
@@ -1228,6 +1274,90 @@ def selftest():
             check=stale_priced)
     finally:
         os.unlink(mut)
+
+    # ---- allocator scoping (#290) ------------------------------------------
+    # Arms 73-75. The preload is applied INSIDE the per-top yosys subshell so
+    # it reaches yosys (and the abc it spawns) and nothing else; sv2v and the
+    # ROM generators keep the caller's environment, and YOSYS_MALLOC=none
+    # UNSETS an inherited LD_PRELOAD for the yosys child. Review [R1] proved
+    # both properties by hand with a shim and then showed that a one-line
+    # regression - exporting the preload once, for every child - passed
+    # every arm here and the allocator self-test. These arms are that shim,
+    # without a compiler: the yosys and sv2v models record the LD_PRELOAD they
+    # ran under, and the fixture library is libc, which every dynamically
+    # linked process already maps, so the loader takes it anywhere.
+    lib = _preloadable_library()
+
+    def _env_lines(home, name):
+        try:
+            with open(os.path.join(home, name)) as fh:
+                return [ln.strip() for ln in fh if ln.strip()]
+        except OSError:
+            return []
+
+    def scoped_to_yosys(log, ooc_tmp, home):
+        y = _env_lines(home, "yosys-env.txt")
+        v = _env_lines(home, "sv2v-env.txt")
+        if not y or not v:
+            return "the models did not run (yosys %d, sv2v %d records)" \
+                   % (len(y), len(v))
+        if any(x != lib for x in y):
+            return "yosys ran under %s, not the selected %s" % (y, lib)
+        if any(x != "<unset>" for x in v):
+            return "the preload leaked to sv2v: %s" % v
+        if "yosys allocator: " + lib not in log:
+            return "the header does not name the selected library"
+        return None
+
+    def none_clears_child(log, ooc_tmp, home):
+        y = _env_lines(home, "yosys-env.txt")
+        v = _env_lines(home, "sv2v-env.txt")
+        if not y or not v:
+            return "the models did not run (yosys %d, sv2v %d records)" \
+                   % (len(y), len(v))
+        if any(x != "<unset>" for x in y):
+            return "YOSYS_MALLOC=none left the inherited preload on yosys: %s" % y
+        if any(x != lib for x in v):
+            return "sv2v lost the caller's own environment: %s" % v
+        if "yosys allocator: system" not in log:
+            return "the header does not say system"
+        return None
+
+    if lib is None:
+        for name in ("alloc-scoped-to-yosys", "alloc-none-clears-child",
+                     "mut-alloc-exported-once"):
+            print("  SKIPPED [%s]: no preloadable library on this machine "
+                  "(libc.so.6 not found, or the loader refused it)" % name)
+            ran += 1
+    else:
+        # Arm 73. An explicit library reaches the yosys model and only it.
+        arm("alloc-scoped-to-yosys", "tcam", None, True,
+            yosys=YOSYS_ENV, sv2v=SV2V_ENV,
+            env={"YOSYS_MALLOC": lib, "LD_PRELOAD": None},
+            check=scoped_to_yosys)
+        # Arm 74. `none` unsets an inherited preload for yosys, and for yosys
+        # only: sv2v still sees what the caller exported.
+        arm("alloc-none-clears-child", "tcam", None, True,
+            yosys=YOSYS_ENV, sv2v=SV2V_ENV,
+            env={"YOSYS_MALLOC": "none", "LD_PRELOAD": lib},
+            check=none_clears_child)
+        # Arm 75. The regression review planted: the preload exported once,
+        # at top level, for every child. The subshell text is untouched, so
+        # the cwd arms cannot see it; arm 73's check must.
+        mut = _mutant(r'MALLOC_LIB="\$\(select_malloc\)" \|\| exit 2\n',
+                      'MALLOC_LIB="$(select_malloc)" || exit 2\n'
+                      'apply_malloc_env "$MALLOC_LIB"\n',
+                      "alloc-exported-once")
+        try:
+            arm("mut-alloc-exported-once", "tcam", None, True, script=mut,
+                yosys=YOSYS_ENV, sv2v=SV2V_ENV,
+                env={"YOSYS_MALLOC": lib, "LD_PRELOAD": None},
+                check=lambda log, t, h: None
+                if scoped_to_yosys(log, t, h) else
+                "the mutant that exports the preload for every child was "
+                "not caught: sv2v ran under it unnoticed")
+        finally:
+            os.unlink(mut)
 
     if ran != ARMS:
         problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this "

--- a/syn/yosys/ooc_selftest.py
+++ b/syn/yosys/ooc_selftest.py
@@ -311,7 +311,15 @@ def _preloadable_library():
     """A shared object the loader will preload into any process, for the
     allocator-scoping arms: libc itself, which every dynamically linked
     process already maps. None when no such library can be found or the
-    loader complains about it (a static or exotic toolchain)."""
+    loader complains about it (a static or exotic toolchain).
+
+    CANONICAL, the way select_malloc hands it on: an explicit YOSYS_MALLOC
+    goes through abs_path (readlink -f) before it reaches the yosys child
+    and the header line, and arm 73 compares both against this value. On a
+    merged-/usr layout ldconfig answers `/lib/<triplet>/libc.so.6` while the
+    loader is given `/usr/lib/<triplet>/libc.so.6` - the two spellings
+    disagreed on the hosted runner and agreed only on a host whose ldconfig
+    already speaks the canonical path."""
     cands = []
     try:
         out = subprocess.run(["ldconfig", "-p"], capture_output=True, text=True)
@@ -326,6 +334,7 @@ def _preloadable_library():
     for c in cands:
         if not (os.path.isfile(c) and true_bin):
             continue
+        c = os.path.realpath(c)
         env = dict(os.environ, LD_PRELOAD=c)
         r = subprocess.run([true_bin], env=env, capture_output=True, text=True)
         if r.returncode == 0 and not r.stderr:

--- a/syn/yosys/ooc_selftest.py
+++ b/syn/yosys/ooc_selftest.py
@@ -890,8 +890,12 @@ def selftest():
     # Arm 32. [R0] round two's plant: cd "$rundir" -> cd "$R", restoring the
     # launch-directory dependency #245 exists to kill. The yosys model
     # refuses to run anywhere but an exclusive per-top dir under $OOC_TMP.
-    mut = _mutant(r'\(cd "\$rundir" && yosys', '(cd "$R" && yosys',
-                  "cwd-escape")
+    # The anchor tracks ooc.sh's text and moved when the allocator preload was
+    # applied inside this subshell (#290). The mutation is unchanged in meaning:
+    # it still runs the synthesis somewhere other than the exclusive per-top
+    # directory, and must still be caught.
+    mut = _mutant(r'\(cd "\$rundir" && apply_malloc_env',
+                  '(cd "$R" && apply_malloc_env', "cwd-escape")
     try:
         arm("mut-cwd-escape", "tcam", "YOSYS-WRONG-CWD", False, script=mut)
     finally:
@@ -1058,8 +1062,9 @@ def selftest():
     # Arm 48. Consumption moved back to the SHARED published directory
     # (cd "$rundir" -> cd "$TMP"): the yosys model refuses $OOC_TMP itself,
     # so the exclusive-run-dir contract cannot silently regress.
-    mut = _mutant(r'\(cd "\$rundir" && yosys', '(cd "$TMP" && yosys',
-                  "consume-shared-dir")
+    # Same anchor move as arm 47 (#290); the mutation is unchanged in meaning.
+    mut = _mutant(r'\(cd "\$rundir" && apply_malloc_env',
+                  '(cd "$TMP" && apply_malloc_env', "consume-shared-dir")
     try:
         arm("mut-consume-shared-dir", "tcam", "YOSYS-WRONG-CWD", False,
             script=mut)

--- a/syn/yosys/run.sh
+++ b/syn/yosys/run.sh
@@ -94,180 +94,20 @@ if [ -n "$EMIT" ] && [ "$LIST" -eq 1 ]; then
   echo "--emit and --list are mutually exclusive" >&2
   exit 2
 fi
+# Same reason as the source guard below: --list must not pull the allocator
+# rules in, so it cannot also be asked to self-test them.
+if [ "$SELFTEST_ALLOC" -eq 1 ] && [ "$LIST" -eq 1 ]; then
+  echo "--selftest-alloc and --list are mutually exclusive" >&2
+  exit 2
+fi
 
-# THIS GATE IS ALLOCATION-BOUND, NOT PARSE-BOUND (#286, #288). On the heaviest
-# top Yosys spends about three quarters of its time in the `opt*` family and
-# 0.5% in `read_verilog`, and a large share of that is glibc's allocator:
-# preloading jemalloc takes milan_datapath from 656 s to 361 s and the whole
-# eight-way sharded gate from 616 s to 358 s, on the same machine, with all 46
-# tops still passing.
-#
-# It is a SPEED knob and never a correctness one: `write_rtlil` after this
-# script's own program is BYTE-IDENTICAL under glibc, tcmalloc, jemalloc and
-# mimalloc (#286). So it is optional in both directions - the documented tool
-# requirement stays "yosys and sv2v on PATH" (README "Tooling") and a machine
-# without jemalloc runs exactly as it did before, with no warning to silence.
-#
-#   YOSYS_MALLOC=<path>   preload that library
-#   YOSYS_MALLOC=none     run yosys under the system allocator
-#   unset                 use jemalloc when it is installed
-#
-# A NAMED library that is absent REFUSES rather than falling back. Falling back
-# would let a run that was asked to reproduce one allocator quietly report
-# another one's timing, which is the measurement defect this whole lane exists
-# to remove.
-ldconfig_path() {
-  local p
-  for p in ldconfig /usr/sbin/ldconfig /sbin/ldconfig; do
-    command -v "$p" >/dev/null 2>&1 && { printf '%s\n' "$p"; return 0; }
-  done
-  return 1
-}
-
-# EVERY PATH IS MADE ABSOLUTE BEFORE IT IS BELIEVED. yosys runs after `cd
-# "$TMP"`, so a relative LD_PRELOAD the caller checked from their own directory
-# resolves against $TMP instead, where it is not there: the loader drops it and
-# the header line reports an allocator that never ran.
-abs_path() {
-  local p="$1" out d b
-  if out="$(readlink -f -- "$p" 2>/dev/null)" && [ -n "$out" ]; then
-    printf '%s\n' "$out"
-    return 0
-  fi
-  d="$(cd -- "$(dirname -- "$p")" 2>/dev/null && pwd)" || return 1
-  b="$(basename -- "$p")"
-  printf '%s/%s\n' "$d" "$b"
-}
-
-# EXISTING IS NOT LOADABLE. The loader takes an unusable LD_PRELOAD by IGNORING
-# it: the process still exits 0 and the complaint goes to stderr, which for a
-# yosys child lands in that top's log and is never read - so `/etc/hosts` was
-# accepted, the gate passed, and the header named it. The test is therefore
-# "stderr stayed empty", never "the command succeeded".
-TRUE_BIN="$(type -P true 2>/dev/null || printf '')"
-preload_is_usable() {
-  local lib="$1" err
-  [ -n "$TRUE_BIN" ] && [ -x "$TRUE_BIN" ] || return 1
-  err="$(LD_PRELOAD="$lib" "$TRUE_BIN" 2>&1 >/dev/null)" || return 1
-  [ -z "$err" ]
-}
-preload_refusal() {
-  [ -n "$TRUE_BIN" ] && [ -x "$TRUE_BIN" ] || { printf 'no external true(1) to probe with\n'; return 0; }
-  LD_PRELOAD="$1" "$TRUE_BIN" 2>&1 >/dev/null | head -1
-}
-
-select_malloc() {
-  local want="${YOSYS_MALLOC-}" cand lc abs
-  case "$want" in
-    none) return 0 ;;
-    "")   ;;
-    *)    # Existence is checked BEFORE canonicalisation so a relative request
-          # is judged against the caller's directory, which is where they meant
-          # it, and so the message says what is actually wrong.
-          [ -e "$want" ] || {
-            echo "YOSYS_MALLOC=$want: no such file" >&2
-            return 2
-          }
-          abs="$(abs_path "$want")" || {
-            echo "YOSYS_MALLOC=$want: cannot be resolved to an absolute path" >&2
-            return 2
-          }
-          preload_is_usable "$abs" || {
-            echo "YOSYS_MALLOC=$want: the loader will not preload it ($abs)" >&2
-            echo "  $(preload_refusal "$abs")" >&2
-            return 2
-          }
-          printf '%s\n' "$abs"
-          return 0 ;;
-  esac
-  # ldconfig answers for the loader's own search path, which is the only
-  # authority on where a distribution put the library - multiarch layouts
-  # included, which is why no such path is spelled below. The literal list is
-  # only the fallback for a machine whose ldconfig a normal user cannot run,
-  # and an empty answer is a valid one: the gate then runs unchanged.
-  # A candidate that the loader will not take is SKIPPED here rather than
-  # refused: the documented default is "use jemalloc when it is installed", and
-  # a broken one is simply not installed. An explicit request is refused above,
-  # because there the caller named it and is owed an answer.
-  if lc="$(ldconfig_path)"; then
-    while IFS= read -r cand; do
-      [ -e "$cand" ] && preload_is_usable "$cand" && { printf '%s\n' "$cand"; return 0; }
-    done < <("$lc" -p 2>/dev/null | sed -n 's/^.* => //p' | grep -F libjemalloc.so.2)
-  fi
-  for cand in /usr/lib/libjemalloc.so.2 /usr/lib64/libjemalloc.so.2 \
-              /usr/local/lib/libjemalloc.so.2; do
-    [ -e "$cand" ] && preload_is_usable "$cand" && { printf '%s\n' "$cand"; return 0; }
-  done
-  return 0
-}
-
-# THE ONLY PLACE that decides what a yosys child sees, so the self-test below
-# exercises the same code the gate runs. An EMPTY selection must actively UNSET
-# LD_PRELOAD rather than merely decline to set it: a caller who already exported
-# one would otherwise have it inherited while the header line said "system",
-# which is the same silent misattribution the refusal above exists to prevent -
-# and it would invalidate any with-versus-without comparison run in that shell.
-apply_malloc_env() {
-  local lib="${1-}"
-  if [ -n "$lib" ]; then
-    export LD_PRELOAD="$lib"
-  else
-    unset LD_PRELOAD
-  fi
-}
-
-# The interesting case is the machine WITHOUT jemalloc, because that is the one
-# the documented tool requirement covers and the one nobody runs by accident.
-# This self-test needs neither jemalloc, nor yosys, nor sv2v, nor a submodule.
-selftest_alloc() {
-  local rc=0 skipped=0 out probe found dir base
-
-  out="$(YOSYS_MALLOC=none select_malloc)" || rc=1
-  [ -z "$out" ] || { echo "selftest: YOSYS_MALLOC=none selected '$out'" >&2; rc=1; }
-
-  # An EXISTING file the loader will not take must be refused, not reported as
-  # the allocator in effect. An empty temp file is exactly that case.
-  probe="$(mktemp)"
-  if out="$(YOSYS_MALLOC="$probe" select_malloc 2>/dev/null)"; then
-    echo "selftest: an unloadable YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
-  fi
-  if out="$(YOSYS_MALLOC="$probe.absent" select_malloc 2>/dev/null)"; then
-    echo "selftest: a missing YOSYS_MALLOC was accepted as '$out'" >&2; rc=1
-  fi
-  rm -f "$probe"
-
-  # The default never names something the loader would drop.
-  found="$(unset YOSYS_MALLOC; select_malloc)" || rc=1
-  if [ -n "$found" ]; then
-    { [ -e "$found" ] && preload_is_usable "$found"; } || {
-      echo "selftest: the default selected an unusable '$found'" >&2; rc=1
-    }
-    # A RELATIVE request must come back absolute, because yosys runs from $TMP.
-    dir="$(dirname -- "$found")"; base="$(basename -- "$found")"
-    out="$(cd "$dir" && YOSYS_MALLOC="./$base" select_malloc)" || rc=1
-    [ "$out" = "$found" ] || {
-      echo "selftest: relative path resolved to '$out', expected '$found'" >&2; rc=1
-    }
-  else
-    echo "selftest: SKIPPED the relative-path and usable-default arms" \
-         "(no preloadable jemalloc on this machine)"
-    skipped=1
-  fi
-
-  # The child environment, through the same function the per-top run uses.
-  out="$(export LD_PRELOAD=/inherited/from/the/caller.so
-         apply_malloc_env ""; printf '%s' "${LD_PRELOAD-<unset>}")"
-  [ "$out" = "<unset>" ] || {
-    echo "selftest: an inherited LD_PRELOAD survived an empty selection as '$out'" >&2; rc=1
-  }
-  out="$(unset LD_PRELOAD; apply_malloc_env /x/y.so; printf '%s' "${LD_PRELOAD-<unset>}")"
-  [ "$out" = "/x/y.so" ] || {
-    echo "selftest: a selected library did not reach the child env ('$out')" >&2; rc=1
-  }
-
-  [ "$rc" -eq 0 ] && echo "allocator selection self-test: PASS$([ "$skipped" -eq 1 ] && echo ' (with skips)')"
-  return "$rc"
-}
+# The allocator rules live in one file, shared with ooc.sh. It is NOT sourced
+# on the `--list` path: check_list_hermetic.sh proves --list reads nothing but
+# this script and scripts/yosys_shards.py, in a tree built to hold only those
+# two files (#190), so sourcing unconditionally would break that contract.
+if [ "$LIST" -eq 0 ]; then
+  . "$(dirname "$0")/malloc.sh"
+fi
 
 if [ "$SELFTEST_ALLOC" -eq 1 ]; then
   selftest_alloc


### PR DESCRIPTION
Closes #290.

`syn/yosys/ooc.sh` now runs its `yosys` under the same `YOSYS_MALLOC` contract
PR #289 landed for the portability gate, and the rules moved into
`syn/yosys/malloc.sh` so the second consumer does not carry a copy.

## Measured

`./syn/yosys/ooc.sh KL_pp_shadow KL_crf_rx tcam`, one machine, `yosys 0.66`:

| | wall |
| --- | ---: |
| `YOSYS_MALLOC=none` | 235.09 s |
| default (jemalloc found) | **177.85 s** (−24.3%) |

`synth_xilinx -flatten` is the heavier program, so this flow gains more than
the portability gate did.

## The area rows do not move

They are the entire point of this script, so they are the acceptance test, and
they are identical across all three tops:

```
KL_crf_rx        355     0    355    509    0    1    0   125
KL_pp_shadow   58209  6008  64217  28937   15    4    4  2019
tcam             678     0    678   1680    0    0    0     0

diff <(rows under jemalloc) <(rows under none)  ->  IDENTICAL
```

Consistent with #286, where `write_rtlil` after the gate's own program was
byte-identical under glibc, tcmalloc, jemalloc and mimalloc.

## One file, not two copies

`syn/yosys/malloc.sh` holds the selection, the child-environment decision and
the self-test; `run.sh` and `ooc.sh` both source it. It defines functions and
sets one variable, starts nothing and changes no directory.

**`run.sh --list` does not source it**, deliberately and with a comment saying
why: `check_list_hermetic.sh` proves `--list` reads nothing but `run.sh` and
`scripts/yosys_shards.py`, in a tree built to hold only those two files (#190).
An unconditional `source` would have broken that contract, so the source is
guarded and `--selftest-alloc` and `--list` are now mutually exclusive, on the
same grounds as `--emit` and `--list`. `check_list_hermetic.sh` passes,
including its negative control.

## Properties carried over from #289's review

Because they were defects there first:

- an explicitly named library is **refused** (exit 2) if absent, or if the
  loader will not take it — the loader rejects an unusable `LD_PRELOAD` by
  *ignoring* it, exiting 0 with the complaint on stderr, so the test is
  "stderr stayed empty";
- a relative `YOSYS_MALLOC` is made absolute before it is used;
- `YOSYS_MALLOC=none` **unsets** `LD_PRELOAD` rather than declining to set it;
- an auto-detected candidate the loader will not take is skipped, not refused.

Proved for `ooc.sh` with a shim that records `program_invocation_short_name`:

```
$ LD_PRELOAD=<probe.so> YOSYS_MALLOC=none ./syn/yosys/ooc.sh tcam
   yosys allocator: system
   yosys=0  abc=0  sv2v=1
```

`sv2v` runs *inside* this script's per-top loop, which is why the preload is
applied in the `yosys` subshell rather than exported once — the ROM generators
and `sv2v` keep the caller's environment, as the README says.

## The self-test anchors moved, and I want that flagged

`ooc_selftest.py` plants its mutations by matching `ooc.sh`'s text. Two arms
anchor on `(cd "$rundir" && yosys`, which is now
`(cd "$rundir" && apply_malloc_env "$MALLOC_LIB" && yosys`. Both anchors were
updated; **neither mutation changed in meaning** — `cwd-escape` still runs the
synthesis outside the exclusive per-top directory and `consume-shared-dir`
still moves it back to the shared published one, and both must still be caught.
The suite refused loudly rather than passing when the anchor moved, which is
the behaviour you want from it. 75/75 arms pass (75 since [A1] added the allocator-scoping arms).

## Validation

```
ooc.sh refusal self-test: 75 arm(s) passed
allocator selection self-test: PASS            (run.sh and ooc.sh)
check_list_hermetic: OK                        (positive and negative control)
dp_srcs self-test: 35 arm(s) passed
LINT GATE: PASS (99 <= ratchet 99)
docs_check: 0 finding(s) across 181 md + 786 scrubbed text files
baremetal-only: OK (0 findings across 784 tracked first-party file(s))
TOC gate: OK
yosys_shards --selftest: PASS
pp_srcs --check: rc=0
```

The two file-census gates were re-run **after** `git add` of the new file, so
their counts include it (783→784 tracked, 785→786 scrubbed).

CI is untouched: its Yosys is still unpinned (#287), and that ordering has not
changed.
