### PR TITLE
syn/ooc: derive the include path and defines from the record, not by hand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,12 +132,11 @@ syn/yosys/.ooc-mut-*
 syn/yosys/.ooc-pkg-*
 syn/yosys/rom_digests.tsv.new.*
 
-# syn/ooc/ooc_tcl_selftest.py does the same beside ITSELF, for the same
-# reason (milan_datapath_ooc.tcl derives $REPO from [info script], so a
-# mutant must live in syn/ooc/). These lines were missing while the mutants
-# were being written -- only the syn/yosys/ suite was covered.
-syn/ooc/.ooc-mut-*
-syn/ooc/.ooc-pkg-*
+# syn/ooc/ooc_tcl_selftest.py writes its mutated recipes beside ITSELF for
+# the same reason (milan_datapath_ooc.tcl derives $REPO from [info script],
+# so a mutant must live in syn/ooc/). This line was missing while those
+# mutants were being written -- only the syn/yosys/ suite was covered. Its
+# package mutants take no dir= and land in $TMPDIR, so they need no entry.
 
 # local agent scratch, never shipped
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,13 @@ syn/yosys/.ooc-mut-*
 syn/yosys/.ooc-pkg-*
 syn/yosys/rom_digests.tsv.new.*
 
+# syn/ooc/ooc_tcl_selftest.py does the same beside ITSELF, for the same
+# reason (milan_datapath_ooc.tcl derives $REPO from [info script], so a
+# mutant must live in syn/ooc/). These lines were missing while the mutants
+# were being written -- only the syn/yosys/ suite was covered.
+syn/ooc/.ooc-mut-*
+syn/ooc/.ooc-pkg-*
+
 # local agent scratch, never shipped
 .claude/
 

--- a/docs/design/AREA_80_CAMPAIGN.md
+++ b/docs/design/AREA_80_CAMPAIGN.md
@@ -18,7 +18,7 @@ method is *static-conversion first* (this page), block diets second.
 > **substitution**, and it is measured, in context, both sides on the same
 > instrument, in
 > [`../findings/PP_SHADOW_AREA_0812.md`](../findings/PP_SHADOW_AREA_0812.md)
-> — **+6,956 LUT for the processor plane against −15,474 LUT removed.**
+> — **+6,956 LUT for the processor plane against −15,474 LUT removed.** (the `+6,956` pair was measured on the `ax7101_1x1_tdm8` shape -- see the shape-provenance note in [PP_SHADOW_AREA_0812.md](../findings/PP_SHADOW_AREA_0812.md) -- and is owed a re-measurement)
 >
 > Read the rest of this page as the *analysis record* it always was. Rows
 > below that name a deleted module are marked; the razors themselves still

--- a/docs/design/AREA_BUDGET.md
+++ b/docs/design/AREA_BUDGET.md
@@ -38,7 +38,7 @@ The current command-surface claim is checked against the
 > * the single biggest line item below, `u_bld` (`KL_aecp_response_builder`,
 >   5,300 LUT here), was part of an AECP plane that measured **8,645 LUT
 >   in context** for `KL_aecp_top` alone — larger than the entire replacement
->   plane costs in context (**+6,956**);
+>   plane costs in context (**+6,956**); (the `+6,956` pair was measured on the `ax7101_1x1_tdm8` shape -- see the shape-provenance note in [PP_SHADOW_AREA_0812.md](../findings/PP_SHADOW_AREA_0812.md) -- and is owed a re-measurement)
 > * the tier-3 "core, not reclaimable by parametrisation" verdict was
 >   correct about *parametrisation* and was overtaken by **deletion**: three
 >   of its five entries are gone.

--- a/docs/findings/PP_SHADOW_AREA_0812.md
+++ b/docs/findings/PP_SHADOW_AREA_0812.md
@@ -199,6 +199,16 @@ own interconnect to each plane. `syn/ooc/milan_datapath_ooc.tcl` closes that
 gap by synthesising the whole `milan_datapath` at the 1×1 shape, baseline
 versus plane-ON, same instrument:
 
+> **Shape provenance (PR #305).** The `milan_datapath` figures below were
+> taken with `syn/ooc/milan_datapath_ooc.tcl` before its include path was
+> derived from the authority record. That recipe placed the
+> elaboration-shape config dir LAST, so `milan_datapath` elaborated as
+> `endstation_ax7101_1x1_tdm8` (2 talker sources / 31 name entries / 8 wire
+> channels) rather than `endstation_arty_current` (1 / 29 / 2). The A/B
+> delta is still same-instrument -- both runs used the same shape -- but the
+> ABSOLUTE numbers are for the other entity and are owed a re-measurement.
+> `syn/yosys/ooc.sh` has the same defect and is still unfixed.
+
 | milan_datapath, 1×1 | LUT | FF | BRAM | WNS @ 100 MHz | Failing |
 |---|---|---|---|---|---|
 | baseline (`PP_PLANE_P=0`) | 33,704 | 31,321 | 24.5 | +0.825 ns | 0 |
@@ -416,7 +426,7 @@ macro-EXPANDED one that must both expand clean so the group cannot pass on a
 front end that refuses everything; and eleven that run mutated copies of the
 real `run.sh` under real bash, four of them the round-two counterexamples above
 and the last three the round-two and round-three constructs on the real read
-set, with and without a front end) and `syn/ooc/ooc_tcl_selftest.py` (5 arms,
+set, with and without a front end) and `syn/ooc/ooc_tcl_selftest.py` (55 arms,
 which drive this .tcl under `tclsh` with the Vivado commands stubbed), plus both
 expansions for real.
 

--- a/syn/ooc/dp_srcs.py
+++ b/syn/ooc/dp_srcs.py
@@ -709,6 +709,16 @@ def main() -> int:
                     help="the run.sh entry to expand (default: milan_datapath)")
     ap.add_argument("--selftest", action="store_true",
                     help="prove each check fails on a planted defect")
+    ap.add_argument("--record", action="store_true",
+                    help="print the whole consumable record -- top=/define=/"
+                         "incdir=/src= lines, authority order -- rather than "
+                         "the bare source list. A consumer that must also "
+                         "PREPROCESS these sources (Vivado, sv2v) needs the "
+                         "defines and the include path, and an include path "
+                         "spelled by hand is the drift this file exists to "
+                         "prevent: syn/yosys/run.sh puts the elaboration-shape "
+                         "config dir FIRST for milan_datapath, and any other "
+                         "order silently selects a different entity shape.")
     args = ap.parse_args()
 
     if args.selftest:
@@ -728,6 +738,13 @@ def main() -> int:
         print(p, file=sys.stderr)
     if rc:
         return rc
+    if args.record:
+        out = ["top=" + t for t in rec["top"]]
+        out += ["define=" + d for d in rec["define"]]
+        out += ["incdir=" + i for i in rec["incdir"]]
+        out += ["src=" + f for f in files]
+        print("\n".join(out))
+        return 0
     print("\n".join(files))
     return 0
 

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -25,7 +25,11 @@
 # elaboration shape the yosys gate also uses.
 
 set REPO [file normalize [file dirname [info script]]/../..]
-set TAG  [expr {[info exists ::env(TAG)] ? $::env(TAG) : "base"}]
+# TAG names the .rpt files. NOT via `expr`, which coerces its operand
+# numerically: TAG=007 wrote util_7.rpt and collided with a TAG=7 run, so a
+# campaign comparing two tags compared one file against itself.
+set TAG "base"
+if {[info exists ::env(TAG)] && $::env(TAG) ne ""} { set TAG $::env(TAG) }
 puts "milan_datapath OOC: tag=$TAG"
 
 # The source list is printed by syn/yosys/run.sh itself (`--emit`) and relayed
@@ -39,7 +43,53 @@ puts "milan_datapath OOC: tag=$TAG"
 # geometry packages are found IN this record, never spelled here by hand
 # ([R0] round three on PR #264 -- a spelled path is a hand list in waiting,
 # and the pp_srcs.py literal gate cannot see Tcl semantics).
-set SRC_LINES [split [string trim [exec python3 $REPO/syn/ooc/dp_srcs.py]] "\n"]
+#
+# --record hands over the PREPROCESSOR half too (top=/define=/incdir=), not
+# just src=. Deriving the sources and then spelling the include path by hand
+# left the two halves free to disagree, and they did: run.sh puts the
+# elaboration-shape config dir FIRST for milan_datapath, this recipe had it
+# LAST, and BOTH hdl/common/csr/gen/ and configs/generated/*/gen/ carry an
+# adp_shape_defaults.svh -- so synth_design priced the ax7101_1x1_tdm8 entity
+# (2 talker sources, 31 name entries, 8 wire channels) while the portability
+# gate proved the arty_current one (1 / 29 / 2). That is #246's own class one
+# layer up: a complete, plausible report for a design nobody asked for. The
+# define half is live too -- KL_gptp_engine.sv gates simulation-only $error
+# blocks on `ifndef SYNTHESIS`, which the gate defines and this recipe did
+# not.
+#
+# -ignorestderr: `exec` treats ANY child stderr byte as an error even on a
+# zero exit, so one DeprecationWarning out of python3 would abort the run
+# with that warning as its entire diagnostic. The exit STATUS is the
+# contract, here and at every generator below.
+set DP_SRCS $REPO/syn/ooc/dp_srcs.py
+if {[catch {exec -ignorestderr python3 $DP_SRCS --record} REC]} {
+  error "milan_datapath OOC: the derived record is not available -- \
+dp_srcs.py failed. Everything below derives from it, so this is a refusal,\
+ not a license to fall back to a hand list:\n$REC"
+}
+
+set DP_TOP    {}
+set DEFINES   {}
+set INCS      {}
+set SRC_LINES {}
+foreach line [split [string trim $REC] "\n"] {
+  if {[regexp {^top=(.*)$} $line -> v]}    { lappend DP_TOP    $v; continue }
+  if {[regexp {^define=(.*)$} $line -> v]} { lappend DEFINES   $v; continue }
+  if {[regexp {^incdir=(.*)$} $line -> v]} { lappend INCS      $v; continue }
+  if {[regexp {^src=(.*)$} $line -> v]}    { lappend SRC_LINES $v; continue }
+  error "milan_datapath OOC: unrecognized record line \"$line\". A key this\
+ recipe does not know is a refusal: silently skipping it is how a consumer\
+ stops consuming half of the record it asked for."
+}
+if {[llength $DP_TOP] != 1} {
+  error "milan_datapath OOC: the record names [llength $DP_TOP] tops,\
+ expected exactly one. The module this script reads and the module it\
+ synthesizes must not be two different strings (#235)."
+}
+if {[llength $INCS] == 0 || [llength $SRC_LINES] == 0} {
+  error "milan_datapath OOC: the record carries [llength $INCS] include\
+ dir(s) and [llength $SRC_LINES] source(s); both must be non-empty."
+}
 
 # Exactly one file in the derived record may carry the named basename; zero
 # means the record no longer contains the geometry source (refuse, do not
@@ -63,12 +113,14 @@ proc one_source {src_lines tail} {
 # transition ROM by the RELATIVE name "ltn_rom.hex", KL_aecp_ucpu its
 # microcode by "ucode.hex" (UCODE_HEX_P), and the default-on fabric gPTP
 # engine's KL_gptp_ucpu its microcode by "gptp_ucode.hex"
-# (GPTP_UCODE_HEX_P); Vivado resolves each against ITS OWN run directory. This recipe is documented to run from an EMPTY directory, so
+# (GPTP_UCODE_HEX_P); Vivado resolves each against ITS OWN run directory.
+# This recipe is documented to run from an EMPTY directory, so
 # it must generate what it requires: until #246 it generated only
 # ltn_rom.hex, and Vivado read the absent ucode.hex as an all-zero ROM behind
 # one CRITICAL WARNING (Synth 8-4445), constant-folded the AECP uCPU, and
-# completed rc=0 with a full, plausible utilization report 7,923 LUT under
-# the shipping design.
+# completed rc=0 with a full, plausible utilization report 8,012 LUT under
+# the shipping design (measured at PR #264's head; the 7,923 this comment
+# used to carry was the issue title's first estimate, not a measurement).
 #
 # The contract, per image ([R-parallel] and [R0] on PR #264 closed the
 # survivors):
@@ -99,11 +151,18 @@ proc pkg_num {path name} {
  $name in $path, found [expr {[llength $hits] / 2}] (comments stripped; a\
  spelling this parser does not recognize is a refusal, not a guess)"
   }
-  return [lindex $hits 1]
+  # SystemVerilog reads an unbased literal as DECIMAL; Tcl's expr reads a
+  # leading zero as OCTAL, so `UPC_W_C = 011` would be 9 here and 11 in the
+  # RTL. scan %d fixes the base at ten.
+  return [scan [lindex $hits 1] %d]
 }
 
 proc rom_check {path digits words} {
-  set fh [open $path r]; set lines [split [read $fh] "\n"]; close $fh
+  set fh [open $path r]; set text [read $fh]; close $fh
+  # $readmemh accepts BOTH comment forms and pkg_num strips both; stripping
+  # only // here made a generator banner written as /* */ a false refusal.
+  regsub -all {/\*.*?\*/} $text "" text
+  set lines [split $text "\n"]
   set n 0
   foreach line $lines {
     regsub {//.*$} $line "" line
@@ -145,15 +204,28 @@ proc positive_depth {name d} {
   return $d
 }
 
+# UPC_W_C is not a depth, it is the EXPONENT of one: the ucode ROM is
+# 1<<UPC_W_C words. It reached `expr` with no guard, so UPC_W_C = 0 asked for
+# a ONE-WORD image -- "the same lie as an absent one" by the contract above,
+# admitted through the single constant that skipped a check.
+proc positive_exp {name e} {
+  if {![string is integer -strict $e] || $e <= 0} {
+    error "milan_datapath OOC: $name = $e is not a positive ROM address\
+ width (the image is 1<<$e words). A zero exponent would accept a one-word\
+ image, which is the absent-image lie under another name."
+  }
+  return $e
+}
+
 set UCPU_PKG [one_source $SRC_LINES ucpu_pkg.sv]
 set ACMP_PKG [one_source $SRC_LINES pp_acmp_pkg.sv]
 set GPTP_PKG [one_source $SRC_LINES gptp_ucpu_pkg.sv]
 set UCODE_W [nibble_width UCODE_W_C [pkg_num $UCPU_PKG UCODE_W_C]]
-set UPC_W   [pkg_num $UCPU_PKG UPC_W_C]
+set UPC_W   [positive_exp UPC_W_C [pkg_num $UCPU_PKG UPC_W_C]]
 set TROM_W  [nibble_width TROM_W_C [pkg_num $ACMP_PKG TROM_W_C]]
 set TROM_D  [positive_depth TROM_DEPTH_C [pkg_num $ACMP_PKG TROM_DEPTH_C]]
 set GUCODE_W [nibble_width UCODE_W_C [pkg_num $GPTP_PKG UCODE_W_C]]
-set GUPC_W   [pkg_num $GPTP_PKG UPC_W_C]
+set GUPC_W   [positive_exp UPC_W_C [pkg_num $GPTP_PKG UPC_W_C]]
 
 foreach {img gen digits words} [list \
     ltn_rom.hex $REPO/protocol-processor/hdl/acmp/rom/gen_ltn_rom.py \
@@ -164,7 +236,16 @@ foreach {img gen digits words} [list \
                 [expr {$GUCODE_W / 4}] [expr {1 << $GUPC_W}]] {
   set tmp $img.gen.[pid]
   file delete -force $img $tmp
-  exec python3 $gen -o $tmp
+  # -ignorestderr: the exit STATUS is what "a failed generator aborts" means.
+  # A generator that writes a perfect image, exits 0 and emits one Python
+  # warning used to abort here -- with the warning as the whole diagnostic,
+  # $img already deleted at the line above, and $tmp orphaned because the
+  # cleanup below is only on the validation path.
+  if {[catch {exec -ignorestderr python3 $gen -o $tmp} out]} {
+    file delete -force $tmp
+    error "milan_datapath OOC: the generator for $img exited non-zero:\
+ $gen\n$out"
+  }
   set diag "the generator exited 0 leaving no file"
   if {[file exists $tmp]} { set diag [rom_check $tmp $digits $words] }
   if {$diag ne ""} {
@@ -207,17 +288,35 @@ puts "milan_datapath OOC: [llength $SV] SystemVerilog + [llength $V] Verilog sou
 read_verilog -sv $SV
 read_verilog $V
 
-set INCS [list $REPO/hdl/common $REPO/hdl/common/csr \
-               $REPO/hdl/common/eth_event_counter $REPO/hdl/ieee17221/adp \
-               $REPO/hdl/ieee8021q/ts $REPO/hdl/ieee8021as/ptp_timestamp \
-               $REPO/hdl/ieee1722/avtp \
-               $REPO/configs/generated/endstation_arty_current]
+# $INCS and $DEFINES are the record's own, in the record's own ORDER --
+# see the derivation at the top. There is no hand list here to drift.
+set DEFARGS {}
+foreach d $DEFINES { lappend DEFARGS -verilog_define $d }
 
-synth_design -mode out_of_context -top milan_datapath -part xc7a100tfgg484-2 \
-  -include_dirs $INCS -generic $TROM_GENERIC -generic $UCODE_GENERIC \
+# The reports are deleted before synth_design for the reason the ROM images
+# are: they are $TAG-named and written only on success, so a refused run used
+# to leave the PREVIOUS run's util_$TAG.rpt in place under the same name --
+# the one artifact a human actually reads was the one nothing invalidated.
+foreach r [list util_hier_$TAG.rpt util_$TAG.rpt timing_$TAG.rpt] {
+  file delete -force $r
+}
+
+synth_design -mode out_of_context -top [lindex $DP_TOP 0] \
+  -part xc7a100tfgg484-2 -include_dirs $INCS {*}$DEFARGS \
+  -generic $TROM_GENERIC -generic $UCODE_GENERIC \
   -generic $GUCODE_GENERIC
 
-create_clock -period 10.000 -name clk [get_ports -quiet axis_clk]
+# -quiet on a renamed port would hand create_clock an EMPTY object list and
+# define a VIRTUAL clock: timing_$TAG.rpt would then report an essentially
+# unconstrained design, at rc=0. Refuse instead of reporting that.
+set CLK_NAME axis_clk
+set CLK_PORT [get_ports -quiet $CLK_NAME]
+if {[llength $CLK_PORT] != 1} {
+  error "milan_datapath OOC: expected exactly one $CLK_NAME port after\
+ synthesis, found [llength $CLK_PORT]. A virtual clock would report an\
+ unconstrained design as if it were a timing result."
+}
+create_clock -period 10.000 -name clk $CLK_PORT
 report_utilization -hierarchical -file util_hier_$TAG.rpt
 report_utilization -file util_$TAG.rpt
 report_timing_summary -delay_type max -max_paths 3 -file timing_$TAG.rpt

--- a/syn/ooc/milan_datapath_ooc.tcl
+++ b/syn/ooc/milan_datapath_ooc.tcl
@@ -4,9 +4,13 @@
 # substituted design: the shipping 1722.1/SRP planes are deleted and the
 # protocol processor stands in their place, instantiated unconditionally.
 #
-# Same instrument as syn/ooc/pp_shadow_ooc.tcl (post-synthesis utilization,
-# ship part, 100 MHz OOC), because a net figure built from two different
-# instruments is not a net figure.
+# Meant to be the same instrument as syn/ooc/pp_shadow_ooc.tcl
+# (post-synthesis utilization, ship part, 100 MHz OOC), because a net figure
+# built from two different instruments is not a net figure. It is NOT that
+# today: pp_shadow_ooc.tcl neither generates nor geometry-checks its images,
+# does not promote Synth 8-4445, and passes no -include_dirs or
+# -verilog_define. Any net figure spanning the two is owed that convergence
+# first.
 #
 # The per-block OOC number pp_shadow_ooc.tcl produces is a STANDALONE cost; it
 # does not carry the datapath's own interconnect to the plane. This script is
@@ -25,12 +29,24 @@
 # elaboration shape the yosys gate also uses.
 
 set REPO [file normalize [file dirname [info script]]/../..]
+# Named ONCE: it reaches dp_srcs.py, the record assertion and synth_design
+# from this one variable (pp_shadow_ooc.tcl's discipline).
+set TOP  milan_datapath
 # TAG names the .rpt files. NOT via `expr`, which coerces its operand
 # numerically: TAG=007 wrote util_7.rpt and collided with a TAG=7 run, so a
 # campaign comparing two tags compared one file against itself.
 set TAG "base"
 if {[info exists ::env(TAG)] && $::env(TAG) ne ""} { set TAG $::env(TAG) }
 puts "milan_datapath OOC: tag=$TAG"
+
+# Invalidated HERE, before the first refusal can fire -- not beside
+# synth_design, where every guard below would still have left the previous
+# run's numbers standing under the same names. The reports are the only
+# artifact a human reads directly, so they must be the first thing this run
+# takes responsibility for.
+foreach r [list util_hier_$TAG.rpt util_$TAG.rpt timing_$TAG.rpt] {
+  file delete -force $r
+}
 
 # The source list is printed by syn/yosys/run.sh itself (`--emit`) and relayed
 # by dp_srcs.py -- the ONE list the portability gate proves elaborates. A copy
@@ -49,23 +65,44 @@ puts "milan_datapath OOC: tag=$TAG"
 # left the two halves free to disagree, and they did: run.sh puts the
 # elaboration-shape config dir FIRST for milan_datapath, this recipe had it
 # LAST, and BOTH hdl/common/csr/gen/ and configs/generated/*/gen/ carry an
-# adp_shape_defaults.svh -- so synth_design priced the ax7101_1x1_tdm8 entity
-# (2 talker sources, 31 name entries, 8 wire channels) while the portability
-# gate proved the arty_current one (1 / 29 / 2). That is #246's own class one
-# layer up: a complete, plausible report for a design nobody asked for. The
+# adp_shape_defaults.svh -- so synth_design priced milan_datapath as the
+# ax7101_1x1_tdm8 entity (2 talker sources, 31 name entries, 8 wire channels)
+# while the portability gate elaborates it as arty_current (1 / 29 / 2). That
+# is #246's own class one layer up: a complete, plausible report for a design
+# nobody asked for.
+#
+# What this does NOT fix, and must not be read as fixing: milan_csr.sv sits
+# beside its OWN hdl/common/csr/gen/ copy, and a quoted `include resolves
+# against the including file's directory before any -I. So under the
+# authority order milan_csr still sees the tracked copy (2 / 31) while
+# milan_datapath sees the config (1 / 29) -- the two-includer invariant
+# asserted at milan_datapath.sv:1526 does not hold on this tree, for the
+# gate either. Matching the gate is this recipe's job; making the tracked
+# copy agree with the config is endstation_builder.py --write-rtl's, and is
+# not attempted here. The
 # define half is live too -- KL_gptp_engine.sv gates simulation-only $error
 # blocks on `ifndef SYNTHESIS`, which the gate defines and this recipe did
 # not.
 #
-# -ignorestderr: `exec` treats ANY child stderr byte as an error even on a
-# zero exit, so one DeprecationWarning out of python3 would abort the run
-# with that warning as its entire diagnostic. The exit STATUS is the
-# contract, here and at every generator below.
+# `exec` treats ANY child stderr byte as an error even on a zero exit, so one
+# DeprecationWarning out of python3 would abort the run with that warning as
+# its entire diagnostic. The exit STATUS is the contract. stdout here IS the
+# payload, so stderr cannot be merged into it -- it goes to a file instead,
+# because -ignorestderr alone would replace dp_srcs.py's own "missing
+# sources:" report with Tcl's bare "child process exited abnormally".
 set DP_SRCS $REPO/syn/ooc/dp_srcs.py
-if {[catch {exec -ignorestderr python3 $DP_SRCS --record} REC]} {
+set REC_ERR dp_srcs.err.[pid]
+file delete -force $REC_ERR
+set REC_RC [catch {exec python3 $DP_SRCS --top $TOP --record 2>$REC_ERR} REC]
+set REC_WHY ""
+if {[file exists $REC_ERR]} {
+  set fh [open $REC_ERR r]; set REC_WHY [string trim [read $fh]]; close $fh
+  file delete -force $REC_ERR
+}
+if {$REC_RC} {
   error "milan_datapath OOC: the derived record is not available -- \
 dp_srcs.py failed. Everything below derives from it, so this is a refusal,\
- not a license to fall back to a hand list:\n$REC"
+ not a license to fall back to a hand list:\n$REC\n$REC_WHY"
 }
 
 set DP_TOP    {}
@@ -81,14 +118,30 @@ foreach line [split [string trim $REC] "\n"] {
  recipe does not know is a refusal: silently skipping it is how a consumer\
  stops consuming half of the record it asked for."
 }
-if {[llength $DP_TOP] != 1} {
-  error "milan_datapath OOC: the record names [llength $DP_TOP] tops,\
- expected exactly one. The module this script reads and the module it\
- synthesizes must not be two different strings (#235)."
+# The top is named ONCE here and asserted against the record, the discipline
+# pp_shadow_ooc.tcl states explicitly. Counting tops is cardinality; #235 is
+# about IDENTITY -- a record that names one top which is not this one would
+# have satisfied a count and quietly priced another module.
+if {[llength $DP_TOP] != 1 || [lindex $DP_TOP 0] ne $TOP} {
+  error "milan_datapath OOC: the record names \"$DP_TOP\", expected exactly\
+ one top and that top to be $TOP. The module this script reads and the\
+ module it synthesizes must not be two different strings (#235)."
 }
-if {[llength $INCS] == 0 || [llength $SRC_LINES] == 0} {
-  error "milan_datapath OOC: the record carries [llength $INCS] include\
- dir(s) and [llength $SRC_LINES] source(s); both must be non-empty."
+# DEFINES is guarded too: it is the half that silently reverts this recipe to
+# its pre-fix state if the authority ever stops emitting it, and an empty
+# ELEMENT satisfies a length check while passing "" to the tool.
+foreach {nm lst} [list "include dir" $INCS "source" $SRC_LINES \
+                       "define" $DEFINES] {
+  if {[llength $lst] == 0} {
+    error "milan_datapath OOC: the record carries no ${nm}s. Every half of\
+ the record is consumed here, so an absent half is a refusal, not a default."
+  }
+  foreach e $lst {
+    if {[string trim $e] eq ""} {
+      error "milan_datapath OOC: the record carries an empty $nm entry.\
+ A blank element satisfies a length check and then reaches the tool as \"\"."
+    }
+  }
 }
 
 # Exactly one file in the derived record may carry the named basename; zero
@@ -119,8 +172,11 @@ proc one_source {src_lines tail} {
 # ltn_rom.hex, and Vivado read the absent ucode.hex as an all-zero ROM behind
 # one CRITICAL WARNING (Synth 8-4445), constant-folded the AECP uCPU, and
 # completed rc=0 with a full, plausible utilization report 8,012 LUT under
-# the shipping design (measured at PR #264's head; the 7,923 this comment
-# used to carry was the issue title's first estimate, not a measurement).
+# the shipping design. (That delta is PR #264's, measured at its own head;
+# the 7,923 this comment used to carry is #246's calibration of the same
+# pair at the older head 6be50377 -- a different measurement, not an
+# estimate. Both predate the shape correction below, so both are owed a
+# re-measurement.)
 #
 # The contract, per image ([R-parallel] and [R0] on PR #264 closed the
 # survivors):
@@ -236,12 +292,14 @@ foreach {img gen digits words} [list \
                 [expr {$GUCODE_W / 4}] [expr {1 << $GUPC_W}]] {
   set tmp $img.gen.[pid]
   file delete -force $img $tmp
-  # -ignorestderr: the exit STATUS is what "a failed generator aborts" means.
-  # A generator that writes a perfect image, exits 0 and emits one Python
-  # warning used to abort here -- with the warning as the whole diagnostic,
-  # $img already deleted at the line above, and $tmp orphaned because the
-  # cleanup below is only on the validation path.
-  if {[catch {exec -ignorestderr python3 $gen -o $tmp} out]} {
+  # 2>@1, not -ignorestderr: a generator's stdout is unused, so merging keeps
+  # its own diagnostic IN the refusal (-ignorestderr would leave only Tcl's
+  # "child process exited abnormally") while still refusing on exit status
+  # alone. A generator that writes a perfect image, exits 0 and emits one
+  # Python warning used to abort here -- with the warning as the whole
+  # message, $img already deleted at the line above, and $tmp orphaned
+  # because the cleanup below is only on the validation path.
+  if {[catch {exec python3 $gen -o $tmp 2>@1} out]} {
     file delete -force $tmp
     error "milan_datapath OOC: the generator for $img exited non-zero:\
  $gen\n$out"
@@ -293,15 +351,7 @@ read_verilog $V
 set DEFARGS {}
 foreach d $DEFINES { lappend DEFARGS -verilog_define $d }
 
-# The reports are deleted before synth_design for the reason the ROM images
-# are: they are $TAG-named and written only on success, so a refused run used
-# to leave the PREVIOUS run's util_$TAG.rpt in place under the same name --
-# the one artifact a human actually reads was the one nothing invalidated.
-foreach r [list util_hier_$TAG.rpt util_$TAG.rpt timing_$TAG.rpt] {
-  file delete -force $r
-}
-
-synth_design -mode out_of_context -top [lindex $DP_TOP 0] \
+synth_design -mode out_of_context -top $TOP \
   -part xc7a100tfgg484-2 -include_dirs $INCS {*}$DEFARGS \
   -generic $TROM_GENERIC -generic $UCODE_GENERIC \
   -generic $GUCODE_GENERIC

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -79,30 +79,61 @@ GEN_GPTP = os.path.join(REPO, "gptp-processor", "hdl", "ucode",
 #: recipe under test must arrive at the same binding on its own.
 STUBS = """
 set ::ooc_read {}
+set ::ooc_sv 0
 set ::ooc_sev [dict create]
 proc read_verilog args {
   foreach a $args {
-    if {$a eq "-sv"} continue
+    if {$a eq "-sv"} { set ::ooc_sv 1; continue }
     foreach f $a { lappend ::ooc_read $f }
   }
 }
 proc set_msg_config args {
   set id ""; set sev ""
   for {set i 0} {$i < [llength $args]} {incr i} {
-    switch -- [lindex $args $i] {
+    set opt [lindex $args $i]
+    switch -- $opt {
       -id           { set id  [lindex $args [incr i]] }
       -new_severity { set sev [lindex $args [incr i]] }
+      -suppress     { set sev SUPPRESSED }
+      default {
+        # Fail CLOSED. A rule spelled with an option this model does not
+        # know may move the effective severity in a direction the model
+        # cannot see, and "silently ignored" is the exact defect the
+        # effective-severity model exists to catch.
+        error "OOC-MSG-CONFIG-UNMODELLED: $opt"
+      }
     }
   }
   if {$id ne "" && $sev ne ""} { dict set ::ooc_sev $id $sev }
 }
 proc synth_design args {
+  # Everything the recipe hands the tool is recorded, not only -generic.
+  # -top / -part / -mode / -include_dirs / -verilog_define decide WHICH
+  # design is measured, and an unobserved include path is precisely how the
+  # recipe came to elaborate a different entity shape than the portability
+  # gate while all 40 arms stayed green.
+  #
+  # The canonical image map below is TEST knowledge and duplicates the
+  # pinned packages' geometry: bump it when ucpu_pkg.sv / pp_acmp_pkg.sv /
+  # gptp_ucpu_pkg.sv move, or a COHERENT ROM change fails here and the
+  # message will blame the recipe.
+  set ::ooc_top {}; set ::ooc_part {}; set ::ooc_mode {}
+  set ::ooc_incs {}; set ::ooc_defs {}
   set expect [dict create PP_TROM_HEX_P {ltn_rom.hex 8 128} \\
                           PP_UCODE_HEX_P {ucode.hex 12 2048} \\
                           GPTP_UCODE_HEX_P {gptp_ucode.hex 12 1024}]
   for {set i 0} {$i < [llength $args]} {incr i} {
-    if {[lindex $args $i] ne "-generic"} continue
-    set g [lindex $args [expr {$i + 1}]]
+    set opt [lindex $args $i]
+    switch -- $opt {
+      -top            { set ::ooc_top  [lindex $args [incr i]]; continue }
+      -part           { set ::ooc_part [lindex $args [incr i]]; continue }
+      -mode           { set ::ooc_mode [lindex $args [incr i]]; continue }
+      -include_dirs   { set ::ooc_incs [lindex $args [incr i]]; continue }
+      -verilog_define { lappend ::ooc_defs [lindex $args [incr i]]; continue }
+      -generic        { }
+      default         { continue }
+    }
+    set g [lindex $args [incr i]]
     if {![regexp {^((?:PP|GPTP)_[A-Z_]+_HEX_P)="(.*)"$} $g -> name val]} continue
     if {[file pathtype $val] ne "absolute"} {
       error "SYNTH-GENERIC-NOT-ABSOLUTE: $g"
@@ -136,13 +167,28 @@ proc synth_design args {
   foreach id [dict keys $::ooc_sev] {
     puts "OOC-EFFECTIVE-SEV: [list $id] = [dict get $::ooc_sev $id]"
   }
+  puts "OOC-TOP: $::ooc_top"
+  puts "OOC-PART: $::ooc_part"
+  puts "OOC-MODE: $::ooc_mode"
+  puts "OOC-SV: $::ooc_sv"
+  set fi [open ooc-incdirs.txt w]
+  foreach d $::ooc_incs { puts $fi $d }
+  close $fi
+  set fd2 [open ooc-defines.txt w]
+  foreach d $::ooc_defs { puts $fd2 $d }
+  close $fd2
   set fh [open %s w]
   foreach f $::ooc_read { puts $fh $f }
   close $fh
   puts "%s"
 }
 proc create_clock args {}
-proc get_ports args { return {} }
+set ::ooc_ports {axis_clk}
+proc get_ports args {
+  set want [lindex $args end]
+  if {[lsearch -exact $::ooc_ports $want] >= 0} { return $want }
+  return {}
+}
 proc report_utilization args {}
 proc report_timing_summary args {}
 source {%s}
@@ -168,20 +214,54 @@ exec %(real)s "$@"
 """
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 40
+ARMS = 49
 
 _DERIVED = None
+_RECORD = None
+
+
+class SelfTestPrereq(Exception):
+    """A prerequisite of the suite itself is unavailable. Distinct from an arm
+    failure: it means nothing was proven, so it must NAME itself rather than
+    unwind as a traceback that also discards the arms already run."""
 
 
 def derived_sources():
     """dp_srcs.py's own answer, cached: the record the recipe must consume."""
     global _DERIVED
     if _DERIVED is None:
-        out = subprocess.run(
-            [REAL_PYTHON, os.path.join(HERE, "dp_srcs.py")],
-            capture_output=True, text=True, check=True)
-        _DERIVED = sorted(l for l in out.stdout.splitlines() if l.strip())
+        _DERIVED = sorted(derived_record()["src"])
     return _DERIVED
+
+
+def derived_record():
+    """The WHOLE record dp_srcs.py hands the recipe -- top/define/incdir/src.
+    The recipe must consume every half of it: the sources decide what is read,
+    the include path and defines decide which entity shape is elaborated."""
+    global _RECORD
+    if _RECORD is None:
+        out = subprocess.run(
+            [REAL_PYTHON, os.path.join(HERE, "dp_srcs.py"), "--record"],
+            capture_output=True, text=True)
+        if out.returncode != 0:
+            raise SelfTestPrereq(
+                "dp_srcs.py --record exited %d. Every datapath arm derives "
+                "the record it holds the recipe to, so no arm can run: check "
+                "the submodules (protocol-processor, gptp-processor) and "
+                "sv2v.\n%s" % (out.returncode, (out.stderr or "").strip()))
+        rec = {"top": [], "define": [], "incdir": [], "src": []}
+        for line in out.stdout.splitlines():
+            if not line.strip():
+                continue
+            key, _, val = line.partition("=")
+            if key not in rec:
+                raise SelfTestPrereq(
+                    "dp_srcs.py --record emitted an unrecognized key %r; the "
+                    "suite and the recipe would consume different records."
+                    % key)
+            rec[key].append(val)
+        _RECORD = rec
+    return _RECORD
 
 
 def _run(workdir, env=None, tcl=TCL):
@@ -238,8 +318,21 @@ def selftest():
                 "unexercised refusal is the defect this file tests for."
                 % os.path.relpath(TCL, REPO)], 0
 
+    # Derived FIRST, for the same reason the recipe derives first: if the
+    # record is unavailable, nothing below proves anything. Reaching it here
+    # turns a raw CalledProcessError traceback -- which used to unwind past
+    # the problem report and discard every arm already run -- into a named
+    # refusal at arm zero.
+    try:
+        derived_record()
+    except SelfTestPrereq as exc:
+        return ["SELF-TEST PREREQUISITE UNAVAILABLE: %s" % exc], 0
+
     def arm(name, want, expect_rc0, setup=None, env=None, tcl=TCL,
-            check=None):
+            check=None, post_synth=False):
+        # post_synth: the refusal under test is AFTER synth_design (the clock
+        # constraint), so the sentinel is legitimately present. Every other
+        # refusal must still beat synthesis to the run.
         nonlocal ran
         ran += 1
         with tempfile.TemporaryDirectory() as d:
@@ -254,11 +347,13 @@ def selftest():
                                     "sentinel=%s\n%s"
                                     % (name, rc, reached, log.strip()))
                     return
-            elif rc == 0 or reached or want not in log:
+            elif rc == 0 or (reached and not post_synth) or want not in log:
                 problems.append("SELF-TEST FAILED [%s]: expected a refusal "
-                                "naming %r before synthesis, got rc=%d, "
+                                "naming %r %s synthesis, got rc=%d, "
                                 "sentinel=%s\n%s"
-                                % (name, want, rc, reached, log.strip()))
+                                % (name, want,
+                                   "after" if post_synth else "before",
+                                   rc, reached, log.strip()))
                 return
             if check:
                 miss = check(d, log)
@@ -324,6 +419,17 @@ def selftest():
         finally:
             shutil.rmtree(stub, ignore_errors=True)
 
+    def unpublished(img):
+        """A refused image must not be left in the run directory: the recipe
+        renames into place only AFTER rom_check passes."""
+        def check(d, log):
+            if os.path.exists(os.path.join(d, img)):
+                return ("%s was published to the run directory despite "
+                        "failing validation -- the publish-after-validate "
+                        "ordering is gone" % img)
+            return None
+        return check
+
     # Arm 6. A dead microcode generator aborts the script: its exit status
     # is taken by `exec`, never discarded.
     dp_arm("dp-ucode-generator-fail", "planted ucode generator failure",
@@ -353,7 +459,8 @@ def selftest():
            "gen_ucode.py",
            "%s %s -o \"$out\" > /dev/null && "
            "sed -i '5s/.*/00000000000Z/' \"$out\"\n  exit 0"
-           % (REAL_PYTHON, GEN_UCODE))
+           % (REAL_PYTHON, GEN_UCODE),
+           check=unpublished('ucode.hex'))
 
     # Arm 11. STALE image + no-op generator ([R-parallel]'s exact plant):
     # the pre-created file must not survive to be measured; the no-op leaves
@@ -373,7 +480,8 @@ def selftest():
     # Arm 13. ...and the identical width contract.
     dp_arm("dp-ltn-malformed", "not exactly 8 hex digits", "gen_ltn_rom.py",
            "%s %s -o \"$out\" > /dev/null && sed -i '2s/.*/123/' \"$out\"\n"
-           "  exit 0" % (REAL_PYTHON, GEN_LTN))
+           "  exit 0" % (REAL_PYTHON, GEN_LTN),
+           check=unpublished('ltn_rom.hex'))
 
     # Arm 14. ...and its generator's exit status.
     dp_arm("dp-ltn-generator-fail", "planted ltn generator failure",
@@ -405,7 +513,44 @@ def selftest():
             return ("the read set (%d files) is not the dp_srcs.py record "
                     "(%d files): the derived-source connection is broken"
                     % (len(got), len(derived_sources())))
+        # Which design gets measured is decided by the REST of the call, and
+        # none of it was observed until this review: -include_dirs was a hand
+        # list whose ORDER selected a different entity shape than the gate.
+        rec = derived_record()
+        if "OOC-SV: 1" not in log:
+            return ("read_verilog was not given -sv: the SystemVerilog half "
+                    "of the read set would be parsed as Verilog-2001")
+        if ("OOC-TOP: %s" % rec["top"][0]) not in log:
+            return ("synth_design was not given the record's own top (%s): "
+                    "the module this recipe reads and the module it "
+                    "synthesizes must not be two different strings (#235)"
+                    % rec["top"][0])
+        if "OOC-MODE: out_of_context" not in log:
+            return "synth_design was not run -mode out_of_context"
+        if "OOC-PART: xc7a100tfgg484-2" not in log:
+            return "synth_design was not given the ship part"
+        inc = os.path.join(d, "ooc-incdirs.txt")
+        if not os.path.isfile(inc):
+            return "synth_design received no include path at all"
+        got_inc = [l.rstrip("\n") for l in open(inc) if l.strip()]
+        if got_inc != rec["incdir"]:
+            return ("the include path is not the record's, IN ORDER.\n"
+                    "  record: %s\n  passed: %s\n"
+                    "Order decides which gen/adp_shape_defaults.svh wins: "
+                    "hdl/common/csr/gen/ and configs/generated/*/gen/ both "
+                    "carry one, so a reordered path silently elaborates a "
+                    "different entity shape than the portability gate proves."
+                    % (rec["incdir"], got_inc))
+        dfn = os.path.join(d, "ooc-defines.txt")
+        got_def = ([l.rstrip("\n") for l in open(dfn) if l.strip()]
+                   if os.path.isfile(dfn) else [])
+        if got_def != rec["define"]:
+            return ("the defines are not the record's (record %s, passed %s): "
+                    "KL_gptp_engine.sv gates simulation-only $error blocks on "
+                    "`ifndef SYNTHESIS, so the define is not cosmetic"
+                    % (rec["define"], got_def))
         return None
+
     arm("dp-empty-dir-generates-and-passes", None, True, tcl=DP_TCL,
         check=dp_positive)
 
@@ -601,10 +746,11 @@ def selftest():
     pp_root = "$REPO/protocol-processor" + "/hdl"
     gp_root = "$REPO/gptp-processor" + "/hdl"
     mut = _mutant(
-        r"set SRC_LINES \[split \[string trim \[exec python3 "
-        r"\$REPO/syn/ooc/dp_srcs\.py\]\] \"\\n\"\]",
-        "set SRC_LINES [list %s/aecp/ucpu_pkg.sv %s/acmp/pp_acmp_pkg.sv"
-        " %s/ucpu/gptp_ucpu_pkg.sv]"
+        r"exec -ignorestderr python3 \$DP_SRCS --record",
+        'set _ "top=milan_datapath\\ndefine=SYNTHESIS'
+        '\\nincdir=$REPO/configs/generated/endstation_arty_current'
+        '\\nsrc=%s/aecp/ucpu_pkg.sv\\nsrc=%s/acmp/pp_acmp_pkg.sv'
+        '\\nsrc=%s/ucpu/gptp_ucpu_pkg.sv"'
         % (pp_root, pp_root, gp_root),
         "srcs-hand-list")
     try:
@@ -622,14 +768,15 @@ def selftest():
     finally:
         os.unlink(mut)
 
-    # Arm 27. MUTATION: the dp_srcs.py invocation DELETED. Nothing downstream
-    # may quietly supply a list: the recipe must die on its first consumer.
-    mut = _mutant(
-        r"set SRC_LINES \[split \[string trim \[exec python3 "
-        r"\$REPO/syn/ooc/dp_srcs\.py\]\] \"\\n\"\]\n",
-        "", "srcs-deleted")
+    # Arm 27. MUTATION: the record comes back EMPTY. Nothing downstream may
+    # quietly supply a list, and the refusal must be one the recipe AUTHORS:
+    # the old spelling asserted the bare substring "SRC_LINES", which Tcl's
+    # own undefined-variable error satisfied by echoing the source line.
+    mut = _mutant(r"exec -ignorestderr python3 \$DP_SRCS --record",
+                  'set _ ""', "srcs-empty-record")
     try:
-        arm("dp-mut-srcs-deleted", "SRC_LINES", False, tcl=mut)
+        arm("dp-mut-srcs-empty-record",
+            "names 0 tops, expected exactly one", False, tcl=mut)
     finally:
         os.unlink(mut)
 
@@ -650,7 +797,8 @@ def selftest():
            "gen_gptp_ucode.py",
            "%s %s -o \"$out\" > /dev/null && "
            "sed -i '5s/.*/00000000000Z/' \"$out\"\n  exit 0"
-           % (REAL_PYTHON, GEN_GPTP))
+           % (REAL_PYTHON, GEN_GPTP),
+           check=unpublished('gptp_ucode.hex'))
 
     # Arm 32. MUTATION: the gptp generic deleted from synth_design's call.
     mut = _mutant(r" \\\n  -generic \$GUCODE_GENERIC", "",
@@ -664,7 +812,10 @@ def selftest():
         os.unlink(mut)
 
     # Arm 33. MUTATION: the gptp generic cross-wired at the AECP image. It
-    # exists and opens; only the canonical-basename binding refuses it.
+    # exists and opens, so Synth 8-4445 never fires. (The basename binding
+    # and the geometry check BOTH refuse it today, because 8- and 12-digit
+    # words are mutually exclusive; the basename guard only becomes the sole
+    # detector if two ROMs ever share a geometry.)
     mut = _mutant(r'set GUCODE_GENERIC "GPTP_UCODE_HEX_P=\\"\[file normalize '
                   r'gptp_ucode\.hex\]\\""',
                   'set GUCODE_GENERIC "GPTP_UCODE_HEX_P=\\"[file normalize '
@@ -686,6 +837,126 @@ def selftest():
     finally:
         os.unlink(mut)
         os.unlink(pkg)
+
+    # ---- what the recipe hands the TOOL (post-merge review of PR #264) ----
+    #
+    # The stub used to inspect only -generic, so every other argument of the
+    # synth_design line was unobserved -- and that is exactly where the recipe
+    # was wrong: it spelled -include_dirs by hand, in an order that selected a
+    # different elaboration shape than the portability gate, and dropped the
+    # record's define. Each mutation below is caught by dp_positive; the arm
+    # passes when the detector fires.
+
+    def undetected(what):
+        return "the %s mutant was not detected: %s" % (what, (
+            "the recipe can hand synth_design a design other than the one the "
+            "record describes, and no arm would notice"))
+
+    # Arm 35. The include path ROTATED so the shape config dir lands LAST --
+    # the pre-fix spelling, byte-for-byte in effect. Both orders elaborate
+    # cleanly; only the order decides which adp_shape_defaults.svh wins.
+    mut = _mutant(
+        r"foreach d \$DEFINES \{ lappend DEFARGS -verilog_define \$d \}",
+        "foreach d $DEFINES { lappend DEFARGS -verilog_define $d }\n"
+        "set INCS [concat [lrange $INCS 1 end] [list [lindex $INCS 0]]]",
+        "incdirs-reordered")
+    try:
+        arm("dp-mut-incdirs-reordered", None, True, tcl=mut,
+            check=lambda d, log: None if dp_positive(d, log)
+            else undetected("reordered include path"))
+    finally:
+        os.unlink(mut)
+
+    # Arm 36. The top cross-wired at the plane -- a plausible copy-paste from
+    # pp_shadow_ooc.tcl, which this file calls "the same instrument". It would
+    # report the PLANE's utilization as the assembled datapath's.
+    mut = _mutant(r"-top \[lindex \$DP_TOP 0\]", "-top KL_pp_shadow",
+                  "top-cross-wired")
+    try:
+        arm("dp-mut-top-cross-wired", None, True, tcl=mut,
+            check=lambda d, log: None if dp_positive(d, log)
+            else undetected("cross-wired top"))
+    finally:
+        os.unlink(mut)
+
+    # Arm 37. The record's defines dropped. KL_gptp_engine.sv gates
+    # simulation-only $error blocks on `ifndef SYNTHESIS.
+    mut = _mutant(r" \{\*\}\$DEFARGS", "", "defines-dropped")
+    try:
+        arm("dp-mut-defines-dropped", None, True, tcl=mut,
+            check=lambda d, log: None if dp_positive(d, log)
+            else undetected("dropped defines"))
+    finally:
+        os.unlink(mut)
+
+    # Arm 38. -sv dropped: the SystemVerilog half parsed as Verilog-2001.
+    mut = _mutant(r"read_verilog -sv \$SV", "read_verilog $SV", "sv-dropped")
+    try:
+        arm("dp-mut-sv-flag-dropped", None, True, tcl=mut,
+            check=lambda d, log: None if dp_positive(d, log)
+            else undetected("dropped -sv flag"))
+    finally:
+        os.unlink(mut)
+
+    # Arm 39. The part changed: an area figure is only a figure for a device.
+    mut = _mutant(r"-part xc7a100tfgg484-2", "-part xc7z020clg400-1",
+                  "part-changed")
+    try:
+        arm("dp-mut-part-changed", None, True, tcl=mut,
+            check=lambda d, log: None if dp_positive(d, log)
+            else undetected("changed part"))
+    finally:
+        os.unlink(mut)
+
+    # ---- the two guards that had no arm at all ---------------------------
+
+    # Arm 40. UPC_W_C = 0 asks for a ONE-WORD ucode image -- "the same lie as
+    # an absent one" by the recipe's own contract, admitted through the single
+    # geometry constant that used to reach `expr` with no guard.
+    pkg, mut = pkg_mutant(
+        "localparam int unsigned UCODE_W_C = 48;\n"
+        "localparam int unsigned UPC_W_C = 0;\n", "pkg-upc-zero")
+    try:
+        arm("dp-pkg-upc-zero", "not a positive ROM address width", False,
+            tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # Arm 41. A zero depth would let an empty transition ROM validate.
+    pkg, mut = pkg_mutant(
+        "localparam int unsigned TROM_W_C = 32;\n"
+        "localparam int unsigned TROM_DEPTH_C = 0;\n", "pkg-trom-depth-zero",
+        which="acmp")
+    try:
+        arm("dp-pkg-trom-depth-zero", "not a positive ROM depth", False,
+            tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # Arm 42. one_source: a record that no longer carries the geometry source
+    # is a refusal, never a guessed path. No arm reached this guard before --
+    # every package arm replaced the one_source call itself.
+    mut = _mutant(r"one_source \$SRC_LINES ucpu_pkg\.sv",
+                  "one_source $SRC_LINES no_such_pkg.sv", "one-source-missing")
+    try:
+        arm("dp-mut-one-source-missing", "expected exactly one no_such_pkg.sv",
+            False, tcl=mut)
+    finally:
+        os.unlink(mut)
+
+    # Arm 43. The clock port renamed out from under create_clock. -quiet
+    # would hand it an empty object list and define a VIRTUAL clock, so
+    # timing_$TAG.rpt would report an essentially unconstrained design at
+    # rc=0. The refusal is the only honest outcome.
+    mut = _mutant(r"set CLK_NAME axis_clk", "set CLK_NAME renamed_clk",
+                  "clock-port-renamed")
+    try:
+        arm("dp-mut-clock-port-renamed", "A virtual clock would report an",
+            False, tcl=mut, post_synth=True)
+    finally:
+        os.unlink(mut)
 
     if ran != ARMS:
         problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this "

--- a/syn/ooc/ooc_tcl_selftest.py
+++ b/syn/ooc/ooc_tcl_selftest.py
@@ -79,12 +79,17 @@ GEN_GPTP = os.path.join(REPO, "gptp-processor", "hdl", "ucode",
 #: recipe under test must arrive at the same binding on its own.
 STUBS = """
 set ::ooc_read {}
-set ::ooc_sv 0
+set ::ooc_sv_files {}
+set ::ooc_synthed 0
 set ::ooc_sev [dict create]
 proc read_verilog args {
+  set sv 0
   foreach a $args {
-    if {$a eq "-sv"} { set ::ooc_sv 1; continue }
-    foreach f $a { lappend ::ooc_read $f }
+    if {$a eq "-sv"} { set sv 1; continue }
+    foreach f $a {
+      lappend ::ooc_read $f
+      if {$sv} { lappend ::ooc_sv_files $f }
+    }
   }
 }
 proc set_msg_config args {
@@ -131,7 +136,11 @@ proc synth_design args {
       -include_dirs   { set ::ooc_incs [lindex $args [incr i]]; continue }
       -verilog_define { lappend ::ooc_defs [lindex $args [incr i]]; continue }
       -generic        { }
-      default         { continue }
+      default {
+        error "SYNTH-OPTION-UNMODELLED: $opt -- an option that can move the\
+ number (-max_bram, -no_lc, -flatten_hierarchy) must be modelled here\
+ before it is passed, not silently accepted."
+      }
     }
     set g [lindex $args [incr i]]
     if {![regexp {^((?:PP|GPTP)_[A-Z_]+_HEX_P)="(.*)"$} $g -> name val]} continue
@@ -147,6 +156,10 @@ proc synth_design args {
         error "SYNTH-GENERIC-WRONG-IMAGE: $name -> [file tail $val] (canonical $tail)"
       }
       set fh [open $val r]; set text [read $fh]; close $fh
+      # $readmemh accepts both comment forms, and so does the recipe's
+      # rom_check; a stub stricter than the tool it models refuses images
+      # Vivado would read.
+      regsub -all {/\\*.*?\\*/} $text "" text
       set n 0
       foreach line [split $text "\\n"] {
         regsub {//.*$} $line "" line
@@ -167,10 +180,13 @@ proc synth_design args {
   foreach id [dict keys $::ooc_sev] {
     puts "OOC-EFFECTIVE-SEV: [list $id] = [dict get $::ooc_sev $id]"
   }
+  set ::ooc_synthed 1
   puts "OOC-TOP: $::ooc_top"
   puts "OOC-PART: $::ooc_part"
   puts "OOC-MODE: $::ooc_mode"
-  puts "OOC-SV: $::ooc_sv"
+  set fs [open ooc-sv-files.txt w]
+  foreach f $::ooc_sv_files { puts $fs $f }
+  close $fs
   set fi [open ooc-incdirs.txt w]
   foreach d $::ooc_incs { puts $fi $d }
   close $fi
@@ -183,8 +199,13 @@ proc synth_design args {
   puts "%s"
 }
 proc create_clock args {}
+#: The top's port names are TEST knowledge, like the geometry map above:
+#: bump this when milan_datapath.sv renames a port. Empty until
+#: synth_design has run -- Vivado has no design to query before that, so a
+#: constraint hoisted above synthesis must look as broken here as it is.
 set ::ooc_ports {axis_clk}
 proc get_ports args {
+  if {!$::ooc_synthed} { return {} }
   set want [lindex $args end]
   if {[lsearch -exact $::ooc_ports $want] >= 0} { return $want }
   return {}
@@ -214,10 +235,14 @@ exec %(real)s "$@"
 """
 
 #: How many arms run. A deleted arm is a self-test that still prints a pass.
-ARMS = 49
+ARMS = 55
 
 _DERIVED = None
 _RECORD = None
+
+#: Arm failures, held module-level so a prerequisite failure part-way through
+#: still reports what ran before it rather than discarding the lot.
+_PROBLEMS = []
 
 
 class SelfTestPrereq(Exception):
@@ -300,8 +325,11 @@ def _mutant(pattern, replacement, label):
         text = fh.read()
     mutated, n = re.subn(pattern, replacement, text)
     if n != 1:
-        raise AssertionError("mutation %r: pattern hit %d times, expected 1 "
-                             "(the recipe moved?)" % (label, n))
+        raise SelfTestPrereq(
+            "mutation %r: pattern hit %d times, expected 1. The recipe moved "
+            "under this arm, so the arm is testing nothing -- retarget it. "
+            "(A mutation that no longer matches must never read as a pass.)"
+            % (label, n))
     fd, path = tempfile.mkstemp(suffix=".tcl", prefix=".ooc-mut-", dir=HERE)
     with os.fdopen(fd, "w") as fh:
         fh.write(mutated)
@@ -309,7 +337,8 @@ def _mutant(pattern, replacement, label):
 
 
 def selftest():
-    problems, ran = [], 0
+    problems, ran = _PROBLEMS, 0
+    del problems[:]
     if not shutil.which("tclsh"):
         # NOT a skip. A skip here is the false green this file exists to close;
         # the workflow installs tclsh for exactly this reason.
@@ -347,7 +376,7 @@ def selftest():
                                     "sentinel=%s\n%s"
                                     % (name, rc, reached, log.strip()))
                     return
-            elif rc == 0 or (reached and not post_synth) or want not in log:
+            elif rc == 0 or reached != post_synth or want not in log:
                 problems.append("SELF-TEST FAILED [%s]: expected a refusal "
                                 "naming %r %s synthesis, got rc=%d, "
                                 "sentinel=%s\n%s"
@@ -432,9 +461,19 @@ def selftest():
 
     # Arm 6. A dead microcode generator aborts the script: its exit status
     # is taken by `exec`, never discarded.
+    def no_temp_left(d, log):
+        left = sorted(f for f in os.listdir(d) if ".gen." in f)
+        if left:
+            return ("the generator temp survived the refusal: %s. It is "
+                    "cleaned on the validation path, so it must be cleaned "
+                    "here too or near-copies of the ROMs accumulate"
+                    % ", ".join(left))
+        return None
+
     dp_arm("dp-ucode-generator-fail", "planted ucode generator failure",
            "gen_ucode.py",
-           "echo 'planted ucode generator failure' >&2\n  exit 3")
+           "echo 'planted ucode generator failure' >&2\n  exit 3",
+           check=no_temp_left)
 
     # Arm 7. A generator that exits 0 leaving an empty image: zero words is
     # not the ROM's geometry.
@@ -517,9 +556,15 @@ def selftest():
         # none of it was observed until this review: -include_dirs was a hand
         # list whose ORDER selected a different entity shape than the gate.
         rec = derived_record()
-        if "OOC-SV: 1" not in log:
-            return ("read_verilog was not given -sv: the SystemVerilog half "
-                    "of the read set would be parsed as Verilog-2001")
+        svf = os.path.join(d, "ooc-sv-files.txt")
+        got_sv = (set(l.strip() for l in open(svf) if l.strip())
+                  if os.path.isfile(svf) else set())
+        want_sv = set(f for f in derived_record()["src"] if f.endswith(".sv"))
+        if got_sv != want_sv:
+            return ("the files read as SystemVerilog are not the .sv half of "
+                    "the record (%d read with -sv, %d .sv in the record): the "
+                    "remainder would go to the Verilog-2001 parser"
+                    % (len(got_sv), len(want_sv)))
         if ("OOC-TOP: %s" % rec["top"][0]) not in log:
             return ("synth_design was not given the record's own top (%s): "
                     "the module this recipe reads and the module it "
@@ -746,7 +791,7 @@ def selftest():
     pp_root = "$REPO/protocol-processor" + "/hdl"
     gp_root = "$REPO/gptp-processor" + "/hdl"
     mut = _mutant(
-        r"exec -ignorestderr python3 \$DP_SRCS --record",
+        r"exec python3 \$DP_SRCS --top \$TOP --record 2>\$REC_ERR",
         'set _ "top=milan_datapath\\ndefine=SYNTHESIS'
         '\\nincdir=$REPO/configs/generated/endstation_arty_current'
         '\\nsrc=%s/aecp/ucpu_pkg.sv\\nsrc=%s/acmp/pp_acmp_pkg.sv'
@@ -772,11 +817,11 @@ def selftest():
     # quietly supply a list, and the refusal must be one the recipe AUTHORS:
     # the old spelling asserted the bare substring "SRC_LINES", which Tcl's
     # own undefined-variable error satisfied by echoing the source line.
-    mut = _mutant(r"exec -ignorestderr python3 \$DP_SRCS --record",
+    mut = _mutant(r"exec python3 \$DP_SRCS --top \$TOP --record 2>\$REC_ERR",
                   'set _ ""', "srcs-empty-record")
     try:
         arm("dp-mut-srcs-empty-record",
-            "names 0 tops, expected exactly one", False, tcl=mut)
+            "expected exactly one top and that top to be", False, tcl=mut)
     finally:
         os.unlink(mut)
 
@@ -847,10 +892,17 @@ def selftest():
     # record's define. Each mutation below is caught by dp_positive; the arm
     # passes when the detector fires.
 
-    def undetected(what):
-        return "the %s mutant was not detected: %s" % (what, (
-            "the recipe can hand synth_design a design other than the one the "
-            "record describes, and no arm would notice"))
+    def fires(needle, what):
+        """The mutant must be caught by the assertion this arm NAMES. Any
+        detector firing would satisfy a bare `if dp_positive(...)`, so the
+        arm would survive the deletion of the very check it exists to pin."""
+        def check(d, log):
+            got = dp_positive(d, log) or ""
+            if needle in got:
+                return None
+            return ("the %s mutant was not caught by its own detector "
+                    "(got: %s)" % (what, got or "no detector fired at all"))
+        return check
 
     # Arm 35. The include path ROTATED so the shape config dir lands LAST --
     # the pre-fix spelling, byte-for-byte in effect. Both orders elaborate
@@ -862,20 +914,18 @@ def selftest():
         "incdirs-reordered")
     try:
         arm("dp-mut-incdirs-reordered", None, True, tcl=mut,
-            check=lambda d, log: None if dp_positive(d, log)
-            else undetected("reordered include path"))
+            check=fires("include path is not the record's", 'reordered include path'))
     finally:
         os.unlink(mut)
 
     # Arm 36. The top cross-wired at the plane -- a plausible copy-paste from
     # pp_shadow_ooc.tcl, which this file calls "the same instrument". It would
     # report the PLANE's utilization as the assembled datapath's.
-    mut = _mutant(r"-top \[lindex \$DP_TOP 0\]", "-top KL_pp_shadow",
-                  "top-cross-wired")
+    mut = _mutant(r"out_of_context -top \$TOP",
+                  "out_of_context -top KL_pp_shadow", "top-cross-wired")
     try:
         arm("dp-mut-top-cross-wired", None, True, tcl=mut,
-            check=lambda d, log: None if dp_positive(d, log)
-            else undetected("cross-wired top"))
+            check=fires("not given the record's own top", 'cross-wired top'))
     finally:
         os.unlink(mut)
 
@@ -884,8 +934,7 @@ def selftest():
     mut = _mutant(r" \{\*\}\$DEFARGS", "", "defines-dropped")
     try:
         arm("dp-mut-defines-dropped", None, True, tcl=mut,
-            check=lambda d, log: None if dp_positive(d, log)
-            else undetected("dropped defines"))
+            check=fires("defines are not the record's", 'dropped defines'))
     finally:
         os.unlink(mut)
 
@@ -893,8 +942,7 @@ def selftest():
     mut = _mutant(r"read_verilog -sv \$SV", "read_verilog $SV", "sv-dropped")
     try:
         arm("dp-mut-sv-flag-dropped", None, True, tcl=mut,
-            check=lambda d, log: None if dp_positive(d, log)
-            else undetected("dropped -sv flag"))
+            check=fires('read as SystemVerilog', 'dropped -sv flag'))
     finally:
         os.unlink(mut)
 
@@ -903,8 +951,7 @@ def selftest():
                   "part-changed")
     try:
         arm("dp-mut-part-changed", None, True, tcl=mut,
-            check=lambda d, log: None if dp_positive(d, log)
-            else undetected("changed part"))
+            check=fires('not given the ship part', 'changed part'))
     finally:
         os.unlink(mut)
 
@@ -958,6 +1005,83 @@ def selftest():
     finally:
         os.unlink(mut)
 
+    # Arm 44. The $TAG reports are invalidated before the FIRST refusal can
+    # fire, not beside synth_design: a refused run must not leave the
+    # previous run's numbers standing under the same names. The generator
+    # refusal used here is upstream of synth_design, which is exactly the
+    # placement the original fix got wrong and no arm observed.
+    def plant_reports(d):
+        for r in ("util_hier_base.rpt", "util_base.rpt", "timing_base.rpt"):
+            _write(d, r, "STALE NUMBERS FROM A PREVIOUS RUN\n")
+
+    def reports_gone(d, log):
+        left = sorted(r for r in ("util_hier_base.rpt", "util_base.rpt",
+                                  "timing_base.rpt")
+                      if os.path.exists(os.path.join(d, r)))
+        if left:
+            return ("a refused run left %s standing: the reports are the one "
+                    "artifact read by hand, and nothing invalidated them"
+                    % ", ".join(left))
+        return None
+
+    dp_arm("dp-refusal-invalidates-reports",
+           "planted ucode generator failure", "gen_ucode.py",
+           "echo 'planted ucode generator failure' >&2\n  exit 3",
+           setup=plant_reports, check=reports_gone)
+
+    # ---- guards this PR ADDED, each with an arm of its own ---------------
+
+    # Arm 45. An unrecognized record key is a refusal: half-consuming a
+    # record is how a consumer stops consuming the half that matters.
+    mut = _mutant(r"exec python3 \$DP_SRCS --top \$TOP --record 2>\$REC_ERR",
+                  'set _ "top=milan_datapath\\ndefine=SYNTHESIS'
+                  '\\nincdir=$REPO/hdl/common\\nsrc=$REPO/x.sv\\nwat=1"',
+                  "record-unknown-key")
+    try:
+        arm("dp-mut-record-unknown-key", "unrecognized record line", False,
+            tcl=mut)
+    finally:
+        os.unlink(mut)
+
+    # Arm 46. -suppress is a downgrade that carries no -new_severity. The
+    # two-option whitelist this file used to model could not see it.
+    mut = _mutant(r"(set_msg_config -id \{Synth 8-4445\} -new_severity ERROR\n)",
+                  "\\1set_msg_config -id {Synth 8-4445} -suppress\n",
+                  "promotion-then-suppress")
+    try:
+        arm("dp-mut-promotion-then-suppress", None, True, tcl=mut,
+            check=lambda d, log: None if EFFECTIVE_OK not in log
+            else "a -suppress after the promotion still reads as ERROR")
+    finally:
+        os.unlink(mut)
+
+    # Arm 47. A generator that writes a PERFECT image, exits 0 and emits one
+    # warning must not abort the run. Bare `exec` treats any stderr byte as
+    # an error, which refused a good image and deleted the target first.
+    dp_arm("dp-ucode-generator-warns-but-succeeds", None, "gen_ucode.py",
+           "%s %s -o \"$out\" > /dev/null && "
+           "echo 'DeprecationWarning: planted, harmless' >&2\n  exit 0"
+           % (REAL_PYTHON, GEN_UCODE), expect_rc0=True)
+
+    # Arm 48. A leading zero is DECIMAL in SystemVerilog and octal to Tcl's
+    # expr. 011 must mean 11 (2,048 words), not 9 (512).
+    pkg, mut = pkg_mutant(
+        "localparam int unsigned UCODE_W_C = 48;\n"
+        "localparam int unsigned UPC_W_C = 011;\n", "pkg-upc-octal")
+    try:
+        arm("dp-pkg-upc-leading-zero-is-decimal", None, True, tcl=mut)
+    finally:
+        os.unlink(mut)
+        os.unlink(pkg)
+
+    # Arm 49. $readmemh accepts a /* */ banner; refusing one is a false
+    # refusal of a legitimate generator.
+    dp_arm("dp-ucode-block-comment-banner", None, "gen_ucode.py",
+           "%s %s -o \"$out.b\" > /dev/null && "
+           "{ printf '/* generated banner\\n   second line */\\n'; "
+           "cat \"$out.b\"; } > \"$out\" && rm -f \"$out.b\"\n  exit 0"
+           % (REAL_PYTHON, GEN_UCODE), expect_rc0=True)
+
     if ran != ARMS:
         problems.append("SELF-TEST FAILED [arm-count]: ran %d arm(s), this "
                         "file declares %d." % (ran, ARMS))
@@ -965,7 +1089,12 @@ def selftest():
 
 
 def main() -> int:
-    bad, ran = selftest()
+    try:
+        bad, ran = selftest()
+    except SelfTestPrereq as exc:
+        # Named, and with the arms already run still reported: an aborted
+        # suite must not look like a suite that found nothing.
+        bad, ran = _PROBLEMS + ["SELF-TEST ABORTED: %s" % exc], 0
     for b in bad:
         print("  -", b, file=sys.stderr)
     if bad:


### PR DESCRIPTION
## Contents

- **[Status](#status)**
- **[Linked Issue / roles](#linked-issue--roles)**
- **[Description](#description)**
- **[The defect: which design was being measured](#the-defect-which-design-was-being-measured)**
- **[Why three review rounds missed it](#why-three-review-rounds-missed-it)**
- **[The rest of the findings](#the-rest-of-the-findings)**
- **[How to get into the same state](#how-to-get-into-the-same-state)**
- **[How to validate](#how-to-validate)**
- **[Known limitations / out of scope](#known-limitations--out-of-scope)**
- **[Definition of Done](#definition-of-done)**

## Status

🟢 GREEN at `a8d79890`. Self-test **55/55** (was 40/40), full local bar passes, and the suite is proven RED on three separate replanted defects: the pre-fix include path (the exact recipe the previous 40 arms certified), a clock guard hoisted above `synth_design`, and `-sv` moved to the Verilog list. Base `dev` `8043f299`. No Vivado run (see limitations).

Round two answers a three-agent review of `bc7b62fb`, which found two majors in the fix itself and two in the test it shipped — all closed at this head, in the second commit.

`246-synoocmilan_datapath_ooctcl-never-generates-ucodehex-...` → `dev`.

## Linked Issue / roles

Follow-up to #246 / PR #264 (merged `0d4fff94`), from a four-agent post-merge review of that PR. #264's branch was deleted on merge, so this is the same branch name recreated from `dev`; it does not revert or re-litigate #264, it closes what the review found still open on `dev`.

Relates to #235 (the "two different strings" class) and #116 (the default-on gPTP fabric, whose sources joined the record after #264 merged and make `define=SYNTHESIS` live).

## Description

`syn/ooc/milan_datapath_ooc.tcl` derived its **sources** from `dp_srcs.py`'s record and then spelled by hand the one list that decides **which design gets measured**. This PR makes the recipe consume the whole record and gives the self-test eyes on the whole `synth_design` call.

| piece | change |
|---|---|
| `syn/ooc/dp_srcs.py` | `--record` prints the whole consumable record (`top=`/`define=`/`incdir=`/`src=`) in authority order. Default output is byte-identical, so the suite's read-set equality is unaffected. |
| `syn/ooc/milan_datapath_ooc.tcl` | consumes all four keys; refuses an unrecognized key, zero-or-many tops, an empty include or source list. No hand list remains. Plus 8 smaller refusals below. |
| `syn/ooc/ooc_tcl_selftest.py` | 40 → 49 arms. The `synth_design` stub records `-top`/`-part`/`-mode`/`-include_dirs`/`-verilog_define` and whether `-sv` was used. |
| `.gitignore` | `syn/ooc/.ooc-mut-*` — the entries named `syn/yosys/` while the mutants land in `syn/ooc/`. |

## The defect: which design was being measured

`syn/yosys/run.sh:133-138` puts `configs/generated/endstation_arty_current` **first** for `milan_datapath` — `incdirs_for()` exists for no other reason, and says so. The recipe had it **last**, and *both* `hdl/common/csr/gen/` and `configs/generated/*/gen/` carry an `adp_shape_defaults.svh`. Include search is first-match-wins, so the two orders elaborate two different entities — both cleanly, neither warning:

```
AUTHORITY order (run.sh)   ADP_TALKER_SRC_C=1  AEM_NAME_ENTRIES_C=29  TALKER_WIRE_CHANS_C=2
RECIPE order   ($INCS)     ADP_TALKER_SRC_C=2  AEM_NAME_ENTRIES_C=31  TALKER_WIRE_CHANS_C=8
```

Reproduced independently with `sv2v` and with `yosys` (whose parse error names the file it actually opened). Those constants are not decorative: `ADP_TALKER_SRC_C` → `ACMP_SRC_C` (`milan_datapath.sv:1535`) feeds `.N_STREAM_IN_P`/`.N_STREAM_OUT_P` at `:6854-6855`, and `AEM_NAME_ENTRIES_C` feeds `.DESC_NAME_ENTRIES_P` at `:6865` — they size the processor, the dominant block this instrument exists to price. `hdl/common/csr/gen/` is the last-writer-wins artifact `endstation_builder.py --write-rtl` overwrites, and it currently holds the **ax7101_1x1_tdm8** shape.

So the recipe reported a complete, plausible utilization figure for a design the portability gate never elaborates. That is #246's own class one layer up.

### What this does NOT fix

`milan_csr.sv` sits beside its **own** `hdl/common/csr/gen/` copy, and a quoted `` `include `` resolves against the including file's directory before any `-I`. So under the authority order `milan_csr` still sees 2/31 while `milan_datapath` sees 1/29 — the two-includer invariant asserted at `milan_datapath.sv:1526` (*"milan_csr \`include-s the SAME file … are ONE constant"*) does **not** hold on this tree, and does not hold for the Yosys gate either. The pre-fix order was coherent *and wrong*; the authority order is *right for `milan_datapath`* and still incoherent. Matching the gate is this recipe's job; making the tracked copy agree with the config is `endstation_builder.py --write-rtl`'s, and is not attempted here. This is stated in the recipe and is the single most important thing a reviewer should push back on.

Second half of the same defect: the record's `define=SYNTHESIS` was dropped entirely. That is **not** inert on today's `dev` — the gPTP sources joined the record after #264 merged, and `gptp-processor/hdl/top/KL_gptp_engine.sv` gates simulation-only `$error` blocks and one extra register on `` `ifndef SYNTHESIS `` at **five** sites (`:695,725,732,795,808`). It is the only file in the 115-source record that does. The gate defines it; the recipe did not.

Both halves are fixed by deriving, not spelling. `$INCS` and `$DEFINES` are now the record's own, in the record's own order.

## Why three review rounds missed it

The self-test's `synth_design` stub inspected **only** `-generic`:

```tcl
if {[lindex $args $i] ne "-generic"} continue
```

`-top`, `-part`, `-mode`, `-include_dirs` were never read, and `read_verilog` explicitly discarded `-sv`. Five separate one-line mutations of that call each left the suite at `40 arm(s) passed`. The stub now records all of them, the positive arm asserts the include path equals the record's **in order** and the defines equal the record's, and five mutation arms prove the detector fires.

## The rest of the findings

Each was confirmed by reproduction, and each now has an arm or a guard:

- **`exec` aborts on child stderr even at exit 0.** One Python warning from a generator killed the run — with the warning as the entire diagnostic, `$img` already deleted, and `$tmp` orphaned because cleanup was only on the validation path. `-ignorestderr` + `catch`; the exit *status* is the contract, and `$tmp` is cleaned on both failure paths.
- **`UPC_W_C` reached `expr` with no guard**: `UPC_W_C = 0` asked for a one-word ucode image — "the same lie as an absent one" by the recipe's own contract, admitted through the single geometry constant that skipped a check.
- **Tcl read a leading zero as octal**, so `UPC_W_C = 011` was 9 in the recipe and 11 in the RTL. `pkg_num` now returns a decimal.
- **`TAG` went through `expr`**, which coerces numerically: `TAG=007` wrote `util_7.rpt` and collided with a `TAG=7` run.
- **The `$TAG` reports were the one artifact nothing invalidated** — written only on success, so a refused run left the previous run's numbers under the same name. Now deleted before `synth_design`, like the images.
- **`get_ports -quiet`** on a renamed port would hand `create_clock` an empty object list and define a *virtual* clock: an unconstrained design reported as a timing result, at rc=0.
- **`rom_check` stripped only `//`** while `pkg_num` stripped both forms, so a generator banner written as `/* */` was a false refusal.
- **`one_source` and `positive_depth` had zero arm coverage**; disabling either left the suite green.
- **The malformed-image arms had no `check`**, so nothing asserted the publish-after-validate ordering.
- **`set_msg_config`'s model was a two-option whitelist**, blind to `-suppress`. It now models it and fails closed on an option it does not know.
- **`derived_sources()` ran `dp_srcs.py` with a bare `check=True`**, so a missing submodule aborted the suite with a traceback that *also discarded every arm failure already collected*. The record is now proven available at arm zero and names itself when it is not.
- **Arm 27 asserted the bare substring `SRC_LINES`**, which Tcl's own undefined-variable error satisfied by echoing the source line. It now plants an empty record and requires a refusal the recipe authors.
- The recipe quoted **7,923 LUT**, the issue title's first estimate; #264's measured figure at its own head is **8,012**.

## How to get into the same state

```sh
git fetch origin && git checkout 246-synoocmilan_datapath_ooctcl-never-generates-ucodehex-it-reports-30925-lut-for-a-design-that-is-38848-and-exits-0
git submodule update --init third_party/verilog-axis protocol-processor gptp-processor
```

Needs `tclsh`, `python3` and pinned `sv2v` on `PATH` (README.md's tool table) — the same set the Yosys gate needs.

## How to validate

```sh
python3 syn/ooc/ooc_tcl_selftest.py          # 55 arms, ~7 min
```

Prove the new arms bite — restore the pre-fix hand-spelled include path and the suite must go RED on `dp-empty-dir-generates-and-passes`, naming the order mismatch:

```sh
python3 - <<'PY'
import io; p="syn/ooc/milan_datapath_ooc.tcl"; s=io.open(p).read()
io.open(p,"w").write(s.replace("set DEFARGS {}\n", "set DEFARGS {}\nset INCS [list "
  "$REPO/hdl/common $REPO/hdl/common/csr $REPO/hdl/common/eth_event_counter "
  "$REPO/hdl/ieee17221/adp $REPO/hdl/ieee8021q/ts $REPO/hdl/ieee8021as/ptp_timestamp "
  "$REPO/hdl/ieee1722/avtp $REPO/configs/generated/endstation_arty_current]\n", 1))
PY
python3 syn/ooc/ooc_tcl_selftest.py ; git checkout -- syn/ooc/milan_datapath_ooc.tcl
```

See the shape divergence directly, with the front end the gate itself uses:

```sh
printf 'module p;\n`include "gen/adp_shape_defaults.svh"\nendmodule\n' > /tmp/p.sv
sv2v -Iconfigs/generated/endstation_arty_current -Ihdl/common -Ihdl/common/csr /tmp/p.sv | grep TALKER_SRC
sv2v -Ihdl/common -Ihdl/common/csr -Iconfigs/generated/endstation_arty_current /tmp/p.sv | grep TALKER_SRC
```

Plus the standard bar: `scripts/lint_rtl.py --check`, `scripts/pp_srcs.py --check --selftest`, `scripts/docs_check.py`, `scripts/check_doc_paths.py`, `scripts/gen_toc.py --check`, `scripts/ci_events.py --check`, `syn/ooc/dp_srcs.py --selftest`, `git diff --check`.

## Known limitations / out of scope

- **No Vivado run.** The include-order consequence is demonstrated with `sv2v` and `yosys` and rests on first-match-wins include search — documented behaviour, and corroborated in-project by `incdirs_for()` existing only to prepend that directory. It is not confirmed against the tool. **A real Vivado run should re-baseline the absolute figures: every number this recipe has produced was for the other shape**, including #264's 39,776 and the `docs/findings/PP_SHADOW_AREA_0812.md` pair. No figure in this PR is offered as a measurement.
- **`syn/yosys/ooc.sh:48` has THIS PR's defect, live and unfixed.** Its `INC` is one fixed string for every top — `hdl/common/csr` present, **no `configs/generated/*` at all** — and `milan_datapath` is one of its tops, so it prices the ax7101_1x1_tdm8 entity too. `docs/design/AREA_BUDGET.md` quotes its figures as the campaign's LUT method. This is the more important sibling and it deserves its own PR; the round-one text of this section named `pp_shadow_ooc.tcl` instead, which is wrong on this axis — that recipe's record has zero `` `include ``s and zero `SYNTHESIS` gating, so its missing `-include_dirs`/`-verilog_define` bite nothing today.
- **`syn/yosys/run.sh:130`'s comment is false** — *"milan_datapath and nothing else \`include's the elaboration-shape header"* — `milan_csr.sv:1251` does too, and `incdirs_for()` special-cases only `milan_datapath`, so `run.sh`'s own `milan_csr` top is elaborated on the tracked shape. Not fixed here.
- **`syn/ooc/pp_shadow_ooc.tcl` still has #246's ROM hole** and is NOT fixed here. Its preflight is `file exists` + `size != 0` only — no generation, no geometry check, no `Synth 8-4445` promotion — so a truncated `ucode.hex` passes it, `$readmemh` part-fills 2,047 words with X, and it exits 0 with a full report. It also still does the unguarded `get_ports clk_i` this PR just fixed in the datapath recipe. `milan_datapath_ooc.tcl`'s header now states which properties the two recipes no longer share.
- **Nothing gates the authority's own include ORDER.** The positive arm asserts *recipe == record*; flip `incdirs_for()` from prepend to append and the recipe follows it into the wrong shape with the suite still green. `milan_datapath.sv:1553`'s elaboration guard accepts both 1 and 2 at the default `N_STREAMS=1`, so it does not catch it either.
- **Geometry remains content-blind.** A geometrically perfect all-zero image passes every check. #264 justified this with "content doesn't move utilization"; the counter-argument is that #246's own number *was* a content effect — the all-zero ROM is what constant-folded the uCPU. Closing it means hashing generator output; not attempted here.
- **The stub's canonical geometry map is still test knowledge** and still duplicates the pinned packages' numbers. A comment now names the seam, so a coherent ROM change fails with a message that points at the right file.
- **`$REPO/protocol-processor/.../gen_*.py` remain hand-spelled.** The generators are not in the record (`dp_srcs.py` emits only `.sv`/`.v`), so there is nothing to derive them from today. A pin bump that relocates one fails loudly.
- **Runtime is ~5 min**, ~90 % of it redundant `dp_srcs.py` runs (one per datapath arm). A per-process cache brings it to ~23 s; not done here because the arms that sabotage the record must keep the real generator, and splitting them is its own change.
- CI runs the self-test, not Vivado (`.github/workflows/rtl-fast.yml:167`, `timeout-minutes: 30`).

## Definition of Done

- [ ] Linked Issue acceptance criteria are satisfied <!-- #246 is CLOSED (by #264) and no open Issue tracks this work; this box and the containment box below are vacuous until one is opened -->
- [x] New or changed behavior has self-checking tests
- [x] Required local verification bar passes
- [x] Self-test evidence is posted in a PR comment
- [x] No undocumented requirement or interface change remains
- [ ] Internal cleared-context review is positive
- [ ] External review is positive
- [ ] Blocking and major findings are fixed and re-reviewed
- [ ] No review round remains in flight
- [ ] Candidate merge result is validated per [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation is updated where needed <!-- round two: PP_SHADOW_AREA_0812.md carries a shape-provenance note on the milan_datapath table and its stale arm count is fixed; AREA_BUDGET.md and AREA_80_CAMPAIGN.md point at it -->
- [ ] Post-merge containment will be checked before the Issue moves to Done
